### PR TITLE
fix query for yearlyincome

### DIFF
--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -274,9 +274,11 @@ module.exports = function(Sequelize, DataTypes) {
         return Sequelize.query(`
           SELECT
             (SELECT
-              COALESCE(SUM(t."netAmountInGroupCurrency"*12),0)
-              FROM "Transactions" t
-              LEFT JOIN "Subscriptions" s ON t."SubscriptionId" = s.id
+             COALESCE(SUM( t."netAmountInGroupCurrency"*12),0)
+              FROM "Subscriptions" s
+              LEFT JOIN "Transactions" t
+              ON (s.id = t."SubscriptionId"
+                AND t.id = (SELECT MAX(id) from "Transactions" t where t."SubscriptionId" = s.id))
               WHERE "GroupId" = :GroupId
                 AND t.amount > 0
                 AND t."deletedAt" IS NULL
@@ -287,7 +289,7 @@ module.exports = function(Sequelize, DataTypes) {
             (SELECT
               COALESCE(SUM(t."netAmountInGroupCurrency"),0) FROM "Transactions" t
               LEFT JOIN "Subscriptions" s ON t."SubscriptionId" = s.id
-              WHERE "GroupId" = :GroupId
+              WHERE "GroupId" = "GroupId"
                 AND t.amount > 0
                 AND t."deletedAt" IS NULL
                 AND ((s.interval = 'year' AND s."isActive" IS TRUE AND s."deletedAt" IS NULL) OR s.interval IS NULL)) "yearlyIncome"


### PR DESCRIPTION
Existing query counts each transaction separately for a recurring monthly donation. This removes the duplicates.