### PR TITLE
make sure logo file name isn't longer than 255

### DIFF
--- a/server/controllers/images.js
+++ b/server/controllers/images.js
@@ -27,8 +27,7 @@ module.exports = function(app) {
      */
 
     var ext = path.extname(file.originalname);
-    var name = file.originalname.replace(/\W/g, ''); // remove non alphanumeric
-    var filename = ['/', name, '_', uuid.v1(), ext].join('');
+    var filename = ['/', uuid.v1(), ext].join('');
 
     var put = app.knox.put(filename, {
       'Content-Length': file.size,


### PR DESCRIPTION
Sometimes the name of the file was too long and uuid appended to it created a string longer than 255 characters, causing the error we saw yesterday.