### PR TITLE
Making sure we return an error message to the user when paypal fails

### DIFF
--- a/app/controllers/transactions.js
+++ b/app/controllers/transactions.js
@@ -475,6 +475,10 @@ module.exports = function(app) {
     }, function(err, results) {
       if (err && results.callService) {
         console.error('PayPal error', JSON.stringify(results.callService));
+        if (results.callService.error instanceof Array) {
+          const message = results.callService.error[0].message;
+          return next(new errors.BadRequest(message));
+        }
       }
 
       if (err) return next(err);


### PR DESCRIPTION
Fixes #41 

But: 
- We should have a better error message than the default (very cryptic) _"The total amount of all payments exceeds the maximum total amount for all payments"_
- That message should also suggest an action. In this case: "Re-approve your Paypal account for another $2,000 allowance"

It's good for now. But I'll create another issue to better deal with this.
