### PR TITLE
specify currency to be group currency by default in a transaction

### DIFF
--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -156,6 +156,8 @@ export default (Sequelize, DataTypes) => {
         } else {
           // populate netAmountInGroupCurrency for "Add Funds" and Expenses
           transaction.netAmountInGroupCurrency = transaction.amount*100;
+          // set the currency to be group's currency, if not specified
+          transaction.currency = transaction.currency || group.currency;
         }
         return Transaction.create(transaction);
       },


### PR DESCRIPTION
When WWCode adds funds currently, we always add them in dollars. Instead, we should do group's default currency.