### PR TITLE
fix github username again

### DIFF
--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -43,7 +43,6 @@ export const createOrUpdate = (req, res, next, accessToken, data, emails) => {
           name: data.profile.displayName,
           avatar,
           email: emails[0],
-          suggestedUsername: data.profile.username
         }))
         .tap(u => user = u)
         .tap(user => attrs.UserId = user.id)

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -424,7 +424,7 @@ export const createFromGithub = (req, res, next) => {
                 return ca.getUser();
               }
             })
-            .then(user => user || User.create(Object.assign(userAttr, {suggestedUsername: contributor})))
+            .then(user => user || User.create(Object.assign(userAttr)))
             .then(user => contributorUser = user)
             .then(() => fetchGithubUser(contributor))
             .tap(json => {

--- a/server/lib/userlib.js
+++ b/server/lib/userlib.js
@@ -126,6 +126,7 @@ export default {
     const potentialUserNames = [
       user.username,
       user.suggestedUsername,
+      user.avatar ? this.getUsernameFromGithubURL(user.avatar) : null,
       user.twitterHandle ? user.twitterHandle.replace(/@/g, '') : null,
       user.name ? user.name.replace(/ /g, '') : null,
       user.email ? user.email.split(/@|\+/)[0] : null]
@@ -164,5 +165,20 @@ export default {
       return this.usernameSuggestionHelper(`${usernameToCheck}`, usernameList, count+1);
     }
   },
+
+  /*
+   * Extract username from github avatar url
+   * Needed to get usernames for github signups
+   */ 
+  getUsernameFromGithubURL(url) {
+    const githubUrl = 'avatars.githubusercontent.com/';
+    if (url && url.indexOf(githubUrl) !== -1) {
+      const tokens = url.split(githubUrl);
+      if (tokens.length === 2 && tokens[1] !== '') {
+        return tokens[1];
+      }
+    }
+    return null;
+  }
     
 };


### PR DESCRIPTION
Turns out `beforeCreate` hooks wipe all non-object fields, so my (clever) solution of appending a `suggestedUsername` to a `User` object didn't work. This should undo last fix and use avatar info in username suggestor. 