### PR TITLE
Detect proper entry when User has several UserGroup entries

### DIFF
--- a/server/middleware/security/authorization.js
+++ b/server/middleware/security/authorization.js
@@ -134,7 +134,7 @@ module.exports = function (app) {
             return next(e);
           }
           if (!hasUser) {
-            return next(new Forbidden('Forbidden'));
+            return next(new Forbidden('User does not have expected role'));
           }
           next();
         });

--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -198,22 +198,15 @@ module.exports = function(Sequelize, DataTypes) {
     },
 
     instanceMethods: {
-      hasUserWithRole(userId, roles, cb) {
+      hasUserWithRole(userId, expectedRoles, cb) {
         this
           .getUsers({
             where: {
               id: userId
             }
           })
-          .tap((users) => {
-            if (users.length === 0) {
-              return cb(null, false);
-            } else if (!_.contains(roles, users[0].UserGroup.role)) {
-              return cb(null, false);
-            }
-
-            cb(null, true);
-          })
+          .then(users => users.map(user => user.UserGroup.role))
+          .tap(actualRoles => cb(null, _.intersection(expectedRoles, actualRoles).length > 0))
           .catch(cb);
       },
 


### PR DESCRIPTION
Found when playing with my test DB, my testuser was both HOST and BACKER after I gave a donation with it (two rows in UserGroup). I couldn't use it to approve expenses any more.