### PR TITLE
Prepend http to website addresse that might be missing a scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "paypal-rest-sdk": "1.6.8",
     "pg": "4.5.5",
     "pg-hstore": "2.3.2",
+    "prepend-http": "^2.0.0",
     "querystring": "0.2.0",
     "request-as-curl": "0.1.0",
     "request-promise": "4.1.1",

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -5,6 +5,7 @@ import _, { get } from 'lodash';
 import Temporal from 'sequelize-temporal';
 import config from 'config';
 import deepmerge from 'deepmerge';
+import prependHttp from 'prepend-http';
 import queries from '../lib/queries';
 import { difference, uniq, pick } from 'lodash';
 import { types } from '../constants/collectives';
@@ -190,10 +191,7 @@ export default function(Sequelize, DataTypes) {
       get() {
         let website = this.getDataValue('website');
         if (website) {
-          if (!website.match(/^http/i)) {
-            website = `http://${website}`;
-          }
-          return website;
+          return prependHttp(website);
         }
         return (this.getDataValue('twitterHandle')) ? `https://twitter.com/${this.getDataValue('twitterHandle')}` : null;
       }


### PR DESCRIPTION
Some users `website` property end up being sent without a scheme, which means sites embedding opencollective links to users will have broken links on their pages.

Example in the wild where this error occurs:

https://webpack.js.org/
```js
// Select all opencollective links where website is missing a scheme
Array.from(document.querySelectorAll('.support__item'))
  .map(a => a.getAttribute('href'))
  .filter(href => !href.startsWith('http'))
```

I haven't been able to run the tests on my windows machine, so this PR is untested.
The diff on `package-lock.json` seemed quite massive, leading me to think it's not being continuously updated on `master`. I left it out of the commit

Closes https://github.com/webpack/webpack.js.org/pull/1911