### PR TITLE
adding the paypal email address as the card number 

### DIFF
--- a/app/controllers/paypal.js
+++ b/app/controllers/paypal.js
@@ -165,6 +165,7 @@ module.exports = function(app) {
         var card = results.getCard.rows[0];
         card.confirmedAt = new Date();
         card.data = results.callPaypal;
+        card.number = results.callPaypal.senderEmail;
         card.save().done(cb);
       }],
 

--- a/test/paypal.preapproval.routes.test.js
+++ b/test/paypal.preapproval.routes.test.js
@@ -219,6 +219,7 @@ describe('paypal.preapproval.routes.test.js', function() {
       });
 
       it('should confirm the payment of a transaction', function(done) {
+        var mock = paypalMock.adaptive.preapprovalDetails;
         request(app)
           .post('/users/' + user.id + '/paypal/preapproval/' + preapprovalkey)
           .set('Authorization', 'Bearer ' + user.jwt(application))
@@ -233,6 +234,7 @@ describe('paypal.preapproval.routes.test.js', function() {
                   expect(res.count).to.equal(1);
                   expect(res.rows[0].confirmedAt).not.to.be.null;
                   expect(res.rows[0].service).to.equal('paypal');
+                  expect(res.rows[0].number).to.equal(mock.completed.senderEmail);
                   expect(res.rows[0].UserId).to.equal(user.id);
                   cb();
                 });


### PR DESCRIPTION
so that we can list it in the list of payment methods, see #42 
