### PR TITLE
fixes: do not infer org name; skip forks via upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-slack": "0.0.7",
     "node-uuid": "1.4.7",
     "nodemailer": "1.11.0",
-    "opencollective-jobs": "github:opencollective/opencollective-jobs#v0.1.0",
+    "opencollective-jobs": "github:opencollective/opencollective-jobs#v0.2.0",
     "passport": "0.3.2",
     "passport-github": "1.1.0",
     "paypal-adaptive": "0.4.2",

--- a/scripts/update-contributions.js
+++ b/scripts/update-contributions.js
@@ -17,7 +17,6 @@ Group.findAll({
   attributes: [
     'id',
     'name',
-    'slug',
     'settings'
   ]
 })
@@ -25,7 +24,11 @@ Group.findAll({
     log.verbose('groups', `Found ${groups.length} group(s) to inspect`);
   })
   .each(group => {
-    const org = _.get(group, 'settings.githubOrg', group.slug);
+    const org = _.get(group, 'settings.githubOrg');
+    if (!org) {
+      log.warn(group.name, `GitHub org not associated`);
+      return;
+    }
     return client.contributorsInOrg({orgs: [org]})
       .get(org)
       .then(perRepo => {


### PR DESCRIPTION
- updates `opencollective-jobs` to v0.2.0

@asood123 this is what we talked about.  this should suppress most errors, and the corresponding changes [here](https://github.com/OpenCollective/opencollective-jobs/commit/a70b182db01265f5773c5f6c81b5160d6a53f31d) will address the erroneous contributor data.