### PR TITLE
Use a randomly generated session secret value

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -3,3 +3,4 @@ API_KEY=dvl-1510egmf4a23d80342403fb599qd
 PG_DATABASE=opencollective_dvl
 PORT=3060
 WEBSITE_URL=http://localhost:3000
+SESSION_SECRET=i&j@/V6Wx.`g>Aq?qQQF(>u)/Erm;3A=

--- a/config/circleci.json
+++ b/config/circleci.json
@@ -6,7 +6,8 @@
   "keys": {
     "opencollective": {
       "api_key": "circleci-1510egmf4a23d80342403fb599qd",
-      "secret": "circleci-a6ad8e62b53b18b4c30295f45d849c1"
+      "secret": "circleci-a6ad8e62b53b18b4c30295f45d849c1",
+      "session_secret": "circleci-i&j@/V6Wx.`g>Aq?qQQF(>u)/Erm;3A="
     }
   },
   "stripe": {

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -14,6 +14,7 @@
   "keys": {
     "opencollective": {
       "api_key": "API_KEY",
+      "session_secret": "SESSION_SECRET",
       "secret": "JWT_SECRET",
       "resetPasswordSecret": "RESET_PASSWORD_SECRET"
     }

--- a/config/development.json
+++ b/config/development.json
@@ -13,7 +13,8 @@
   "keys": {
     "opencollective": {
       "api_key": "dvl-1510egmf4a23d80342403fb599qd",
-      "secret": "dvl-7749ba6ad8e62b53b18b4c30295f45d849c1"
+      "secret": "dvl-7749ba6ad8e62b53b18b4c30295f45d849c1",
+      "session_secret": "i&j@/V6Wx.`g>Aq?qQQF(>u)/Erm;3A="
     }
   },
   "stripe": {

--- a/server/lib/express.js
+++ b/server/lib/express.js
@@ -91,7 +91,7 @@ export default function(app) {
 
   app.use(cookieParser());
   app.use(session({
-    secret: 'my_precious',
+    secret: config.keys.opencollective.session_secret,
     resave: false,
     cookie: { maxAge: 1000 * 60 * 5 },
     saveUninitialized: false,


### PR DESCRIPTION
We don't seem to be storing any data in cookies but if we ever do we don't want to have anyone besides the user's browser to be able to know what's inside of it.

I already executed the following command for both staging & production:

`heroku config:set -a <HEROKU-APP-ID> SESSION_SECRET=$(apg -a1 -m56 -n1)`

