### PR TITLE
Add parameters dateFrom & dateTo to gql query `allTransactions'

### DIFF
--- a/server/graphql/queries.js
+++ b/server/graphql/queries.js
@@ -77,7 +77,9 @@ const queries = {
       CollectiveId: { type: new GraphQLNonNull(GraphQLInt) },
       type: { type: GraphQLString },
       limit: { type: GraphQLInt },
-      offset: { type: GraphQLInt }
+      offset: { type: GraphQLInt },
+      dateFrom: { type: GraphQLString },
+      dateTo: { type: GraphQLString },
     },
     resolve(_, args) {
       const query = {
@@ -87,6 +89,13 @@ const queries = {
       if (args.type) query.where.type = args.type;
       if (args.limit) query.limit = args.limit;
       if (args.offset) query.offset = args.offset;
+
+      // Add date ranges to the query
+      if (args.dateFrom || args.dateTo) {
+        query.where.createdAt = {};
+        if (args.dateFrom) query.where.createdAt['$gte'] = args.dateFrom;
+        if (args.dateTo) query.where.createdAt['$lte'] = args.dateTo;
+      }
       return models.Transaction.findAll(query);
     }
   },

--- a/test/graphql.transaction.test.js
+++ b/test/graphql.transaction.test.js
@@ -145,6 +145,55 @@ describe('graphql.transaction.test.js', () => {
       });
     });
 
+    it('with dateFrom', async () => {
+      // Given the followin query
+      const query = `
+        query allTransactions($CollectiveId: Int!, $limit: Int, $offset: Int, $type: String, $dateFrom: String $dateTo: String) {
+          allTransactions(CollectiveId: $CollectiveId, limit: $limit, offset: $offset, type: $type, dateFrom: $dateFrom, dateTo: $dateTo) {
+            id,
+          }
+        }
+      `;
+
+      // When the query is executed with the parameter `dateFrom`
+      const result = await utils.graphqlQuery(query, {
+        CollectiveId: 2,
+        dateFrom: '2017-10-01',
+      });
+
+      // Then the result should contain no errors
+      expect(result.errors).to.not.exist;
+
+      // TODO: If the database rows change, this test will likely fail
+      // And then the results should only include the rows with
+      // `createdAt` after `dateFrom`.
+      expect(result.data.allTransactions.length).to.equal(5);
+    });
+
+    it('with dateTo', async () => {
+      // Given the followin query
+      const query = `
+        query allTransactions($CollectiveId: Int!, $limit: Int, $offset: Int, $type: String, $dateFrom: String $dateTo: String) {
+          allTransactions(CollectiveId: $CollectiveId, limit: $limit, offset: $offset, type: $type, dateFrom: $dateFrom, dateTo: $dateTo) {
+            id,
+          }
+        }
+      `;
+
+      // When the query is executed with the parameter `dateFrom`
+      const result = await utils.graphqlQuery(query, {
+        CollectiveId: 2,
+        dateTo: '2017-10-01',
+      });
+
+      // Then the result should contain no errors
+      expect(result.errors).to.not.exist;
+
+      // TODO: If the database rows change, this test will likely fail
+      // And then there should bring all the rows created before `2017-10-01`
+      expect(result.data.allTransactions.length).to.equal(78);
+    });
+
     it('with pagination', async () => {
       const limit = 20;
       const offset = 20;


### PR DESCRIPTION
This will allow users to query for all transactions of a collective
between two dates. It's related to the following ticket:

  https://github.com/opencollective/opencollective/issues/794