### PR TITLE
fix paypal payment method

### DIFF
--- a/test/mocks/data.json
+++ b/test/mocks/data.json
@@ -271,7 +271,8 @@
         "status": "paid back on 4/17/15",
         "comment": "",
         "link": "http://cl.ly/image/39212o302x2c",
-        "createdAt": "2015-03-04T08:00:00.000Z"
+        "createdAt": "2015-03-04T08:00:00.000Z",
+        "payoutMethod": "paypal"
       },
       {
         "vendor": "OrangeWebsite",


### PR DESCRIPTION
The problem was that we weren't giving Paypal the `preapprovalKey`. Instead of returning an error, Paypal considers such request as "this request hasn't been pre-approved yet, please create a payKey so that we can redirect the user to the paypal.com website to manually approve it". 
Because that's not an error, our API was thinking that the reimbursement happened normally.

I made sure that we are now not considering an expense as reimbursed if the payment hasn't been completed.
