### PR TITLE
improvements to scripts/db_copy_to_localhost.sh

### DIFF
--- a/scripts/db_copy_to_localhost.sh
+++ b/scripts/db_copy_to_localhost.sh
@@ -5,68 +5,79 @@
 # To run the API with the local version of the production database, run:
 # PG_DATABASE=opencollective_prod_snapshot npm start
 
-ENV=$1
+ENV="${1}"
+set -e
 
-if [ "$1" != "staging" ] && [ "$1" != "prod" ]; then
-  echo "you need to specify from which environment you want to pull the database (valid values: staging or prod)"
-  exit 0;
+if [[ ${ENV} != staging ]] && [[ ${ENV} != prod ]]; then
+  echo "You must specify from which environment you want to pull the database (valid values: 'staging' or 'prod')"
+  exit 1;
 fi
 
 LOCALDBUSER="opencollective"
 LOCALDBNAME="opencollective_${ENV}_snapshot"
-PG_URL=`heroku config:get PG_URL -a opencollective-${ENV}-api`
+PG_URL=`heroku config:get PG_URL -a "opencollective-${ENV}-api"`
 DBDUMPS_DIR="dbdumps/"
 
-FILENAME=`date +"%Y-%m-%d"`-prod.pgsql
+FILENAME="`date +"%Y-%m-%d"`-prod.pgsql"
 
-if [ ! -d $DBDUMPS_DIR ]; then
-  mkdir $DBDUMPS_DIR
+if [[ ! -d ${DBDUMPS_DIR} ]]; then
+  mkdir -p "${DBDUMPS_DIR}"
 fi
 
-if psql ${LOCALDBNAME} -c '\q' 2>/dev/null; then
-  echo "Dropping $LOCALDBNAME"
-  dropdb $LOCALDBNAME 
+if psql "${LOCALDBNAME}" -c '\q' 2>/dev/null; then
+  echo "Dropping ${LOCALDBNAME}"
+  dropdb "${LOCALDBNAME}"
 fi
 
-echo "Creating $LOCALDBNAME"
-psql -c "CREATE DATABASE $LOCALDBNAME" 
+echo "Creating ${LOCALDBNAME}"
+createdb "${LOCALDBNAME}"
 
-if [ ! -f "$DBDUMPS_DIR$FILENAME" ]; then
-  echo "Dumping $PG_URL"
-  pg_dump -O -F t $PG_URL > $DBDUMPS_DIR$FILENAME
+if [[ ! -s ${DBDUMPS_DIR}${FILENAME} ]]; then
+  echo "Dumping ${PG_URL}"
+  pg_dump -O -F t "${PG_URL}" > "${DBDUMPS_DIR}${FILENAME}"
 fi
 
-echo "DB dump saved in $DBDUMPS_DIR$FILENAME"
+echo "DB dump saved in ${DBDUMPS_DIR}${FILENAME}"
 
 # The first time we run it, we will trigger FK constraints errors
-pg_restore -n public -O -c -d $LOCALDBNAME $DBDUMPS_DIR$FILENAME 2>/dev/null
+set +e
+pg_restore -n public -O -c -d "${LOCALDBNAME}" "${DBDUMPS_DIR}${FILENAME}" 2>/dev/null
+set -e
 
 # So we run it twice :-)
-pg_restore -n public -O -c -d $LOCALDBNAME $DBDUMPS_DIR$FILENAME
+pg_restore -n public -O -c -d "${LOCALDBNAME}" "${DBDUMPS_DIR}${FILENAME}"
 
-echo "DB restored to postgres://localhost/$LOCALDBNAME"
+echo "DB restored to postgres://localhost/${LOCALDBNAME}"
 
-# We make sure the user $LOCALDBUSER has access
-psql $LOCALDBNAME -c "CREATE ROLE $LOCALDBUSER WITH login;"
+# cool trick: all stdout ignored in this block
+{
+  set +e
+  # We make sure the user $LOCALDBUSER has access; could fail
+  psql "${LOCALDBNAME}" -c "CREATE ROLE ${LOCALDBUSER} WITH login;" 2>/dev/null
+  set -e
 
-# Change ownership of all tables
-tables=`psql -qAt -c "select tablename from pg_tables where schemaname = 'public';" $LOCALDBNAME`
+  # Change ownership of all tables
+  tables=`psql -qAt -c "select tablename from pg_tables where schemaname = 'public';" "${LOCALDBNAME}"`
 
-for tbl in $tables ; do
-  psql $LOCALDBNAME -c "alter table \"$tbl\" owner to $LOCALDBUSER";
-done
+  for tbl in $tables ; do
+    psql "${LOCALDBNAME}" -c "alter table \"${tbl}\" owner to ${LOCALDBUSER};"
+  done
 
-# Change ownership of the database
-psql $LOCALDBNAME -c "alter database $LOCALDBNAME owner to $LOCALDBUSER;"
+  # Change ownership of the database
+  psql "${LOCALDBNAME}" -c "alter database ${LOCALDBNAME} owner to ${LOCALDBUSER};"
 
-psql $LOCALDBNAME -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $LOCALDBUSER;"
+  psql "${LOCALDBNAME}" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ${LOCALDBUSER};"
 
-# Insert the local development api_key
-psql $LOCALDBNAME -c "INSERT INTO \"Applications\" (api_key, name) VALUES ('0ac43519edcf4421d80342403fb5985d','opencollective-mobileapp-dev');"
+  # Insert the local development api_key
+  psql "${LOCALDBNAME}" -c "INSERT INTO \"Applications\" (api_key, name) VALUES ('0ac43519edcf4421d80342403fb5985d','opencollective-mobileapp-dev');"
+} | tee >/dev/null
 
-echo ""
+echo "
+---------
+All done!
+---------
 
-echo " All done"
-echo ""
-echo "To run the OpenCollective API with the local version of the production database, run: "
-echo "PG_DATABASE=$LOCALDBNAME npm start"
+To start the OpenCollective API with the local version of the production database, run:
+
+PG_DATABASE=\"${LOCALDBNAME}\" npm start
+"


### PR DESCRIPTION
- avoid potential string interpolation issues (e.g. spaces in pathnames)
- avoid potential parameter expansion issues (e.g. `"$FOOs"` vs `"${FOO}s"`)
- fail with nonzero code if no environment specified
- fail fast otherwise
- squelch useless output

* * *

Was having some problems with this script after not having used it for awhile, so here.  :smile: