### PR TITLE
Simplify existing paypal calls and add support for new preapproval flow

### DIFF
--- a/migrations/20170228184811-add-fields-to-PaymentMethod-migration.js
+++ b/migrations/20170228184811-add-fields-to-PaymentMethod-migration.js
@@ -2,16 +2,12 @@
 
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    return queryInterface.addColumn('PaymentMethods', 'startDate', {
+    return queryInterface.addColumn('PaymentMethods', 'expiryDate', {
       type: Sequelize.DATE
     })
-    .then(() => queryInterface.addColumn('PaymentMethods', 'endDate', {
-      type: Sequelize.DATE
-    }))
   },
 
   down: function (queryInterface, Sequelize) {
-    return queryInterface.removeColumn('PaymentMethods', 'startDate')
-    .then(() => queryInterface.addColumn('PaymentMethods', 'endDate'))
+    return queryInterface.removeColumn('PaymentMethods', 'expiryDate')
   }
 };

--- a/migrations/20170228184811-add-fields-to-PaymentMethod-migration.js
+++ b/migrations/20170228184811-add-fields-to-PaymentMethod-migration.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.addColumn('PaymentMethods', 'startDate', {
+      type: Sequelize.DATE
+    })
+    .then(() => queryInterface.addColumn('PaymentMethods', 'endDate', {
+      type: Sequelize.DATE
+    }))
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.removeColumn('PaymentMethods', 'startDate')
+    .then(() => queryInterface.addColumn('PaymentMethods', 'endDate'))
+  }
+};

--- a/server/controllers/paymentMethods.js
+++ b/server/controllers/paymentMethods.js
@@ -11,7 +11,7 @@ const { PaymentMethod } = models;
  */
 export default function getPaymentMethods(req, res, next) {
   const { filter } = req.query;
-  const query = _.extend({}, filter, { UserId: req.user.id });
+  const query = _.extend({}, filter, { UserId: req.user.id, confirmedAt: {$ne: null} });
 
   return PaymentMethod.findAll({ where: query })
   .then((response) => {

--- a/server/controllers/paypal.js
+++ b/server/controllers/paypal.js
@@ -16,7 +16,7 @@ export const getDetails = function(req, res, next) {
   const preapprovalKey = req.params.preapprovalkey;
 
   return getPreapprovalDetailsAndUpdatePaymentMethod(preapprovalKey, req.remoteUser.id)
-    .then(res.json)
+    .then(response => res.json(response))
     .catch(next);
 };
 
@@ -109,7 +109,6 @@ export const confirmPreapproval = function(req, res, next) {
 const getPreapprovalDetailsAndUpdatePaymentMethod = function(preapprovalKey, userId, paymentMethod = null) {
 
   let preapprovalDetailsResponse;
-
   return paypalAdaptive.preapprovalDetails(preapprovalKey)
     .tap(response => preapprovalDetailsResponse = response)
     .then(response => response.approved === 'false' ? 

--- a/server/controllers/paypal.js
+++ b/server/controllers/paypal.js
@@ -23,186 +23,99 @@ export const getDetails = function(req, res, next) {
 
 /**
  * Get a preapproval key for a user.
- * TODO: remove async and simplify with promises #promisify
  */
 export const getPreapprovalKey = function(req, res, next) {
-  // TODO: This return and cancel URL doesn't work - no routes right now.
+  // TODO: The cancel URL doesn't work - no routes right now.
   const uri = `/users/${req.remoteUser.id}/paypal/preapproval/`;
-  const baseUrl = config.host.webapp + uri;
+  const baseUrl = config.host.website + uri;
   const cancelUrl = req.query.cancelUrl || (`${baseUrl}/cancel`);
   const returnUrl = req.query.returnUrl || (`${baseUrl}/success`);
   const endingDate = (req.query.endingDate && (new Date(req.query.endingDate)).toISOString()) || moment().add(1, 'years').toISOString();
+  
   const maxTotalAmountOfAllPayments = req.query.maxTotalAmountOfAllPayments || 2000; // 2000 is the maximum: https://developer.paypal.com/docs/classic/api/adaptive-payments/Preapproval_API_Operation/
 
-  async.auto({
+  const payload = {
+    currencyCode: 'USD', // TODO: figure out if there is a reliable way to specify correct currency for a HOST.
+    startingDate: new Date().toISOString(),
+    endingDate,
+    returnUrl,
+    cancelUrl,
+    displayMaxTotalAmount: true,
+    feesPayer: 'SENDER',
+    maxTotalAmountOfAllPayments,
+    clientDetails: req.remoteUser.id
+  };
 
-    getExistingPaymentMethod: [function(cb) {
-      PaymentMethod
-        .findAndCountAll({
-          where: {
-            service: 'paypal',
-            UserId: req.remoteUser.id
-          }
-        })
-        .then(paymentMethods => cb(null, paymentMethods))
-        .catch(cb);
-    }],
+  let response;
 
-    checkExistingPaymentMethod: ['getExistingPaymentMethod', function(cb, results) {
-      async.each(results.getExistingPaymentMethod.rows, (paymentMethod, cbEach) => {
-        if (!paymentMethod.token) {
-          return paymentMethod.destroy()
-            .then(() => cbEach())
-            .catch(cbEach);
-        }
-
-        paypalAdaptive.preapprovalDetails(paymentMethod.token)
-        .then(response => {
-          if (response.approved === 'false' || new Date(response.endingDate) < new Date()) {
-            paymentMethod.destroy()
-              .then(() => cbEach())
-              .catch(cbEach)
-          } else {
-            cbEach();
-          }
-        })
-        .catch(cbEach)
-      }, cb);
-    }],
-
-    createPaymentMethod: ['checkExistingPaymentMethod', function(cb) {
-      PaymentMethod.create({
-        service: 'paypal',
-        UserId: req.remoteUser.id
-      })
-      .then(paymentMethod => cb(null, paymentMethod))
-      .catch(cb);
-    }],
-
-    createPayload: ['createPaymentMethod', function(cb, results) {
-      const payload = {
-        currencyCode: 'USD',
-        startingDate: new Date().toISOString(),
-        endingDate,
-        returnUrl,
-        cancelUrl,
-        displayMaxTotalAmount: false,
-        feesPayer: 'SENDER',
-        maxTotalAmountOfAllPayments,
-        requestEnvelope: {
-          errorLanguage:  'en_US'
-        },
-        clientDetails: results.createPaymentMethod.id
-      };
-      return cb(null, payload);
-    }],
-
-    callPaypal: ['createPayload', function(cb, results) {
-      paypalAdaptive.preapproval(results.createPayload)
-      .then(response => cb(null, response))
-      .catch(cb)
-    }],
-
-    updatePaymentMethod: ['createPaymentMethod', 'createPayload', 'callPaypal', function(cb, results) {
-      const paymentMethod = results.createPaymentMethod;
-      paymentMethod.token = results.callPaypal.preapprovalKey;
-      paymentMethod.save()
-        .then(paymentMethod => cb(null, paymentMethod))
-        .catch(cb);
-    }]
-
-  }, (err, results) => {
-    if (err) return next(err);
-    res.json(results.callPaypal);
-  });
-
+  return paypalAdaptive.preapproval(payload)
+  .tap(r => response = r)
+  .then(response => PaymentMethod.create({
+    service: 'paypal',
+    UserId: req.remoteUser.id,
+    token: response.preapprovalKey
+  }))
+  .then(() => res.json(response))
+  .catch(next);
 };
 
 /**
  * Confirm a preapproval.
- * TODO: remove async and simplify with promises #promisify
  */
 export const confirmPreapproval = function(req, res, next) {
+  let paymentMethod;
 
-  async.auto({
+  // fetch original payment method
+  return PaymentMethod.findOne({
+    where: {
+      service: 'paypal',
+      UserId: req.remoteUser.id,
+      token: req.params.preapprovalkey
+    }
+  })
+  .tap(pm => paymentMethod = pm)
+  .then(pm => pm ? Promise.resolve() : Promise.reject(new errors.NotFound('This preapprovalKey does not exist.')))
 
-    getPaymentMethod: [function(cb) {
-      PaymentMethod
-        .findAndCountAll({
-          where: {
-            service: 'paypal',
-            UserId: req.remoteUser.id,
-            token: req.params.preapprovalkey
-          }
-        })
-        .then(paymentMethod => cb(null, paymentMethod))
-        .catch(cb);
-    }],
+  // get preapprovalkey details from Paypal
+  .then(() => paypalAdaptive.preapprovalDetails(req.params.preapprovalkey))
+  .tap(response => response.approved === 'false' ? Promise.reject(new errors.BadRequest('This preapprovalkey is not approved yet.')) : Promise.resolve())
 
-    checkPaymentMethod: ['getPaymentMethod', function(cb, results) {
-      if (results.getPaymentMethod.rows.length === 0) {
-        return cb(new errors.NotFound('This preapprovalKey doesn not exist.'));
-      } else {
-        cb();
+  // update paymentMethod
+  .then(response => {
+    const maxTotalAmountOfAllPayments = response.maxTotalAmountOfAllPayments * 100;
+    const amountUsed = response.curPaymentsAmount * 100;
+    const amountRemaining = maxTotalAmountOfAllPayments - response.curPaymentsAmount;
+
+    return paymentMethod.update({
+      confirmedAt: new Date(),
+      number: response.senderEmail,
+      data: {
+        response,
+        maxTotalAmountOfAllPayments,
+        amountUsed,
+        amountRemaining
       }
-    }],
+    })
+  })  
+  .then(() => Activity.create({
+    type: 'user.paymentMethod.created',
+    UserId: req.remoteUser.id,
+    data: {
+      user: req.remoteUser.info,
+      paymentMethod
+    }
+  }))
+  
+  // clean any old payment methods
+  .then(() => PaymentMethod.findAll({
+    where: {
+      service: 'paypal',
+      UserId: req.remoteUser.id,
+      token: {$ne: req.params.preapprovalkey}
+    }
+  }))
+  .then(oldPMs => oldPMs && oldPMs.map(pm => pm.destroy()))
 
-    callPaypal: [function(cb) {
-      paypalAdaptive.preapprovalDetails(req.params.preapprovalkey)
-      .then(response => { 
-        if (response.approved === 'false') {
-          return cb(new errors.BadRequest('This preapprovalkey is not approved yet.'));
-        }
-        cb(null, response);
-      })
-      .catch(cb)
-    }],
-
-    updatePaymentMethod: ['callPaypal', 'getPaymentMethod', 'checkPaymentMethod', function(cb, results) {
-      const paymentMethod = results.getPaymentMethod.rows[0];
-      paymentMethod.confirmedAt = new Date();
-      paymentMethod.data = results.callPaypal;
-      paymentMethod.number = results.callPaypal.senderEmail;
-      paymentMethod.save()
-        .then(paymentMethod => cb(null, paymentMethod))
-        .catch(cb);
-    }],
-
-    cleanOldPaymentMethods: ['updatePaymentMethod', function(cb) {
-      PaymentMethod
-        .findAndCountAll({
-          where: {
-            service: 'paypal',
-            UserId: req.remoteUser.id,
-            token: {$ne: req.params.preapprovalkey}
-          }
-        })
-        .then((results) => {
-          async.each(results.rows, (paymentMethod, cbEach) => {
-            paymentMethod.destroy()
-              .then(() => cbEach())
-              .catch(cbEach);
-          }, cb);
-        })
-        .catch(cb);
-    }],
-
-    createActivity: ['updatePaymentMethod', function(cb, results) {
-      Activity.create({
-        type: 'user.paymentMethod.created',
-        UserId: req.remoteUser.id,
-        data: {
-          user: req.remoteUser,
-          paymentMethod: results.updatePaymentMethod
-        }
-      })
-      .then(activity => cb(null, activity))
-      .catch(cb);
-    }]
-
-  }, (err, results) => {
-    if (err) return next(err);
-    else res.json(results.updatePaymentMethod.info);
-  });
-
+  .then(() => res.send(paymentMethod.info))
+  .catch(next)
 };

--- a/server/controllers/paypal.js
+++ b/server/controllers/paypal.js
@@ -16,7 +16,7 @@ export const getDetails = function(req, res, next) {
   const preapprovalKey = req.params.preapprovalkey;
 
   return getPreapprovalDetailsAndUpdatePaymentMethod(preapprovalKey, req.remoteUser.id)
-    .then(response => res.json(response))
+    .then(res.json)
     .catch(next);
 };
 
@@ -30,13 +30,12 @@ export const getPreapprovalKey = function(req, res, next) {
   // TODO: The cancel URL doesn't work - no routes right now.
   const cancelUrl = req.query.cancelUrl || (`${baseUrl}/cancel`);
   const returnUrl = req.query.returnUrl || (`${baseUrl}/success`);
-  const startDate = new Date();
-  const endDate = (req.query.endingDate && (new Date(req.query.endingDate))) || moment().add(1, 'years');
+  const expiryDate = (req.query.endingDate && (new Date(req.query.endingDate))) || moment().add(1, 'years');
   
   const payload = {
     currencyCode: 'USD', // TODO: figure out if there is a reliable way to specify correct currency for a HOST.
-    startingDate: startDate.toISOString(),
-    endingDate: endDate.toISOString(),
+    startingDate: new Date().toISOString(),
+    endingDate: expiryDate.toISOString(),
     returnUrl,
     cancelUrl,
     displayMaxTotalAmount: false,
@@ -53,8 +52,7 @@ export const getPreapprovalKey = function(req, res, next) {
     service: 'paypal',
     UserId: req.remoteUser.id,
     token: response.preapprovalKey,
-    startDate,
-    endDate
+    expiryDate
   }))
   .then(() => res.json(response))
   .catch(next);
@@ -86,7 +84,7 @@ export const confirmPreapproval = function(req, res, next) {
     UserId: req.remoteUser.id,
     data: {
       user: req.remoteUser.minimal,
-      paymentMethod
+      paymentMethod: paymentMethod.minimal()
     }
   }))
   

--- a/server/controllers/paypal.js
+++ b/server/controllers/paypal.js
@@ -41,7 +41,7 @@ export const getPreapprovalKey = function(req, res, next) {
     cancelUrl,
     displayMaxTotalAmount: false,
     feesPayer: 'SENDER',
-    maxAmountPerPayment: 2500.00, 
+    maxAmountPerPayment: 2500.00, // PayPal claims this can go up to $10k without needing additional permissions from them.
     clientDetails: req.remoteUser.id
   };
 

--- a/server/controllers/paypal.js
+++ b/server/controllers/paypal.js
@@ -1,4 +1,3 @@
-import async from 'async';
 import config from 'config';
 import moment from 'moment';
 import models from '../models';

--- a/server/controllers/paypal.js
+++ b/server/controllers/paypal.js
@@ -84,7 +84,7 @@ export const confirmPreapproval = function(req, res, next) {
     UserId: req.remoteUser.id,
     data: {
       user: req.remoteUser.minimal,
-      paymentMethod: paymentMethod.minimal()
+      paymentMethod: paymentMethod.minimal
     }
   }))
   

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -54,7 +54,9 @@ export default function(Sequelize, DataTypes) {
           service: this.service,
           createdAt: this.createdAt,
           updatedAt: this.updatedAt,
-          confirmedAt: this.confirmedAt
+          confirmedAt: this.confirmedAt,
+          amountRemaining: this.data && this.data.amountRemaining,
+          amountUsed: this.data && this.data.amountUsed
         };
       }
     },

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -33,6 +33,12 @@ export default function(Sequelize, DataTypes) {
     confirmedAt: {
       type: DataTypes.DATE
     },
+    startDate: {
+      type: DataTypes.DATE
+    },
+    endDate: {
+      type: DataTypes.DATE
+    },
     UserId: {
       type: DataTypes.INTEGER,
       references: {
@@ -55,8 +61,8 @@ export default function(Sequelize, DataTypes) {
           createdAt: this.createdAt,
           updatedAt: this.updatedAt,
           confirmedAt: this.confirmedAt,
-          amountRemaining: this.data && this.data.amountRemaining,
-          amountUsed: this.data && this.data.amountUsed
+          startDate: this.startDate,
+          endDate: this.endDate
         };
       }
     },

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -62,7 +62,8 @@ export default function(Sequelize, DataTypes) {
           updatedAt: this.updatedAt,
           confirmedAt: this.confirmedAt,
           startDate: this.startDate,
-          endDate: this.endDate
+          endDate: this.endDate,
+          number: this.number
         };
       }
     },

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -33,10 +33,7 @@ export default function(Sequelize, DataTypes) {
     confirmedAt: {
       type: DataTypes.DATE
     },
-    startDate: {
-      type: DataTypes.DATE
-    },
-    endDate: {
+    expiryDate: {
       type: DataTypes.DATE
     },
     UserId: {
@@ -61,8 +58,19 @@ export default function(Sequelize, DataTypes) {
           createdAt: this.createdAt,
           updatedAt: this.updatedAt,
           confirmedAt: this.confirmedAt,
-          startDate: this.startDate,
-          endDate: this.endDate,
+          expiryDate: this.expiryDate,
+          number: this.number
+        };
+      },
+
+      minimal() {
+        return {
+          id: this.id,
+          service: this.service,
+          createdAt: this.createdAt,
+          updatedAt: this.updatedAt,
+          confirmedAt: this.confirmedAt,
+          expiryDate: this.expiryDate,
           number: this.number
         };
       }

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -154,7 +154,7 @@ export default (Sequelize, DataTypes) => {
             GroupId: transaction.GroupId,
             UserId: transaction.UserId,
             data: {
-              transaction: transaction.get(),
+              transaction: transaction.info,
               user: transaction.User && transaction.User.minimal,
               group: transaction.Group && transaction.Group.minimal
             }

--- a/test/expenses.routes.test.js
+++ b/test/expenses.routes.test.js
@@ -625,7 +625,7 @@ describe('expenses.routes.test.js', () => {
                     error: {
                       code: 400,
                       type: 'bad_request',
-                      message: 'This user has no confirmed paymentMethod linked with this service.',
+                      message: 'No payment method found',
                     }
                   }));
                 });

--- a/test/mocks/data.js
+++ b/test/mocks/data.js
@@ -168,13 +168,17 @@ export default {
 
   "paymentMethod1": {
     "token": "PA-1B0110758V169653C",
-    "service": "paypal"
+    "service": "paypal",
+    "startDate": "2017-01-30T07:31:37.747Z",
+    "endDate": "2018-01-30T07:31:37.747Z",
+    "confirmedAt": "2017-01-30T07:31:37.747Z"
   },
 
   "paymentMethod2": {
     "token": "stripetoken123",
     "service": "stripe",
-    "customerId": "cus_123"
+    "customerId": "cus_123",
+    "confirmedAt": "2017-01-30T07:31:37.747Z"
   },
 
   "activities1": {

--- a/test/paypal.preapproval.routes.test.js
+++ b/test/paypal.preapproval.routes.test.js
@@ -14,8 +14,19 @@ const application = utils.data('application');
 
 describe('paypal.preapproval.routes.test.js', () => {
 
-  let user;
-  let user2;
+  let user, user2, sandbox;
+
+  before(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  after(() => sandbox.restore());
+
+  // Create a stub for clearbit
+  beforeEach((done) => {
+    utils.clearbitStubBeforeEach(sandbox);
+    done();
+  });
 
   beforeEach(() => {
     sinon.stub(paypalAdaptive, 'preapproval', 
@@ -24,6 +35,10 @@ describe('paypal.preapproval.routes.test.js', () => {
 
   afterEach(() => {
     paypalAdaptive.preapproval.restore();
+  });
+
+  afterEach(() => {
+    utils.clearbitStubAfterEach(sandbox);
   });
 
   beforeEach((done) => {
@@ -128,7 +143,7 @@ describe('paypal.preapproval.routes.test.js', () => {
           .end(done);
       });
 
-      it.only('should confirm the payment of a transaction', (done) => {
+      it('should confirm the payment of a transaction', (done) => {
         const mock = paypalMock.adaptive.preapprovalDetails;
         request(app)
           .post(`/users/${user.id}/paypal/preapproval/${preapprovalkey}?api_key=${application.api_key}`)
@@ -203,7 +218,7 @@ describe('paypal.preapproval.routes.test.js', () => {
     describe('Preapproval details', () => {
       beforeEach(() => {
         sinon.stub(paypalAdaptive, 'preapprovalDetails',
-          () => Promise.resolve(paypalMock.adaptive.preapprovalDetails.created));
+          () => Promise.resolve(paypalMock.adaptive.preapprovalDetails.completed));
       });
 
       afterEach(() => {
@@ -236,6 +251,15 @@ describe('paypal.preapproval.routes.test.js', () => {
           UserId: user.id,
           token: 'blah'
         })
+      });
+
+      beforeEach(() => {
+        sinon.stub(paypalAdaptive, 'preapprovalDetails',
+          () => Promise.resolve(paypalMock.adaptive.preapprovalDetails.completed));
+      });
+
+      afterEach(() => {
+        paypalAdaptive.preapprovalDetails.restore();
       });
 
       it('should delete all other paymentMethods entries in the database to clean up', (done) => {

--- a/test/paypal.preapproval.routes.test.js
+++ b/test/paypal.preapproval.routes.test.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Promise from 'bluebird';
 import app from '../server/index';
 import async from 'async';

--- a/test/paypal.preapproval.routes.test.js
+++ b/test/paypal.preapproval.routes.test.js
@@ -11,7 +11,7 @@ import paypalAdaptive from '../server/gateways/paypalAdaptive';
 
 const application = utils.data('application');
 
-describe('paypal.preapproval.routes.test.js', () => {
+describe.only('paypal.preapproval.routes.test.js', () => {
 
   let user, user2, sandbox;
 
@@ -159,9 +159,7 @@ describe('paypal.preapproval.routes.test.js', () => {
               expect(res.rows[0].service).to.equal('paypal');
               expect(res.rows[0].number).to.equal(mock.completed.senderEmail);
               expect(res.rows[0].UserId).to.equal(user.id);
-              expect(res.rows[0].data.maxTotalAmountOfAllPayments).to.equal(200000);
               expect(res.rows[0].data.amountUsed).to.equal(0);
-              expect(res.rows[0].data.amountRemaining).to.equal(200000);
             })
             .then(() => models.Activity.findAndCountAll({where: {type: 'user.paymentMethod.created'} }))
             .then(res => {

--- a/test/paypal.preapproval.routes.test.js
+++ b/test/paypal.preapproval.routes.test.js
@@ -11,7 +11,7 @@ import paypalAdaptive from '../server/gateways/paypalAdaptive';
 
 const application = utils.data('application');
 
-describe.only('paypal.preapproval.routes.test.js', () => {
+describe('paypal.preapproval.routes.test.js', () => {
 
   let user, user2, sandbox;
 

--- a/test/paypal.preapproval.routes.test.js
+++ b/test/paypal.preapproval.routes.test.js
@@ -159,7 +159,6 @@ describe('paypal.preapproval.routes.test.js', () => {
               expect(res.rows[0].service).to.equal('paypal');
               expect(res.rows[0].number).to.equal(mock.completed.senderEmail);
               expect(res.rows[0].UserId).to.equal(user.id);
-              expect(res.rows[0].data.amountUsed).to.equal(0);
             })
             .then(() => models.Activity.findAndCountAll({where: {type: 'user.paymentMethod.created'} }))
             .then(res => {


### PR DESCRIPTION
Under the new paypal setup, we don't need to worry about anything except expiry date of a preapproval key. So, this PR records start and end date of the keys separately in a table row.