### PR TITLE
remove checkifenoughfunds for approves

### DIFF
--- a/server/controllers/expenses.js
+++ b/server/controllers/expenses.js
@@ -141,7 +141,6 @@ export const update = (req, res, next) => {
 export const setApprovalStatus = (req, res, next) => {
   const user = req.remoteUser || req.user;
   const { expense } = req;
-  let preapprovalDetails;
 
   assertExpenseStatus(expense, status.PENDING)
     .then(() => {
@@ -154,7 +153,7 @@ export const setApprovalStatus = (req, res, next) => {
       }
     })
     .then(() => res.send({success: true}))
-    .catch(next());
+    .catch(next);
 };
 
 /**
@@ -172,7 +171,6 @@ export const pay = (req, res, next) => {
     .then(() => models.Group.findById(expense.GroupId))
     .then(group => group.getBalance())
     .then(balance => checkIfEnoughFundsInGroup(expense, balance))
-    // get payment method of group's host and make sure the logged in user is the host
     .then(() => isManual ? null : getPaymentMethod())
     .tap(m => paymentMethod = m)
     .then(getBeneficiaryEmail)


### PR DESCRIPTION
**Previously:**
- When approving an expense,
   - if it's manual, we'd check that there were enough funds in the group
   - if it's paypal, we'd ping paypal to make sure the host has enough preapproved funds (we never checked collective for enough funds)
- When paying an expense,
   - if it's manual, we'd pay it right away
   - if it's paypal, we'd try to pay via paypal and pass error back.

**Now:**
- When approving an expense,
   - we just approve (manual or non-manual)
- When paying an expense,
   - we check enough funds in the group
      - if it's manual, then pay (meaning create a txn)
      - if it's paypal, try to pay through paypal and pass error back