### PR TITLE
better log for prod with DEBUG=operation

### DIFF
--- a/server/lib/express.js
+++ b/server/lib/express.js
@@ -16,6 +16,7 @@ import { sequelize as db } from '../models';
 import { middleware } from '../graphql/loaders';
 import debug from 'debug';
 import lruCache from '../middleware/lru_cache';
+import { sanitizeForLogs } from '../lib/utils';
 
 const SequelizeStore = connectSessionSequelize(session.Store);
 
@@ -59,7 +60,7 @@ export default function(app) {
       if (timeElapsed > (process.env.SLOW_REQUEST_THRESHOLD || 1000)) {
         if (req.body && req.body.query) {
           console.log(">>> slow request", req.body.operationName, "query:", req.body.query.substr(0, req.body.query.indexOf(")")+1));
-          console.log(">>> variables: ", req.body.variables);
+          console.log(">>> variables: ", sanitizeForLogs(req.body.variables));
         }
       }
       temp.apply(this,arguments);

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -317,7 +317,7 @@ const getCollectivesByTag = (tag, limit, excludeList, minTotalDonationInCents, r
   }
 
   return sequelize.query(`
-    with "totalDonations" AS (
+    WITH "totalDonations" AS (
       SELECT t."CollectiveId", SUM("netAmountInCollectiveCurrency") as "totalDonations"
       FROM "Collectives" c
       LEFT JOIN "Transactions" t ON t."CollectiveId" = c.id

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -22,7 +22,9 @@ if (process.env.DEBUG && process.env.DEBUG.match(/psql/)) {
 if (config.options.logging) {
   if (process.env.NODE_ENV === 'production') {
     config.options.logging = (query, executionTime) => {
-      console.log(query.slice(0, 100), '|', executionTime, 'ms');
+      if (executionTime > 50) {
+        console.log(query.replace(/(\n|\t| +)/g,' ').slice(0, 100), '|', executionTime, 'ms');
+      }
     }
   } else {
     config.options.logging = (query, executionTime) => {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -4,6 +4,7 @@
 import pg from 'pg';
 import Sequelize from 'sequelize';
 import { database as config } from 'config';
+import debug from 'debug';
 
 // this is needed to prevent sequelize from converting integers to strings, when model definition isn't clear
 // like in case of the key totalOrders and raw query (like User.getTopBackers())
@@ -23,12 +24,12 @@ if (config.options.logging) {
   if (process.env.NODE_ENV === 'production') {
     config.options.logging = (query, executionTime) => {
       if (executionTime > 50) {
-        console.log(query.replace(/(\n|\t| +)/g,' ').slice(0, 100), '|', executionTime, 'ms');
+        debug("psql")(query.replace(/(\n|\t| +)/g,' ').slice(0, 100), '|', executionTime, 'ms');
       }
     }
   } else {
     config.options.logging = (query, executionTime) => {
-      console.log(`\n-------------------- <query> --------------------\n`,query,`\n-------------------- </query executionTime="${executionTime}"> --------------------\n`);
+      debug("psql")(`\n-------------------- <query> --------------------\n`,query,`\n-------------------- </query executionTime="${executionTime}"> --------------------\n`);
     }
   }
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -30,7 +30,7 @@ import errors from './lib/errors';
 import { formatError } from 'apollo-errors';
 
 import sanitizer from './middleware/sanitizer';
-
+import { sanitizeForLogs } from './lib/utils';
 import debug from 'debug';
 
 /**
@@ -50,7 +50,8 @@ export default (app) => {
 
   if (process.env.DEBUG) {
     app.use('*', (req, res, next) => {
-      const body = Object.assign({}, req.body);
+      const body = sanitizeForLogs(req.body || {});
+      debug('operation')(body.operationName, JSON.stringify(body.variables, null));
       if (body.query) {
         const query = body.query;
         debug('params')(query);

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,7 +1,26 @@
 import {expect} from 'chai';
-import { exportToPDF } from '../server/lib/utils';
+import { exportToPDF, sanitizeForLogs } from '../server/lib/utils';
 
 describe("utils", () => {
+
+  it("sanitize for logs", () => {
+    const obj = {
+      user: {
+        name: "Xavier",
+        email: "xavier@gmail.com"
+      },
+      card: {
+        expYear: 2022,
+        token: "tok_32112123"
+      }
+    };
+
+    const res = sanitizeForLogs(obj);
+    expect(res.user.name).to.equal(obj.user.name);
+    expect(res.user.email).to.equal("(email obfuscated)");
+    expect(res.card.token).to.equal("(token obfuscated)");
+    expect(res.card.expYear).to.equal(obj.card.expYear);
+  });
 
   it("exports PDF", function(done) {
     this.timeout(10000);


### PR DESCRIPTION
**Goal:** make it easier to identify reasons for short downtimes
**Problem:** right now, we only see `POST /graphql` which doesn't say much about the operation being executed.
**Solution:** when passing `DEBUG=operation`, we display the graphQL operation with variables (that we sanitize for logs)

Example:

```
POST /graphql?api_key=dvl-xxxxxxxxx 204 2.256 ms - -
  operation createOrder +10s {"order":{"user":{"email":"(email obfuscated)","firstName":"fdfs","lastName":"fsdfdss","company":"fsddsfd","website":"fdsdfds","twitterHandle":"dfsdfs","description":"dsfsd"},"collective":{"id":302},"fromCollective":{},"publicMessage":"fdfdsf","quantity":1,"interval":null,"totalAmount":5000,"paymentMethod":{"service":"stripe","type":"creditcard","token":"(token obfuscated)","data":{"expMonth":4,"expYear":2022,"brand":"Visa","country":"US","funding":"credit","zip":"11111"},"name":"4242","save":true}}}
```