### PR TITLE
[bug] Fix broken image in login link email

### DIFF
--- a/templates/partials/footer.hbs
+++ b/templates/partials/footer.hbs
@@ -5,7 +5,7 @@
     <td colspan="3" align="center">
       <table width="100%"><tr><td></td><td width="200">
         <a href="https://opencollective.com?{{@root.utm}}">
-          <img width="220"  height="28" src="https://opencollective.com/public/images/image-email-footer@2x.png" />
+          <img width="220"  height="28" src="https://opencollective.com/public/images/logo-email-footer@2x.png" />
         </a>
       </td><td></td></tr></table>
     </td>


### PR DESCRIPTION
PR incoming

![screenshot of broken image in email](https://imgur.com/P26Dg6U.png)

Seems `image-email-footer@2x.png` was renamed to `logo-email-footer@2x.png`.