### PR TITLE
making sure new events created are active by default …

### DIFF
--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -71,6 +71,9 @@ const mutations = {
             .then(pc => {
               if (!pc) return Promise.reject(new Error(`Parent collective with id ${args.collective.ParentCollectiveId} not found`));
               parentCollective = pc;
+              if (req.remoteUser.hasRole([roles.ADMIN, roles.HOST, roles.MEMBER], parentCollective.id)) {
+                collectiveData.isActive = true;
+              }
             })
         );
       }

--- a/test/graphql.mutation.test.js
+++ b/test/graphql.mutation.test.js
@@ -122,11 +122,12 @@ describe('Mutation Tests', () => {
         const query = `
         mutation createCollective($collective: CollectiveInputType!) {
           createCollective(collective: $collective) {
-            id,
-            slug,
+            id
+            slug
+            isActive
             tiers {
-              id,
-              name,
+              id
+              name
               amount
             }
           }
@@ -137,7 +138,7 @@ describe('Mutation Tests', () => {
         const createdEvent = result.data.createCollective;
         expect(createdEvent.slug).to.equal(`brusselstogether-meetup-3-4ev`);
         expect(createdEvent.tiers.length).to.equal(event.tiers.length);
-
+        expect(createdEvent.isActive).to.be.true;
         event.id = createdEvent.id;
         event.slug = 'newslug';
         event.tiers = createdEvent.tiers;


### PR DESCRIPTION
…if creator is admin/member/host of the parent collective

Fixes https://github.com/opencollective/opencollective/issues/510