### PR TITLE
Remove "+" sign from generated username.

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -340,7 +340,11 @@ export default (Sequelize, DataTypes) => {
         let username = user.username || user.twitterHandle || user.name.replace(/ /g,'').toLowerCase();
         if (!username && user.email) {
           username = user.email.substr(0,user.email.indexOf('@'));
-          username = username.substr(0,username.indexOf('+'));
+        }
+        
+        const plusIndex = username.indexOf('+');
+        if (plusIndex !== -1) {
+          username = username.substr(0,plusIndex);
         }
 
         if (!username) return Promise.resolve();

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -338,8 +338,10 @@ export default (Sequelize, DataTypes) => {
 
       suggestUsername: (user) => {
         let username = user.username || user.twitterHandle || user.name.replace(/ /g,'').toLowerCase();
-        if (!username && user.email)
+        if (!username && user.email) {
           username = user.email.substr(0,user.email.indexOf('@'));
+          username = username.substr(0,username.indexOf('+'));
+        }
 
         if (!username) return Promise.resolve();
 

--- a/test/user.model.test.js
+++ b/test/user.model.test.js
@@ -88,6 +88,14 @@ describe('user.models.test.js', () => {
         })
     })
 
+    it('creates a valid username from an email', () => {
+      return User
+        .create({email: 'xdamman+opencollective@gmail.com'})
+        .tap(user => {
+          expect(user.username).to.equal('xdamman')
+        })
+    })
+    
   });
 
   /**


### PR DESCRIPTION
 Fix [OpenCollective/OpenCollective#252](https://github.com/OpenCollective/OpenCollective/issues/252).
A username cannot contains a `+` sign but email address can.
Given the usage of the + sign in an email address, the generated username should only be the part before the + sign.