### PR TITLE
Public activity feed

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -45,7 +45,7 @@
     "website": "WEBSITE_URL"
   },
   "slack": {
-    "hookUrl": "SLACK_HOOK_URL"
+    "webhookUrl": "SLACK_HOOK_URL"
   },
   "clearbit": "CLEARBIT_KEY",
   "github": {

--- a/config/default.json
+++ b/config/default.json
@@ -43,7 +43,8 @@
     "redirectUri": "http://localhost:3060/stripe/oauth/callback"
   },
   "slack": {
-    "activityChannel": "#activity_test"
+    "privateActivityChannel": "#activity-private-test",
+    "publicActivityChannel": "#activity-public-test"
   },
   "clearbit": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 }

--- a/config/production.json
+++ b/config/production.json
@@ -19,7 +19,8 @@
     "redirectUri": "https://opencollective-prod-api.herokuapp.com/stripe/oauth/callback"
   },
   "slack": {
-    "activityChannel": "#activity"
+    "privateActivityChannel": "#activity-private",
+    "publicActivityChannel": "#activity-public"
   },
   "paypal": {
     "rest": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cors": "2.7.1",
     "express": "4.13.4",
     "express-server-status": "1.0.3",
+    "flat": "^2.0.0",
     "form-data": "0.2.0",
     "handlebars": "4.0.5",
     "joi": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cors": "2.7.1",
     "express": "4.13.4",
     "express-server-status": "1.0.3",
-    "flat": "^2.0.0",
+    "flat": "2.0.0",
     "form-data": "0.2.0",
     "handlebars": "4.0.5",
     "joi": "7.3.0",

--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -3,6 +3,7 @@
  */
 
 module.exports = {
+  ACTIVITY_ALL: 'all',
   GROUP_CREATED: 'group.created',
   GROUP_EXPENSE_CREATED: 'group.expense.created',
   GROUP_TRANSACTION_CREATED: 'group.transaction.created',
@@ -10,6 +11,5 @@ module.exports = {
   GROUP_USER_ADDED: 'group.user.added',
   SUBSCRIPTION_CONFIRMED: 'subscription.confirmed',
   USER_CREATED: 'user.created',
-  WEBHOOK_STRIPE_RECEIVED: 'webhook.stripe.received',
-  ACTIVITY_ALL: 'all'
+  WEBHOOK_STRIPE_RECEIVED: 'webhook.stripe.received'
 };

--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -10,5 +10,6 @@ module.exports = {
   GROUP_USER_ADDED: 'group.user.added',
   SUBSCRIPTION_CONFIRMED: 'subscription.confirmed',
   USER_CREATED: 'user.created',
-  WEBHOOK_STRIPE_RECEIVED: 'webhook.stripe.received'
+  WEBHOOK_STRIPE_RECEIVED: 'webhook.stripe.received',
+  ACTIVITY_ALL: 'all'
 };

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -92,8 +92,8 @@ module.exports = function(app) {
       GroupId: group.id,
       data: {
         group: group.info,
-        user: options.remoteUser.info,
-        target: user.info,
+        creator: options.remoteUser.info,
+        user: user.info,
         role: options.role
       }
     });

--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -1,4 +1,5 @@
-var activities = require('../constants/activities');
+const activities = require('../constants/activities');
+const flatten = require('flat');
 
 module.exports = {
 
@@ -7,7 +8,6 @@ module.exports = {
    */
   formatMessageForPrivateChannel: (activity, linkify) => {
 
-    // declare common variables used across multiple activity types
     var userString = '';
     var userId;
     var groupName = '';
@@ -72,10 +72,8 @@ module.exports = {
       case activities.GROUP_TRANSACTION_CREATED:
 
         if (activity.data.transaction.isDonation) {
-          // Ex: Aseem gave 1 USD/month to WWCode-Seattle
           return `New Donation: ${userString} gave ${currency} ${amount} to ${group}!`;
         } else if (activity.data.transaction.isExpense) {
-          // Ex: Aseem submitted a Foods & Beverage expense to WWCode-Seattle: USD 12.57 for 'pizza'
           return `New Expense: ${userString} submitted a ${tags} expense to ${group}: ${currency} ${amount} for ${description}!`
         } else {
           return `Hmm found a group.transaction.created that's neither donation or expense. Activity id: ${activity.id}`;
@@ -83,12 +81,10 @@ module.exports = {
         break;
 
       case activities.GROUP_TRANSACTION_PAID:
-        // Ex: Jon approved a transaction for WWCode-Seattle: USD 12.57 for 'pizza';
         return `Expense approved on ${group}: ${currency} ${amount} for '${description}'`;
         break;
 
       case activities.USER_CREATED:
-        // Ex: New user joined: Alice Walker (alice@walker.com) | @alicewalker | websiteUrl
         return `New user joined: ${userString}`;
         break;
 
@@ -97,7 +93,6 @@ module.exports = {
         break;
 
       case activities.SUBSCRIPTION_CONFIRMED:
-        // Ex: Confirmed subscription of 1 USD/month from Aseem to WWCode-Seattle!
         return `New subscription confirmed: ${currency} ${recurringAmount} from ${userString} to ${group}!`;
         break;
 
@@ -106,11 +101,11 @@ module.exports = {
         break;
 
       case activities.GROUP_USER_ADDED:
-        return `New user ${userString} (UserId: ${userId}) added to group: ${group}`;
+        return `New user: ${userString} (UserId: ${userId}) added to group: ${group}`;
         break;
 
       default:
-        return `Oops... I got an unknown activity type: ${activity.type}`;
+        return `New event: ${activity.type}`;
     }
   },
 
@@ -121,7 +116,6 @@ module.exports = {
    */
   formatMessageForPublicChannel: (activity, linkify) => {
 
-    // declare common variables used across multiple activity types
     var userString = '';
     var groupName = '';
     var publicUrl = '';
@@ -199,6 +193,14 @@ module.exports = {
       default:
         return '';
     }
+  },
+
+  formatAttachment: (attachment) => {
+    const flattenedData = flatten(attachment);
+    const rows = Object.keys(flattenedData)
+      .filter(key => flattenedData[key])
+      .map(key => `${key}: ${flattenedData[key]}`);
+    return rows.join('\n');
   }
 }
 

--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -18,27 +18,12 @@ module.exports = {
     var currency = '';
     var tags = [];
     var description = '';
-    var twitter = ''
-    var website = '';
     var eventType = '';
 
     // get user data
     if (activity.data.user) {
-      const userName = activity.data.user.name;
-      const userEmail = activity.data.user.email;
-      const userAvatar = activity.data.user.avatar;
+      userString = getUserString(activity.data.user, linkify, true);
       userId = activity.data.user.id;
-      userString = userName ? `${userName} (${userEmail})` : userEmail;
-      userString = userString ? `${userString}` : userAvatar;
-
-      const twitterHandle = activity.data.user.twitterHandle;
-      if (linkify) {
-        twitter = linkifyForSlack(`http://www.twitter.com/${twitterHandle}`, `@${twitterHandle}`);
-        website = linkifyForSlack(activity.data.user.websiteUrl, null);
-      } else {
-        twitter = `@${twitterHandle}`;
-        website = activity.data.user.websiteUrl;
-      }
     }
 
     // get group data
@@ -104,7 +89,7 @@ module.exports = {
 
       case activities.USER_CREATED:
         // Ex: New user joined: Alice Walker (alice@walker.com) | @alicewalker | websiteUrl
-        return `New user joined: ${userString} | ${twitter} | ${website}`;
+        return `New user joined: ${userString}`;
         break;
 
       case activities.WEBHOOK_STRIPE_RECEIVED:

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -7,15 +7,10 @@ const activityType = require('../constants/activities');
 
 module.exports = (Sequelize, activity) => {
   // publish everything to our private channel
-  return publishToSlackPrivateChannel(activity,
-    {
-      webhookUrl: config.slack.hookUrl,
-      channel: config.slack.privateActivityChannel
-    })
+  return publishToSlackPrivateChannel(activity)
     // publish a filtered version to our public channel
-    .then(() => publishToSlack(activity,
+    .then(() => publishToSlack(activity, config.slack.webhookUrl,
       {
-        webhookUrl: config.slack.hookUrl,
         channel: config.slack.publicActivityChannel
       }))
     // process notification entries
@@ -42,7 +37,7 @@ module.exports = (Sequelize, activity) => {
         if (notifConfig.channel === 'gitter') {
           return publishToGitter(activity, notifConfig);
         } else if (notifConfig.channel === 'slack') {
-          return publishToSlack(activity, notifConfig);
+          return publishToSlack(activity, notifConfig.webhookUrl, {});
         } else {
           return Promise.resolve();
         }
@@ -62,10 +57,10 @@ function publishToGitter(activity, notifConfig) {
   }
 }
 
-function publishToSlack(activity, notifConfig) {
-  return slackLib.postActivityOnPublicChannel(activity, notifConfig);
+function publishToSlack(activity, webhookUrl, options) {
+  return slackLib.postActivityOnPublicChannel(activity, webhookUrl, options);
 }
 
-function publishToSlackPrivateChannel(activity, notifConfig) {
-  return slackLib.postActivityOnPrivateChannel(activity, notifConfig);
+function publishToSlackPrivateChannel(activity) {
+  return slackLib.postActivityOnPrivateChannel(activity);
 }

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -1,48 +1,67 @@
 const axios = require('axios');
+const config = require('config');
+
 const activitiesLib = require('../lib/activities');
 const slackLib = require('./slack');
-
-const ACTIVITY_ALL = 'all';
+const activities = require('../constants');
 
 module.exports = (Sequelize, activity) => {
-  if(!activity.GroupId || !activity.type) {
-    return activity;
-  }
-  return Sequelize.models.Notification.findAll({
-    where: {
-      type: [
-        ACTIVITY_ALL,
-        activity.type
-      ],
-      GroupId: activity.GroupId,
-      // for now, only handle gitter and slack webhooks in this lib
-      // TODO sdubois: move email + internal slack channels to this lib
-      channel: ['gitter', 'slack'],
-      active: true
-    }
-  }).then(notifConfigs =>
-    Promise.all(notifConfigs, notifConfig => {
-      if (notifConfig.channel === 'gitter') {
-        return publishToGitter(activity, notifConfig);
-      } else if (notifConfig.channel === 'slack') {
-        return publishToSlack(activity, notifConfig);
+  // publish everything to our private channel
+  console.log('reached inside notify');
+  return publishToSlackPrivateChannel(activity,
+    {
+      webhookUrl: config.slack.hookUrl,
+      channel: config.slack.privateActivityChannel
+    })
+    // publish a filtered version to our public channel
+    .then(() => publishToSlack(activity,
+      {
+        webhookUrl: config.slack.hookUrl,
+        channel: config.slack.publicActivityChannel
+      }))
+    // process notification entries
+    .then(() => {
+      if(!activity.GroupId || !activity.type) {
+        return activity;
       }
-    }))
-  .catch(err => {
-    console.error(`Error while publishing activity type ${activity.type} for group ${activity.GroupId}`, err);
-  });
+      return Sequelize.models.Notification.findAll({
+        where: {
+          type: [
+            activities.ACTIVITY_ALL,
+            activity.type
+          ],
+          GroupId: activity.GroupId,
+          // for now, only handle gitter and slack webhooks in this lib
+          // TODO sdubois: move email + internal slack channels to this lib
+          channel: ['gitter', 'slack'],
+          active: true
+        }
+      })
+    })
+    .then(notifConfigs =>
+      Promise.all(notifConfigs, notifConfig => {
+        if (notifConfig.channel === 'gitter') {
+          return publishToGitter(activity, notifConfig);
+        } else if (notifConfig.channel === 'slack') {
+          return publishToSlack(activity, notifConfig);
+        }
+      }))
+    .catch(err => {
+      console.error(`Error while publishing activity type ${activity.type} for group ${activity.GroupId}`, err);
+    });
 };
 
 function publishToGitter(activity, notifConfig) {
   return axios
     .post(notifConfig.webhookUrl, {
-      message: activitiesLib.formatMessage(activity, false)
+      message: activitiesLib.formatMessageForPublicChannel(activity, false)
     });
 }
 
 function publishToSlack(activity, notifConfig) {
-  return slackLib.postActivity(activity, {
-    webhookUrl: notifConfig.webhookUrl,
-    channel: undefined
-  });
+  return slackLib.postActivityOnPublicChannel(activity, notifConfig);
+}
+
+function publishToSlackPrivateChannel(activity, notifConfig) {
+  return slackLib.postActivityOnPrivateChannel(activity, notifConfig);
 }

--- a/server/lib/slack.js
+++ b/server/lib/slack.js
@@ -13,7 +13,6 @@ module.exports = {
    * Post a given activity to a private channel for Open Collective Core Team
    */
   postActivityOnPrivateChannel: function(activity, options) {
-    console.log('reached inside private channel');
     if (!options) {
       options = {};
     }
@@ -27,7 +26,6 @@ module.exports = {
    * Post a given activity to a public channel for anyone to see the activity
    */
   postActivityOnPublicChannel: function(activity, options) {
-    console.log('reached inside public channell');
     if (!options) {
       options = {};
     }
@@ -41,7 +39,6 @@ module.exports = {
    * Posts a message to a slack webhook
    */
   postMessage: function(msg, webhookUrl, options) {
-    console.log('reaching inside postMessage: ', msg);
     if(!options) {
       options = {};
     }
@@ -59,7 +56,7 @@ module.exports = {
 
     return new Promise((resolve, reject) => {
       if (!slackOptions.text) {
-        resolve();
+        return resolve();
       }
 
       return new Slack(webhookUrl, {})
@@ -68,7 +65,7 @@ module.exports = {
             console.error(err);
             return reject(err);
           }
-          resolve();
+          return resolve();
         });
     });
   }

--- a/server/lib/slack.js
+++ b/server/lib/slack.js
@@ -10,36 +10,34 @@ const constants = require('../constants/activities');
 module.exports = {
 
   /*
-   * Post a given activity to a private channel for Open Collective Core Team
+   * Post a given activity to OpenCollective private channel
+   * This method can only publish to our webhookUrl and our private channel, so we don't leak info by mistake
    */
-  postActivityOnPrivateChannel: function(activity, options) {
-    if (!options) {
-      options = {};
-    }
-    var message = activitiesLib.formatMessageForPrivateChannel(activity, true);
-    options.attachments = formatAttachment(activity);
-    options.channel = config.slack.privateActivityChannel;
-    return this.postMessage(message, config.slack.hookUrl, options);
+  postActivityOnPrivateChannel: function(activity) {
+    const message = activitiesLib.formatMessageForPrivateChannel(activity, true);
+    const options = {
+      attachments: formatAttachment(activity),
+      channel: config.slack.privateActivityChannel
+    };
+    return this.postMessage(message, config.slack.webhookUrl, options);
   },
 
   /*
-   * Post a given activity to a public channel for anyone to see the activity
+   * Post a given activity to a public channel (meaning scrubbed info only)
    */
-  postActivityOnPublicChannel: function(activity, options) {
+  postActivityOnPublicChannel: function(activity, webhookUrl, options) {
     if (!options) {
       options = {};
     }
-    var message = activitiesLib.formatMessageForPublicChannel(activity, true);
-    options.attachments = [];
-    options.channel = config.slack.publicActivityChannel;
-    return this.postMessage(message, config.slack.hookUrl, options);
+    const message = activitiesLib.formatMessageForPublicChannel(activity, true);
+    return this.postMessage(message, webhookUrl, options);
   },
 
   /*
    * Posts a message to a slack webhook
    */
   postMessage: function(msg, webhookUrl, options) {
-    if(!options) {
+    if (!options) {
       options = {};
     }
     var slackOptions = {
@@ -71,7 +69,7 @@ module.exports = {
   }
 };
 
-function formatAttachment(activity) {
+const formatAttachment = (activity) => {
   if (activity.type === constants.WEBHOOK_STRIPE_RECEIVED) {
     return [{
       title: 'Data',

--- a/server/models/Activity.js
+++ b/server/models/Activity.js
@@ -1,4 +1,3 @@
-const slackLib = require('../lib/slack');
 const notify = require('../lib/notifications');
 
 module.exports = function(Sequelize, DataTypes) {
@@ -17,9 +16,6 @@ module.exports = function(Sequelize, DataTypes) {
 
     hooks: {
       afterCreate: function(activity) {
-        if (process.env.NODE_ENV === 'production') {
-          slackLib.postActivity(activity);
-        }
         return notify(Sequelize, activity);
       }
     }

--- a/server/models/Activity.js
+++ b/server/models/Activity.js
@@ -16,7 +16,9 @@ module.exports = function(Sequelize, DataTypes) {
 
     hooks: {
       afterCreate: function(activity) {
-        return notify(Sequelize, activity);
+        if (process.env.NODE_ENV === 'production') {
+          return notify(Sequelize, activity);
+        }
       }
     }
   });

--- a/test/lib.activities.test.js
+++ b/test/lib.activities.test.js
@@ -12,54 +12,92 @@ const activitiesLib = require('../server/lib/activities');
  */
 describe('lib.activities.test.js', () => {
 
-  it (`formatMessage: ${constants.GROUP_TRANSACTION_CREATED} donation`, () => {
-    var actual = activitiesLib.formatMessage(activitiesData[12], true);
-    expect(actual).to.equal('New Donation: john@doe.com gave USD 10.42 to <pubquiz.com|Pub quiz>!');
+  describe('formatMessageForPrivateChannel', () => {
+
+    it (`formatMessageForPrivateChannel: ${constants.GROUP_TRANSACTION_CREATED} donation`, () => {
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[12], true);
+      expect(actual).to.equal('New Donation: john@doe.com gave USD 10.42 to <pubquiz.com|Pub quiz>!');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.GROUP_TRANSACTION_CREATED} expense`, () => {
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[13], true);
+      expect(actual).to.equal('New Expense: john@doe.com submitted a undefined expense to Pub quiz: USD -12.98 for pizza!');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.GROUP_TRANSACTION_PAID} expense paid`, () => {
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[14], true);
+      expect(actual).to.equal('Expense approved on Pub quiz: USD -12.98 for \'pizza\'');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.USER_CREATED} all fields present`, () =>{
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[0], true);
+      expect(actual).to.equal('New user joined: john doe (john@doe.com) | <http://www.twitter.com/johndoe|@johndoe> | <opencollective.com|opencollective.com>');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.USER_CREATED} only email present`, () =>{
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[1], true);
+      expect(actual).to.equal('New user joined: john@doe.com | <http://www.twitter.com/undefined|@undefined> | ');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.WEBHOOK_STRIPE_RECEIVED}`, () =>{
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[15], true);
+      expect(actual).to.equal('Stripe event received: invoice.payment_succeeded');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.SUBSCRIPTION_CONFIRMED}`, () =>{
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[16], true);
+      expect(actual).to.equal('New subscription confirmed: EUR 12.34 from jussi@kuohujoki.fi to <blah.com|Blah>!');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.SUBSCRIPTION_CONFIRMED} with month interval`, () =>{
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[17], true);
+      expect(actual).to.equal('New subscription confirmed: EUR 12.34/month from jussi@kuohujoki.fi to <blah.com|Blah>!');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.GROUP_CREATED}`, () =>{
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[18], true);
+      expect(actual).to.equal('New group created: <blah.com|Blah> by jussi@kuohujoki.fi');
+    });
+
+    it (`formatMessageForPrivateChannel: ${constants.GROUP_USER_ADDED}`, () =>{
+      var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[19], true);
+      expect(actual).to.equal('New user http://avatar.githubusercontent.com/asood123 (UserId: 2) added to group: <blah.com|Blah>');
+    });
   });
 
-  it (`formatMessage: ${constants.GROUP_TRANSACTION_CREATED} expense`, () => {
-    var actual = activitiesLib.formatMessage(activitiesData[13], true);
-    expect(actual).to.equal('New Expense: john@doe.com submitted a undefined expense to Pub quiz: USD -12.98 for pizza!');
-  });
+  describe('formatMessageForPublicChannel', () => {
 
-  it (`formatMessage: ${constants.GROUP_TRANSACTION_PAID} expense paid`, () => {
-    var actual = activitiesLib.formatMessage(activitiesData[14], true);
-    expect(actual).to.equal('Expense approved on Pub quiz: USD -12.98 for \'pizza\'');
-  });
+    it (`formatMessageForPublicChannel: ${constants.GROUP_TRANSACTION_CREATED} donation`, () => {
+      var actual = activitiesLib.formatMessageForPublicChannel(activitiesData[12], true);
+      expect(actual).to.equal('New Donation: someone gave USD 10.42 to <pubquiz.com|Pub quiz>!');
+    });
 
-  it (`formatMessage: ${constants.USER_CREATED} all fields present`, () =>{
-    var actual = activitiesLib.formatMessage(activitiesData[0], true);
-    expect(actual).to.equal('New user joined: john doe (john@doe.com) | <http://www.twitter.com/johndoe|@johndoe> | <opencollective.com|opencollective.com>');
-  });
+    it (`formatMessageForPublicChannel: ${constants.GROUP_TRANSACTION_CREATED} expense`, () => {
+      var actual = activitiesLib.formatMessageForPublicChannel(activitiesData[13], true);
+      expect(actual).to.equal('New Expense: someone submitted a undefined expense to Pub quiz: USD -12.98 for pizza!');
+    });
 
-  it (`formatMessage: ${constants.USER_CREATED} only email present`, () =>{
-    var actual = activitiesLib.formatMessage(activitiesData[1], true);
-    expect(actual).to.equal('New user joined: john@doe.com | <http://www.twitter.com/undefined|@undefined> | ');
-  });
+    it (`formatMessageForPublicChannel: ${constants.GROUP_TRANSACTION_PAID} expense paid`, () => {
+      var actual = activitiesLib.formatMessageForPublicChannel(activitiesData[14], true);
+      expect(actual).to.equal('Expense approved on Pub quiz: USD -12.98 for \'pizza\'');
+    });
 
-  it (`formatMessage: ${constants.WEBHOOK_STRIPE_RECEIVED}`, () =>{
-    var actual = activitiesLib.formatMessage(activitiesData[15], true);
-    expect(actual).to.equal('Stripe event received: invoice.payment_succeeded');
-  });
+    it (`formatMessageForPublicChannel: ${constants.SUBSCRIPTION_CONFIRMED}`, () =>{
+      var actual = activitiesLib.formatMessageForPublicChannel(activitiesData[16], true);
+      expect(actual).to.equal('New subscription confirmed: EUR 12.34 from someone to <blah.com|Blah>!');
+    });
 
-  it (`formatMessage: ${constants.SUBSCRIPTION_CONFIRMED}`, () =>{
-    var actual = activitiesLib.formatMessage(activitiesData[16], true);
-    expect(actual).to.equal('New subscription confirmed: EUR 12.34 from jussi@kuohujoki.fi to <blah.com|Blah>!');
-  });
+    it (`formatMessageForPublicChannel: ${constants.SUBSCRIPTION_CONFIRMED} with month interval`, () =>{
+      var actual = activitiesLib.formatMessageForPublicChannel(activitiesData[17], true);
+      expect(actual).to.equal('New subscription confirmed: EUR 12.34/month from someone to <blah.com|Blah>!');
+    });
 
-  it (`formatMessage: ${constants.SUBSCRIPTION_CONFIRMED} with month interval`, () =>{
-    var actual = activitiesLib.formatMessage(activitiesData[17], true);
-    expect(actual).to.equal('New subscription confirmed: EUR 12.34/month from jussi@kuohujoki.fi to <blah.com|Blah>!');
-  });
+    it (`formatMessageForPublicChannel: ${constants.GROUP_CREATED}`, () =>{
+      var actual = activitiesLib.formatMessageForPublicChannel(activitiesData[18], true);
+      expect(actual).to.equal('New group created: <blah.com|Blah> by someone');
+    });
 
-  it (`formatMessage: ${constants.GROUP_CREATED}`, () =>{
-    var actual = activitiesLib.formatMessage(activitiesData[18], true);
-    expect(actual).to.equal('New group created: <blah.com|Blah> by jussi@kuohujoki.fi');
   });
+})
 
-  it (`formatMessage: ${constants.GROUP_USER_ADDED}`, () =>{
-    var actual = activitiesLib.formatMessage(activitiesData[19], true);
-    expect(actual).to.equal('New user <http://avatar.githubusercontent.com/asood123|http://avatar.githubusercontent.com/asood123> (UserId: 2) added to group: <blah.com|Blah>');
-  });
 
-});

--- a/test/lib.activities.test.js
+++ b/test/lib.activities.test.js
@@ -16,12 +16,12 @@ describe('lib.activities.test.js', () => {
 
     it (`formatMessageForPrivateChannel: ${constants.GROUP_TRANSACTION_CREATED} donation`, () => {
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[12], true);
-      expect(actual).to.equal('New Donation: john@doe.com gave USD 10.42 to <pubquiz.com|Pub quiz>!');
+      expect(actual).to.equal('New Donation: someone (john@doe.com) gave USD 10.42 to <pubquiz.com|Pub quiz>!');
     });
 
     it (`formatMessageForPrivateChannel: ${constants.GROUP_TRANSACTION_CREATED} expense`, () => {
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[13], true);
-      expect(actual).to.equal('New Expense: john@doe.com submitted a undefined expense to Pub quiz: USD -12.98 for pizza!');
+      expect(actual).to.equal('New Expense: someone (john@doe.com) submitted a undefined expense to Pub quiz: USD -12.98 for pizza!');
     });
 
     it (`formatMessageForPrivateChannel: ${constants.GROUP_TRANSACTION_PAID} expense paid`, () => {
@@ -31,12 +31,12 @@ describe('lib.activities.test.js', () => {
 
     it (`formatMessageForPrivateChannel: ${constants.USER_CREATED} all fields present`, () =>{
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[0], true);
-      expect(actual).to.equal('New user joined: john doe (john@doe.com) | <http://www.twitter.com/johndoe|@johndoe> | <opencollective.com|opencollective.com>');
+      expect(actual).to.equal('New user joined: <http://www.twitter.com/johndoe|john doe> (john@doe.com)');
     });
 
     it (`formatMessageForPrivateChannel: ${constants.USER_CREATED} only email present`, () =>{
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[1], true);
-      expect(actual).to.equal('New user joined: john@doe.com | <http://www.twitter.com/undefined|@undefined> | ');
+      expect(actual).to.equal('New user joined: someone (john@doe.com)');
     });
 
     it (`formatMessageForPrivateChannel: ${constants.WEBHOOK_STRIPE_RECEIVED}`, () =>{
@@ -46,22 +46,22 @@ describe('lib.activities.test.js', () => {
 
     it (`formatMessageForPrivateChannel: ${constants.SUBSCRIPTION_CONFIRMED}`, () =>{
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[16], true);
-      expect(actual).to.equal('New subscription confirmed: EUR 12.34 from jussi@kuohujoki.fi to <blah.com|Blah>!');
+      expect(actual).to.equal('New subscription confirmed: EUR 12.34 from someone (jussi@kuohujoki.fi) to <blah.com|Blah>!');
     });
 
     it (`formatMessageForPrivateChannel: ${constants.SUBSCRIPTION_CONFIRMED} with month interval`, () =>{
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[17], true);
-      expect(actual).to.equal('New subscription confirmed: EUR 12.34/month from jussi@kuohujoki.fi to <blah.com|Blah>!');
+      expect(actual).to.equal('New subscription confirmed: EUR 12.34/month from someone (jussi@kuohujoki.fi) to <blah.com|Blah>!');
     });
 
     it (`formatMessageForPrivateChannel: ${constants.GROUP_CREATED}`, () =>{
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[18], true);
-      expect(actual).to.equal('New group created: <blah.com|Blah> by jussi@kuohujoki.fi');
+      expect(actual).to.equal('New group created: <blah.com|Blah> by someone (jussi@kuohujoki.fi)');
     });
 
     it (`formatMessageForPrivateChannel: ${constants.GROUP_USER_ADDED}`, () =>{
       var actual = activitiesLib.formatMessageForPrivateChannel(activitiesData[19], true);
-      expect(actual).to.equal('New user http://avatar.githubusercontent.com/asood123 (UserId: 2) added to group: <blah.com|Blah>');
+      expect(actual).to.equal('New user: someone (UserId: 2) added to group: <blah.com|Blah>');
     });
   });
 

--- a/test/lib.slack.test.js
+++ b/test/lib.slack.test.js
@@ -11,18 +11,18 @@ describe('lib/slack', () => {
   describe('calling postMessage', () => {
 
     const message = "lorem ipsum";
+    const webhookUrl = 'hookurl';
     const basePayload = {
       text: message,
       username: 'OpenCollective Activity Bot',
       icon_url: 'https://opencollective.com/favicon.ico',
       attachments: [],
-      channel: '#activity_test'
     };
 
     it('with message succeeds', done => {
       expectPayload(basePayload);
 
-      callSlackLib(done, message);
+      callSlackLib(done, message, webhookUrl);
     });
 
     it('with attachment succeeds', done => {
@@ -30,7 +30,7 @@ describe('lib/slack', () => {
 
       expectPayload(_.extend({}, basePayload, { attachments }));
 
-      callSlackLib(done, message, { attachments });
+      callSlackLib(done, message, webhookUrl, { attachments });
     });
 
     it('with channel succeeds', done => {
@@ -38,7 +38,7 @@ describe('lib/slack', () => {
 
       expectPayload(_.extend({}, basePayload, { channel }));
 
-      callSlackLib(done, message, { channel });
+      callSlackLib(done, message, webhookUrl, { channel });
     });
   });
 
@@ -47,9 +47,10 @@ describe('lib/slack', () => {
     var formatMessageStub, postMessageStub;
     const activity = "my activity";
     const formattedMessage = "my formatted activity";
+    const webhookUrl = 'hookurl';
 
     beforeEach(() => {
-      formatMessageStub = sinon.stub(activitiesLib, "formatMessage");
+      formatMessageStub = sinon.stub(activitiesLib, "formatMessageForPublicChannel");
       postMessageStub = sinon.stub(slackLib, "postMessage");
     });
 
@@ -65,25 +66,25 @@ describe('lib/slack', () => {
         .returns(formattedMessage);
 
       const expected = postMessageStub
-        .withArgs(formattedMessage, { attachments: [] });
+        .withArgs(formattedMessage, webhookUrl, {});
 
-      slackLib.postActivity(activity);
+      slackLib.postActivityOnPublicChannel(activity, webhookUrl, {});
 
       expect(expected.called).to.be.ok;
       done();
     });
 
     it('with options keeps the options', done => {
-      const options = { option1: "option1" };
+      const options = { option1: "option1",  attachments: []  };
 
       formatMessageStub
         .withArgs(activity, true)
         .returns(formattedMessage);
 
       const expected = postMessageStub
-        .withArgs(formattedMessage, _.extend({}, { attachments: [] }, options));
+        .withArgs(formattedMessage, webhookUrl, options);
 
-      slackLib.postActivity(activity, options);
+      slackLib.postActivityOnPublicChannel(activity, webhookUrl, options);
 
       expect(expected.called).to.be.ok;
       done();
@@ -98,9 +99,9 @@ function expectPayload(expectedPayload) {
   };
 }
 
-function callSlackLib(done, msg, options) {
+function callSlackLib(done, msg, webhookUrl, options) {
   slackLib
-    .postMessage(msg, options)
+    .postMessage(msg, webhookUrl, options)
     .then(done)
     .catch(done);
 }

--- a/test/mocks/data.json
+++ b/test/mocks/data.json
@@ -124,7 +124,7 @@
 
   "activities1": {
     "activities": [
-      {"type": "user.created", "UserId": 1, "data": {"user": {"username": "john doe", "email": "john@doe.com", "twitterHandle":"johndoe", "websiteUrl": "opencollective.com"}}},
+      {"type": "user.created", "UserId": 1, "data": {"user": {"name": "john doe", "email": "john@doe.com", "twitterHandle":"johndoe", "websiteUrl": "opencollective.com"}}},
       {"type": "user.created", "UserId": 2, "data": {"user": {"email": "john@doe.com"}}},
       {"type": "user.created", "UserId": 3, "data": {}},
       {"type": "group.created", "UserId": 1, "GroupId": 1, "data": {}},


### PR DESCRIPTION
Cleaned up activity feed to support 

- Private activity feed (like we have today)
- Public activity feed (with scrubbed info - no emails, etc)
- gitter and slack support for our users to plug their own hookurls
- also brought back attachments for private feed
- updated language a little bit, that needs more cleaning. Will do that in a separate PR after this goes live.