### PR TITLE
use aws multiload to upload clearbit logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jsonwebtoken": "5.7.0",
     "juice": "2.0.0",
     "knox": "github:automattic/knox#278337d7673341658efcc81e631c3f63fa53d374",
+    "knox-mpu-alt": "0.2.2",
     "lodash": "3.10.1",
     "mailgun-js": "0.7.11",
     "mime": "1.3.4",

--- a/server/lib/imageUrlToAmazonUrl.js
+++ b/server/lib/imageUrlToAmazonUrl.js
@@ -25,7 +25,7 @@ function imageUrlToAmazonUrl(knox_client, src, callback) {
       const ext = mime.extension(contentType) || path.extname(src).substr(1);
       const filename = `/${name}_${uuid.v1()}.${ext}`;
 
-      const upload = new MultiPartUpload({
+    new MultiPartUpload({
         client: knox_client,
         objectName: filename,
         stream: request.get(src),

--- a/server/lib/imageUrlToAmazonUrl.js
+++ b/server/lib/imageUrlToAmazonUrl.js
@@ -25,7 +25,7 @@ function imageUrlToAmazonUrl(knox_client, src, callback) {
       const ext = mime.extension(contentType) || path.extname(src).substr(1);
       const filename = `/${name}_${uuid.v1()}.${ext}`;
 
-    new MultiPartUpload({
+    this.multiPartUpload({
         client: knox_client,
         objectName: filename,
         stream: request.get(src),
@@ -40,4 +40,12 @@ function imageUrlToAmazonUrl(knox_client, src, callback) {
   });
 }
 
-export default imageUrlToAmazonUrl;
+// separate function to make stubbing easier.
+function multiPartUpload(object, callback) {
+   new MultiPartUpload(object, callback);
+}
+
+export default {
+  imageUrlToAmazonUrl,
+  multiPartUpload
+}

--- a/server/lib/imageUrlToAmazonUrl.js
+++ b/server/lib/imageUrlToAmazonUrl.js
@@ -1,8 +1,8 @@
-export default imageUrlToAmazonUrl;
 import path from 'path';
 import uuid from 'node-uuid';
 import mime from 'mime';
 import request from 'request';
+import MultiPartUpload from 'knox-mpu-alt';
 
 /**
 * Takes an external image URL and returns a Amazon S3 URL with the
@@ -11,37 +11,33 @@ import request from 'request';
 * @param knox_client {Client} Knox `Client` instance e.g `app.knox`
 * @param src {String}
 * @param callback {Function}
-* 		@param error {Error|null}
-* 		@param aws_src {String}
+*     @param error {Error|null}
+*     @param aws_src {String}
 */
 function imageUrlToAmazonUrl(knox_client, src, callback) {
-	const options = {url: src, method: 'HEAD'};
-	request(options, (error, response) => {
-		if (error) return callback(error)
-		const contentLength = response.headers['content-length'];
-		const contentType = response.headers['content-type'];
-		if (contentLength) {
-			const name = path.basename(src).replace(/\W/g, ''); // remove non alphanumeric
-			const ext = mime.extension(contentType) || path.extname(src).substr(1);
-			const filename = `/${name}_${uuid.v1()}.${ext}`;
+  request.head(src, (error, response) => {
+    if (error) {
+      return callback(error);
+    }
+    const contentType = response.headers['content-type'];
+    if (response.statusCode === 200) {
+      const name = path.basename(src).replace(/\W/g, ''); // remove non alphanumeric
+      const ext = mime.extension(contentType) || path.extname(src).substr(1);
+      const filename = `/${name}_${uuid.v1()}.${ext}`;
 
-			const put = knox_client.put(filename, {
-				'Content-Length': contentLength,
-				'Content-Type': contentType,
-				'x-amz-acl': 'public-read'
-			});
-
-			request.get(src).on('response', (response) => response.pipe(put));
-
-			put.on('response', (response) => {
-				if (response.statusCode === 200) {
-					setImmediate(callback, (put.url) ? null : new Error('Upload Failed - s3 URL was not created'), put.url);
-				} else {
-					callback(new Error(`AWS Upload Failed - ${response.statusCode} ${response.statusMessage}`));
-				}
-			});
-		} else {
-			callback(new Error('Not found - missing header: Content-Length'));
-		}
-	});
+      const upload = new MultiPartUpload({
+        client: knox_client,
+        objectName: filename,
+        stream: request.get(src),
+        headers: {
+          'Content-Type': contentType,
+          'x-amz-acl': 'public-read'
+        }
+      }, (err, body) => err ? callback(err) : callback(null, body.Location));
+    } else {
+      callback(new Error('Image not found'));
+    }
+  });
 }
+
+export default imageUrlToAmazonUrl;

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -34,7 +34,7 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
       MultiPartUpload.restore();
     })
 
-    it.only('successfully converts cloudfront.net url to amazon aws url', done => {
+    it('successfully converts cloudfront.net url to amazon aws url', done => {
       imageUrlToAmazonUrl(
         knox,
         SAMPLE,

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -9,6 +9,7 @@ const SAMPLE = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4
 
 describe('lib.imageUrlToAmazonUrl.js', () => {
   describe('#Convert an external image url to a Amazon url', () => {
+    let multiPartStub;
 
     before(() => {
       sinon.stub(knox, 'put', () => {
@@ -27,18 +28,15 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
     })
 
     before(() => {
-      sinon.stub(MultiPartUpload).returns({Location: `https://${config.aws.s3.bucket}.s3-us-west-1.amazonaws.com/31654v3_2ba16cc0-124d-11e6-b36a-2d79eed36137.png`})
+      multiPartStub = sinon.createStubInstance(MultiPartUpload)
     });
-
-    after(() => {
-      MultiPartUpload.restore();
-    })
 
     it('successfully converts cloudfront.net url to amazon aws url', done => {
       imageUrlToAmazonUrl(
         knox,
         SAMPLE,
         (e, aws_src) => {
+          console.log(aws_src);
           expect(e).to.not.exist;
           expect(aws_src).to.contain('.amazonaws.com/');
           expect(aws_src).to.contain(config.aws.s3.bucket);

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -29,6 +29,11 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
     });
 
     beforeEach(() => {
+      const s = stream.Readable();
+      s.write = function(){};
+      s.end = function(){
+        s.emit('response', {statusCode: 200, statusMessage: 'OK'});
+      }
       nocks['cloudfront.get'] = nock(imageUrl)
         .get('')
         .reply(200, s);

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -2,7 +2,7 @@ import config from 'config';
 import imageUrlToAmazonUrl from '../server/lib/imageUrlToAmazonUrl';
 import { expect } from 'chai';
 import sinon from 'sinon';
-//import knox from '../server/gateways/knox';
+import knox from '../server/gateways/knox';
 import MultiPartUpload from 'knox-mpu-alt'
 
 const SAMPLE = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764'

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -7,7 +7,7 @@ import MultiPartUpload from 'knox-mpu-alt'
 
 const SAMPLE = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764'
 
-describe.only('lib.imageUrlToAmazonUrl.js', () => {
+describe('lib.imageUrlToAmazonUrl.js', () => {
   describe('#Convert an external image url to a Amazon url', () => {
 
     before(() => {

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -9,7 +9,6 @@ const SAMPLE = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4
 
 describe('lib.imageUrlToAmazonUrl.js', () => {
   describe('#Convert an external image url to a Amazon url', () => {
-    let multiPartStub;
 
     before(() => {
       sinon.stub(knox, 'put', () => {
@@ -28,7 +27,7 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
     })
 
     before(() => {
-      multiPartStub = sinon.createStubInstance(MultiPartUpload)
+      sinon.createStubInstance(MultiPartUpload)
     });
 
     it('successfully converts cloudfront.net url to amazon aws url', done => {
@@ -36,7 +35,6 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
         knox,
         SAMPLE,
         (e, aws_src) => {
-          console.log(aws_src);
           expect(e).to.not.exist;
           expect(aws_src).to.contain('.amazonaws.com/');
           expect(aws_src).to.contain(config.aws.s3.bucket);

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -1,43 +1,77 @@
 import config from 'config';
-import imageUrlToAmazonUrl from '../server/lib/imageUrlToAmazonUrl';
+import imageUrlLib from '../server/lib/imageUrlToAmazonUrl';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import knox from '../server/gateways/knox';
-import MultiPartUpload from 'knox-mpu-alt'
+import nock from 'nock';
+import knox from 'knox';
+import uuid from 'node-uuid';
+import stream from 'stream';
 
-const SAMPLE = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764'
+import MultiPartUpload from 'knox-mpu-alt';
+import amazonMockData from './mocks/amazon';
+
+const imageUrl = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764';
+const returnUrl = 'https://opencollective-test.s3-us-west-1.amazonaws.com/31654v3_2ba16cc0-124d-11e6-b36a-2d79eed36137.png';
 
 describe('lib.imageUrlToAmazonUrl.js', () => {
+  
   describe('#Convert an external image url to a Amazon url', () => {
+    
+    const nocks = {};
+    let multiPartStub, knoxStub
 
     before(() => {
-      sinon.stub(knox, 'put', () => {
-        const s = new require('stream').Readable();
-        s.write = function(){}
-        s.end = function(){
-          s.url = `https://${config.aws.s3.bucket}.s3-us-west-1.amazonaws.com/31654v3_2ba16cc0-124d-11e6-b36a-2d79eed36137.png`
-          s.emit('response', {statusCode: 200, statusMessage: 'OK'})
-        }
-        return s
-      });
+      knoxStub = sinon.stub(knox, 'createClient', () => {});
+      sinon.stub(uuid, 'v1', () => 'testuuid');
+    
+      multiPartStub = sinon.stub(imageUrlLib, 'multiPartUpload')
+      multiPartStub.yields(null, {Location: returnUrl});
+    });
+
+    beforeEach(() => {
+      nocks['cloudfront.get'] = nock(imageUrl)
+        .get('')
+        .reply(200, s);
     });
 
     after(() => {
-      knox.put.restore()
+      knox.createClient.restore();
+      uuid.v1.restore();
     })
 
-    before(() => {
-      sinon.createStubInstance(MultiPartUpload)
+    it('returns an error if the image url is not found', () => {
+      nocks['cloudfront.head'] = nock(imageUrl)
+        .head('')
+        .reply(404);
+
+      imageUrlLib.imageUrlToAmazonUrl(
+        knox,
+        imageUrl,
+        (e, aws_src) => {
+          expect(e).to.equal('Image not found');
+          expect(multiPartStub).to
+        })
     });
 
     it('successfully converts cloudfront.net url to amazon aws url', done => {
-      imageUrlToAmazonUrl(
+      nocks['cloudfront.head'] = nock(imageUrl)
+      .head('')
+      .reply(200, amazonMockData.cloudfront.head, {
+        'Content-Type': 'image/png'
+      });
+
+      imageUrlLib.imageUrlToAmazonUrl(
         knox,
-        SAMPLE,
+        imageUrl,
         (e, aws_src) => {
           expect(e).to.not.exist;
-          expect(aws_src).to.contain('.amazonaws.com/');
-          expect(aws_src).to.contain(config.aws.s3.bucket);
+          expect(multiPartStub.callCount).to.equal(1);
+          expect(multiPartStub.firstCall.args[0].objectName).to.equal('/1dca3d829c914d2a8fc94a565c531764_testuuid.png');
+          expect(multiPartStub.firstCall.args[0].headers).to.deep.equal({
+            'Content-Type': 'image/png',
+            'x-amz-acl': 'public-read'
+          });
+          expect(aws_src).to.equal(returnUrl);
           done();
         }
       );

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -16,7 +16,7 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
   describe('#Convert an external image url to a Amazon url', () => {
     
     const nocks = {};
-    let multiPartStub, knoxStub
+    let multiPartStub
 
     before(() => {
       sinon.stub(uuid, 'v1', () => 'testuuid');
@@ -48,7 +48,7 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
       imageUrlLib.imageUrlToAmazonUrl(
         knox,
         imageUrl,
-        (e, aws_src) => {
+        (e) => {
           expect(e).to.equal('Image not found');
         })
     });

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -2,11 +2,12 @@ import config from 'config';
 import imageUrlToAmazonUrl from '../server/lib/imageUrlToAmazonUrl';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import knox from '../server/gateways/knox';
+//import knox from '../server/gateways/knox';
+import MultiPartUpload from 'knox-mpu-alt'
 
 const SAMPLE = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764'
 
-describe('lib.imageUrlToAmazonUrl.js', () => {
+describe.only('lib.imageUrlToAmazonUrl.js', () => {
   describe('#Convert an external image url to a Amazon url', () => {
 
     before(() => {
@@ -25,7 +26,15 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
       knox.put.restore()
     })
 
-    it('successfully converts cloudfront.net url to amazon aws url', done => {
+    before(() => {
+      sinon.stub(MultiPartUpload).returns({Location: `https://${config.aws.s3.bucket}.s3-us-west-1.amazonaws.com/31654v3_2ba16cc0-124d-11e6-b36a-2d79eed36137.png`})
+    });
+
+    after(() => {
+      MultiPartUpload.restore();
+    })
+
+    it.only('successfully converts cloudfront.net url to amazon aws url', done => {
       imageUrlToAmazonUrl(
         knox,
         SAMPLE,

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -1,4 +1,3 @@
-import config from 'config';
 import imageUrlLib from '../server/lib/imageUrlToAmazonUrl';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -7,7 +6,6 @@ import knox from 'knox';
 import uuid from 'node-uuid';
 import stream from 'stream';
 
-import MultiPartUpload from 'knox-mpu-alt';
 import amazonMockData from './mocks/amazon';
 
 const imageUrl = 'https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/1dca3d82-9c91-4d2a-8fc9-4a565c531764';
@@ -21,7 +19,6 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
     let multiPartStub, knoxStub
 
     before(() => {
-      knoxStub = sinon.stub(knox, 'createClient', () => {});
       sinon.stub(uuid, 'v1', () => 'testuuid');
     
       multiPartStub = sinon.stub(imageUrlLib, 'multiPartUpload')
@@ -40,7 +37,6 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
     });
 
     after(() => {
-      knox.createClient.restore();
       uuid.v1.restore();
     })
 
@@ -54,7 +50,6 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
         imageUrl,
         (e, aws_src) => {
           expect(e).to.equal('Image not found');
-          expect(multiPartStub).to
         })
     });
 

--- a/test/mocks/amazon.js
+++ b/test/mocks/amazon.js
@@ -1,0 +1,17 @@
+export default {
+  cloudfront: {
+    head: {
+      header: {
+        "Content-Type": 'image/png' 
+      },
+      status: 200
+    },
+    get: {
+      header: {
+        "Content-Type": 'image/png'
+      },
+      status: 200,
+      body: 'blahblahblah'
+    }
+  }
+}


### PR DESCRIPTION
Lots of images sent from clearbit weren't uploading properly because they had no content-length header set. This cleans up the logic and switches upload library that doesn't require content-length.