### PR TITLE
db_restore.js: Don't force restoring by default

### DIFF
--- a/scripts/db_restore.js
+++ b/scripts/db_restore.js
@@ -1,17 +1,60 @@
+import { ArgumentParser } from 'argparse';
 import * as libdb from '../server/lib/db';
 
-/** Launcher that recreates a database & load a dump into it. */
-async function main() {
-  if (process.argv.length !== 3) {
-    console.error(`Usage: ${process.argv.join(' ')} <filename>.pgsql`);
-    process.exit(1);
-  }
-
-  const [client, clientApp] = await libdb.recreateDatabase();
-  await Promise.all([client.end(), clientApp.end()]);
-
-  const fileName = process.argv[2];
-  await libdb.loadDB(fileName);
+/** Help on how to use this script */
+function usage() {
+  console.error(`Usage: ${process.argv.join(' ')} <filename>.pgsql`);
+  process.exit(1);
 }
 
-if (!module.parent) main();
+/** Return true if there's any data within the Collectives table */
+async function hasData(client) {
+  try {
+    const exists = await client.query('SELECT 1 FROM "Collectives"');
+    return Boolean(exists.rowCount);
+  } catch (error) {
+    return false;
+  }
+}
+
+/** Launcher that recreates a database & load a dump into it. */
+async function main(args) {
+  if (!args.file) {
+    return usage();
+  }
+
+  const [client, clientApp] = await libdb.recreateDatabase(args.force);
+
+  if (await hasData(clientApp) && args.force) {
+    await libdb.loadDB(args.file);
+  }
+
+  await Promise.all([client.end(), clientApp.end()]);
+}
+
+/** Return the options passed by the user to run the script */
+function parseCommandLineArguments() {
+  const parser = new ArgumentParser({
+    addHelp: true,
+    description: 'Restore dump file into a Database'
+  });
+  parser.addArgument(['-q', '--quiet'], {
+    help: 'Silence output',
+    defaultValue: true,
+    action: 'storeConst',
+    constant: false,
+  });
+  parser.addArgument(['-f', '--force'], {
+    help: "Overwrite existing database",
+    defaultValue: false,
+    action: 'storeConst',
+    constant: true,
+  });
+  parser.addArgument(['file'], {
+    help: "Path for the dump file",
+    action: 'store',
+  });
+  return parser.parseArgs();
+}
+
+if (!module.parent) main(parseCommandLineArguments());


### PR DESCRIPTION
The db_restore.js script now runs on the `predev` role and it kinda
breaks the whole setup if the database is being used (by a database
visualization tool for example) because it tries to recreate the
database.

This patch adds the `-f` flag to the `db_restore.js` script and makes
it less intrusive by default, not trying to recreate anything if data
exists.