### PR TITLE
Fix sequelize references warning

### DIFF
--- a/server/models/Donation.js
+++ b/server/models/Donation.js
@@ -9,16 +9,20 @@ module.exports = function(Sequelize, DataTypes) {
 
     UserId: {
       type: DataTypes.INTEGER,
-      references: 'Users',
-      referencesKey: 'id',
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     },
 
     GroupId: {
       type: DataTypes.INTEGER,
-      references: 'Groups',
-      referencesKey: 'id',
+      references: {
+        model: 'Groups',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     },
@@ -51,8 +55,10 @@ module.exports = function(Sequelize, DataTypes) {
 
     SubscriptionId: {
       type: DataTypes.INTEGER,
-      references: 'Subscriptions',
-      referencesKey: 'id',
+      references: {
+        model: 'Subscriptions',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     },

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -13,8 +13,10 @@ module.exports = function (Sequelize, DataTypes) {
 
     UserId: {
       type: DataTypes.INTEGER,
-      references: 'Users',
-      referencesKey: 'id',
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE',
       allowNull: false
@@ -22,8 +24,10 @@ module.exports = function (Sequelize, DataTypes) {
 
     GroupId: {
       type: DataTypes.INTEGER,
-      references: 'Groups',
-      referencesKey: 'id',
+      references: {
+        model: 'Groups',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE',
       allowNull: false
@@ -57,8 +61,10 @@ module.exports = function (Sequelize, DataTypes) {
 
     lastEditedById: {
       type: DataTypes.INTEGER,
-      references: 'Users',
-      referencesKey: 'id',
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     },

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -35,8 +35,10 @@ module.exports = function(Sequelize, DataTypes) {
     },
     UserId: {
       type: DataTypes.INTEGER,
-      references: 'Users',
-      referencesKey: 'id',
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     },

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -123,8 +123,10 @@ module.exports = function(Sequelize, DataTypes) {
 
     referrerId: {
       type: DataTypes.INTEGER,
-      references: 'Users',
-      referencesKey: 'id',
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     },


### PR DESCRIPTION
As seen in the logs:

```
Utils deprecated Non-object references property found. Support for that will be removed in version 4. Expected { references: { model: "value", key: "key" } } instead of { references: "value", referencesKey: "key" }. node_modules/sequelize/lib/model.js:87:25
module.js:341
```