### PR TITLE
update .editorconfig to leave trailing whitespace in Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
no big whoop