### PR TITLE
fix beforeCreate hook on User model to always add a username

### DIFF
--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -42,7 +42,8 @@ export const createOrUpdate = (req, res, next, accessToken, data, emails) => {
         .then(u => u || User.create({
           name: data.profile.displayName,
           avatar,
-          email: emails[0]
+          email: emails[0],
+          username: data.profile.username
         }))
         .tap(u => user = u)
         .tap(user => attrs.UserId = user.id)

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -414,7 +414,7 @@ export const createFromGithub = (req, res, next) => {
                 return ca.getUser();
               }
             })
-            .then(user => user || User.create(userAttr))
+            .then(user => user || User.create(Object.assign(userAttr, {username: contributor})))
             .then(user => contributorUser = user)
             .then(() => fetchGithubUser(contributor))
             .tap(json => {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -454,10 +454,14 @@ export default (Sequelize, DataTypes) => {
       beforeCreate: (instance) => {
         // If we explicitly specify a username before creating a user,
         // we should rather return an error if it's not available
-        if (instance.getDataValue('username')) return;
-        return User.suggestUsername(instance).then(username => {
-          return instance.setDataValue('username', username);
-        });
+        if (!instance.username) {
+          return User.suggestUsername(instance)
+            .then(username => {
+              instance.username = username;
+              return Promise.resolve();
+            })
+        }
+        return Promise.resolve();
       },
       afterCreate: (instance) => {
         return Sequelize.models.Notification.create({ channel: 'email', type: 'user.yearlyreport', UserId: instance.id });


### PR DESCRIPTION
BeforeCreate hook wasn't working before. It should now populate a username every time. Separately, there are other bugs in suggestUsername (like it doesn't check Group.slug column for duplicates) that we'll fix later.