### PR TITLE
Properly populate transaction fees

### DIFF
--- a/scripts/properly_populate_transaction_fees.js
+++ b/scripts/properly_populate_transaction_fees.js
@@ -1,5 +1,23 @@
+/**
+ * These are some recommendations for using the script in
+ * *development* mode. We currently have ~70000 transactions in our
+ * database, running it with a large batch to process all the
+ * transactions at once is the fastest way to run it and get the
+ * output, however it also exhausts node's memory limits with batches
+ * larger than ~50000. Use --max-old-space=8192 to do it all in one
+ * batch and iterate faster.
+ *
+ * For production usage, It might be a good idea to break it down in
+ * multiple batches to leave some room for the database to process
+ * operations from the web clients. I've been running 7 batches of
+ * 10000 and didn't take more than ~20s in my machine (i7~2.2GHz),
+ * which is just a little bit slower than running it all in one batch.
+ */
 import { ArgumentParser } from 'argparse';
 import models, { sequelize } from '../server/models';
+import * as transactionsLib from '../server/lib/transactions';
+import * as paymentsLib from '../server/lib/payments';
+import { OC_FEE_PERCENT } from '../server/constants/transactions';
 
 class Migration {
   constructor(options) {
@@ -19,29 +37,15 @@ class Migration {
       where: { deletedAt: null },
       order: ['TransactionGroup'],
       limit: this.options.batchSize,
-      offset: this.offset
+      offset: this.offset,
+      include: [{ model: models.Collective, as: 'collective' }]
     });
     this.offset += transactions.length;
     return transactions;
   }
 
-  /** net value of a transaction */
-  trValue = (tr) => Math.round(
-      tr.amountInHostCurrency +
-      tr.hostFeeInHostCurrency +
-      tr.platformFeeInHostCurrency +
-      tr.paymentProcessorFeeInHostCurrency) * tr.hostCurrencyFxRate;
-
-  /** Verify net value of a transaction */
-  verify = (tr) => this.trValue(tr) === tr.netAmountInCollectiveCurrency;
-
-  /** Difference between transaction net value & netAmountInCollectiveCurrency */
-  difference = (tr) => this.trValue(tr) - tr.netAmountInCollectiveCurrency;
-
   /** Convert `value` to negative if it's possitive */
-  toNegative = (value) => {
-    return value > 0 ? -value : value;
-  }
+  toNegative = (value) => value > 0 ? -value : value;
 
   /** Ensure that `tr` has the `hostCurrencyFxRate` field filled in */
   ensureHostCurrencyFxRate = (tr) => {
@@ -49,46 +53,130 @@ class Migration {
       tr.hostCurrencyFxRate = 1;
   }
 
+  /** Return true if the transaction has any host fees */
+  hasHostFee = (tr) => tr.hostFeeInHostCurrency
+    && parseInt(tr.hostFeeInHostCurrency, 10) !== 0;
+  /** Return true if the transaction has any platform fees */
+  hasPlatformFee = (tr) => tr.paymentProcessorFeeInHostCurrency
+    && parseInt(tr.paymentProcessorFeeInHostCurrency, 10) !== 0;
   /** Return false if there are no fees on a transaction */
-  hasFees = (tr) => (tr.hostFeeInHostCurrency && parseInt(tr.hostFeeInHostCurrency, 10) !== 0)
-    || (tr.platformFeeInHostCurrency && parseInt(tr.platformFeeInHostCurrency, 10) !== 0)
-    || (tr.paymentProcessorFeeInHostCurrency && parseInt(tr.paymentProcessorFeeInHostCurrency, 10) !== 0);
+  hasFees = (tr) => this.hasHostFee(tr) || this.hasPlatformFee(tr)
+    || (tr.platformFeeInHostCurrency && parseInt(tr.platformFeeInHostCurrency, 10) !== 0);
 
-  /** Rewrite the values of the fees */
   rewriteFees = (credit, debit) => {
-    credit.hostFeeInHostCurrency = debit.hostFeeInHostCurrency = this.toNegative(credit.hostFeeInHostCurrency);
-    credit.platformFeeInHostCurrency = debit.platformFeeInHostCurrency = this.toNegative(credit.platformFeeInHostCurrency);
-    credit.paymentProcessorFeeInHostCurrency = debit.paymentProcessorFeeInHostCurrency = this.toNegative(credit.paymentProcessorFeeInHostCurrency);
+    credit.hostFeeInHostCurrency = debit.hostFeeInHostCurrency =
+      this.toNegative(credit.hostFeeInHostCurrency || credit.hostFeeInHostCurrency);
+    credit.platformFeeInHostCurrency = debit.platformFeeInHostCurrency =
+      this.toNegative(credit.platformFeeInHostCurrency || debit.platformFeeInHostCurrency);
+    credit.paymentProcessorFeeInHostCurrency = debit.paymentProcessorFeeInHostCurrency =
+      this.toNegative(credit.paymentProcessorFeeInHostCurrency || debit.paymentProcessorFeeInHostCurrency);
+  }
+
+  /** Fix rounding errors in fees and rewrite netAmount */
+  rewriteFeesAndNetAmount = (credit, debit) => {
+    if (!credit.collective || !debit.collective) {
+      if (!credit.collective) console.log('credit with no collective!!!!', credit.id);
+      if (!debit.collective) console.log('debit with no collective!!!!', credit.id);
+      return;
+    }
+
+    /* Recalculate Host Fee */
+    let hostFeePercent;
+    if (this.hasHostFee(credit) || this.hasHostFee(debit)) {
+      hostFeePercent = Math.round(-this.toNegative(
+        (credit.hostFeePercent || debit.hostFeePercent) * 100 / credit.amountInHostCurrency));
+    }
+    if (hostFeePercent != 5 && hostFeePercent != 10 && hostFeePercent !== 0)
+      console.log('Suspicious hostFee',
+                  credit.id,
+                  credit.amountInHostCurrency,
+                  credit.amountInHostCurrency * hostFeePercent / 100,
+                  hostFeePercent);
+
+    /* Recalculate Platform Fee */
+    const platformFeePercent = Math.round(-this.toNegative(
+      credit.platformFeeInHostCurrency * 100 / credit.amountInHostCurrency));
+    if (platformFeePercent != 5 && platformFeePercent !== 0)
+      console.log('Suspicious platformFee',
+                  credit.id,
+                  credit.amountInHostCurrency,
+                  credit.amountInHostCurrency * 0.05,
+                  platformFeePercent);
+
+    /* This */
+    credit.platformFeeInHostCurrency = this.toNegative(
+      paymentsLib.calcFee(credit.amountInHostCurrency, OC_FEE_PERCENT));
+    debit.platformFeeInHostCurrency = this.toNegative(
+      paymentsLib.calcFee(credit.amountInHostCurrency, OC_FEE_PERCENT));
+
+    credit.netAmountInCollectiveCurrency = transactionsLib.netAmount(credit);
+    debit.netAmountInCollectiveCurrency = -credit.amountInHostCurrency * credit.hostCurrencyFxRate;
+  }
+
+  /** Make sure two transactions are pairs of each other */
+  validatePair = (tr1, tr2) => {
+    if (tr1.TransactionGroup !== tr2.TransactionGroup) {
+      throw new Error('Wrong transaction pair detected');
+    }
+    if (tr1.ExpenseId !== tr2.ExpenseId) {
+      throw new Error('Wrong transaction pair detected: ExpenseId does not match');
+    }
+    if (tr1.OrderId !== tr2.OrderId) {
+      throw new Error('Wrong transaction pair detected: OrderId does not match');
+    }
   }
 
   /** Migrate one pair of transactions */
   migrate = async (tr1, tr2) => {
     console.log(tr1.TransactionGroup);
     console.log(tr2.TransactionGroup);
-    if (tr1.TransactionGroup !== tr2.TransactionGroup) {
-      throw new Error('Wrong transaction pair detected');
-    }
+    this.validatePair(tr1, tr2);
+
     const credit = tr1.type === 'CREDIT' ? tr1 : tr2;
     const debit =  tr1.type === 'DEBIT' ? tr1 : tr2;
-    if (tr1.ExpenseId !== null && tr1.ExpenseId === tr2.ExpenseId) {
-      console.log('  Expense.:', this.verify(tr1), this.verify(tr2));
-    } else if (tr1.OrderId !== null && tr1.OrderId === tr2.OrderId) {
+
+    if (tr1.ExpenseId !== null) {
+      // Both CREDIT & DEBIT transactions add up
+      if (transactionsLib.verify(credit) && transactionsLib.verify(debit)) {
+        console.log('Expense.: true, true');
+        return;
+      }
+
+      // this.rewriteFees(credit, debit);
+
+      console.log('  Expense.:', transactionsLib.verify(tr1), transactionsLib.verify(tr2));
+
+      if (!transactionsLib.verify(credit)) {
+        console.log(`| EDAU | CREDIT | ${credit.id} | ${credit.TransactionGroup} | ${transactionsLib.difference(credit)} |`);
+      }
+      if (!transactionsLib.verify(debit)) {
+        console.log(`| EDAU  | DEBIT | ${debit.id} | ${debit.TransactionGroup}  | ${transactionsLib.difference(debit)}  |`);
+      }
+    } else if (tr1.OrderId !== null) {
       this.ensureHostCurrencyFxRate(credit);
       this.ensureHostCurrencyFxRate(debit);
+      this.rewriteFees(credit, debit);
 
-      console.log('  Order...:', this.verify(credit), this.verify(debit));
+      // Both CREDIT & DEBIT transactions add up
+      if (transactionsLib.verify(credit) && transactionsLib.verify(debit)) {
+        console.log('Order...: true, true');
+        return;
+      }
+
+      // Something is off
+      console.log('  Order...:', transactionsLib.verify(credit), transactionsLib.verify(debit));
       if (!this.hasFees(tr1) && !this.hasFees(tr2)) {
         console.log('    No fees, skipping');
         return;
       }
 
-      this.rewriteFees(credit, debit);
+      this.rewriteFeesAndNetAmount(credit, debit);
 
-      if (!this.verify(credit)) {
-        console.log(`    doesn't add up | ${credit.id} | CREDIT | ${credit.TransactionGroup} | ${this.difference(credit)} |`);
+      if (!transactionsLib.verify(credit)) {
+        console.log(`| ODAU | CREDIT | ${credit.id} | ${credit.TransactionGroup} | ${transactionsLib.difference(credit)} |`);
       }
-      if (!this.verify(debit)) {
-        console.log(`    doesn't add up | ${debit.id}  | DEBIT  | ${debit.TransactionGroup}  | ${this.difference(debit)}  |`);
+      if (!transactionsLib.verify(debit)) {
+        console.log(`| ODAU | DEBIT  | ${debit.id}  | ${debit.TransactionGroup}  | ${transactionsLib.difference(debit)}  |`);
       }
 
       // if (!credit.hostFeeInHostCurrency)
@@ -98,20 +186,20 @@ class Migration {
       // if (!credit.paymentProcessorFeeInHostCurrency)
       //   console.log('    * WARNING: C:ppFee.......: ', credit.paymentProcessorFeeInHostCurrency);
     } else {
-      console.log('  WAT.....:', this.verify(tr1), this.verify(tr2));
+      console.log('  WAT.....:', transactionsLib.verify(tr1), transactionsLib.verify(tr2));
     }
 
-    console.log('    * C:amount......: ', credit.amountInHostCurrency);
-    console.log('    * C:netAmount...: ', credit.netAmountInCollectiveCurrency);
-    console.log('    * C:hostFee.....: ', credit.hostFeeInHostCurrency);
-    console.log('    * C:platformFee.: ', credit.platformFeeInHostCurrency);
-    console.log('    * C:ppFee.......: ', credit.paymentProcessorFeeInHostCurrency);
+    // console.log('    * C:amount......: ', credit.amountInHostCurrency);
+    // console.log('    * C:netAmount...: ', credit.netAmountInCollectiveCurrency);
+    // console.log('    * C:hostFee.....: ', credit.hostFeeInHostCurrency);
+    // console.log('    * C:platformFee.: ', credit.platformFeeInHostCurrency);
+    // console.log('    * C:ppFee.......: ', credit.paymentProcessorFeeInHostCurrency);
 
-    console.log('    * D:amount......: ', debit.amountInHostCurrency);
-    console.log('    * D:netAmount...: ', debit.netAmountInCollectiveCurrency);
-    console.log('    * D:hostFee.....: ', debit.hostFeeInHostCurrency);
-    console.log('    * D:platformFee.: ', debit.platformFeeInHostCurrency);
-    console.log('    * D:ppFee.......: ', debit.paymentProcessorFeeInHostCurrency);
+    // console.log('    * D:amount......: ', debit.amountInHostCurrency);
+    // console.log('    * D:netAmount...: ', debit.netAmountInCollectiveCurrency);
+    // console.log('    * D:hostFee.....: ', debit.hostFeeInHostCurrency);
+    // console.log('    * D:platformFee.: ', debit.platformFeeInHostCurrency);
+    // console.log('    * D:ppFee.......: ', debit.paymentProcessorFeeInHostCurrency);
   }
 
   /** Run the whole migration */
@@ -143,11 +231,11 @@ function parseCommandLineArguments() {
     addHelp: true,
     description: 'Charge due subscriptions'
   });
-  parser.addArgument(['-v', '--verbose'], {
-    help: 'Verbose output',
-    defaultValue: false,
+  parser.addArgument(['-q', '--quiet'], {
+    help: 'Silence output',
+    defaultValue: true,
     action: 'storeConst',
-    constant: true
+    constant: false
   });
   parser.addArgument(['--notdryrun'], {
     help: "Pass this flag when you're ready to run the script for real",
@@ -165,7 +253,7 @@ function parseCommandLineArguments() {
   const args = parser.parseArgs();
   return {
     dryRun: !args.notdryrun,
-    verbose: args.verbose,
+    verbose: !args.quiet,
     limit: args.limit,
     batchSize: args.batch_size || 100
   };

--- a/scripts/properly_populate_transaction_fees.js
+++ b/scripts/properly_populate_transaction_fees.js
@@ -249,10 +249,10 @@ export class Migration {
       console.log('  Expense.:', transactionsLib.verify(tr1), transactionsLib.verify(tr2));
 
       if (!transactionsLib.verify(credit)) {
-        console.log(`| EDAU | CREDIT | ${credit.id} | ${credit.TransactionGroup} | ${transactionsLib.difference(credit)} |`);
+        console.log(`EDAU, CREDIT, ${credit.id}, ${credit.TransactionGroup}, ${transactionsLib.difference(credit)}`);
       }
       if (!transactionsLib.verify(debit)) {
-        console.log(`| EDAU  | DEBIT | ${debit.id} | ${debit.TransactionGroup}  | ${transactionsLib.difference(debit)}  |`);
+        console.log(`EDAU, DEBIT, ${debit.id}, ${debit.TransactionGroup}, ${transactionsLib.difference(debit)}`);
       }
     } else if (tr1.OrderId !== null) {
       if (transactionsLib.verify(credit) && transactionsLib.verify(debit)) {
@@ -285,10 +285,10 @@ export class Migration {
       // Something is still off
       console.log('Order...:', transactionsLib.verify(credit), transactionsLib.verify(debit));
       if (!transactionsLib.verify(credit)) {
-        console.log(`| ODAU | CREDIT | ${credit.id} | ${credit.TransactionGroup} | ${transactionsLib.netAmount(credit)} | ${transactionsLib.difference(credit)} |`);
+        console.log(`ODAU, CREDIT, ${credit.id}, ${credit.TransactionGroup}, ${transactionsLib.netAmount(credit)}, ${transactionsLib.difference(credit)}`);
       }
       if (!transactionsLib.verify(debit)) {
-        console.log(`| ODAU | DEBIT  | ${debit.id}  | ${debit.TransactionGroup}  | ${transactionsLib.netAmount(debit)} | ${transactionsLib.difference(debit)}  |`);
+        console.log(`ODAU, DEBIT, ${debit.id}, ${debit.TransactionGroup}, ${transactionsLib.netAmount(debit)}, ${transactionsLib.difference(debit)}`);
       }
     } else {
       console.log('  WAT.....:', transactionsLib.verify(tr1), transactionsLib.verify(tr2));

--- a/scripts/properly_populate_transaction_fees.js
+++ b/scripts/properly_populate_transaction_fees.js
@@ -1,0 +1,120 @@
+import { ArgumentParser } from 'argparse';
+import models, { sequelize } from '../server/models';
+
+class Migration {
+  constructor(options) {
+    this.options = options;
+    this.offset = 0;
+    this.migrated = 0;
+
+    this.countValidTransactions = this.countValidTransactions.bind(this);
+    this.retrieveValidTransactions = this.retrieveValidTransactions.bind(this);
+    this.migrate = this.migrate.bind(this);
+    this.run = this.run.bind(this);
+  }
+  /** Retrieve the total number of valid transactions */
+  async countValidTransactions() {
+    return models.Transaction.count({ where: { deletedAt: null } });
+  }
+  /** Retrieve a batch of valid transactions */
+  async retrieveValidTransactions() {
+    const transactions = await models.Transaction.findAll({
+      where: { deletedAt: null },
+      order: ['TransactionGroup'],
+      limit: this.options.batchSize,
+      offset: this.offset
+    });
+    this.offset += transactions.length;
+    return transactions;
+  }
+  /** Verify values of fees in a transaction */
+  verifyFees(tr) {
+    return tr.amountInHostCurrency +
+      tr.hostFeeInHostCurrency +
+      tr.platformFeeInHostCurrency +
+      tr.paymentProcessorFeeInHostCurrency === (tr.netAmountInCollectiveCurrency * tr.hostCurrencyFxRate);
+  }
+  /** Migrate one pair of transactions */
+  async migrate(tr1, tr2) {
+    // if (tr1.type === 'CREDIT') {}
+    console.log(tr1.TransactionGroup);
+    console.log(this.verifyFees(tr1));
+    console.log(this.verifyFees(tr2));
+  }
+  /** Run the whole migration */
+  async run() {
+    const count = this.options.limit || await this.countValidTransactions();
+    while (this.offset < count) {
+      /* Transactions are sorted by their TransactionGroup, which
+       * means that the first transaction is followed by its negative
+       * transaction, the third transaction is followed by its pair
+       * and so forth. */
+      const transactions = await this.retrieveValidTransactions();
+      for (let i = 0; i < transactions.length; i += 2) {
+        /* Sanity check */
+        if (transactions[i].TransactionGroup !== transactions[i + 1].TransactionGroup) {
+          throw new Error(`Cannot find pair for the transaction id ${transactions[i].id}`);
+        }
+        /* Migrate the pair that we just found */
+        this.migrate(transactions[i], transactions[i + 1]);
+      }
+    }
+  }
+}
+
+/* -- Utilities & Script Entry Point -- */
+
+/** Return the options passed by the user to run the script */
+function parseCommandLineArguments() {
+  const parser = new ArgumentParser({
+    addHelp: true,
+    description: 'Charge due subscriptions'
+  });
+  parser.addArgument(['-v', '--verbose'], {
+    help: 'Verbose output',
+    defaultValue: false,
+    action: 'storeConst',
+    constant: true
+  });
+  parser.addArgument(['--notdryrun'], {
+    help: "Pass this flag when you're ready to run the script for real",
+    defaultValue: false,
+    action: 'storeConst',
+    constant: true
+  });
+  parser.addArgument(['-l', '--limit'], {
+    help: 'total subscriptions to process'
+  });
+  parser.addArgument(['-b', '--batch-size'], {
+    help: 'batch size to fetch at a time',
+    defaultValue: 10
+  });
+  const args = parser.parseArgs();
+  return {
+    dryRun: !args.notdryrun,
+    verbose: args.verbose,
+    limit: args.limit,
+    batchSize: args.batch_size || 100
+  };
+}
+
+/** Print `message` to console if `options.verbose` is true */
+function vprint(options, message) {
+  if (options.verbose) {
+    console.log(message);
+  }
+}
+
+/** Kick off the script with all the user selected options */
+async function entryPoint(options) {
+  vprint(options, 'Starting to migrate fees');
+  try {
+    await (new Migration(options)).run();
+  } finally {
+    await sequelize.close();
+  }
+  vprint(options, 'Finished migrating fees');
+}
+
+/* Entry point */
+entryPoint(parseCommandLineArguments());

--- a/scripts/properly_populate_transaction_fees.js
+++ b/scripts/properly_populate_transaction_fees.js
@@ -73,7 +73,7 @@ export class Migration {
   rewriteFees = (credit, debit) => {
     // Update hostFeeInHostCurrency
     const newHostFeeInHostCurrency = this.toNegative(credit.hostFeeInHostCurrency || debit.hostFeeInHostCurrency);
-    if (newHostFeeInHostCurrency) {
+    if (newHostFeeInHostCurrency || newHostFeeInHostCurrency === 0) {
       this.saveTransactionChange(credit, 'hostFeeInHostCurrency', credit.hostFeeInHostCurrency, newHostFeeInHostCurrency);
       credit.hostFeeInHostCurrency = newHostFeeInHostCurrency;
       this.saveTransactionChange(debit, 'hostFeeInHostCurrency', debit.hostFeeInHostCurrency, newHostFeeInHostCurrency);
@@ -81,7 +81,7 @@ export class Migration {
     }
     // Update platformFeeInHostCurrency
     const newPlatformFeeInHostCurrency = this.toNegative(credit.platformFeeInHostCurrency || debit.platformFeeInHostCurrency);
-    if (newPlatformFeeInHostCurrency) {
+    if (newPlatformFeeInHostCurrency || newPlatformFeeInHostCurrency === 0) {
       this.saveTransactionChange(credit, 'platformFeeInHostCurrency', credit.platformFeeInHostCurrency, newPlatformFeeInHostCurrency);
       credit.platformFeeInHostCurrency = newPlatformFeeInHostCurrency;
       this.saveTransactionChange(debit, 'platformFeeInHostCurrency', debit.platformFeeInHostCurrency, newPlatformFeeInHostCurrency);
@@ -89,7 +89,7 @@ export class Migration {
     }
     // Update paymentProcessorFeeInHostCurrency
     const newPaymentProcessorFeeInHostCurrency = this.toNegative(credit.paymentProcessorFeeInHostCurrency || debit.paymentProcessorFeeInHostCurrency);
-    if (newPaymentProcessorFeeInHostCurrency) {
+    if (newPaymentProcessorFeeInHostCurrency || newPaymentProcessorFeeInHostCurrency === 0) {
       this.saveTransactionChange(credit, 'paymentProcessorFeeInHostCurrency', credit.paymentProcessorFeeInHostCurrency, newPaymentProcessorFeeInHostCurrency);
       credit.paymentProcessorFeeInHostCurrency = newPaymentProcessorFeeInHostCurrency;
       this.saveTransactionChange(debit, 'paymentProcessorFeeInHostCurrency', debit.paymentProcessorFeeInHostCurrency, newPaymentProcessorFeeInHostCurrency);
@@ -147,7 +147,7 @@ export class Migration {
     //   const newHostFeeInHostCurrency =
     //         this.toNegative(paymentsLib.calcFee(
     //           credit.amountInHostCurrency, roundHostFeePercent));
-    //   if (newHostFeeInHostCurrency) {
+    //   if (newHostFeeInHostCurrency || newHostFeeInHostCurrency === 0) {
     //     this.saveTransactionChange(credit, 'hostFeeInHostCurrency', credit.hostFeeInHostCurrency, newHostFeeInHostCurrency);
     //     credit.hostFeeInHostCurrency = newHostFeeInHostCurrency;
     //     this.saveTransactionChange(debit, 'hostFeeInHostCurrency', debit.hostFeeInHostCurrency, newHostFeeInHostCurrency);

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -7,11 +7,17 @@ import { types } from '../constants/collectives';
 import paymentProviders from '../paymentProviders';
 import * as libsubscription from './subscriptions';
 
+/** Unpack actual method from Payment Method attached to the order */
 export async function processOrder(order, options) {
   const provider = order.paymentMethod ? order.paymentMethod.service : 'manual';
   const methodType = order.paymentMethod.type || 'default';
   const method = paymentProviders[provider].types[methodType]; // eslint-disable-line import/namespace
   return await method.processOrder(order, options);
+}
+
+/** Calculates how much an amount's fee is worth */
+export function calcFee(amount, fee) {
+  return Math.round(amount * fee / 100);
 }
 
 /**

--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -115,12 +115,11 @@ export function createFromPaidExpense(host, paymentMethod, expense, paymentRespo
 
 /** Calculate net amount of a transaction */
 export function netAmount(tr) {
-  const valueAndFees = Math.round(
-    tr.amountInHostCurrency +
-    tr.hostFeeInHostCurrency +
-    tr.platformFeeInHostCurrency +
-    tr.paymentProcessorFeeInHostCurrency);
-  return valueAndFees * tr.hostCurrencyFxRate;
+  return Math.round((
+      tr.amountInHostCurrency +
+      tr.hostFeeInHostCurrency +
+      tr.platformFeeInHostCurrency +
+      tr.paymentProcessorFeeInHostCurrency) * tr.hostCurrencyFxRate);
 }
 
 /** Verify net amount of a transaction */

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -544,3 +544,8 @@ export const promiseSeq = (arr, predicate, consecutive) => {
     });
   }, Promise.resolve([]));
 };
+
+/** Sleeps for MS milliseconds */
+export function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -2,6 +2,7 @@ import models, { sequelize } from '../../models';
 import { type as TransactionTypes } from '../../constants/transactions';
 import Promise from 'bluebird';
 import { getFxRate } from '../../lib/currency';
+import * as paymentsLib from '../../lib/payments';
 
 export default {
   features: {
@@ -85,8 +86,12 @@ export default {
       return getFxRate(order.currency, order.paymentMethod.currency)
       .then(fxrate => {
         const totalAmountInPaymentMethodCurrency = order.totalAmount * fxrate;
-        const hostFeeInHostCurrency = hostFeePercent / 100 * order.totalAmount * fxrate;
-        const platformFeeInHostCurrency = platformFeePercent / 100 * order.totalAmount * fxrate;
+        const hostFeeInHostCurrency = paymentsLib.calcFee(
+          order.totalAmount * fxrate,
+          hostFeePercent);
+        const platformFeeInHostCurrency = paymentsLib.calcFee(
+          order.totalAmount * fxrate,
+          platformFeePercent);
         payload.transaction = {
           type: TransactionTypes.CREDIT,
           OrderId: order.id,

--- a/test/graphql.createOrder.test.js
+++ b/test/graphql.createOrder.test.js
@@ -148,7 +148,7 @@ describe('createOrder', () => {
       expect(transaction.CollectiveId).to.equal(collective.id);
       expect(transaction.currency).to.equal(collective.currency);
       // expect(transaction.hostFeeInHostCurrency).to.equal(0.05 * order.totalAmount); // need to update BrusselsTogether.hostFee in opencollective_dvl DB
-      expect(transaction.platformFeeInHostCurrency).to.equal(0.05 * order.totalAmount);
+      expect(transaction.platformFeeInHostCurrency).to.equal(-(0.05 * order.totalAmount));
       expect(transaction.data.charge.currency).to.equal(collective.currency.toLowerCase());
       expect(transaction.data.charge.status).to.equal('succeeded');
       expect(transaction.data.balanceTransaction.net - transaction.hostFeeInHostCurrency).to.equal(transaction.netAmountInCollectiveCurrency);
@@ -206,7 +206,7 @@ describe('createOrder', () => {
       expect(transaction.CollectiveId).to.equal(collective.id);
       expect(transaction.currency).to.equal(collective.currency);
       expect(transaction.hostFeeInHostCurrency).to.equal(0);
-      expect(transaction.platformFeeInHostCurrency).to.equal(0.05 * order.totalAmount);
+      expect(transaction.platformFeeInHostCurrency).to.equal(-(0.05 * order.totalAmount));
       expect(transaction.data.charge.currency).to.equal(collective.currency.toLowerCase());
       expect(transaction.data.charge.status).to.equal('succeeded');
       expect(transaction.data.balanceTransaction.net - transaction.hostFeeInHostCurrency).to.equal(transaction.netAmountInCollectiveCurrency);
@@ -266,7 +266,7 @@ describe('createOrder', () => {
       expect(transaction.CollectiveId).to.equal(collective.id);
       expect(transaction.currency).to.equal(collective.currency);
       expect(transaction.hostFeeInHostCurrency).to.equal(0);
-      expect(transaction.platformFeeInHostCurrency).to.equal(0.05 * order.totalAmount);
+      expect(transaction.platformFeeInHostCurrency).to.equal(-(0.05 * order.totalAmount));
       expect(transaction.data.charge.currency).to.equal(collective.currency.toLowerCase());
       expect(transaction.data.charge.status).to.equal('succeeded');
       expect(transaction.data.balanceTransaction.net - transaction.hostFeeInHostCurrency).to.equal(transaction.netAmountInCollectiveCurrency);

--- a/test/graphql.paymentMethods.test.js
+++ b/test/graphql.paymentMethods.test.js
@@ -230,7 +230,7 @@ describe('graphql.paymentMethods.test.js', () => {
       expect(transaction.CreatedByUserId).to.equal(admin.id);
       expect(org.CreatedByUserId).to.equal(admin.id);
       expect(transaction.FromCollectiveId).to.equal(org.id);
-      expect(transaction.hostFeeInHostCurrency).to.equal(Math.round(hostFeePercent/100*order.totalAmount*fxrate));
+      expect(transaction.hostFeeInHostCurrency).to.equal(-Math.round(hostFeePercent/100*order.totalAmount*fxrate));
       expect(transaction.platformFeeInHostCurrency).to.equal(0);
       expect(transaction.paymentProcessorFeeInHostCurrency).to.equal(0);
       expect(transaction.hostCurrency).to.equal(host.currency);

--- a/test/scripts.properly_populate_transaction_fees.test.js
+++ b/test/scripts.properly_populate_transaction_fees.test.js
@@ -1,0 +1,216 @@
+import { expect } from 'chai';
+import { Migration } from '../scripts/properly_populate_transaction_fees';
+
+describe('Migration', () => {
+  describe('#saveTransactionChange', () => {
+    it('should create a new change within the data field', () => {
+      // Given a transaction with an empty data field
+      const transaction = { data: null };
+
+      // When a new change is added
+      (new Migration).saveTransactionChange(transaction, 'hostCurrencyFxRate', null, 1);
+
+      // Then the data field should reflect that update
+      expect(transaction.data).to.have.property('migration');
+      expect(transaction.data.migration).to.have.property('hostCurrencyFxRate');
+      expect(transaction.data.migration.hostCurrencyFxRate).to.deep.equal({ oldValue: null, newValue: 1 });
+    });
+
+    it('should not override previously created fields', () => {
+      // Given a transaction with a data field that contains a
+      // migration field
+      const transaction = { data: { migration: { hostCurrencyFxRate: { oldValue: null, newValue: 1 } } } };
+
+      // When a new field is added
+      (new Migration).saveTransactionChange(transaction, 'platformFeeInHostCurrency', 1082, 1083);
+
+      // Then both fields should be saved in the data.migration property
+      expect(transaction.data).to.have.property('migration');
+      expect(transaction.data.migration).to.have.property('hostCurrencyFxRate');
+      expect(transaction.data.migration.hostCurrencyFxRate).to.deep.equal({ oldValue: null, newValue: 1 });
+      expect(transaction.data.migration).to.have.property('platformFeeInHostCurrency');
+      expect(transaction.data.migration.platformFeeInHostCurrency).to.deep.equal({ oldValue: 1082, newValue: 1083 });
+    });
+  });
+  describe('#toNegative', () => {
+    it('should convert positive numbers to negative', () => {
+      expect((new Migration).toNegative(10)).to.equal(-10);
+    });
+    it('should not do anything with negative numbers', () => {
+      expect((new Migration).toNegative(-10)).to.equal(-10);
+    });
+  });
+  describe('#ensureHostCurrencyFxRate', () => {
+    it('should not touch transactions that contain a hostCurrencyFxRate value', () => {
+      // Given a transaction *with a value* for hostCurrencyFxRate
+      const transaction = { hostCurrencyFxRate: 1.5 };
+
+      // When we call the function that ensures the value exists
+      (new Migration).ensureHostCurrencyFxRate(transaction);
+
+      // Then nothing changes in the transaction.hostCurrencyFxRate
+      // value
+      expect(transaction.hostCurrencyFxRate).to.equal(1.5);
+    });
+    it('should not touch transactions between different currencies', () => {
+      // Given a transaction between different currencies
+      const transaction = { currency: 'MXN', hostCurrency: 'USD', hostCurrencyFxRate: 18.2 };
+      // when we call the function to that the value exists
+      (new Migration).ensureHostCurrencyFxRate(transaction);
+      // Then we see that nothing is done to hostCurrencyFxRate
+      expect(transaction.hostCurrencyFxRate).to.equal(18.2);
+    });
+    it('should not touch transactions that amount is different from amountInHostCurrency', () => {
+      // Given a transaction with amount different from amountInHostCurrency
+      const transaction = { amount: 10, amountInHostCurrency: 20, hostCurrencyFxRate: 2 };
+      // when we call the function to that the value exists
+      (new Migration).ensureHostCurrencyFxRate(transaction);
+      // Then we see that nothing is done to hostCurrencyFxRate
+      expect(transaction.hostCurrencyFxRate).to.equal(2);
+    });
+  });
+  describe('#rewriteFees', () => {
+    it('should find hostFeeInHostCurrency in the credit transaction & ensure it is negative in both credit & debit', () => {
+      // Given a credit and a debit transactions
+      const [credit1, debit1] = [
+        { hostFeeInHostCurrency: 250 },
+        { hostFeeInHostCurrency: 0 },
+      ];
+      const [credit2, debit2] = [
+        { hostFeeInHostCurrency: null },
+        { hostFeeInHostCurrency: 250 },
+      ];
+
+      // When the fee is rewritten
+      (new Migration).rewriteFees(credit1, debit1);
+      (new Migration).rewriteFees(credit2, debit2);
+
+      // Then we see that both hostFeeInHostCurrency values are
+      // negative
+      expect(credit1.hostFeeInHostCurrency).to.equal(-250);
+      expect(debit1.hostFeeInHostCurrency).to.equal(-250);
+      expect(credit1.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: 250, newValue: -250 } });
+      expect(debit1.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: 0, newValue: -250 } });
+
+      expect(credit2.hostFeeInHostCurrency).to.equal(-250);
+      expect(debit2.hostFeeInHostCurrency).to.equal(-250);
+      expect(credit2.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: null, newValue: -250 } });
+      expect(debit2.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: 250, newValue: -250 } });
+    });
+    it('should find platformFeeInHostCurrency in the credit transaction & ensure it is negative in both credit & debit', () => {
+      // Given a credit and a debit transactions
+      const [credit1, debit1] = [
+        { platformFeeInHostCurrency: 250 },
+        { platformFeeInHostCurrency: 0 },
+      ];
+      const [credit2, debit2] = [
+        { platformFeeInHostCurrency: null },
+        { platformFeeInHostCurrency: 250 },
+      ];
+
+      // When the fee is rewritten
+      (new Migration).rewriteFees(credit1, debit1);
+      (new Migration).rewriteFees(credit2, debit2);
+
+      // Then we see that both platformFeeInHostCurrency values are
+      // negative
+      expect(credit1.platformFeeInHostCurrency).to.equal(-250);
+      expect(debit1.platformFeeInHostCurrency).to.equal(-250);
+      expect(credit1.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: 250, newValue: -250 } });
+      expect(debit1.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: 0, newValue: -250 } });
+
+      expect(credit2.platformFeeInHostCurrency).to.equal(-250);
+      expect(debit2.platformFeeInHostCurrency).to.equal(-250);
+      expect(credit2.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: null, newValue: -250 } });
+      expect(debit2.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: 250, newValue: -250 } });
+    });
+    it('should find paymentProcessorFeeInHostCurrency in the credit transaction & ensure it is negative in both credit & debit', () => {
+      // Given a credit and a debit transactions
+      const [credit1, debit1] = [
+        { paymentProcessorFeeInHostCurrency: 250 },
+        { paymentProcessorFeeInHostCurrency: 0 },
+      ];
+      const [credit2, debit2] = [
+        { paymentProcessorFeeInHostCurrency: null },
+        { paymentProcessorFeeInHostCurrency: 250 },
+      ];
+
+      // When the fee is rewritten
+      (new Migration).rewriteFees(credit1, debit1);
+      (new Migration).rewriteFees(credit2, debit2);
+
+      // Then we see that both paymentProcessorFeeInHostCurrency
+      // values are negative
+      expect(credit1.paymentProcessorFeeInHostCurrency).to.equal(-250);
+      expect(debit1.paymentProcessorFeeInHostCurrency).to.equal(-250);
+      expect(credit1.data.migration).to.deep.equal({ paymentProcessorFeeInHostCurrency: { oldValue: 250, newValue: -250 } });
+      expect(debit1.data.migration).to.deep.equal({ paymentProcessorFeeInHostCurrency: { oldValue: 0, newValue: -250 } });
+
+      expect(credit2.paymentProcessorFeeInHostCurrency).to.equal(-250);
+      expect(debit2.paymentProcessorFeeInHostCurrency).to.equal(-250);
+      expect(credit2.data.migration).to.deep.equal({ paymentProcessorFeeInHostCurrency: { oldValue: null, newValue: -250 } });
+      expect(debit2.data.migration).to.deep.equal({ paymentProcessorFeeInHostCurrency: { oldValue: 250, newValue: -250 } });
+    });
+  });
+  describe('#recalculatePlatformFee', () => {
+    it('should recalculate the platform fee making sure it is properly round up', () => {
+      // Given a transaction that has the platformFeeInHostCurrency
+      // off because of a rounding error (one case for credit & one
+      // for debit)
+      const [credit1, debit1] = [
+        { platformFeeInHostCurrency: 1082, amountInHostCurrency: 21650 },
+        { platformFeeInHostCurrency: 0 },
+      ];
+      const [credit2, debit2] = [
+        { platformFeeInHostCurrency: 0, amountInHostCurrency: 21650 },
+        { platformFeeInHostCurrency: 1082 },
+      ];
+
+      // When the fee is recalculated
+      (new Migration).recalculatePlatformFee(credit1, debit1);
+      (new Migration).recalculatePlatformFee(credit2, debit2);
+
+      // Then we see that both platformFeeInHostCurrency values were
+      // fixed
+      expect(credit1.platformFeeInHostCurrency).to.equal(-1083);
+      expect(debit1.platformFeeInHostCurrency).to.equal(-1083);
+      expect(credit1.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: 1082, newValue: -1083 } });
+      expect(debit1.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: 0, newValue: -1083 } });
+
+      expect(credit2.platformFeeInHostCurrency).to.equal(-1083);
+      expect(debit2.platformFeeInHostCurrency).to.equal(-1083);
+      expect(credit2.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: 0, newValue: -1083 } });
+      expect(debit2.data.migration).to.deep.equal({ platformFeeInHostCurrency: { oldValue: 1082, newValue: -1083 } });
+    });
+  });
+  describe('#recalculateHostFee', () => {
+    it('should recalculate the host fee from credit', () => {
+      // Given a transaction that has the hostFeeInHostCurrency off
+      // because of a rounding error
+      const [credit1, debit1] = [
+        { hostFeeInHostCurrency: 1082, amountInHostCurrency: 21650, collective: { hostFeePercent: 5 } },
+        { hostFeeInHostCurrency: 0 },
+      ];
+      const [credit2, debit2] = [
+        { hostFeeInHostCurrency: 0, amountInHostCurrency: 21650, collective: { hostFeePercent: 5 } },
+        { hostFeeInHostCurrency: 1082 },
+      ];
+
+      // When the fee is recalculated
+      (new Migration).recalculateHostFee(credit1, debit1);
+      (new Migration).recalculateHostFee(credit2, debit2);
+
+      // Then we see that both hostFeeInHostCurrency values were
+      // fixed
+      expect(credit1.hostFeeInHostCurrency).to.equal(-1083);
+      expect(debit1.hostFeeInHostCurrency).to.equal(-1083);
+      expect(credit1.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: 1082, newValue: -1083 } });
+      expect(debit1.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: 0, newValue: -1083 } });
+
+      expect(credit2.hostFeeInHostCurrency).to.equal(-1083);
+      expect(debit2.hostFeeInHostCurrency).to.equal(-1083);
+      expect(credit2.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: 0, newValue: -1083 } });
+      expect(debit2.data.migration).to.deep.equal({ hostFeeInHostCurrency: { oldValue: 1082, newValue: -1083 } });
+    });
+  });
+});

--- a/test/webhooks.stripe.bitcoin.test.js
+++ b/test/webhooks.stripe.bitcoin.test.js
@@ -150,7 +150,7 @@ describe('webhooks.stripe.bitcoin.test.js', () => {
           .then(transactions => {
             expect(transactions.length).to.equal(2);
             expect(transactions[0].OrderId).to.equal(order.id)
-            expect(transactions[1].paymentProcessorFeeInHostCurrency).to.equal(order.totalAmount*0.008)
+            expect(transactions[1].paymentProcessorFeeInHostCurrency).to.equal(-(order.totalAmount*0.008))
             // TODO: write test case for $5 cap on stripe fees
           })
 


### PR DESCRIPTION
# TL;DR
Migration to fill in all the fee columns so the expression `netAmount = amount + hostFee + platformFee + paymentProcessorFee` is true for every single transaction in the database.

## Details
A single real transaction is currently represented by two rows in the `Transactions` table. One of the type `DEBIT` to represent the change in the **User ledger** and another one of the type `CREDIT` to represent changes in the **Collective Ledger**.

That's all good so far. The representation of the fees, however, is a little more confusing. Both rows (`CREDIT` & `DEBIT`) contain the columns to store the fees. But they're currently only populated on the `CREDIT` row. And their values are positive, so they don't really express exactly what is going on with that transaction. To make it a little easier to understand. Here's how a transaction is currently stored:

### How one transaction is stored

|            | User Ledger | Collective Ledger |
|------------|------------:|------------------:|
| Type       |       DEBIT |            CREDIT |
| Amount     |       -4075 |              5000 |
| Host Fee   |           0 |               500 |
| Plat Fee   |           0 |               250 |
| PP Fee     |           0 |               175 |
| Net Amount |       -5000 |              4075 |

### How it should look after the migration

|            | User Ledger | Collective Ledger |
|------------|------------:|------------------:|
| Type       |       DEBIT |            CREDIT |
| Amount     |       -4075 |              5000 |
| Host Fee   |        -500 |              -500 |
| Plat Fee   |        -250 |              -250 |
| PP Fee     |        -175 |              -175 |
| Net Amount |       -5000 |              4075 |

## Motivation

There are two features that we want to add that will greatly benefit from this change:

1. Refund transactions. There's an ongoing effort to automate refunding transactions. Although the feature is [already implemented and ready to be deployed](https://github.com/opencollective/opencollective-api/pull/1134), it greatly increases the complexity of managing transactions and fees. Especially when Payment Processing Fees are not refunded.

2. We're planning to unfold each transaction between User & Collective into more transactions between *User & Payment Processor*, *Payment Processor & Host* and *Host & Collective*. Having the fees correctly filled in will make this job a few orders of magnitude easier

## Challenges

1. **Currency conversion**. The formula `netAmount = amount + hostFee + platformFee + paymentProcessorFee` doesn't apply for transactions between hosts and collectives that use different currencies. That's OK for 93% of our transactions because they're between USD & USD but we need to improve the formula to account for the conversion.

2. **Manual changes**. Some database entries have the fees registered in both types of transactions (`DEBIT` and `CREDIT`) so some care has to be taken to make sure that we don't automate the replication of mistakes made by manual changes.

