### PR TITLE
Add more configuration for twitter oauth1 + don't store sessions in memory

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,6 @@ require('./server/lib/load-dot-env');
 
 app.errors = require('./server/lib/errors');
 
-require('./server/lib/express')(app);
-
 /**
  * Config.
  */
@@ -28,6 +26,8 @@ require('./server/lib/config')(app);
  */
 
 app.set('models', require('./server/models'));
+
+require('./server/lib/express')(app);
 
 /**
  * Controllers.

--- a/migrations/20160815115600-add-sessions-table.js
+++ b/migrations/20160815115600-add-sessions-table.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.createTable(
+      'Sessions', {
+        sid: {
+          type: Sequelize.STRING(32),
+          primaryKey: true
+        },
+
+        expires: {
+          type: Sequelize.DATE
+        },
+
+        data: {
+          type: Sequelize.TEXT
+        },
+
+        createdAt: {
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.NOW,
+          allowNull: false
+        },
+
+        updatedAt: {
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.NOW,
+          allowNull: false
+        }
+      }, {
+        paranoid: true
+      });
+  },
+
+  down: function (queryInterface) {
+    return queryInterface.dropTable('Sessions');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "child-process-promise": "1.1.0",
     "clearbit": "1.2.1",
     "config": "1.19.0",
+    "connect-session-sequelize": "3.1.0",
+    "cookie-parser": "1.4.3",
     "cors": "2.7.1",
     "express": "4.14.0",
     "express-server-status": "1.0.3",


### PR DESCRIPTION
Implemented this after more doc reading:
- https://github.com/passport/express-4.x-twitter-example/blob/master/server.js
- https://www.npmjs.com/package/express-session
- https://www.npmjs.com/package/connect-session-sequelize

As usual, works locally but need to test in staging.