### PR TITLE
Fix env loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 /**
  * Dependencies.
  */
-import './server/env'
-
+import './server/env' // important to load first for environment config
 import express from 'express';
 import models from './server/models';
 import controllers from './server/controllers';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /**
  * Dependencies.
  */
+import './server/env'
+
 import express from 'express';
 import models from './server/models';
 import controllers from './server/controllers';
@@ -9,14 +11,7 @@ import config from './server/lib/config';
 import errors from './server/lib/errors';
 import os from 'os';
 
-var NODE_ENV = process.env.NODE_ENV;
 const app = express();
-
-if (!NODE_ENV) {
-  NODE_ENV = process.env.NODE_ENV = 'development';
-}
-
-require('./server/lib/load-dot-env');
 
 app.errors = errors;
 

--- a/server/env.js
+++ b/server/env.js
@@ -1,0 +1,7 @@
+var NODE_ENV = process.env.NODE_ENV;
+
+if (!NODE_ENV) {
+  NODE_ENV = process.env.NODE_ENV = 'development';
+}
+
+require('./lib/load-dot-env');


### PR DESCRIPTION
Changes were made recently to take advantage of new syntax features in
ES6.  Since ES6 module imports are hoisted, they are run before any
code. This causes conflicts with the load order of our dotenv system,
which made it so the `config/custom-environment-variables.json` did not
get loaded in time.