### PR TITLE
Fix deployment by not depending on git

### DIFF
--- a/scripts/sequelize.sh
+++ b/scripts/sequelize.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # This script wraps the sequelize command with babel-node and passes
 # parameters required in every single call.
-ROOT=$(git rev-parse --show-toplevel)
+ROOT="$( dirname "$(readlink -f "$0/..")" )"
 NODEBIN=${ROOT}/node_modules/.bin
 PATH=${PATH}:$NODEBIN
 SQLENV=${SEQUELIZE_ENV:=${NODE_ENV:=development}}


### PR DESCRIPTION
The scripts within the `package.json` file must be able to run on an
environment without git.