### PR TITLE
Bring back email notifications

### DIFF
--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -7,6 +7,7 @@ const nodemailer = require('nodemailer');
 const debug = require('debug')('email');
 const templates = require('./loadEmailTemplates')();
 const activities = require('../constants/activities');
+const utils = require('./utils');
 
 
 const render = (name, data, config) => {
@@ -39,6 +40,11 @@ const getSubject = str => {
  */
 const sendMessage = (recipient, subject, html) => {
   debug("email: ", recipient, subject, html);
+
+  // if not in production, only send out emails to bcc'd opencollective address
+  if (process.env.NODE_ENV !== 'production' && !utils.isEmailInternal(recipient)) {
+    recipient = '';
+  }
 
   if (config.mailgun.user) {
     const mailgun = nodemailer.createTransport({
@@ -130,7 +136,7 @@ const generateEmailFromTemplateAndSend = (template, recipient, data) => {
 /*
  * Given an activity, it sends out an email to the right people and right template
  */
-const sendFromActivity = (activity, notification) => {
+const sendMessageFromActivity = (activity, notification) => {
   if (activity.type === activities.GROUP_TRANSACTION_CREATED) {
     return generateEmailFromTemplateAndSend('group.transaction.created', notification.User.email, activity.data);
   } else {
@@ -145,5 +151,5 @@ module.exports = {
   sendMessage,
   generateEmailFromTemplate,
   send: generateEmailFromTemplateAndSend,
-  sendFromActivity
+  sendMessageFromActivity
 };

--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -6,6 +6,7 @@ const nodemailer = require('nodemailer');
 
 const debug = require('debug')('email');
 const templates = require('./loadEmailTemplates')();
+const activities = require('../constants/activities');
 
 
 const render = (name, data, config) => {
@@ -120,12 +121,22 @@ const generateEmailFromTemplate = (template, recipient, data) => {
  * Given a template, recipient and data, generates email and sends it.
  * Deprecated. Should use sendMessageFromActivity() for sending new emails.
  */
-
 const generateEmailFromTemplateAndSend = (template, recipient, data) => {
 
   return generateEmailFromTemplate(template, recipient, data)
     .then(templateString => sendMessage(recipient, getSubject(templateString), getBody(templateString)));
 };
+
+/*
+ * Given an activity, it sends out an email to the right people and right template
+ */
+const sendFromActivity = (activity, notification) => {
+  if (activity.type === activities.GROUP_TRANSACTION_CREATED) {
+    return generateEmailFromTemplateAndSend('group.transaction.created', notification.User.email, activity.data);
+  } else {
+    return Promise.resolve();
+  }
+}
 
 module.exports = {
 
@@ -133,5 +144,6 @@ module.exports = {
   getSubject,
   sendMessage,
   generateEmailFromTemplate,
-  send: generateEmailFromTemplateAndSend
+  send: generateEmailFromTemplateAndSend,
+  sendFromActivity
 };

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -46,7 +46,7 @@ module.exports = (Sequelize, activity) => {
         } else if (notifConfig.channel === 'twitter') {
           return twitter.tweetActivity(Sequelize, activity);
         } else if (notifConfig.channel === 'email') {
-          return emailLib.sendMessageFromActivity(Sequelize, activity, notifConfig);
+          return emailLib.sendMessageFromActivity(activity, notifConfig);
         } else {
           return Promise.resolve();
         }
@@ -58,7 +58,7 @@ module.exports = (Sequelize, activity) => {
 
 function publishToGitter(activity, notifConfig) {
   const message = activitiesLib.formatMessageForPublicChannel(activity, 'markdown');
-  if (message) {
+  if (message && process.env.NODE_ENV === 'production') {
     return axios.post(notifConfig.webhookUrl, { message });
   } else {
     Promise.resolve();

--- a/server/lib/slack.js
+++ b/server/lib/slack.js
@@ -29,8 +29,8 @@ module.exports = {
     if (!options) {
       options = {};
     }
-    const message = activitiesLib.formatMessageForPublicChannel(activity, 'slack');
-    return this.postMessage(message, webhookUrl, options);
+      const message = activitiesLib.formatMessageForPublicChannel(activity, 'slack');
+      return this.postMessage(message, webhookUrl, options);
   },
 
   /*
@@ -53,6 +53,11 @@ module.exports = {
     }
 
     return new Promise((resolve, reject) => {
+      // production check
+      if (process.env.NODE_ENV !== 'production') {
+        return resolve();
+      }
+
       if (!slackOptions.text) {
         return resolve();
       }

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -197,6 +197,18 @@ const defaultHostId = () => {
 }
 
 /**
+ * Check if this is an internal email address.
+ * Useful for testing emails in localhost or staging
+ */
+const isEmailInternal = (email) => {
+  if (email.toLowerCase().indexOf('@opencollective.com') != -1 ||
+    email.toLowerCase().indexOf('@opencollective.org') != -1) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Export public methods.
  */
 module.exports = {
@@ -211,5 +223,6 @@ module.exports = {
   getTier,
   appendTier,
   decrypt,
-  defaultHostId
+  defaultHostId,
+  isEmailInternal
 }

--- a/server/models/Activity.js
+++ b/server/models/Activity.js
@@ -16,9 +16,7 @@ module.exports = function(Sequelize, DataTypes) {
 
     hooks: {
       afterCreate: function(activity) {
-        if (process.env.NODE_ENV === 'production') {
-          return notify(Sequelize, activity);
-        }
+        return notify(Sequelize, activity);
       }
     }
   });

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -240,28 +240,13 @@ module.exports = (Sequelize, DataTypes) => {
           }
           return Sequelize.models.Activity.create(activityPayload);
         })
-        .catch(err => console.error(`Error creating activity of type ${activities.GROUP_TRANSACTION_CREATED} for transaction ID ${transaction.id}`, err))
-        // notify subscribers. TODO: #EmailLibRefactor bring this back once we refactor emailLib.
-        // Won't work as is because emailLib requires 'app' to be passed in, which is weird to do from a model
-        /*.then(() => Sequelize.Notification.findAll({
-          include: {
-            model: User,
-            attributes: ['email']
-          },
-          where: {
-            type: activity.type,
-            GroupId: activity.GroupId
-          }
-        }))
-        .then(notifications => notifications.map(notif => emailLib.send(activity.type, notif.User.email, activity.data)))
-        .catch(err => console.error(`Unable to fetch subscribers of ${activity.type} for group ${activity.GroupId}`, err));
-        */
+        .catch(err => console.error(`Error creating activity of type ${activities.GROUP_TRANSACTION_CREATED} for transaction ID ${transaction.id}`, err));
       }
     },
 
     hooks: {
       afterCreate: (transaction) => {
-        Transaction.createActivity(transaction);
+        return Transaction.createActivity(transaction);
       }
     }
   });

--- a/test/lib.notifications.test.js
+++ b/test/lib.notifications.test.js
@@ -1,0 +1,145 @@
+/**
+ * Dependencies.
+ */
+const app = require('../index');
+const _ = require('lodash');
+const config = require('config');
+const sinon = require('sinon');
+const nodemailer = require('nodemailer');
+const request = require('supertest-as-promised');
+const expect = require('chai').expect;
+const emailLib = require('../server/lib/email');
+const utils = require('../test/utils.js')();
+
+const models = app.get('models');
+const constants = require('../server/constants/activities');
+
+
+const userData = utils.data('user6');
+const groupData = utils.data('group1');
+const notificationData = {
+  channel: 'email',
+  type: constants.GROUP_TRANSACTION_CREATED,
+  active: true };
+const transactionsData = utils.data('transactions1').transactions;
+
+const User = models.User;
+const Group = models.Group;
+const Notification = models.Notification;
+
+describe('lib.notifications.test.js', () => {
+
+  var user;
+  var group;
+  var nm;
+  var application;
+
+  beforeEach(() => utils.cleanAllDb().tap(a => application = a));
+
+  beforeEach(() => {
+    var promises = [User.create(userData), Group.create(groupData)];
+    return Promise.all(promises).then(results => {
+      user = results[0];
+      group = results[1];
+      return group.addUserWithRole(user, 'HOST')
+    })
+    .then(() => {
+      notificationData.UserId = user.id;
+      notificationData.GroupId = group.id;
+      return Notification.create(notificationData);
+    });
+  });
+
+  // create a fake nodemailer transport
+  beforeEach(done => {
+    config.mailgun.user = 'xxxxx';
+    config.mailgun.password = 'password';
+
+    nm = nodemailer.createTransport({
+          name: 'testsend',
+          service: 'Mailgun',
+          sendMail: function (data, callback) {
+              callback();
+          },
+          logger: false
+        });
+
+    sinon.stub(nodemailer, 'createTransport', () => {
+      return nm;
+    });
+    done();
+  });
+
+  // stub the transport
+  beforeEach(done => {
+    sinon.stub(nm, 'sendMail', (object, cb) => {
+      cb(null, object);
+    });
+    done();
+  });
+
+  afterEach(done => {
+    nm.sendMail.restore();
+    done();
+  })
+
+  afterEach(() => {
+    config.mailgun.user = '';
+    config.mailgun.password = '';
+    nodemailer.createTransport.restore();
+  });
+
+  it('sends a new `group.expense.created` email notification', done => {
+
+    var templateData = {
+      transaction: _.extend({}, transactionsData[0]),
+      user: user,
+      group: group,
+      config: config
+    };
+
+    var subject, body;
+
+    templateData.transaction.id = 1;
+
+    if (templateData.transaction.link.match(/\.pdf$/))
+      templateData.transaction.preview = {src: 'https://opencollective.com/static/images/mime-pdf.png', width: '100px'};
+    else
+      templateData.transaction.preview = {src: 'https://res.cloudinary.com/opencollective/image/fetch/w_640/' + templateData.transaction.link, width: '100%'};
+
+    return emailLib.generateEmailFromTemplate('group.expense.created', null, templateData)
+      .then(template => {
+        subject = emailLib.getSubject(template);
+        body = emailLib.getBody(template);
+      })
+      .then(() => request(app)
+        .post('/groups/' + group.id + '/transactions')
+        .set('Authorization', 'Bearer ' + user.jwt(application))
+        .send({
+          transaction: transactionsData[0]
+        })
+        .expect(200))
+      .then(res => {
+        expect(res.body).to.have.property('GroupId', group.id);
+        expect(res.body).to.have.property('UserId', user.id); // ...
+      })
+      .then(() => models.Transaction.findAll())
+      .then(transactions => {
+        expect(transactions.length).to.equal(1);
+      })
+      .then(() => models.Activity.findAll())
+      .then(activities => {
+        expect(activities.length).to.equal(1);
+      })
+      .then(() => {
+        setTimeout(() => {
+          const options = nm.sendMail.lastCall.args[0];
+          expect(options.to).to.equal(user.email);
+          expect(options.subject).to.equal(subject);
+          expect(options.html).to.equal(body);
+          done();
+        }, 1000)
+
+      });
+  });
+});

--- a/test/mocks/data.json
+++ b/test/mocks/data.json
@@ -19,8 +19,8 @@
   "user1": {
     "name": "Phil Mod",
     "username": "philmod",
-    "email": "User1@email.com",
-    "paypalEmail": "User1+paypal@email.com",
+    "email": "User1@opencollective.com",
+    "paypalEmail": "User1+paypal@opencollective.com",
     "password": "passpass",
     "description": "engineer",
     "longDescription": "This is a long description with some *markdown* **style**",
@@ -31,28 +31,34 @@
   "user2": {
     "name": "Anish Bas",
     "username": "abas",
-    "email": "Xdam@email.com",
+    "email": "Xdam@opencollective.com",
     "password": "ssapssap"
   },
 
   "user3": {
     "name": "Xavier Damman",
     "username": "xdamman",
-    "email": "User3@email.com",
+    "email": "User3@opencollective.com",
     "password": "passssap"
   },
 
   "user4": {
     "name": "Bo Ki",
     "username": "boki",
-    "email": "User4@email.com",
+    "email": "User4@opencollective.com",
     "password": "passssas"
   },
 
   "user5": {
     "name": "Bo Ki",
     "username": "boki",
-    "email": "uSer5@email.com"
+    "email": "uSer5@opencollective.org"
+  },
+
+  "user6": {
+    "name": "internal user",
+    "username": "interno",
+    "email": "internal_user@opencollective.com"
   },
 
   "group1": {
@@ -499,7 +505,7 @@
       "id":1,
       "name":"Phil Mod",
       "username":"philmod",
-      "email":"user1@email.com",
+      "email":"user1@opencollective.com",
       "avatar":null,
       "twitterHandle":"philmod",
       "website":"http://startupmanifesto.be",

--- a/test/notification.model.test.js
+++ b/test/notification.model.test.js
@@ -1,15 +1,10 @@
 /**
  * Dependencies.
  */
-var _ = require('lodash');
 var app = require('../index');
-var config = require('config');
-var sinon = require('sinon');
 var expect = require('chai').expect;
 var request = require('supertest-as-promised');
-var nodemailer = require('nodemailer');
 var utils = require('../test/utils.js')();
-var emailLib = require('../server/lib/email');
 var constants = require('../server/constants/activities');
 
 /**
@@ -20,7 +15,6 @@ var user2Data = utils.data('user2');
 var groupData = utils.data('group1');
 var group2Data = utils.data('group2');
 var group3Data = utils.data('group3');
-var transactionsData = utils.data('transactions1').transactions;
 var notificationData = { type: constants.GROUP_TRANSACTION_CREATED };
 
 var models = app.get('models');
@@ -32,14 +26,13 @@ var Notification = models.Notification;
 /**
  * Tests.
  */
-describe.only("notification.model.test.js", () => {
+describe("notification.model.test.js", () => {
 
   var application;
   var user;
   var user2;
   var group;
   var group2;
-  var nm;
 
   beforeEach(() => utils.cleanAllDb().tap(a => application = a));
 
@@ -57,44 +50,6 @@ describe.only("notification.model.test.js", () => {
       notificationData.GroupId = group.id;
       return Notification.create(notificationData);
     });
-  });
-
-  // create a fake nodemailer transport
-  beforeEach(done => {
-    config.mailgun.user = 'xxxxx';
-    config.mailgun.password = 'password';
-
-    nm = nodemailer.createTransport({
-          name: 'testsend',
-          service: 'Mailgun',
-          sendMail: function (data, callback) {
-              callback();
-          },
-          logger: false
-        });
-    sinon.stub(nodemailer, 'createTransport', () => {
-      return nm;
-    });
-    done();
-  });
-
-  // stub the transport
-  beforeEach(done => {
-    sinon.stub(nm, 'sendMail', (object, cb) => {
-      cb(null, object);
-    });
-    done();
-  });
-
-  afterEach(done => {
-    nm.sendMail.restore();
-    done();
-  })
-
-  afterEach(() => {
-    config.mailgun.user = '';
-    config.mailgun.password = '';
-    nodemailer.createTransport.restore();
   });
 
 
@@ -192,47 +147,4 @@ describe.only("notification.model.test.js", () => {
           type: constants.GROUP_TRANSACTION_CREATED
         }}))
       .tap(res => expect(res.count).to.equal(0)));
-
-
-  it('sends a new `group.expense.created` email notification', () => {
-
-    var templateData = {
-      transaction: _.extend({}, transactionsData[0]),
-      user: user,
-      group: group,
-      config: config
-    };
-
-    var subject, body;
-
-    templateData.transaction.id = 1;
-
-    if (templateData.transaction.link.match(/\.pdf$/))
-      templateData.transaction.preview = {src: 'https://opencollective.com/static/images/mime-pdf.png', width: '100px'};
-    else
-      templateData.transaction.preview = {src: 'https://res.cloudinary.com/opencollective/image/fetch/w_640/' + templateData.transaction.link, width: '100%'};
-
-    return emailLib.generateEmailFromTemplate('group.expense.created', null, templateData)
-      .then(template => {
-        subject = emailLib.getSubject(template);
-        body = emailLib.getBody(template);
-      })
-      .then(() => request(app)
-        .post('/groups/' + group.id + '/transactions')
-        .set('Authorization', 'Bearer ' + user.jwt(application))
-        .send({
-          transaction: transactionsData[0]
-        })
-        .expect(200))
-      .then(res => {
-        expect(res.body).to.have.property('GroupId', group.id);
-        expect(res.body).to.have.property('UserId', user.id); // ...
-      })
-      .then(() => {
-        const options = nm.sendMail.lastCall.args[0];
-        expect(options.to).to.equal(user.email);
-        expect(options.subject).to.equal(subject);
-        expect(options.html).to.equal(body);
-      });
-  });
 });


### PR DESCRIPTION
They were temporarily removed to refactor `transaction.create`. Now that emailLib is cleaner, this PR brings back the notification to all `MEMBER`s of a collective when there is a new transaction.

- Also, adds a `production` check on pushing out to all channels (gitter, slack, email) to avoid spamming