### PR TITLE
Save empty string instead of string `undefined` in Update.markdown

### DIFF
--- a/server/graphql/mutations/updates.js
+++ b/server/graphql/mutations/updates.js
@@ -13,9 +13,12 @@ export async function createUpdate(_, args, req) {
   mustHaveRole(req.remoteUser, 'ADMIN', CollectiveId, "create an update");
   require(args, 'update.title');
 
+  const markdown = args.update.markdown
+        ? strip_tags(args.update.markdown)
+        : '';
   const update = await models.Update.create({
     title: args.update.title,
-    markdown: strip_tags(args.update.markdown),
+    markdown,
     html: strip_tags(args.update.html),
     CollectiveId,
     TierId: get(args, 'update.tier.id'),


### PR DESCRIPTION
It's also required to execute the following query to clean the database:

```sql
update "Updates" set markdown = '' where markdown = 'undefined';
```

This closes https://github.com/opencollective/opencollective/issues/1014
