### PR TITLE
cc the collective on cancel

### DIFF
--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -292,7 +292,7 @@ const sendMessageFromActivity = (activity, notification) => {
       return generateEmailFromTemplateAndSend('collective.created', userEmail, data);
 
     case activities.SUBSCRIPTION_CANCELED:
-      return generateEmailFromTemplateAndSend('subscription.canceled', userEmail, data);
+      return generateEmailFromTemplateAndSend('subscription.canceled', userEmail, data, { cc: `info@${data.collective.slug}.opencollective.com` });
 
     default:
       return Promise.resolve();

--- a/templates/emails/subscription.canceled.hbs
+++ b/templates/emails/subscription.canceled.hbs
@@ -10,9 +10,9 @@ Subject: Subscription canceled to {{collective.name}}
 <p>Hi!</p>
 {{/if}}
 
-<p> We wanted to confirm that your subscription to {{collective.name}} for {{{currency subscription.amount currency=subscription.currency}}}/{{subscription.interval}} has been canceled. </p>
+<p>We wanted to confirm that your subscription to {{collective.name}} (cced) for {{{currency subscription.amount currency=subscription.currency}}}/{{subscription.interval}} has been canceled.</p>
 
-<p> We are sad 😞 to see you go. If you have any feedback about your experience - good, bad, or ugly - we want to hear about it. Just hit 'reply' and type away. </p>
+<p>We are sad 😞 to see you go. If you have any feedback about your experience - good, bad, or ugly - we want to hear about it. Just hit 'reply all' and type away.</p>
  
 <p>Warmly,</p>
 

--- a/test/subscriptions.routes.test.js
+++ b/test/subscriptions.routes.test.js
@@ -212,7 +212,7 @@ describe('subscriptions.routes.test.js', () => {
         .end(done);
     });
 
-    it.only('cancels the subscription', (done) => {
+    it('cancels the subscription', (done) => {
        request(app)
         .post(`/subscriptions/${order.SubscriptionId}/cancel?api_key=${application.api_key}`)
         .set('Authorization', `Bearer ${user.jwt()}`)

--- a/test/subscriptions.routes.test.js
+++ b/test/subscriptions.routes.test.js
@@ -212,7 +212,7 @@ describe('subscriptions.routes.test.js', () => {
         .end(done);
     });
 
-    it('cancels the subscription', (done) => {
+    it.only('cancels the subscription', (done) => {
        request(app)
         .post(`/subscriptions/${order.SubscriptionId}/cancel?api_key=${application.api_key}`)
         .set('Authorization', `Bearer ${user.jwt()}`)
@@ -239,10 +239,11 @@ describe('subscriptions.routes.test.js', () => {
               expect(activity.data.user.id).to.be.equal(user.id);
             })
             .then(() => {
-              const subject = nm.sendMail.lastCall.args[0].subject;
-              const html = nm.sendMail.lastCall.args[0].html;
+              const { subject, html, cc } = nm.sendMail.lastCall.args[0];
+
               expect(subject).to.contain('Subscription canceled to Scouts');
               expect(html).to.contain('20/month has been canceled');
+              expect(cc).to.equal(`info@${collective.slug}.opencollective.com`);
               done();
             })
             .catch(done);


### PR DESCRIPTION
When sending the sorry to see you go email, this will make sure the core contributors of the collective are cced.