### PR TITLE
Disable clearbit again

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -438,8 +438,9 @@ export default (Sequelize, DataTypes) => {
 
       },
       afterCreate: (instance) => {
-        return Sequelize.models.Notification.create({ channel: 'email', type: 'user.yearlyreport', UserId: instance.id })
-          .then(() => userLib.updateUserInfoFromClearbit(instance));
+        return Sequelize.models.Notification.create({ channel: 'email', type: 'user.yearlyreport', UserId: instance.id });
+          // TODO: reenable after investigating why clearbit is still blocking
+          //.then(() => userLib.updateUserInfoFromClearbit(instance));
       }
     }
   });

--- a/test/users.routes.test.js
+++ b/test/users.routes.test.js
@@ -170,7 +170,7 @@ describe('users.routes.test.js', () => {
           done();
         });
     });
-
+    /* Bring back when reenable clearbit
     it('successfully create a user with just an email and auto prefills firstName, lastName, twitter, avatar', (done) => {
       request(app)
         .post('/users')
@@ -191,6 +191,7 @@ describe('users.routes.test.js', () => {
             .catch(done);
         });
     });
+    */
 
     it('successfully creates a user with a referrer', (done) => {
       models.User.create(utils.data('user2'))


### PR DESCRIPTION
Clearbit is still somehow blocking us... Maybe this is because node is a single process?

See for example the 9 seconds we didn't process anything:

```
Feb 07 20:05:06 opencollective-prod-api app/web.1:  Executed (default): INSERT INTO "Users" ("id","_access","username","email","_salt","refresh_token"," | 5 ms 
Feb 07 20:05:06 opencollective-prod-api app/web.1:  Executed (default): INSERT INTO "Notifications" ("id","channel","type","active","createdAt","updated | 2 ms 
Feb 07 20:05:15 opencollective-prod-api app/web.1:  Executed (default): UPDATE "Users" SET "email"='vmaggarwal@gmail.com',"username"='vmaggarwal',"first | 2 ms 
```