### PR TITLE
More promise chain fixes for bluebird upgrade + upgrade Sequelize

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "request": "2.72.0",
     "request-as-curl": "0.1.0",
     "request-promise": "3.0.0",
-    "sequelize": "2.1.0",
+    "sequelize": "3.23.3",
     "sequelize-cli": "1.9.2",
     "slug": "0.9.1",
     "stripe": "3.9.0"

--- a/server/controllers/donations.js
+++ b/server/controllers/donations.js
@@ -29,13 +29,8 @@ module.exports = (app) => {
           email: attributes.email
         }
       })
-      .tap((user) => {
-        if (user) {
-          return cb(null, user);
-        }
-
-        users._create(attributes, cb);
-      })
+      .then(user => user || users._create(attributes))
+      .then(user => cb(null, user))
       .catch(cb);
   };
 
@@ -87,9 +82,8 @@ module.exports = (app) => {
           service: 'stripe',
           UserId: user.id
         })
-        .then((paymentMethod) => {
-          return cb(null, paymentMethod);
-        })
+        .tap(paymentMethod => cb(null, paymentMethod))
+        .catch(cb);
       }],
 
       createCustomer: ['getOrCreatePaymentMethod', (cb, results) => {

--- a/server/controllers/middlewares.js
+++ b/server/controllers/middlewares.js
@@ -53,6 +53,10 @@ module.exports = function(app) {
         return this.authenticate(req, res, next);
       }
 
+      const userData = {
+        email: email || paypalEmail,
+        paypalEmail
+      };
       models.User.findOne({
         where: {
           $or: {
@@ -61,21 +65,10 @@ module.exports = function(app) {
           }
         }
       })
-      .then(user => {
-        if (user) {
-          return user;
-        } else {
-          const userData = {
-            email: email || paypalEmail,
-            paypalEmail
-          };
-          return users._create(userData);
-        }
-      })
+      .then(user => user || users._create(userData))
       .tap(user => req.user = user)
       .tap(() => next())
-      // why was error ignored in previous version of this code? TODO try to return it
-      .catch(() => next());
+      .catch(next);
 
     },
 

--- a/server/controllers/stripe.js
+++ b/server/controllers/stripe.js
@@ -84,7 +84,7 @@ module.exports = function(app) {
 
     var host;
     checkIfUserIsHost(UserId)
-      .then(() => models.User.find(UserId))
+      .then(() => models.User.findById(UserId))
       .tap(h => host = h)
       .then(getToken(req.query.code))
       .then(createStripeAccount)

--- a/server/controllers/subscriptions.js
+++ b/server/controllers/subscriptions.js
@@ -45,10 +45,11 @@ module.exports = function(app) {
       // If you don't find a user, proceed without error
       // Otherwise, we can leak email addresses
       if (user) {
-        email.send('user.new.token', req.body.email, {
+        return email.send('user.new.token', req.body.email, {
           subscriptionsLink: user.generateSubscriptionsLink(req.application)
         });
       }
+      return null;
     })
     .then(() => res.send({ success: true }))
     .catch(next);

--- a/server/controllers/transactions.js
+++ b/server/controllers/transactions.js
@@ -163,7 +163,7 @@ var payServices = {
 
       getBeneficiary: ['checkTransaction', function(cb) {
         User
-          .find(parseInt(transaction.UserId))
+          .findById(parseInt(transaction.UserId))
           .then((user) => {
             if (!user) {
               return cb(new errors.NotFound(`Beneficiary ${userid} not found`));

--- a/server/lib/userlib.js
+++ b/server/lib/userlib.js
@@ -32,23 +32,19 @@ module.exports = {
   },
 
   getUserData(email) {
-    // TODO possible to simplify promise syntax?
-    return new Promise(resolve => {
-      if(!email || !email.match(/.+@.+\..+/)) {
-        return resolve();
-      }
+    if(!email || !email.match(/.+@.+\..+/)) {
+      return Promise.resolve();
+    }
 
-      if(this.memory[email] !== undefined) {
-        return resolve(this.memory[email]);
-      }
+    if(this.memory[email] !== undefined) {
+      return Promise.resolve(this.memory[email]);
+    }
 
-      this.clearbit.Enrichment.find({email: email, stream: true})
-        .tap(res => this.memory[email] = res.person)
-        .then(res => res.person)
-        .catch(clearbit.Enrichment.NotFoundError, () => this.memory[email] = null)
-        .catch(err => console.error('Clearbit error', err))
-        .tap(obj => resolve(obj));
-    });
+    return this.clearbit.Enrichment.find({email: email, stream: true})
+      .tap(res => this.memory[email] = res.person)
+      .then(res => res.person)
+      .catch(clearbit.Enrichment.NotFoundError, () => this.memory[email] = null)
+      .catch(err => console.error('Clearbit error', err));
   },
 
   resolveUserAvatars(userData, cb) {

--- a/server/middleware/security/authentication.js
+++ b/server/middleware/security/authentication.js
@@ -80,7 +80,7 @@ module.exports = function (app) {
       const appId = parseInt(req.jwtPayload.aud);
 
       Application
-        .find(appId)
+        .findById(appId)
         .tap(application => {
           if (application.disabled) {
             throw new Unauthorized();
@@ -179,7 +179,7 @@ module.exports = function (app) {
 
     _authenticateUserByJwt: (req, res, next) => {
       User
-        .find(req.jwtPayload.sub)
+        .findById(req.jwtPayload.sub)
         .tap(user => {
           req.remoteUser = user;
           next();

--- a/server/middleware/security/authorization.js
+++ b/server/middleware/security/authorization.js
@@ -197,7 +197,7 @@ module.exports = function (app) {
     authorizeGroupAccessToTransaction(options) {
       return this.authorizeGroupAccessTo('transaction', options);
     },
-    
+
     authorizeAccessToUserWithRecentDonation: (req, res, next) => {
       models.Donation.findOne({
         where: {
@@ -207,7 +207,7 @@ module.exports = function (app) {
           }
         }
       })
-        .then(donation => {
+        .tap(donation => {
           if (!donation) {
             return next(new Unauthorized("Can only modify user who had donation in last 10 min"));
           }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -284,7 +284,7 @@ module.exports = function(Sequelize, DataTypes) {
               user.updateAttributes({
                 seenAt: new Date()
               })
-                .then(user => cb(null, user))
+                .tap(user => cb(null, user))
                 .catch(cb);
             } else {
               cb(new errors.BadRequest(msg));

--- a/server/params/index.js
+++ b/server/params/index.js
@@ -35,7 +35,7 @@ module.exports = (app) => {
      */
     userid: (req, res, next, userid) => {
       parseId(userid)
-        .then(id => User.find(id))
+        .then(id => User.findById(id))
         .then((user) => {
           if (!user) {
             return next(new errors.NotFound(`User '${userid}' not found`));
@@ -71,7 +71,7 @@ module.exports = (app) => {
           .catch(next)
       } else {
         Group
-          .find(groupid)
+          .findById(groupid)
           .tap(callback)
           .catch(next);
       }
@@ -82,7 +82,7 @@ module.exports = (app) => {
      */
     transactionid: (req, res, next, transactionid) => {
       parseId(transactionid)
-        .then(id => Transaction.find(id))
+        .then(id => Transaction.findById(id))
         .then((transaction) => {
           if (!transaction) {
             return next(new errors.NotFound(`Transaction '${transactionid}' not found`));
@@ -121,7 +121,7 @@ module.exports = (app) => {
      */
     expenseid: (req, res, next, expenseid) => {
       parseId(expenseid)
-        .then(id => Expense.find(id))
+        .then(id => Expense.findById(id))
         .then((expense) => {
           if (!expense) {
             return next(new errors.NotFound(`Expense '${expenseid}' not found`));

--- a/test/donations.routes.test.js
+++ b/test/donations.routes.test.js
@@ -98,7 +98,7 @@ describe('donations.routes.test.js', () => {
       .end((e, res) => {
         expect(e).to.not.exist;
         models.Group
-          .find(parseInt(res.body.id))
+          .findById(parseInt(res.body.id))
           .then((g) => {
             group = g;
             done();
@@ -125,7 +125,7 @@ describe('donations.routes.test.js', () => {
       .end((e, res) => {
         expect(e).to.not.exist;
         models.Group
-          .find(parseInt(res.body.id))
+          .findById(parseInt(res.body.id))
           .tap((g) => {
             group2 = g;
             done();

--- a/test/groups.routes.test.js
+++ b/test/groups.routes.test.js
@@ -303,7 +303,8 @@ describe('groups.routes.test.js', () => {
           api_key: application.api_key
         })
         .expect(200)
-        .then(res => {
+        .toPromise()
+        .tap(res => {
           expect(res.body).to.have.property('id');
           expect(res.body).to.have.property('name', 'Loot');
           expect(res.body).to.have.property('slug', 'loot');
@@ -313,26 +314,21 @@ describe('groups.routes.test.js', () => {
           expect(res.body).to.have.property('expensePolicy', 'expense policy');
           expect(res.body).to.have.property('isPublic', false);
           expect(app.mailgun.sendMail.lastCall.args[0].to).to.equal('githubuser@gmail.com');
-
-          var caUser;
-          ConnectedAccount.findOne({where: {username: 'asood123'}})
-            .then(ca => {
-              expect(ca).to.have.property('provider', 'github');
-              return ca.getUser();
-            })
-            .then(user => expect(user).to.exist)
-            .then(() => ConnectedAccount.findOne({where: {username: 'oc'}}))
-            .then(ca => {
-              expect(ca).to.have.property('provider', 'github');
-              return ca.getUser();
-            })
-            .then(user => {
-              caUser = user;
-              expect(user).to.exist;
-            })
-            .then(() => caUser.getGroups())
-            .tap(groups => expect(groups).to.have.length(1));
-        }));
+        })
+        .then(() => ConnectedAccount.findOne({where: {username: 'asood123'}}))
+        .then(ca => {
+          expect(ca).to.have.property('provider', 'github');
+          return ca.getUser();
+        })
+        .then(user => expect(user).to.exist)
+        .then(() => ConnectedAccount.findOne({where: {username: 'oc'}}))
+        .then(ca => {
+          expect(ca).to.have.property('provider', 'github');
+          return ca.getUser();
+        })
+        .tap(user => expect(user).to.exist)
+        .then(caUser => caUser.getGroups())
+        .tap(groups => expect(groups).to.have.length(1)));
     });
 
   });
@@ -375,7 +371,7 @@ describe('groups.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           models.Group
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .then((g) => {
               privateGroup = g;
               done();
@@ -402,7 +398,7 @@ describe('groups.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           models.Group
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .tap((g) => {
               publicGroup = g;
               done();
@@ -719,7 +715,7 @@ describe('groups.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           models.Group
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .tap((g) => {
               group = g;
               done();

--- a/test/transactions.routes.test.js
+++ b/test/transactions.routes.test.js
@@ -453,7 +453,7 @@ describe('transactions.routes.test.js', () => {
 
           async.parallel([
             (cb) => {
-              models.Transaction.find(transactions[0].id).then((t) => {
+              models.Transaction.findById(transactions[0].id).then((t) => {
                 expect(t).to.not.exist;
                 cb();
               });
@@ -817,7 +817,7 @@ describe('transactions.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           models.Transaction
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .then((t) => {
               transaction = t;
               done();
@@ -838,7 +838,7 @@ describe('transactions.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           models.Transaction
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .then((t) => {
               transaction2 = t;
               done();
@@ -936,7 +936,7 @@ describe('transactions.routes.test.js', () => {
           expect(e).to.not.exist;
           expect(res.body).to.have.property('success', true);
           models.Transaction
-            .find(parseInt(transaction.id))
+            .findById(parseInt(transaction.id))
             .then((t) => {
               expect(t.approved).to.be.true;
               expect(t.approvedAt).not.to.be.null;
@@ -958,7 +958,7 @@ describe('transactions.routes.test.js', () => {
           expect(e).to.not.exist;
           expect(res.body).to.have.property('success', true);
           models.Transaction
-            .find(parseInt(transaction.id))
+            .findById(parseInt(transaction.id))
             .then((t) => {
               expect(t.approved).to.be.false;
               expect(t.approvedAt).not.to.be.null;
@@ -991,7 +991,7 @@ describe('transactions.routes.test.js', () => {
             .end((e, res) => {
               expect(e).to.not.exist;
               models.Transaction
-                .find(parseInt(res.body.id))
+                .findById(parseInt(res.body.id))
                 .then(t => cb(null, t))
                 .catch(cb);
             });
@@ -1007,7 +1007,7 @@ describe('transactions.routes.test.js', () => {
             .end((e, res) => {
               expect(e).to.not.exist;
               models.Transaction
-                .find(parseInt(res.body.id))
+                .findById(parseInt(res.body.id))
                 .then(t => cb(null, t))
                 .catch(cb);
             });
@@ -1081,7 +1081,7 @@ describe('transactions.routes.test.js', () => {
           expect(e).to.not.exist;
           expect(res.body).to.have.property('success', true);
           models.Transaction
-            .find(parseInt(transaction.id))
+            .findById(parseInt(transaction.id))
             .then((t) => {
               expect(t.UserId).to.equal(user4.id);
               done();
@@ -1101,7 +1101,7 @@ describe('transactions.routes.test.js', () => {
           expect(e).to.not.exist;
           expect(res.body).to.have.property('success', true);
           models.Transaction
-            .find(parseInt(transaction.id))
+            .findById(parseInt(transaction.id))
             .then((t) => {
               expect(t.UserId).to.equal(user4.id);
               done();

--- a/test/usergroup.routes.test.js
+++ b/test/usergroup.routes.test.js
@@ -7,6 +7,7 @@ var expect = require('chai').expect;
 var request = require('supertest');
 var utils = require('../test/utils.js')();
 var roles = require('../server/constants/roles');
+const Promise = require('bluebird');
 
 /**
  * Variables.
@@ -51,13 +52,9 @@ describe('usergroup.routes.test.js', () => {
   });
 
   // Create users.
-  beforeEach(function(done) {
-    this.timeout(2000);
-    utils.createUsers(['user1','user2','user3', 'user4'], (results) => {
-      users = results;
-      done();
-    });
-  });
+  beforeEach(() =>
+    Promise.map(['user1','user2','user3', 'user4'], u => models.User.create(utils.data(u)))
+      .tap(results => users = results));
 
   // Create group.
   beforeEach(() => models.Group.create(utils.data('group1')).tap(g => group = g));

--- a/test/userlib.spec.test.js
+++ b/test/userlib.spec.test.js
@@ -14,7 +14,7 @@ var userData3 = utils.data('user3');
 var mock = require('./mocks/clearbit.json');
 
 describe("userlib", () => {
-  
+
   var sandbox, stub;
   beforeEach(() => {
     userlib.memory = {};
@@ -37,56 +37,40 @@ describe("userlib", () => {
 
   afterEach(() => sandbox.restore() );
 
-  it("doesn't call clearbit if email invalid", (done) => {
-    userlib.fetchAvatar({email: "email.com"}, (err, user) => {
-      expect(err).to.exist;
-      expect(user.avatar).to.be.undefined;
-      expect(user.email).to.equal("email.com");
-      expect(stub.called).to.be.false;
-      done();
-    });
-  });
+  it("doesn't call clearbit if email invalid", () =>
+    userlib.fetchAvatar({email: "email.com"})
+      .then(() => expect(stub.called).to.be.false));
 
-  it("can't fetch the avatar of an unknown email", (done) => {
-    userlib.fetchAvatar(userData1, (err, user) => {
-      expect(err).to.be.an.instanceof(userlib.clearbit.Enrichment.NotFoundError);
+  it("can't fetch the avatar of an unknown email", () =>
+    userlib.fetchAvatar(userData1).then(user => {
       expect(userlib.memory).to.have.property(userData1.email);
       expect(stub.callCount).to.equal(1);
       expect(user).to.deep.equal(userData1);
-      done();
-    });
-  });
+    }));
 
-  it("only calls clearbit server once for an email not found", (done) => {
-    userlib.fetchAvatar(userData1, (err, user) => {
-      userlib.fetchAvatar(userData1, (err, user) => {
+  it("only calls clearbit server once for an email not found", () =>
+    userlib.fetchAvatar(userData1)
+      .then(() => userlib.fetchAvatar(userData1))
+      .then(user => {
         expect(stub.callCount).to.equal(1);
-        expect(err).to.be.null;
-        expect(user.avatar).to.be.undefined;
+        expect(user.avatar).to.be.falsy;
         expect(user).to.deep.equal(userData1);
-        done();
-      });
-    });
-  });
+    }));
 
-  it("fetches the avatar of a known email and only updates the user.avatar", (done) => {
-    userlib.fetchAvatar(userData3, (err, user) => {
-      expect(err).to.not.exist;
+  it("fetches the avatar of a known email and only updates the user.avatar", () =>
+    userlib.fetchAvatar(userData3).then(user => {
       expect(Object.keys(user).length).to.equal(Object.keys(userData3).length);
       expect(user.name).to.equal(userData3.name);
       expect(user.avatar).to.equal('https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764');
-      expect(user.name)
-      done();
-    });
-  });
+      expect(user.name);
+    }));
 
-  it("doesn't fetch the avatar if one has already been provided", (done) => {
+  it("doesn't fetch the avatar if one has already been provided", () => {
     userData3.avatar = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764';
     var currentCallCount = stub.callCount;
-    userlib.fetchAvatar(userData3, (err, user) => {
+    return userlib.fetchAvatar(userData3).then(user => {
       expect(stub.callCount).to.equal(currentCallCount);
       expect(user).to.deep.equal(userData3);
-      done();
     });
   });
 

--- a/test/users.routes.test.js
+++ b/test/users.routes.test.js
@@ -162,7 +162,7 @@ describe('users.routes.test.js', () => {
           expect(res.body).to.not.have.property('password');
           expect(res.body).to.not.have.property('password_hash');
           models.User
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .then((user) => {
               expect(user).to.have.property('ApplicationId', application.id);
               done();
@@ -181,7 +181,7 @@ describe('users.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           models.User
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .then((user) => {
               expect(user.name).to.equal("Xavier Damman");
               expect(user.twitterHandle).to.equal("xdamman");
@@ -203,7 +203,7 @@ describe('users.routes.test.js', () => {
           .end((e, res) => {
             expect(e).to.not.exist;
             models.User
-              .find(parseInt(res.body.id))
+              .findById(parseInt(res.body.id))
               .then((user) => {
                 expect(user.name).to.equal("Xavier Damman");
                 expect(user.twitterHandle).to.equal("xdamman");
@@ -225,7 +225,7 @@ describe('users.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           models.User
-            .find(parseInt(res.body.id))
+            .findById(parseInt(res.body.id))
             .tap((user) => {
               expect(user).to.have.property('ApplicationId', application3.id);
               done();
@@ -630,7 +630,7 @@ describe('users.routes.test.js', () => {
           expect(options.html).to.contain(`${config.host.webapp}/reset/`);
           expect(options.to).to.equal(user.email);
         })
-        .then(() => models.User.find(user.id))
+        .then(() => models.User.findById(user.id))
         .tap(u => {
           const today = (new Date()).toString().substring(0, 15);
 
@@ -772,8 +772,8 @@ describe('users.routes.test.js', () => {
           models.User.auth(user.email, password, (err) => {
             expect(err).to.not.exist;
 
-            models.User.find(user.id)
-            .then(u => {
+            models.User.findById(user.id)
+            .tap(u => {
               expect(u.resetPasswordTokenHash).to.be.equal(null);
               expect(u.resetPasswordSentAt).to.be.equal(null);
               done();

--- a/test/utils.js
+++ b/test/utils.js
@@ -39,14 +39,6 @@ module.exports = () => {
         });
     },
 
-    createUsers: (users, cb) => {
-      const promises = users.map(u => models.User.create(getData(u)));
-      Promise.all(promises).then(cb)
-      .catch(e => {
-        console.error("Sequelize Error: ", e.errors);
-      });
-    },
-
     /**
      * Test data.
      */


### PR DESCRIPTION
If preferred, the sequelize upgrade itself can be removed and done in separate PR (needs rolling back `findById` -> `find`)