### PR TITLE
remove backerscount from contributorscount

### DIFF
--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -596,7 +596,6 @@ export const getOne = (req, res, next) => {
     group.donationTotal = values[4];
     group.backersCount = values[5];
     group.contributorsCount = (group.data && group.data.githubContributors) ? Object.keys(group.data.githubContributors).length : 0;
-    group.contributorsCount += group.backersCount;
     group.settings = group.settings || {};
     group.settings.twitter = values[6];
     group.related = values[7];


### PR DESCRIPTION
It was being added twice: backend and frontend adding it up. Better to send it separately, so frontend can do whatever it wants.