### PR TITLE
Monthly revenue query: Add filter for refund transactions

### DIFF
--- a/sql/all-sponsors.sql
+++ b/sql/all-sponsors.sql
@@ -17,6 +17,9 @@ where
 	((t."OrderId" IS NOT NULL AND t.type LIKE 'CREDIT')
 	OR (t."ExpenseId" IS NOT NULL AND t.type LIKE 'DEBIT'))
 	AND c.type ilike 'organization'
+    AND ((t."RefundTransactionId" IS NOT NULL AND
+          t."data"->'refund' IS NULL AND
+          t.type = 'CREDIT') OR t."RefundTransactionId" IS NULL)
 
 group by c.slug, "month"
 order by c.slug


### PR DESCRIPTION
These changes aim to solve the issue https://github.com/opencollective/opencollective/issues/1026

## Changes introduced

### New filters to the sub-query

The clause `t."RefundTransactionId" IS NULL` from the `WHERE` statement of the sub-query `conversions` and the following *mutually exclusive* new filters were created:

  * `isRefund`: A refund is true when the transaction represents moving funds from Collective to User after a refund.
  *  `hasBeenRefunded`: A refunded transaction represents the original donation from User to Collective
  * `isNotRefund`: The transaction isn't either a refund or refunded.

## Updates to the columns that aggregate transactions

All aggregations that depend on the following fields in the virtual table required changes:  `recurringMonthlyTotal`, `recurringAnnuallyTotal`, `oneTimeDonations`, `addedFunds`.

The above aggregations only sum up a given transaction if it's either not related to a refund at all or if it's the refund transaction (decreasing collective ledger and increasing user ledger).