### PR TITLE
fix for approve/reject expense email

### DIFF
--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -243,6 +243,7 @@ export default function(Sequelize, DataTypes) {
           id: this.id,
           name: this.name,
           logo: this.logo,
+          slug: this.slug,
           publicUrl: this.publicUrl,
           mission: this.mission,
           isSupercollective: this.isSupercollective

--- a/templates/emails/group.expense.created.hbs
+++ b/templates/emails/group.expense.created.hbs
@@ -30,7 +30,7 @@ Subject: New expense on {{group.name}}: {{{currency expense.amount currency=expe
   <div>Paypal Email: {{user.paypalEmail}}</div>
   <p><font color="#999">{{expense.notes}}</font></p>
 
-  <a href="{{config.host.website}}/{group.slug}/expenses#exp{{expense.id}}" style="color:#7fadf2">
+  <a href="{{config.host.website}}/{{group.slug}}/expenses#exp{{expense.id}}" style="color:#7fadf2">
     <img src="https://res.cloudinary.com/opencollective/image/fetch/w_640,f_jpg/{{expense.attachment}}" width="100%" />
   </a>
 
@@ -39,7 +39,7 @@ Subject: New expense on {{group.name}}: {{{currency expense.amount currency=expe
   <a href="{{actions.reject}}"><div class="btn red">REJECT</div></a>
 
   <br /><br />
-  <a href="{{config.host.website}}/{group.slug}/expenses#exp{{expense.id}}" style="color:#7fadf2;text-decoration:none;">View this expense on the Open Collective website</a>
+  <a href="{{config.host.website}}/{{group.slug}}/expenses#exp{{expense.id}}" style="color:#7fadf2;text-decoration:none;">View this expense on the Open Collective website</a>
 
 </center>
 


### PR DESCRIPTION
@asood123 looks like you broke this with your clean up of activities.
We need `group.slug` for generating the approve/reject action urls: https://github.com/OpenCollective/opencollective-api/blob/master/server/lib/email.js#L246-L247