### PR TITLE
Ledger fixer currency #0

### DIFF
--- a/scripts/ledger_fixer.js
+++ b/scripts/ledger_fixer.js
@@ -250,20 +250,6 @@ export class Migration {
       return [];
     }
 
-    // Don't do anything for now since these are not in the same currency
-    if (credit.currency !== credit.hostCurrency || debit.currency !== debit.hostCurrency) {
-      const [vc, vd] = [this.verify(credit), this.verify(debit)];
-      if (!vc) {
-        this.incr('not touched due to different currency');
-        this.log('report.txt', ` ${icon(vc)} CREDIT ${credit.id} ${vc} # not touched because currency is different`);
-      }
-      if (!vd) {
-        this.incr('not touched due to different currency');
-        this.log('report.txt', ` ${icon(vd)} DEBIT ${debit.id} ${vd} # not touched because currency is different`);
-      }
-      return [];
-    }
-
     // Try to set up hostCurrencyFxRate if it's null
     if (this.ensureHostCurrencyFxRate(credit) && this.verify(credit)) {
       this.incr('fix hostFeeInHostCurrency');
@@ -288,6 +274,20 @@ export class Migration {
         this.log('report.txt', ` ${icon(true)} DEBIT ${type} ${debit.id} true # after updating fees`);
         fixed.push(debit);
       }
+    }
+
+    // Don't do anything for now since these are not in the same currency
+    if (credit.currency !== credit.hostCurrency || debit.currency !== debit.hostCurrency) {
+      const [vc, vd] = [this.verify(credit), this.verify(debit)];
+      if (!vc) {
+        this.incr('not touched due to different currency');
+        this.log('report.txt', ` ${icon(vc)} CREDIT ${credit.id} ${vc} # not touched because currency is different`);
+      }
+      if (!vd) {
+        this.incr('not touched due to different currency');
+        this.log('report.txt', ` ${icon(vd)} DEBIT ${debit.id} ${vd} # not touched because currency is different`);
+      }
+      return fixed;
     }
 
     // Try to rewrite amounts on the credit

--- a/scripts/ledger_fixer.js
+++ b/scripts/ledger_fixer.js
@@ -177,11 +177,11 @@ export class Migration {
       changed = true;
     }
 
-    /* Rewrite netAmountInHostCurrency for debit */
+    /* Rewrite netAmountInCollectiveCurrency for debit */
     const newNetAmountInCollectiveCurrencyDebit = -credit.amountInHostCurrency;
     if (debit.netAmountInCollectiveCurrency !== newNetAmountInCollectiveCurrencyDebit) {
       this.saveTransactionChange(
-        debit, 'netAmountInHostCurrency',
+        debit, 'netAmountInCollectiveCurrency',
         debit.netAmountInCollectiveCurrency,
         newNetAmountInCollectiveCurrencyDebit);
       debit.netAmountInCollectiveCurrency = newNetAmountInCollectiveCurrencyDebit;

--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -125,7 +125,12 @@ export function netAmount(tr) {
 
 /** Verify net amount of a transaction */
 export function verify(tr) {
-  return netAmount(tr) === tr.netAmountInCollectiveCurrency;
+  if (tr.type === 'CREDIT' && tr.amount <= 0) return 'amount <= 0';
+  if (tr.type === 'DEBIT' && tr.amount >= 0) return 'amount >= 0';
+  if (tr.type === 'CREDIT' && tr.netAmountInCollectiveCurrency <= 0) return 'netAmount <= 0';
+  if (tr.type === 'DEBIT' && tr.netAmountInCollectiveCurrency >= 0) return 'netAmount >= 0';
+  if (netAmount(tr) !== tr.netAmountInCollectiveCurrency) return 'netAmount diff';
+  return true;
 }
 
 /** Calculate how off a transaction is


### PR DESCRIPTION
This is the first step towards cleaning transactions of different currencies. This PR will allow the `rewriteFees` to flip fees for any transactions. The methods `rewriteCreditAmounts` and `rewriteDebitAmounts` are still avoided for these transactions.