### PR TITLE
Remove "predev" and add "docker:dev" with its own pre commands

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   api:
     build: ./api
-    command: /usr/src/api/docker/wait-for-db.sh npm run dev
+    command: /usr/src/api/docker/wait-for-db.sh npm run docker:dev
     environment:
       NODE_ENV: "docker"
       SEQUELIZE_ENV: "docker"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
   },
   "scripts": {
     "start": "node ./dist/index.js",
-    "predev": "npm install && npm run db:setup && babel-node ./scripts/db_restore.js opencollective_dvl",
+    "predevdocker:dev": "npm install && npm run db:setup && babel-node ./scripts/db_restore.js opencollective_dvl",
+    "docker:dev": "npm run dev",
     "dev": "nodemon server/index.js -x babel-node . -e js,hbs",
     "clean": "rm -rf dist && mkdir dist",
     "build-server": "babel server -d ./dist",


### PR DESCRIPTION
This brings the dev environment setup back to what it was before
docker was introduced.