### PR TITLE
WIP: Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:9
+
+ARG UID=991
+ARG GID=991
+
+ENV NODE_ENV=production \
+    SKIP_MIGRATE=true
+
+EXPOSE 3060
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    build-essential \
+    git \
+    postgresql-client \
+    unicode-data \
+  && rm -rf /tmp/* /var/lib/apt/lists/*
+
+RUN addgroup --gid ${GID} opencollective \
+  && useradd \
+    --home-dir /opencollective \
+    --shell /bin/bash \
+    --gid ${GID} \
+    --uid ${UID} \
+    --create-home \
+    opencollective
+
+COPY --chown=991:991 . /opencollective
+
+USER opencollective
+
+WORKDIR /opencollective
+
+RUN npm install
+
+ENTRYPOINT ["/opencollective/docker_entrypoint.sh"]
+
+CMD ["node", "/opencollective/dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,8 @@ services:
       SESSION_SECRET: i&j@/V6Wx.`g>Aq?qQQF(>u)/Erm;3A=
   postgres:
     image: kartoza/postgis:9.6-2.4
-    # Uncomment below for production (persist database)
     # volumes:
-    # - ./.data/database:/data/db
+    # - /path/to/persistent/db:/var/lib/postgresql
     ports:
     - 15432:5432
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2'
+services:
+  api:
+    build: .
+    links:
+      - postgres
+    ports:
+    - 3060:3060
+    environment:
+      NODE_ENV: production
+      SEQUELIZE_ENV: production
+      PG_URL: "postgres://opencollective:opencollective@postgres:5432/opencollective"
+      PG_HOST: postgres
+      PG_DATABASE: opencollective
+      PG_USERNAME: opencollective
+      PG_PASSWORD: opencollective
+      API_URL: http://localhost:3060
+      WEBAPP_URL: http://localhost:3060/app
+      WEBSITE_URL: http://localhost:3000
+      API_KEY: dvl-1510egmf4a23d80342403fb599qd
+      PORT: 3060
+      WEBSITE_URL: http://localhost:3000
+      SESSION_SECRET: i&j@/V6Wx.`g>Aq?qQQF(>u)/Erm;3A=
+  postgres:
+    image: kartoza/postgis:9.6-2.4
+    # Uncomment below for production (persist database)
+    # volumes:
+    # - ./.data/database:/data/db
+    ports:
+    - 15432:5432
+    environment:
+      POSTGRES_DBNAME: opencollective
+      POSTGRES_USER: opencollective
+      POSTGRES_PASS: opencollective

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Executing migrations..."
+# wait for Postgres
+sleep 10
+until npm run db:migrate; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 5
+done
+
+./scripts/postinstall.sh
+echo "Executing process..."
+exec "$@"

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -8,6 +8,5 @@ until npm run db:migrate; do
   sleep 5
 done
 
-./scripts/postinstall.sh
 echo "Executing process..."
 exec "$@"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ "$SKIP_MIGRATE" = true ]; then
+  exit
+fi
+
 # Only run migrations automatically on staging and production
 if [ "$SEQUELIZE_ENV" = "staging" ] || [ "$SEQUELIZE_ENV" = "production" ]; then
   npm run db:migrate


### PR DESCRIPTION
I started working with a docker support for the API, currently the only change needed is skipping migration for the image build. Since docker builds are environment agnostic, we can't run the db migration on it.

As a proposal I added a `SKIP_MIGRATE` env var and manually execute `npm run db:migrate` on the docker entrypoint.