### PR TITLE
enable temporal history on expense table

### DIFF
--- a/migrations/20160613174610-temporal-migration.js
+++ b/migrations/20160613174610-temporal-migration.js
@@ -1,0 +1,42 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, DataTypes) {
+    return queryInterface.createTable('ExpenseHistories', {
+      id: DataTypes.INTEGER,
+      UserId: DataTypes.INTEGER,
+
+      GroupId: DataTypes.INTEGER,
+      currency: DataTypes.STRING,
+      amount: DataTypes.INTEGER,
+      title: DataTypes.STRING,
+      payoutMethod: DataTypes.STRING,
+      notes: DataTypes.TEXT,
+      attachment: DataTypes.STRING,
+      category: DataTypes.STRING,
+      vat: DataTypes.INTEGER,
+      lastEditedById: DataTypes.INTEGER,
+      status: DataTypes.STRING,
+      incurredAt: DataTypes.DATE,
+      createdAt: DataTypes.DATE,
+      updatedAt: DataTypes.DATE,
+      deletedAt: DataTypes.DATE,
+
+      hid: {
+        type: DataTypes.BIGINT,
+        primaryKey: true,
+        autoIncrement: true,
+        unique: true
+      },
+      archivedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW
+      }
+    });
+  },
+
+  down: function (queryInterface) {
+    return queryInterface.dropTable('ExpenseHistories');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "request-promise": "3.0.0",
     "sequelize": "3.23.3",
     "sequelize-cli": "2.4.0",
+    "sequelize-temporal": "1.0.3",
     "slug": "0.9.1",
     "stripe": "3.9.0"
   },

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -1,4 +1,4 @@
-const Temporal = require('Sequelize-Temporal');
+const Temporal = require('sequelize-temporal');
 
 const status = require('../constants/expense_status');
 const type = require('../constants/transactions').type.EXPENSE;

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -1,10 +1,12 @@
+const Temporal = require('Sequelize-Temporal');
+
 const status = require('../constants/expense_status');
 const type = require('../constants/transactions').type.EXPENSE;
 const allowedCurrencies = Object.keys(require('../constants/currencies'));
 
 module.exports = function (Sequelize, DataTypes) {
 
-  return Sequelize.define('Expense', {
+  var Expense = Sequelize.define('Expense', {
     id: {
       type: DataTypes.INTEGER,
       primaryKey: true,
@@ -159,4 +161,6 @@ module.exports = function (Sequelize, DataTypes) {
       }
     }
   });
+  Temporal(Expense, Sequelize);
+  return Expense;
 };


### PR DESCRIPTION
With this, any changes in the Expense table done through Sequelize (not manually) will be recorded. So, whenever an expense gets approved, rejected, paid, etc, we'll know when it happened and what the state was before the row changed.