### PR TITLE
Related groups

### DIFF
--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -27,7 +27,7 @@ module.exports = function(app) {
   const activities = require('../constants/activities');
   const emailLib = require('../lib/email')(app);
   const githubLib = require('../lib/github');
-  const queries = require('../lib/queries')(app);
+  const queries = require('../lib/queries')(models.sequelize);
 
 
   const subscribeUserToGroupEvents = (user, group, role) => {
@@ -462,7 +462,8 @@ module.exports = function(app) {
       req.group.getYearlyIncome(),
       req.group.getTotalDonations(),
       req.group.getBackersCount(),
-      req.group.getTwitterSettings()
+      req.group.getTwitterSettings(),
+      req.group.getRelatedGroups()
       ])
     .then(values => {
       group.stripeAccount = values[0] && _.pick(values[0], 'stripePublishableKey');
@@ -473,6 +474,7 @@ module.exports = function(app) {
       group.backersCount = values[5];
       group.settings = group.settings || {};
       group.settings.twitter = values[6];
+      group.related = values[7];
       return group;
     })
     .then(group => res.send(group))

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -26,7 +26,7 @@ module.exports = (app) => {
   const UserGroup = models.UserGroup;
   const sendEmail = require('../lib/email')(app).send;
   const errors = app.errors;
-  const queries = require('../lib/queries')(app);
+  const queries = require('../lib/queries')(models.sequelize);
   const Unauthorized = errors.Unauthorized;
 
   /**

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1,7 +1,6 @@
-module.exports = function(app) {
+module.exports = function(sequelize) {
 
-  const models = app.set('models');
-  const sequelize = models.sequelize;
+  const models = sequelize.models;
 
   /*
   * Hacky way to do currency conversion on Leaderboard
@@ -48,15 +47,19 @@ module.exports = function(app) {
   /**
    * Get top collectives based on total donations
    */
-  const getTopGroups = (tag) => {
+  const getTopGroups = (tag, limit, excludeList) => {
+    var excludeClause = '';
+    if (excludeList && excludeList.length > 0) {
+      excludeClause = `AND g.id not in (${excludeList})`;
+    }
     return sequelize.query(`
       WITH "totalDonations" AS (
         SELECT "GroupId", SUM(amount) as "totalDonations", MAX(currency) as currency, COUNT(DISTINCT "GroupId") as collectives FROM "Transactions" WHERE amount > 0 AND currency='USD' AND "PaymentMethodId" IS NOT NULL GROUP BY "GroupId"
       )
       SELECT g.id, g.name, g.slug, g.mission, g.logo, t."totalDonations", t.currency, t.collectives
       FROM "totalDonations" t LEFT JOIN "Groups" g ON t."GroupId" = g.id
-      WHERE t."totalDonations" > 100 AND g.tags @> $tag AND g."deletedAt" IS NULL
-      ORDER BY "totalDonations" DESC LIMIT 3
+      WHERE t."totalDonations" > 100 AND g.tags @> $tag AND g."deletedAt" IS NULL ${excludeClause}
+      ORDER BY "totalDonations" DESC LIMIT ${limit}
     `, {
       bind: { tag: [tag] },
       model: models.Group

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -58,7 +58,7 @@ module.exports = function(sequelize) {
       )
       SELECT g.id, g.name, g.slug, g.mission, g.logo, t."totalDonations", t.currency, t.collectives
       FROM "totalDonations" t LEFT JOIN "Groups" g ON t."GroupId" = g.id
-      WHERE t."totalDonations" > 100 AND g.tags @> $tag AND g."deletedAt" IS NULL ${excludeClause}
+      WHERE t."totalDonations" > 100 AND g.tags && $tag AND g."deletedAt" IS NULL ${excludeClause}
       ORDER BY "totalDonations" DESC LIMIT ${limit}
     `, {
       bind: { tag: [tag] },

--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -379,9 +379,9 @@ module.exports = function(Sequelize, DataTypes) {
         return settings.twitter;
       },
 
-      getRelatedGroups(number) {
-        number = number || 3
-        return Group.getGroupsSummaryByTag(this.tags, number, [this.id]);
+      getRelatedGroups(limit) {
+        limit = limit || 3
+        return Group.getGroupsSummaryByTag(this.tags, limit, [this.id]);
       },
 
       hasHost() {

--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -5,9 +5,11 @@ const _ = require('lodash');
 const Joi = require('joi');
 const config = require('config');
 const errors = require('../lib/errors');
+const groupBy = require('lodash/collection/groupBy');
 
 const roles = require('../constants/roles');
 const constants = require('../constants/transactions');
+const utils = require('../lib/utils');
 
 const tier = Joi.object().keys({
   name: Joi.string().required(), // lowercase, act as a slug. E.g. "donors", "sponsors", "backers", "members", ...
@@ -27,6 +29,7 @@ const tiers = Joi.array().items(tier);
 module.exports = function(Sequelize, DataTypes) {
 
   const models = Sequelize.models;
+  const queries = require('../lib/queries')(Sequelize);
 
   const Group = Sequelize.define('Group', {
     name: {
@@ -376,6 +379,11 @@ module.exports = function(Sequelize, DataTypes) {
         return settings.twitter;
       },
 
+      getRelatedGroups(number) {
+        number = number || 3
+        return Group.getGroupsSummaryByTag(this.tags, number, [this.id]);
+      },
+
       hasHost() {
         return Sequelize.models.UserGroup.find({
           where: {
@@ -385,7 +393,40 @@ module.exports = function(Sequelize, DataTypes) {
         })
         .then(userGroup => Promise.resolve(!!userGroup));
       }
+    },
 
+    classMethods: {
+      getGroupsSummaryByTag: (tags, limit, excludeList) => {
+        limit = limit || 3;
+        excludeList = excludeList || [];
+
+        return queries.getTopGroups(tags, limit, excludeList)
+          .then(groups => {
+            return Promise.all(groups.map(group => {
+              const appendTier = backers => {
+                backers = backers.map(backer => {
+                  backer.tier = utils.getTier(backer, group.tiers);
+                  return backer;
+                });
+                return backers;
+              };
+
+              return Promise.all([
+                  group.getYearlyIncome(),
+                  queries.getUsersFromGroupWithTotalDonations(group.id)
+                    .then(appendTier)
+                ])
+                .then(values => {
+                  const groupInfo = group.card;
+                  groupInfo.yearlyIncome = values[0];
+                  const usersByRole = groupBy(values[1], 'role');
+                  groupInfo.backers = usersByRole[roles.BACKER] || [];
+                  groupInfo.members = usersByRole[roles.MEMBER] || [];
+                  return groupInfo;
+                });
+            }));
+          });
+      }
     }
   });
 

--- a/test/homepage.routes.test.js
+++ b/test/homepage.routes.test.js
@@ -23,7 +23,7 @@ describe('homepage.routes.test.js', () => {
   beforeEach(() => utils.cleanAllDb().tap(a => application = a));
 
   beforeEach(() => models.User.create(userData).tap(u => user = u));
-  beforeEach((done) => 
+  beforeEach((done) =>
     models.Group
       .create(groupData).tap(g => {
         group = g;

--- a/test/mocks/data.json
+++ b/test/mocks/data.json
@@ -81,7 +81,7 @@
       "button": "Become a member"
     }],
     "hostFeePercent": 10,
-    "tags": ["open source", "frameworks", "ruby"],
+    "tags": ["open source", "test"],
     "isSupercollective": false
   },
 
@@ -110,7 +110,7 @@
       "button": "Become a member"
     }],
     "hostFeePercent": 0,
-    "tags": ["wwcode", "austin"],
+    "tags": ["meetup", "test"],
     "isSupercollective": false
   },
 
@@ -440,6 +440,18 @@
         "comment": "",
         "link": "",
         "createdAt": "2015-05-29T07:00:00.000Z"
+      },
+      {
+        "vendor": "@montogeek",
+        "description": "Donation to that great project",
+        "tags": ["donation"],
+        "amount": 999,
+        "currency": "USD",
+        "paypalEmail": "userpaypal@gmail.com",
+        "comment": "",
+        "link": "",
+        "createdAt": "2015-05-29T07:00:00.000Z",
+        "PaymentMethodId": 1
       }
     ]
   },

--- a/test/transactions.routes.test.js
+++ b/test/transactions.routes.test.js
@@ -78,6 +78,9 @@ describe('transactions.routes.test.js', () => {
   // Create an independent application.
   beforeEach(() => models.Application.create(utils.data('application3')).tap(a => application3 = a));
 
+  beforeEach(() => models.PaymentMethod.create({UserId: user.id}))
+
+
   afterEach(() => utils.clearbitStubAfterEach(sandbox));
 
   /**


### PR DESCRIPTION
Modifies backend to return related groups data as part of any call that fetches group data for publicgroup on the frontend.

A few other comments:
- refactored `homepage` controller to move the group related call to `Groups` model as a `classMethod` 
- changed `queries` library to only need `Sequelize`, rather than `app`. It's easier to link it from various `Models` that way