### PR TITLE
disable clearbit

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -118,8 +118,9 @@ export const getSocialMediaAvatars = (req, res) => {
   });
 };
 
-export const _create = user => userLib.fetchInfo(user)
-  .then(user => User.create(user))
+  // TODO: reenable asynchronously
+  // userLib.fetchInfo(user)
+export const _create = (user) => User.create(user)
   .tap(dbUser => Activity.create({
     type: constants.USER_CREATED,
     UserId: dbUser.id,

--- a/test/users.routes.test.js
+++ b/test/users.routes.test.js
@@ -171,6 +171,8 @@ describe('users.routes.test.js', () => {
         });
     });
 
+    /*
+    TODO: bring back when we reenable clearbit for new account creation
     it('successfully create a user with just an email and auto prefills firstName, lastName, twitter, avatar', (done) => {
       request(app)
         .post('/users')
@@ -191,6 +193,7 @@ describe('users.routes.test.js', () => {
             .catch(done);
         });
     });
+    */
 
     it('successfully creates a user with a referrer', (done) => {
       models.User.create(utils.data('user2'))


### PR DESCRIPTION
Clearbit is the reason for all of our timeouts. We are using their streaming api which only guarantees that it'll return within 1 minute (and they only recommend using it in a queuing system).

We need to move clearbit to run separately like processDonations does right now. It's more work but in the meantime, this should remove timeouts from payments and new_login_token calls.