### PR TITLE
send host separately in group call

### DIFF
--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -552,7 +552,8 @@ export const getOne = (req, res, next) => {
     req.group.getBackersCount(),
     req.group.getTwitterSettings(),
     getRelatedGroups(),
-    req.group.getSuperCollectiveData()
+    req.group.getSuperCollectiveData(),
+    req.group.getHost()
     ])
   .then(values => {
     group.stripeAccount = values[0] && _.pick(values[0], 'stripePublishableKey');
@@ -566,6 +567,7 @@ export const getOne = (req, res, next) => {
     group.settings.twitter = values[6];
     group.related = values[7];
     group.superCollectiveData = values[8];
+    group.host = values[9];
     if (group.superCollectiveData) {
       group.collectivesCount = group.superCollectiveData.length;
       group.contributorsCount += aggregate(group.superCollectiveData, 'contributorsCount');

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -567,7 +567,7 @@ export const getOne = (req, res, next) => {
     group.settings.twitter = values[6];
     group.related = values[7];
     group.superCollectiveData = values[8];
-    group.host = values[9];
+    group.host = values[9].info;
     if (group.superCollectiveData) {
       group.collectivesCount = group.superCollectiveData.length;
       group.contributorsCount += aggregate(group.superCollectiveData, 'contributorsCount');

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -282,7 +282,7 @@ const processPayment = (donation) => {
       }
 
       return group.getHost()
-      .then(host => host.UserId == user.id)
+      .then(host => host.id === user.id)
       .tap(isHost => isUserHost = isHost)
       .then(isUserHost => {
         payload.transaction.hostFeeInTxnCurrency = isUserHost ? 0 : Math.trunc(group.hostFeePercent/100 * donation.amount);

--- a/server/models/Group.js
+++ b/server/models/Group.js
@@ -567,17 +567,16 @@ export default function(Sequelize, DataTypes) {
       },
 
       getHost() {
-        return Sequelize.models.UserGroup.find({
-          where: {
-            GroupId: this.id,
-            role: roles.HOST
-          }
+        return Sequelize.models.User.findOne({
+          include: [
+            { model: models.UserGroup, where: { role: 'HOST', GroupId: this.id } }
+          ]
         });
       },
 
       hasHost() {
         return this.getHost()
-        .then(userGroup => Promise.resolve(!!userGroup));
+        .then(user => Promise.resolve(!!user));
       },
 
       getSuperCollectiveData() {


### PR DESCRIPTION
Currently, we send a host of a collective at the same time as all the other users (members, backers, etc). 

In a supercollective, we send all the members, backers and hosts of *all* of it's subcollectives. This means the frontend receives multiple hosts and doesn't know which is the right one.

This PR sends Host separately for a collective in it's first group info. 