### PR TITLE
config/test: Add `maintenancedb` section so db:setup works

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -2,6 +2,14 @@
   "database": {
     "database": "opencollective_test"
   },
+  "maintenancedb": {
+    "database": "postgres",
+    "username": "postgres",
+    "password": "",
+    "options": {
+      "host": "127.0.0.1"
+    }
+  },
   "keys": {
     "opencollective": {
       "api_key": "dvl-1510egmf4a23d80342403fb599qd",


### PR DESCRIPTION
The script `db:setup` requires settings for a maintenance database and
the test environment didn't have. This change fixes it making it
possible to run the following command:

  $ NODE_ENV=test npm run db:setup

The above command will attempt to create a user & then the application
database for a given environment.