### PR TITLE
Verify which transactions don't add up in the check_ledger_health script

### DIFF
--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -112,3 +112,26 @@ export function createFromPaidExpense(host, paymentMethod, expense, paymentRespo
     })
     .then(transaction => models.Transaction.createDoubleEntry(transaction));
   }
+
+/** Calculate net amount of a transaction */
+export function netAmount(tr) {
+  const valueAndFees = Math.round(
+    tr.amountInHostCurrency +
+    tr.hostFeeInHostCurrency +
+    tr.platformFeeInHostCurrency +
+    tr.paymentProcessorFeeInHostCurrency);
+  return valueAndFees * tr.hostCurrencyFxRate;
+}
+
+/** Verify net amount of a transaction */
+export function verify(tr) {
+  return netAmount(tr) === tr.netAmountInCollectiveCurrency;
+}
+
+/** Calculate how off a transaction is
+ *
+ * Which is pretty much the difference between transaction net amount
+ * & netAmountInCollectiveCurrency */
+export function difference(tr) {
+  return netAmount(tr) - tr.netAmountInCollectiveCurrency;
+}


### PR DESCRIPTION
Pretty much all the transactions are going to fail this test before we migrate the fees. After that the number of transactions off should decline gradually as we narrow down corner cases that cause correctness errors.