### PR TITLE
add paypalEmail needed by email template

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -232,7 +232,6 @@ export default (Sequelize, DataTypes) => {
         };
       },
 
-      // Minimal (used to feed the jwt token)
       minimal() {
         return {
           id: this.id,
@@ -241,7 +240,8 @@ export default (Sequelize, DataTypes) => {
           firstName: this.firstName,
           lastName: this.lastName,
           name: this.name,
-          email: this.email
+          email: this.email,
+          paypalEmail: this.paypalEmail
         };
       },
 


### PR DESCRIPTION
Email template wasn't receiving the paypalEmail. This includes it. Note that the `user.minimal` isn't used for jwt, so removed that comment.