### PR TITLE
Run esnext on lib directory

### DIFF
--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -1,29 +1,29 @@
-const activities = require('../constants/activities');
-const flatten = require('flat');
-const currencies = require('../constants/currencies');
+import activities from '../constants/activities';
+import flatten from 'flat';
+import currencies from '../constants/currencies';
 
-module.exports = {
+export default {
 
   /*
    * Formats an activity *FOR INTERNAL USE* based on its type
    */
   formatMessageForPrivateChannel: (activity, format) => {
 
-    var userString = '';
-    var userId;
-    var groupName = '';
-    var publicUrl = '';
-    var amount = null;
-    var interval = '';
-    var recurringAmount = null;
-    var currency = '';
-    var description = '';
-    var eventType = '';
-    var provider = '';
-    var connectedAccountUsername = '';
-    var title = '';
+    let userString = '';
+    let userId;
+    let groupName = '';
+    let publicUrl = '';
+    let amount = null;
+    let interval = '';
+    let recurringAmount = null;
+    let currency = '';
+    let description = '';
+    let eventType = '';
+    let provider = '';
+    let connectedAccountUsername = '';
+    let title = '';
     const connectedAccountLink = '';
-    var lastEditedById = 0;
+    let lastEditedById = 0;
 
 
     // get user data
@@ -35,41 +35,41 @@ module.exports = {
     // get group data
     if (activity.data.group) {
       groupName = activity.data.group.name;
-      publicUrl = activity.data.group.publicUrl;
+      ({ publicUrl } = activity.data.group);
     }
 
     // get donation data
     if (activity.data.donation) {
       amount = activity.data.donation.amount/100;
-      currency = activity.data.donation.currency;
+      ({ currency } = activity.data.donation);
     }
 
     // get subscription data
     if (activity.data.subscription) {
-      interval = activity.data.subscription.interval;
+      ({ interval } = activity.data.subscription);
       recurringAmount = amount + (interval ? `/${interval}` : '');
     }
 
     // get transaction data
     if (activity.data.transaction) {
-      amount = activity.data.transaction.amount;
-      interval = activity.data.transaction.interval;
+      ({ amount } = activity.data.transaction);
+      ({ interval } = activity.data.transaction);
       recurringAmount = amount + (interval ? `/${interval}` : '');
-      currency = activity.data.transaction.currency;
-      description = activity.data.transaction.description;
+      ({ currency } = activity.data.transaction);
+      ({ description } = activity.data.transaction);
     }
 
     // get expense data
     if (activity.data.expense) {
       amount = activity.data.expense.amount/100;
-      currency = activity.data.expense.currency;
-      title = activity.data.expense.title;
-      lastEditedById = activity.data.expense.lastEditedById;
+      ({ currency } = activity.data.expense);
+      ({ title } = activity.data.expense);
+      ({ lastEditedById } = activity.data.expense);
     }
 
     // get connected account data
     if (activity.data.connectedAccount) {
-      provider = activity.data.connectedAccount.provider;
+      ({ provider } = activity.data.connectedAccount);
       connectedAccountUsername = activity.data.connectedAccount.username;
       if (provider === 'github') {
         connectedAccountUsernameLink = linkify(format, `https://github.com/${connectedAccountUsername}`, null);
@@ -106,7 +106,7 @@ module.exports = {
 
       case activities.GROUP_TRANSACTION_PAID:
         const details = activity.data.preapprovalDetails;
-        var remainingClause = '';
+        let remainingClause = '';
         if (details && details.maxTotalAmountOfAllPayments && details.curPaymentsAmount) {
           const remaining = Number(details.maxTotalAmountOfAllPayments) - Number(details.curPaymentsAmount);
           remainingClause = `(${remaining} ${currency} remaining on preapproval key)`;
@@ -125,7 +125,7 @@ module.exports = {
         return `New subscription confirmed: ${currency} ${recurringAmount} from ${userString} to ${group}!`;
 
       case activities.SUBSCRIPTION_CANCELED:
-        const subscriptionId = activity.data.subscriptionId;
+        const { subscriptionId } = activity.data;
         return `Subscription ${subscriptionId} canceled`;
 
       case activities.GROUP_CREATED:
@@ -146,19 +146,19 @@ module.exports = {
    */
   formatMessageForPublicChannel: (activity, format) => {
 
-    var userString = '';
-    var groupName = '';
-    var publicUrl = '';
-    var amount = null;
-    var interval = '';
-    var recurringAmount = null;
-    var currency = '';
-    var tags = [];
-    var description = '';
-    var userTwitter = '';
-    var groupTwitter = '';
-    var tweet = '';
-    var title = '';
+    let userString = '';
+    let groupName = '';
+    let publicUrl = '';
+    let amount = null;
+    let interval = '';
+    let recurringAmount = null;
+    let currency = '';
+    let tags = [];
+    let description = '';
+    let userTwitter = '';
+    let groupTwitter = '';
+    let tweet = '';
+    let title = '';
 
     // get user data
     if (activity.data.user) {
@@ -169,42 +169,42 @@ module.exports = {
     // get group data
     if (activity.data.group) {
       groupName = activity.data.group.name;
-      publicUrl = activity.data.group.publicUrl;
+      ({ publicUrl } = activity.data.group);
       groupTwitter = activity.data.group.twitterHandle;
     }
 
     // get donation data
     if (activity.data.donation) {
       amount = activity.data.donation.amount/100;
-      currency = activity.data.donation.currency;
+      ({ currency } = activity.data.donation);
     }
 
     // get subscription data
     if (activity.data.subscription) {
-      interval = activity.data.subscription.interval;
+      ({ interval } = activity.data.subscription);
       recurringAmount = amount + (interval ? `/${interval}` : '');
     }
 
     // get transaction data
     if (activity.data.transaction) {
-      amount = activity.data.transaction.amount;
-      interval = activity.data.transaction.interval;
+      ({ amount } = activity.data.transaction);
+      ({ interval } = activity.data.transaction);
       recurringAmount = amount + (interval ? `/${interval}` : '');
-      currency = activity.data.transaction.currency;
+      ({ currency } = activity.data.transaction);
       tags = JSON.stringify(activity.data.transaction.tags);
-      description = activity.data.transaction.description;
+      ({ description } = activity.data.transaction);
     }
 
-    var tweetLink, tweetThis = '';
+    let tweetLink, tweetThis = '';
 
     // get expense data
     if (activity.data.expense) {
       amount = activity.data.expense.amount/100;
-      currency = activity.data.expense.currency;
-      title = activity.data.expense.title;
+      ({ currency } = activity.data.expense);
+      ({ title } = activity.data.expense);
     }
 
-    var group;
+    let group;
     if (linkify) {
       group = linkify(format, publicUrl, groupName);
     } else {
@@ -292,7 +292,7 @@ const getUserString = (format, user, includeEmail) => {
   const userString = user.name || user.twitterHandle || 'someone';
   const link = user.twitterHandle ? `https://twitter.com/${user.twitterHandle}` : user.website;
 
-  var returnVal;
+  let returnVal;
   if (link) {
     returnVal = linkify(format, link, userString);
   } else {

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -1,15 +1,15 @@
 /**
  * Dependencies.
  */
-const Paypal = require('paypal-adaptive');
-const knox = require('knox');
-const config = require('config');
+import Paypal from 'paypal-adaptive';
+import knox from 'knox';
+import config from 'config';
 
 /**
  * Module.
  */
-module.exports = function(app) {
-  const env = config.env;
+export default function(app) {
+  const { env } = config;
 
   // Stripe.
   app.stripe = require('stripe')(config.stripe.secret);

--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -1,14 +1,14 @@
-const config = require('config');
-const _ = require('lodash');
-const Promise = require('bluebird');
-const juice = require('juice');
-const nodemailer = require('nodemailer');
+import config from 'config';
+import _ from 'lodash';
+import Promise from 'bluebird';
+import juice from 'juice';
+import nodemailer from 'nodemailer';
 
 const debug = require('debug')('email');
 const templates = require('./loadEmailTemplates')();
-const activities = require('../constants/activities');
-const utils = require('./utils');
-const crypto = require('crypto');
+import activities from '../constants/activities';
+import utils from './utils';
+import crypto from 'crypto';
 
 const render = (name, data, config) => {
     data.config = config;
@@ -30,7 +30,7 @@ const getBody = str => str.split('\n').slice(2).join('\n');
  * Appends appropriate prefix and cleans up subject
  */
 const getSubject = str => {
-    var subj = '';
+    let subj = '';
     if (process.env.NODE_ENV === 'staging') {
       subj += '[STAGING] ';
     } else if (process.env.NODE_ENV !== 'production'){
@@ -163,4 +163,4 @@ const emailLib = {
   sendMessageFromActivity
 };
 
-module.exports = emailLib;
+export default emailLib;

--- a/server/lib/errors.js
+++ b/server/lib/errors.js
@@ -1,55 +1,55 @@
-module.exports = {
+const errors = {
 
-  BadRequest: function(msg) {
+  BadRequest(msg) {
     this.code = 400;
     this.type = 'bad_request';
     this.message = msg;
     Error.call(this, msg);
   },
 
-  ValidationFailed: function(type, fields, msg) {
+  ValidationFailed(type, fields, msg) {
     this.code = 400;
     this.type = type || 'validation_failed';
     this.message = msg || 'Missing required fields';
     this.fields = fields;
   },
 
-  Unauthorized: function(msg) {
+  Unauthorized(msg) {
     this.code = 401;
     this.type = 'unauthorized';
     this.message = msg;
     Error.call(this, msg);
   },
 
-  Forbidden: function(msg) {
+  Forbidden(msg) {
     this.code = 403;
     this.type = 'forbidden';
     this.message = msg;
     Error.call(this, msg);
   },
 
-  SpamDetected: function(msg) {
+  SpamDetected(msg) {
     this.code = 403;
     this.type = 'spam_detected';
     this.message = msg;
     Error.call(this, msg);
   },
 
-  NotFound: function(msg) {
+  NotFound(msg) {
     this.code = 404;
     this.type = 'not_found';
     this.message = msg;
     Error.call(this, msg);
   },
 
-  ServerError: function(msg) {
+  ServerError(msg) {
     this.code = 500;
     this.type = 'server_error';
     this.message = msg;
     Error.call(this, msg);
   },
 
-  Timeout: function(url, ms) {
+  Timeout(url, ms) {
     this.code = 408;
     this.timeout = ms;
     this.type = 'timeout';
@@ -57,7 +57,7 @@ module.exports = {
     Error.call(this, this.message);
   },
 
-  ConflictError: function(msg, data) {
+  ConflictError(msg, data) {
     this.code    = 409;
     this.type    = 'conflict';
     this.message = msg;
@@ -65,14 +65,14 @@ module.exports = {
     Error.call(this, msg);
   },
 
-  NotImplemented: function(msg) {
+  NotImplemented(msg) {
     this.code    = 501;
     this.type    = 'not_implemented';
     this.message = msg || 'This is not implemented.';
     Error.call(this, msg);
   },
 
-  CustomError: function(code, type, msg) {
+  CustomError(code, type, msg) {
     this.code = code;
     this.type = type;
     this.message = msg;
@@ -81,8 +81,8 @@ module.exports = {
 
 };
 
-Object.keys(module.exports).forEach((error) => {
-  module.exports[error].prototype.__proto__ = Error.prototype;
+Object.keys(errors).forEach(error => {
+  errors[error].prototype.__proto__ = Error.prototype;
 });
 
 Error.prototype.info = function() {
@@ -100,3 +100,5 @@ Error.prototype.info = function() {
 
   return result;
 };
+
+export default errors;

--- a/server/lib/express.js
+++ b/server/lib/express.js
@@ -1,18 +1,18 @@
-const bodyParser = require('body-parser');
-const config = require('config');
-const cookieParser = require('cookie-parser');
-const cors = require('cors');
-const morgan = require('morgan');
-const multer = require('multer');
-const passport = require('passport');
-const session = require('express-session');
-const GitHubStrategy = require('passport-github').Strategy;
-const TwitterStrategy = require('passport-twitter').Strategy;
-const MeetupStrategy = require('passport-meetup-oauth2').Strategy;
+import bodyParser from 'body-parser';
+import config from 'config';
+import cookieParser from 'cookie-parser';
+import cors from 'cors';
+import morgan from 'morgan';
+import multer from 'multer';
+import passport from 'passport';
+import session from 'express-session';
+import { Strategy as GitHubStrategy } from 'passport-github';
+import { Strategy as TwitterStrategy } from 'passport-twitter';
+import { Strategy as MeetupStrategy } from 'passport-meetup-oauth2';
 
 const SequelizeStore = require('connect-session-sequelize')(session.Store);
 
-module.exports = function(app) {
+export default function(app) {
 
   const Sequelize = app.get('models').sequelize;
 

--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -1,8 +1,8 @@
-const config = require('config');
-const request = require('request');
-const Promise = require('bluebird');
+import config from 'config';
+import request from 'request';
+import Promise from 'bluebird';
 
-module.exports = {
+export default {
 
   fetchUser(username) {
     const options = {

--- a/server/lib/imageUrlToAmazonUrl.js
+++ b/server/lib/imageUrlToAmazonUrl.js
@@ -1,8 +1,8 @@
-module.exports = imageUrlToAmazonUrl;
-const path = require('path');
-const uuid = require('node-uuid');
-const mime = require('mime');
-const request = require('request');
+export default imageUrlToAmazonUrl;
+import path from 'path';
+import uuid from 'node-uuid';
+import mime from 'mime';
+import request from 'request';
 
 /**
 * Takes an external image URL and returns a Amazon S3 URL with the

--- a/server/lib/loadEmailTemplates.js
+++ b/server/lib/loadEmailTemplates.js
@@ -1,13 +1,13 @@
-const fs = require('fs');
-const moment = require('moment');
-const handlebars = require('handlebars');
+import fs from 'fs';
+import moment from 'moment';
+import handlebars from 'handlebars';
 
 /*
 * Loads all the email templates
 */
-module.exports = () => {
+export default () => {
 
-  var templates = {};
+  const templates = {};
 
   const templateNames = [
     'email.approve',
@@ -53,12 +53,12 @@ module.exports = () => {
   });
 
   handlebars.registerHelper('currency', (value, props) => {
-    const currency = props.hash.currency;
+    const { currency } = props.hash;
     value = value/100; // converting cents
 
 	  return value.toLocaleString(currency, {
       style: 'currency',
-      currency: currency,
+      currency,
       minimumFractionDigits : 2,
       maximumFractionDigits : 2
     });

--- a/server/lib/meetup.js
+++ b/server/lib/meetup.js
@@ -1,7 +1,7 @@
-const filter = require('lodash/collection/filter');
-const values = require('lodash/object/values');
-const errors = require('../lib/errors');
-const requestPromise = require('request-promise');
+import filter from 'lodash/collection/filter';
+import values from 'lodash/object/values';
+import errors from '../lib/errors';
+import requestPromise from 'request-promise';
 
 class Meetup {
 
@@ -50,8 +50,8 @@ class Meetup {
     const promises = [];
     return requestPromise(reqopt)
       .then(meetups => {
-        for (var i=0;i<meetups.length;i++) {
-          var meetup = meetups[i];
+        for (let i=0;i<meetups.length;i++) {
+          const meetup = meetups[i];
           if (!meetup.description.match(new RegExp(`^${descriptionHeader.substr(0, 50)}`))) {
             promises.push(this.updateMeetupDescription(meetup.id, `${descriptionHeader}\n ${meetup.description}`));
           }
@@ -67,4 +67,4 @@ class Meetup {
 
 };
 
-module.exports = Meetup;
+export default Meetup;

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -1,14 +1,14 @@
-const axios = require('axios');
-const config = require('config');
-const Promise = require('bluebird');
+import axios from 'axios';
+import config from 'config';
+import Promise from 'bluebird';
 
-const activitiesLib = require('../lib/activities');
-const slackLib = require('./slack');
-const twitter = require('./twitter');
-const emailLib = require('../lib/email');
-const activityType = require('../constants/activities');
+import activitiesLib from '../lib/activities';
+import slackLib from './slack';
+import twitter from './twitter';
+import emailLib from '../lib/email';
+import activityType from '../constants/activities';
 
-module.exports = (Sequelize, activity) => {
+export default (Sequelize, activity) => {
   // publish everything to our private channel
   return publishToSlackPrivateChannel(activity)
     // publish a filtered version to our public channel

--- a/server/lib/payExpense.js
+++ b/server/lib/payExpense.js
@@ -1,8 +1,8 @@
-const config = require('config');
-const Promise = require('bluebird');
-const uuid = require('node-uuid');
+import config from 'config';
+import Promise from 'bluebird';
+import uuid from 'node-uuid';
 
-module.exports = app => {
+export default app => {
   const services = {
     paypal: (group, expense, email, preapprovalKey) => {
       const uri = `/groups/${group.id}/expenses/${expense.id}/paykey/`;

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1,13 +1,13 @@
-module.exports = function(sequelize) {
+export default function(sequelize) {
 
-  const models = sequelize.models;
+  const { models } = sequelize;
 
   /*
   * Hacky way to do currency conversion on Leaderboard
   */
   const generateFXConversionSQL = (aggregate) => {
-    var currencyColumn = "currency";
-    var amountColumn = "amount";
+    let currencyColumn = "currency";
+    let amountColumn = "amount";
 
     if (aggregate) {
       currencyColumn = 'MAX(g.currency)';
@@ -26,7 +26,7 @@ module.exports = function(sequelize) {
       ['CAD', 1.3]
     ];
 
-    var sql = 'CASE ';
+    let sql = 'CASE ';
     sql += fxConversion.map(currency => `WHEN ${currencyColumn} = '${currency[0]}' THEN ${amountColumn} / ${currency[1]}`).join('\n');
     sql += 'ELSE 0 END';
 
@@ -49,11 +49,11 @@ module.exports = function(sequelize) {
    * Get top collectives based on total donations
    */
   const getGroupsByTag = (tag, limit, excludeList, minTotalDonation, randomOrder, orderBy, orderDir, offset) => {
-    var tagClause = '';
-    var excludeClause = '';
-    var minTotalDonationClause = '';
-    var orderClause = 'BY t."totalDonations"';
-    var orderDirection = (orderDir === 'asc') ? 'ASC' : 'DESC';
+    let tagClause = '';
+    let excludeClause = '';
+    let minTotalDonationClause = '';
+    let orderClause = 'BY t."totalDonations"';
+    const orderDirection = (orderDir === 'asc') ? 'ASC' : 'DESC';
     if (orderBy) {
       orderClause = `BY ${ orderBy }`;
     } else if (randomOrder) {

--- a/server/lib/slack.js
+++ b/server/lib/slack.js
@@ -2,18 +2,18 @@
  * Slack message sending logic
  */
 
-const Slack = require('node-slack');
-const config = require('config');
-const activitiesLib = require('../lib/activities');
-const constants = require('../constants/activities');
+import Slack from 'node-slack';
+import config from 'config';
+import activitiesLib from '../lib/activities';
+import constants from '../constants/activities';
 
-module.exports = {
+export default {
 
   /*
    * Post a given activity to OpenCollective private channel
    * This method can only publish to our webhookUrl and our private channel, so we don't leak info by mistake
    */
-  postActivityOnPrivateChannel: function(activity) {
+  postActivityOnPrivateChannel(activity) {
     const message = activitiesLib.formatMessageForPrivateChannel(activity, 'slack');
     const options = {
       attachments: formatAttachment(activity),
@@ -25,7 +25,7 @@ module.exports = {
   /*
    * Post a given activity to a public channel (meaning scrubbed info only)
    */
-  postActivityOnPublicChannel: function(activity, webhookUrl, options) {
+  postActivityOnPublicChannel(activity, webhookUrl, options) {
     if (!options) {
       options = {};
     }
@@ -36,7 +36,7 @@ module.exports = {
   /*
    * Posts a message to a slack webhook
    */
-  postMessage: function(msg, webhookUrl, options) {
+  postMessage(msg, webhookUrl, options) {
     if (!options) {
       options = {};
     }

--- a/server/lib/slug.js
+++ b/server/lib/slug.js
@@ -1,8 +1,8 @@
-const Promise = require('bluebird');
-const roles = require('../constants/roles');
+import Promise from 'bluebird';
+import roles from '../constants/roles';
 
-module.exports = app => {
-  const errors = app.errors;
+export default app => {
+  const { errors } = app;
   const models = app.get('models');
 
   return {

--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -1,10 +1,10 @@
-const constants = require('../constants');
+import constants from '../constants';
 
 const expenseType = require('../constants/transactions').type.EXPENSE;
 
-module.exports = app => {
+export default app => {
 
-  const errors = app.errors;
+  const { errors } = app;
   const models = app.set('models');
 
   function createFromPaidExpense(payoutMethod, paymentMethod, expense, paymentResponse, preapprovalDetails, UserId) {

--- a/server/lib/twitter.js
+++ b/server/lib/twitter.js
@@ -1,7 +1,7 @@
-const config = require('config');
-const Promise = require('bluebird');
-const Twitter = require('twitter');
-const activityType = require('../constants/activities');
+import config from 'config';
+import Promise from 'bluebird';
+import Twitter from 'twitter';
+import activityType from '../constants/activities';
 
 function tweetActivity(Sequelize, activity) {
   if (activity.type === activityType.GROUP_TRANSACTION_CREATED
@@ -41,7 +41,4 @@ function tweetStatus(Sequelize, GroupId, status) {
   });
 }
 
-module.exports = {
-  tweetActivity,
-  tweetStatus
-};
+export { tweetActivity, tweetStatus };

--- a/server/lib/userlib.js
+++ b/server/lib/userlib.js
@@ -1,9 +1,9 @@
-const config = require('config');
+import config from 'config';
 const clearbit = require('clearbit')(config.clearbit);
-const url = require('url');
-const Promise = require('bluebird');
+import url from 'url';
+import Promise from 'bluebird';
 
-module.exports = {
+export default {
 
   memory: {},
 
@@ -40,7 +40,7 @@ module.exports = {
       return Promise.resolve(this.memory[email]);
     }
 
-    return this.clearbit.Enrichment.find({email: email, stream: true})
+    return this.clearbit.Enrichment.find({email, stream: true})
       .tap(res => this.memory[email] = res.person)
       .then(res => res.person)
       .catch(clearbit.Enrichment.NotFoundError, () => this.memory[email] = null)
@@ -48,13 +48,13 @@ module.exports = {
   },
 
   resolveUserAvatars(userData, cb) {
-    const name = userData.name;
-    const email = userData.email;
-    const website = userData.website;
-    const twitterHandle = userData.twitterHandle;
-    var linkedinUrl = userData.linkedinUrl;
-    var facebookUrl = userData.facebookUrl;
-    const ip = userData.ip;
+    const { name } = userData;
+    const { email } = userData;
+    const { website } = userData;
+    const { twitterHandle } = userData;
+    let { linkedinUrl } = userData;
+    let { facebookUrl } = userData;
+    const { ip } = userData;
 
     if (!email || !email.match(/.+@.+\..+/)) {
       return cb(new Error("Invalid email"));
@@ -62,7 +62,7 @@ module.exports = {
 
     if (website) {
       const parsedWebsiteUrl = url.parse(website);
-      const hostname = parsedWebsiteUrl.hostname;
+      const { hostname } = parsedWebsiteUrl;
       if (/facebook.com$/.test(hostname)) {
         facebookUrl = website;
       } else if (/linkedin.com\/pub|in|profile/.test(hostname)) {
@@ -80,15 +80,15 @@ module.exports = {
       stream: true
     })
     .then((res) => {
-      const person = res.person;
-      const company = res.company;
+      const { person } = res;
+      const { company } = res;
       const sources = [];
 
       if (person) {
         const personAvatarSources = ['twitter', 'aboutme', 'gravatar', 'github'];
         personAvatarSources.forEach((source) => {
           if (person[source] && person[source].avatar) {
-            sources.push({src: person[source].avatar, source: source});
+            sources.push({src: person[source].avatar, source});
           }
         });
         if (person.avatar) {
@@ -100,7 +100,7 @@ module.exports = {
         const companyAvatarSources = ['twitter', 'angellist'];
         companyAvatarSources.forEach((source) => {
           if (company[source] && company[source].avatar) {
-            sources.push({src: company[source].avatar, source: source});
+            sources.push({src: company[source].avatar, source});
           }
         });
         if (company.logo) {

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -1,10 +1,10 @@
 /**
  * Dependencies
  */
-const Url = require('url');
-const config = require('config');
-const crypto = require('crypto');
-const base64url = require('base64url');
+import Url from 'url';
+import config from 'config';
+import crypto from 'crypto';
+import base64url from 'base64url';
 
 /**
  * Private methods.
@@ -15,7 +15,7 @@ const base64url = require('base64url');
  */
 const encrypt = (text) => {
   const cipher = crypto.createCipher('aes-256-cbc', config.keys.opencollective.resetPasswordSecret)
-  var crypted = cipher.update(text, 'utf8', 'hex')
+  let crypted = cipher.update(text, 'utf8', 'hex')
   crypted += cipher.final('hex');
   return crypted;
 }
@@ -25,7 +25,7 @@ const encrypt = (text) => {
  */
 const decrypt = (text) => {
   const decipher = crypto.createDecipher('aes-256-cbc', config.keys.opencollective.resetPasswordSecret)
-  var dec = decipher.update(text,'hex','utf8')
+  let dec = decipher.update(text,'hex','utf8')
   dec += decipher.final('utf8');
   return dec;
 }
@@ -59,9 +59,9 @@ const addParameterUrl = (url, parameters) => {
 
   parsedUrl.pathname = removeTrailingChar(parsedUrl.pathname, '/');
 
-  delete parsedUrl.search; // Otherwise .search in used in place of .query
-  for (var p in parameters) {
-    var param = parameters[p];
+  delete parsedUrl.search; // Otherwise .search is used in place of .query
+  for (const p in parameters) {
+    const param = parameters[p];
     parsedUrl.query[p] = param;
   }
 
@@ -90,7 +90,7 @@ const getLinks = (url, options) => {
 
   const links = {
     next: addParameterUrl(url, {page: page + 1, per_page: perPage}),
-    current: addParameterUrl(url, {page: page, per_page: perPage})
+    current: addParameterUrl(url, {page, per_page: perPage})
   };
   if (page > 1) {
     links.prev = addParameterUrl(url, {page: page - 1, per_page: perPage});
@@ -112,9 +112,9 @@ const getLinks = (url, options) => {
  */
 const getLinkHeader = (url, options) => {
   const links = getLinks(url, options);
-  var header = '';
-  var k = 0;
-  for (var i in links) {
+  let header = '';
+  let k = 0;
+  for (const i in links) {
     header += ((k !== 0) ? ', ' : '') + '<' + links[i] + '>; rel="' + i + '"'; // eslint-disable-line
     k += 1;
   }
@@ -148,7 +148,7 @@ const paginateOffset = (page, perPage) => {
  */
 const getTier = (user, tiers) => {
 
-  var defaultTier;
+  let defaultTier;
   switch (user.role) {
     case 'MEMBER':
       return 'contributor';
@@ -211,18 +211,4 @@ const isEmailInternal = (email) => {
 /**
  * Export public methods.
  */
-module.exports = {
-  paginateOffset,
-  getRequestedUrl,
-  addParameterUrl,
-  getLinks,
-  generateURLSafeToken,
-  getLinkHeader,
-  planId,
-  encrypt,
-  getTier,
-  appendTier,
-  decrypt,
-  defaultHostId,
-  isEmailInternal
-}
+export default { paginateOffset, getRequestedUrl, addParameterUrl, getLinks, generateURLSafeToken, getLinkHeader, planId, encrypt, getTier, appendTier, decrypt, defaultHostId, isEmailInternal };


### PR DESCRIPTION
Auto upgrading to latest ES syntax using esnext. Experimented with server/libs (some extra fixes were necessary in non standard code):
`find server/lib/*.js -exec esnext -I {} \;`

Can run on other places if you like the principle:
`find . -name "*.js" -not -path "./node_modules/*" -exec esnext -I {} \;`

BTW wonder why eslint still allowed various `var` to be in the code

@asood123 @xdamman 