### PR TITLE
Transaction test

### DIFF
--- a/test/transaction.model.test.js
+++ b/test/transaction.model.test.js
@@ -6,7 +6,9 @@ const _ = require('lodash');
 const app = require('../index');
 const config = require('config');
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const utils = require('../test/utils.js')();
+var roles = require('../server/constants/roles');
 
 /**
  * Models
@@ -16,12 +18,31 @@ const models = app.get('models');
 const Transaction = models.Transaction;
 
 /**
+ * Data
+ */
+
+var userData = utils.data('user1');
+var groupData = utils.data('group1');
+var transactionsData = utils.data('transactions1').transactions;
+
+
+/**
  * Tests.
  */
 
-describe('transaction model', () => {
+describe.only('transaction model', () => {
+
+  var user, group;
 
   beforeEach(() => utils.cleanAllDb());
+
+  beforeEach(() => models.User.create(userData).tap(u => user = u));
+
+  // Create group2.
+  beforeEach(() =>
+    models.Group.create(groupData)
+      .tap(g => group = g)
+      .then(() => group.addUserWithRole(user, roles.HOST)));
 
   it('isExpense is true if the amount is negative', done => {
     Transaction.create({
@@ -98,4 +119,23 @@ describe('transaction model', () => {
     })
     .catch(done);
   });
+
+  it('createFromPayload() generates a new activity', done => {
+
+    beforeEach(() => sinon.spy(Transaction, 'createActivity'));
+
+    afterEach(() => Transaction.createActivity.restore());
+
+    Transaction.createFromPayload({
+      transaction: transactionsData[7],
+      user,
+      group
+    })
+    .then(transaction => {
+      expect(transaction.GroupId).to.equal(group.id);
+      expect(Transaction.createActivity.lastCall.args[0]).to.equal(transaction);
+      done();
+    })
+    .catch(done);
+  })
 });

--- a/test/transaction.model.test.js
+++ b/test/transaction.model.test.js
@@ -30,7 +30,7 @@ var transactionsData = utils.data('transactions1').transactions;
  * Tests.
  */
 
-describe.only('transaction model', () => {
+describe('transaction model', () => {
 
   var user, group;
 
@@ -119,6 +119,22 @@ describe.only('transaction model', () => {
     })
     .catch(done);
   });
+
+  it('createFromPayload creates a new Transaction', done => {
+    Transaction.createFromPayload({
+      transaction: transactionsData[7],
+      user,
+      group
+    })
+    .then(() => {
+      Transaction.findAll()
+      .then(transactions => {
+        expect(transactions.length).to.equal(1);
+        done();
+      })
+    })
+    .catch(done);
+  })
 
   var createActivitySpy;
 

--- a/test/transaction.model.test.js
+++ b/test/transaction.model.test.js
@@ -120,11 +120,17 @@ describe.only('transaction model', () => {
     .catch(done);
   });
 
-  it('createFromPayload() generates a new activity', done => {
+  var createActivitySpy;
 
-    beforeEach(() => sinon.spy(Transaction, 'createActivity'));
+  before(() => {
+    createActivitySpy = sinon.spy(Transaction, 'createActivity');
+  });
 
-    afterEach(() => Transaction.createActivity.restore());
+  beforeEach(() => createActivitySpy.reset());
+
+  after(() => createActivitySpy.restore());
+
+  it('createFromPayload() generates a new activity', (done) => {
 
     Transaction.createFromPayload({
       transaction: transactionsData[7],
@@ -133,9 +139,9 @@ describe.only('transaction model', () => {
     })
     .then(transaction => {
       expect(transaction.GroupId).to.equal(group.id);
-      expect(Transaction.createActivity.lastCall.args[0]).to.equal(transaction);
+      expect(createActivitySpy.lastCall.args[0]).to.equal(transaction);
       done();
     })
     .catch(done);
-  })
+  });
 });


### PR DESCRIPTION
Found a simple case to figure out tests. 

`Transaction` model (https://github.com/OpenCollective/opencollective-api/blob/master/server/models/Transaction.js) has two classMethods: `createFromPayload()`, which creates a new transaction and `createActivity()`. When a new `transaction` is created, an `afterCreate` hook calls `createActivity()`.



This PR adds a test for this flow. We want to test that `createFromPayload` leads to creating an `activity`. I tried stubbing `createActivity` to confirm it gets called and that didn't work. How would you test this? @arnaudbenard 