### PR TITLE
pass expense and donation info when returning transaction

### DIFF
--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -163,9 +163,13 @@ export const getTransactions = (req, res, next) => {
 
       res.send(transactions.rows.map(transaction => {
 
-        const title = (transaction.Donation && transaction.Donation.title) || (transaction.Expense && transaction.Expense.title) || transaction.description;
+        const title = (transaction.Donation && transaction.Donation.title) || 
+                      (transaction.Expense && transaction.Expense.title) || 
+                      transaction.description;
         // only show the rest if user has permission
-        const notes = canEditGroup && ((transaction.Donation && transaction.Donation.notes) || (transaction.Expense && transaction.Expense.notes));
+        const notes = canEditGroup && 
+                      ((transaction.Donation && transaction.Donation.notes) || 
+                        (transaction.Expense && transaction.Expense.notes));
         const attachment = canEditGroup && transaction.Expense && transaction.Expense.attachment;
         
         return Object.assign({}, transaction.info, {

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -163,20 +163,13 @@ export const getTransactions = (req, res, next) => {
 
       res.send(transactions.rows.map(transaction => {
 
-        const title = (transaction.Donation && transaction.Donation.title) || 
-                      (transaction.Expense && transaction.Expense.title) || 
-                      transaction.description;
-        // only show the rest if user has permission
+        // only show these if user has permission
         const notes = canEditGroup && 
                       ((transaction.Donation && transaction.Donation.notes) || 
                         (transaction.Expense && transaction.Expense.notes));
         const attachment = canEditGroup && transaction.Expense && transaction.Expense.attachment;
         
         return Object.assign({}, transaction.info, {
-          expenseCategory: transaction.Expense && transaction.Expense.category,
-          description: title, // #deprecated
-          title,
-          expenseIncurredAt: transaction.Expense && transaction.Expense.incurredAt,
           notes,
           attachment
         });

--- a/server/controllers/middlewares.js
+++ b/server/controllers/middlewares.js
@@ -7,6 +7,7 @@ import queries from '../lib/queries';
 import models from '../models';
 import errors from '../lib/errors';
 import required from '../middleware/required_param';
+import roles from '../constants/roles';
 
 const {
   User
@@ -257,4 +258,17 @@ export const sorting = (options) => {
 
     next();
   };
+};
+
+/**
+ * Populate req with info on whether this user can edit colletive
+ */
+export const populateEditPermissions = (req, res, next) => {
+  if (req.remoteUser && req.group) {
+    return req.group.hasUserWithRole(req.remoteUser.id, [roles.HOST, roles.MEMBER])
+    .then(canEditGroup => req.remoteUser.canEditGroup = true)
+    .then(() => next()); // for some reason, .then(next) doesn't work here.
+  } else {
+    next();
+  }
 };

--- a/server/controllers/middlewares.js
+++ b/server/controllers/middlewares.js
@@ -266,7 +266,7 @@ export const sorting = (options) => {
 export const populateEditPermissions = (req, res, next) => {
   if (req.remoteUser && req.group) {
     return req.group.hasUserWithRole(req.remoteUser.id, [roles.HOST, roles.MEMBER])
-    .then(canEditGroup => req.remoteUser.canEditGroup = true)
+    .then(canEditGroup => req.remoteUser.canEditGroup = canEditGroup)
     .then(() => next()); // for some reason, .then(next) doesn't work here.
   } else {
     next();

--- a/server/controllers/stripeWebhook.js
+++ b/server/controllers/stripeWebhook.js
@@ -219,7 +219,6 @@ export default function stripeWebhook(req, res, next) {
         platformFeeInTxnCurrency: fees.applicationFee,
         paymentProcessorFeeInTxnCurrency: fees.stripeFee,
         data: {charge, balanceTransaction},
-        description: `${donation.Subscription.interval}ly recurring subscription`,
       };
 
       models.Transaction.createFromPayload({

--- a/server/lib/slug.js
+++ b/server/lib/slug.js
@@ -8,7 +8,7 @@ export function getUserOrGroupFromSlug(slug, userId) {
     .findOne({where: {slug}})
     .then(group => {
       if (group) {
-        return Promise.promisify(group.hasUserWithRole)(userId, roles.HOST)
+        return group.hasUserWithRole(userId, roles.HOST)
           .then(isHost => {
             if (!isHost) {
               return Promise.reject(new errors.Forbidden(`You do not have access to this resource`));

--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -45,7 +45,6 @@ export function createFromPaidExpense(paymentMethod, expense, paymentResponses, 
     type: type.EXPENSE,
     amount: -expense.amount,
     currency: expense.currency,
-    description: expense.title,
     UserId,
     GroupId: expense.GroupId,
   })

--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -301,16 +301,14 @@ export default function(Sequelize, DataTypes) {
           });
       },
 
-      hasUserWithRole(userId, expectedRoles, cb) {
-        this
-          .getUsers({
+      hasUserWithRole(userId, expectedRoles) {
+        return this.getUsers({
             where: {
               id: userId
             }
           })
           .then(users => users.map(user => user.UserGroup.role))
-          .tap(actualRoles => cb(null, _.intersection(expectedRoles, actualRoles).length > 0))
-          .catch(cb);
+          .then(actualRoles => _.intersection(expectedRoles, actualRoles).length > 0)
       },
 
       addUserWithRole(user, role) {

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -15,7 +15,7 @@ export default (Sequelize, DataTypes) => {
   const Transaction = Sequelize.define('Transaction', {
     uuid: DataTypes.STRING(36),
     type: DataTypes.STRING, // Expense or Donation
-    description: DataTypes.STRING,
+    description: DataTypes.STRING, // #deprecated
     amount: DataTypes.INTEGER,
     currency: {
       type: DataTypes.STRING,

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -63,13 +63,32 @@ export default (Sequelize, DataTypes) => {
 
     getterMethods: {
 
+      title() {
+        return (this.Donation && this.Donation.title) ||
+        (this.Expense && this.Expense.title) || 
+        this.description;
+      },
+
+      expenseCategory() {
+        return this.Expense && this.Expense.category
+      },
+
+      expenseIncurredAt() {
+        return this.Expense && this.Expense.incurredAt;
+      },
+
+      expensePayoutMethod() {
+        return this.Expense && this.Expense.payoutMethod;
+      },
+
       // Info.
       info() {
         return {
           id: this.id,
           uuid: this.uuid,
           type: this.type,
-          description: this.description,
+          description: this.description, // #deprecated
+          title: this.title,
           amount: this.amount,
           currency: this.currency,
           createdAt: this.createdAt,
@@ -80,7 +99,12 @@ export default (Sequelize, DataTypes) => {
           paymentProcessorFee: this.paymentProcessorFee,
           netAmountInGroupCurrency: this.netAmountInGroupCurrency,
           amountInTxnCurrency: this.amountInTxnCurrency,
-          txnCurrency: this.txnCurrency
+          txnCurrency: this.txnCurrency,
+
+          // expense related fields
+          expenseCategory: this.expenseCategory,
+          expenseIncurredAt: this.expenseIncurredAt,
+          expensePayoutMethod: this.expensePayoutMethod
         };
       }
     },

--- a/server/routes.js
+++ b/server/routes.js
@@ -172,7 +172,7 @@ export default (app) => {
   /**
    * Transactions (financial).
    */
-  app.get('/groups/:groupid/transactions', mw.paginate(), mw.sorting({key: 'createdAt', dir: 'DESC'}), groups.getTransactions); // Get a group's transactions.
+  app.get('/groups/:groupid/transactions', mw.populateEditPermissions, mw.paginate(), mw.sorting({key: 'createdAt', dir: 'DESC'}), groups.getTransactions); // Get a group's transactions.
   app.get('/transactions/:transactionuuid', transactions.getOne); // Get the transaction details
 
   // TODO remove once app is deprecated, replaced by POST /groups/:groupid/expenses and POST /groups/:groupid/donations/manual

--- a/test/expenses.routes.test.js
+++ b/test/expenses.routes.test.js
@@ -679,7 +679,6 @@ describe('expenses.routes.test.js', () => {
                   expect(transaction).to.have.property('ExpenseId', expense.id);
                   expect(transaction).to.have.property('amount', -12000);
                   expect(transaction).to.have.property('currency', expense.currency);
-                  expect(transaction).to.have.property('description', expense.title);
                   expect(transaction).to.have.property('UserId', expense.UserId);
                   expect(transaction).to.have.property('GroupId', expense.GroupId);
                 }
@@ -818,7 +817,6 @@ describe('expenses.routes.test.js', () => {
                   expect(transaction).to.have.property('ExpenseId', expense.id);
                   expect(transaction).to.have.property('amount', -expense.amount);
                   expect(transaction).to.have.property('currency', expense.currency);
-                  expect(transaction).to.have.property('description', expense.title);
                   expect(transaction).to.have.property('UserId', expense.UserId);
                   expect(transaction).to.have.property('GroupId', expense.GroupId);
                 }

--- a/test/transactions.routes.test.js
+++ b/test/transactions.routes.test.js
@@ -131,7 +131,7 @@ describe('transactions.routes.test.js', () => {
         request(app)
           .post(`/groups/${publicGroup.id}/transactions?api_key=${application.api_key}`)
           .set('Authorization', `Bearer ${user3.jwt()}`)
-          .send({ Object.assign({}, t, { } })
+          .send({ transaction: t })
           .expect(200)
           .end((e, res) => {
             expect(e).to.not.exist;

--- a/test/transactions.routes.test.js
+++ b/test/transactions.routes.test.js
@@ -131,7 +131,7 @@ describe('transactions.routes.test.js', () => {
         request(app)
           .post(`/groups/${publicGroup.id}/transactions?api_key=${application.api_key}`)
           .set('Authorization', `Bearer ${user3.jwt()}`)
-          .send({ transaction: t })
+          .send({ Object.assign({}, t, { } })
           .expect(200)
           .end((e, res) => {
             expect(e).to.not.exist;


### PR DESCRIPTION
This PR populates a `canEditGroup` param on `remoteUser` to let us know if current user should get access to private info and then includes that info when returning a `transaction`.