### PR TITLE
Remove 'WARNING: PostgreSQL does not support TEXT with options' 

### DIFF
--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -39,7 +39,7 @@ module.exports = function (Sequelize, DataTypes) {
 
     amount: DataTypes.INTEGER,
     title: DataTypes.STRING,
-    description: DataTypes.TEXT('long'),
+    description: DataTypes.TEXT,
     attachment: DataTypes.STRING,
     category: DataTypes.STRING,
     vat: DataTypes.INTEGER,

--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -36,8 +36,8 @@ module.exports = function(Sequelize, DataTypes) {
 
     description: DataTypes.STRING, // max 95 characters
 
-    longDescription: DataTypes.TEXT('long'),
-    whyJoin: DataTypes.TEXT('long'),
+    longDescription: DataTypes.TEXT,
+    whyJoin: DataTypes.TEXT,
 
     // We should update those two fields periodically (but no need to be real time)
     budget: DataTypes.INTEGER, // yearly budget in cents
@@ -55,7 +55,7 @@ module.exports = function(Sequelize, DataTypes) {
     image: DataTypes.STRING,
     backgroundImage: DataTypes.STRING,
 
-    expensePolicy: DataTypes.TEXT('long'),
+    expensePolicy: DataTypes.TEXT,
 
     tiers: {
       type: DataTypes.JSON,


### PR DESCRIPTION
shown in newer Sequelize (to be upgraded separately)

Added in Sequelize here:
https://github.com/sequelize/sequelize/pull/3839/files#diff-f94b6eb7897705f7d231b0709bbd707dR24