### PR TITLE
runs server on new port in test; closes #335

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ require('./server/routes')(app);
 /**
  * Start server
  */
-const port = process.env.PORT || 3060;
+const port = process.env.API_PORT || 3060;
 const server = app.listen(port, () => {
   const host = require('os').hostname();
   console.log('OpenCollective API listening at http://%s:%s in %s environment.\n', host, server.address().port, app.set('env'));

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ require('./server/routes')(app);
 /**
  * Start server
  */
-const port = process.env.API_PORT || 3060;
+const port = process.env.API_PORT || process.env.PORT || 3060;
 const server = app.listen(port, () => {
   const host = require('os').hostname();
   console.log('OpenCollective API listening at http://%s:%s in %s environment.\n', host, server.address().port, app.set('env'));

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -21,6 +21,8 @@ main() {
 
     if [ "$REPO_NAME" = "api" ]; then
       setPgDatabase
+      setPort
+      setUrl
     fi
 
     if [ "$PHASE" = "install" ]; then
@@ -193,6 +195,22 @@ setPgDatabase() {
     echo "setting PG_DATABASE=opencollective_test"
     export PG_DATABASE=opencollective_test
   fi
+}
+
+setPort() {
+  [[ ${NODE_ENV} = development ]] && {
+    local DEV_API_PORT="${API_PORT:-3061}"
+    echo "setting API_PORT=${DEV_API_PORT}"
+    export API_PORT="${DEV_API_PORT}"
+  }
+}
+
+setUrl() {
+  [[ ${NODE_ENV} = development ]] && {
+    local DEV_API_URL="http://localhost:${API_PORT:-3061}"
+    echo "setting API_URL=${DEV_API_URL}"
+    export API_URL="${DEV_API_URL}"
+  }
 }
 
 runProcess() {

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const PG_DATABASE = 'opencollective_test';
+const API_PORT = 3061;
+
+if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
+  console.log(`Setting PG_DATABASE=${PG_DATABASE}`);
+  process.env.PG_DATABASE = PG_DATABASE;
+
+  console.log(`Setting API_PORT=${API_PORT}`);
+  process.env.API_PORT = API_PORT;
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
   --timeout 20000
   --reporter spec
   --reporter mocha-circleci-reporter
-  --require=./test/set_pg_database.js
+  --require=./test/fixture.js

--- a/test/set_pg_database.js
+++ b/test/set_pg_database.js
@@ -1,5 +1,0 @@
-
-if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
-  console.log("Setting PG_DATABASE=opencollective_test");
-  process.env.PG_DATABASE = "opencollective_test";
-}


### PR DESCRIPTION
- env var `API_PORT` is now respected; ~~`PORT` is no longer respected~~ (see OpenCollective/opencollective-website#230)
- `test_e2e.sh` sets `API_PORT` and `API_URL` (used by Selenium) in dev mode
- set `API_PORT` in unit test fixture as well
- renamed `test/set_pg_database.js` to more generic `test/fixture.js` since it's no longer just configuring the db env

**UPDATE**: Heroku needs `PORT`, so we'll use `API_PORT` if present, otherwise `PORT`, otherwise the hardcoded default.