### PR TITLE
ledger_fixer: migrate() must return true when it creates a new order

### DIFF
--- a/scripts/ledger_fixer.js
+++ b/scripts/ledger_fixer.js
@@ -249,7 +249,13 @@ export class Migration {
       if (!this.options.dryRun) {
         await this.createOrder(credit, debit);
       }
-      return this.migratePair('Neither', credit, debit);
+      this.migratePair('Neither', credit, debit);
+
+      // Even if the migrate pair doesn't do anything, the call to
+      // createOrder should change the instance thus we need to return
+      // true here otherwise the method `run()` won't know this pair
+      // needs to be updated.
+      return true;
     }
 
     // console.log('    * C:amount......: ', credit.amountInHostCurrency);


### PR DESCRIPTION
This must return as many rows as the counter "orders created" in the
report:

```sql
  select o.*, t.data from "Orders" o
    left join "Transactions" t on (t."OrderId" = o.id )
    where t.data->'migration'->'OrderId' is not null
    order by id desc limit 500;
```