### PR TITLE
avoid warning about lack of repository field from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,9 @@
     "script": "node scripts/execute",
     "install:debs": "bash scripts/install_apt_get_debs.sh"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opencollective/opencollective-api.git"
+  }
 }


### PR DESCRIPTION
that's about it.