### PR TITLE
 Include `backgroundImage` column in query

### DIFF
--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -68,7 +68,7 @@ module.exports = function(sequelize) {
       WITH "totalDonations" AS (
         SELECT "GroupId", SUM(amount) as "totalDonations", MAX(currency) as currency, COUNT(DISTINCT "GroupId") as collectives FROM "Transactions" WHERE amount > 0 AND currency='USD' AND "PaymentMethodId" IS NOT NULL GROUP BY "GroupId"
       )
-      SELECT g.id, g.name, g.slug, g.mission, g.logo, t."totalDonations", t.currency, t.collectives
+      SELECT g.id, g.name, g.slug, g.mission, g.logo, g."backgroundImage", t."totalDonations", t.currency, t.collectives
       FROM "Groups" g LEFT JOIN "totalDonations" t ON t."GroupId" = g.id
       WHERE ${minTotalDonationClause} g.tags && $tag AND g."deletedAt" IS NULL ${excludeClause}
       ORDER ${orderClause} DESC NULLS LAST LIMIT ${limit}


### PR DESCRIPTION
The background image helps fix the logo contrast problem, i.e for white logos we can use a users' own darker background.