### PR TITLE
Revert test changing oauth callbackURL

### DIFF
--- a/server/middleware/security/authentication.js
+++ b/server/middleware/security/authentication.js
@@ -247,11 +247,9 @@ module.exports = function (app) {
 
       const params = qs.stringify({ api_key_enc, utm_source, slug });
       const opts = {
-        callbackURL: `/connected-accounts/${service}/callback?${params}`,
-        proxy: true
+        callbackURL: `${config.host.api}/connected-accounts/${service}/callback?${params}`
       };
       console.log("authenticateService: setting callbackURL", opts.callbackURL);
-      console.log("authenticateService: FYI, config.host.api:", config.host.api);
 
       if (service === 'github') {
         opts.scope = [ 'user:email', 'public_repo' ];

--- a/test/connectedAccounts.routes.test.js
+++ b/test/connectedAccounts.routes.test.js
@@ -42,7 +42,7 @@ describe('connectedAccounts.routes.test.js: GIVEN an application and group', () 
             expect(err).not.to.exist;
             const baseUrl = 'https://github.com/login/oauth/authorize';
             const apiKeyEnc = '.*';
-            const redirectUri = encodeURIComponent(`http://127.0.0.1:.*/connected-accounts/github/callback?api_key_enc=${apiKeyEnc}&utm_source=mm&slug=`);
+            const redirectUri = encodeURIComponent(`${config.host.api}/connected-accounts/github/callback?api_key_enc=${apiKeyEnc}&utm_source=mm&slug=`);
             const scope = encodeURIComponent('user:email,public_repo');
             const location = `^${baseUrl}\\?response_type=code&redirect_uri=${redirectUri}&scope=${scope}&client_id=${clientId}$`;
             expect(res.headers.location).to.match(new RegExp(location));


### PR DESCRIPTION
The following change (which hasn't been helpful for Twitter auth):
https://github.com/OpenCollective/opencollective-api/pull/513/files#diff-b9fa7c5b117a5ce587ee0d44fe9f5374R250

Might have introduced this Github auth issue:
https://github.com/OpenCollective/OpenCollective/issues/209

So reverting. 