### PR TITLE
adding a distinct clause for future running of script

### DIFF
--- a/scripts/send_onetime_email_to_core_contributors.js
+++ b/scripts/send_onetime_email_to_core_contributors.js
@@ -43,14 +43,14 @@ const init = () => {
   .tap(groups => console.log(`Active groups found: ${groups.length}`))
   .map(group => group.id)
   .then(groupIds => sequelize.query(`
-    SELECT u.email, u."firstName", u."lastName" from "UserGroups" ug
+    SELECT distinct(u.email), u."firstName", u."lastName" from "UserGroups" ug
     LEFT JOIN "Users" u on ug."UserId" = u.id
     where ug.role = :role and ug."GroupId" IN (:groupIds)
     `, {
       type: sequelize.QueryTypes.SELECT,
       replacements: { groupIds, role: roles.MEMBER }
     }))
-  .tap(coreContributorsOfActiveGroups => console.log(`Core contributors found: ${JSON.stringify(coreContributorsOfActiveGroups)}`))
+  .tap(coreContributorsOfActiveGroups => console.log(`Core contributors found: ${coreContributorsOfActiveGroups.length}`))
   .then(sendEmail)
   .then(() => {
     const timeLapsed = Math.round((new Date - startTime)/1000);


### PR DESCRIPTION
Query missed a distinct clause. In its current form, sent out about 25 unnecessary emails (out of 575). Fixing for future usage.