### PR TITLE
Fix install process in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,12 @@
 
 ## How to get started
 
-Note: If you see a step below that could be improved (or is outdated), please update instructions. We rarely go through this process ourselves, so your fresh pair of eyes and your recent experience with it, makes you the best candidate to improve them for other users. 
+Note: If you see a step below that could be improved (or is outdated), please update instructions. We rarely go through this process ourselves, so your fresh pair of eyes and your recent experience with it, makes you the best candidate to improve them for other users.
 
 ### Database
 Install Postgres 9.x. Start the database server, if necessary.
 
-For development, ensure that local connections do not require a password. Locate your `pg_hba.conf` file by
-running `ps aux | grep postgres` and note the directory in the `postgres` or `postmaster` process, specified with `-D`.
-It will look something like `/Library/PostgreSQL/9.3/data`. We'll call this the `$POSTGRES_DATADIR`. `cd` to `$POSTGRES_DATADIR`, and
-edit `pg_hba.conf` to `trust` local socket connections and local IP connections. Restart `postgres` - on Mac OS X, there may be
-restart scripts already in place with `brew`, if not use `pg_ctl -D $POSTGRES_DATADIR restart`.
+For development, ensure that local connections do not require a password. Locate your `pg_hba.conf` file by running `SHOW hba_file;` from the psql prompt (`sudo -i -u postgres` + `psql` after clean install). This should look something like `/etc/postgresql/9.5/main/pg_hba.conf`. We'll call the parent directory of `pg_hba.conf` the `$POSTGRES_DATADIR`. `cd` to `$POSTGRES_DATADIR`, and edit `pg_hba.conf` to `trust` local socket connections and local IP connections. Restart `postgres` - on Mac OS X, there may be restart scripts already in place with `brew`, if not use `pg_ctl -D $POSTGRES_DATADIR restart`.
 
 Now, assuming the postgres database superuser is `postgres`, let's create the databases.
 ```


### PR DESCRIPTION
Fix replaces unreliable though common methodology of piping ps aux output through grep to locate pg_hba.conf. This method will not work on all systems, as it relies on a tagentially related query to locate the file. The only reliable method for locating pg_hba.conf is to query directly via the postgres shell using the SHOW hba_file; command, which is specifically designed for this purpose.