### PR TITLE
improve paypal errors on website

### DIFF
--- a/server/controllers/expenses.js
+++ b/server/controllers/expenses.js
@@ -257,6 +257,12 @@ function formatError(err, paypalResponse) {
     if (paypalResponse.error instanceof Array) {
       const { message } = paypalResponse.error[0];
       return new errors.BadRequest(message);
+    } else if (paypalResponse instanceof String) {
+      if (paypalResponse.indexOf('The total amount of all payments exceeds the maximum total amount for all payments') !== -1) {
+        return new errors.BadRequest('Not enough funds in your existing Paypal preapproval. Please reapprove through https://app.opencollective.com.');
+      } else {
+        return new errors.BadRequest(paypalResponse)
+      }
     }
   }
   return err;


### PR DESCRIPTION
Right now, when there aren't enough funds, we only show a 500 and user gets no input. 

This is a temporary change to show a better error message and primary useful for WWCode.