### PR TITLE
added dashboard url to speed up debugging

### DIFF
--- a/app/controllers/webhooks.js
+++ b/app/controllers/webhooks.js
@@ -66,7 +66,10 @@ module.exports = (app) => {
         Activity.create({
           type: activities.WEBHOOK_STRIPE_RECEIVED,
           data: {
-            event: results.fetchEvent.event
+            event: results.fetchEvent.event,
+            stripeAccount: body.user_id,
+            eventId: body.id,
+            dashboardUrl: `https://dashboard.stripe.com/${body.user_id}/events/${body.id}`
           }
         })
         .done(cb);


### PR DESCRIPTION
When something goes wrong on the stripe part, it becomes hard to find the event on the dashboard (connected accounts). I included the url in the activity so that anyone can check the account's event.
