### PR TITLE
docker-compose: Update API URL on the Frontend's process

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       NODE_ENV: "docker"
       API_KEY: "dvl-1510egmf4a23d80342403fb599qd"
       WEBSITE_URL: "http://localhost:13000"
-      API_URL: "http://api:3060"
+      API_URL: "http://localhost:13060"
     volumes:
       - ../../frontend:/usr/src/frontend
     ports:


### PR DESCRIPTION
The frontend goes through the host to access the API (browser is in
the host machine).