### PR TITLE
Search - Pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ output/
 # JetBrains
 *.iml
 
+*.swp

--- a/server/graphql/CollectiveInterface.js
+++ b/server/graphql/CollectiveInterface.js
@@ -1056,3 +1056,22 @@ export const EventCollectiveType = new GraphQLObjectType({
   interfaces: [ CollectiveInterfaceType ],
   fields: CollectiveFields
 });
+
+export const CollectiveSearchResultsType = new GraphQLObjectType({
+  name: 'CollectiveSearchResults',
+  description: 'The results from searching for collectives with pagination info',
+  fields: () => ({
+    collectives: {
+      type: new GraphQLList(CollectiveType),
+    },
+    limit: {
+      type: GraphQLInt,
+    },
+    offset: {
+      type: GraphQLInt,
+    },
+    total: {
+      type: GraphQLInt,
+    },
+  }),
+});

--- a/server/graphql/schema.js
+++ b/server/graphql/schema.js
@@ -5,6 +5,7 @@ import {
 
 import {
   CollectiveInterfaceType,
+  CollectiveSearchResultsType,
   CollectiveType,
   CollectiveStatsType,
   UserCollectiveType,
@@ -40,6 +41,7 @@ const Mutation = new GraphQLObjectType({
 const Schema = new GraphQLSchema({
   types: [
     CollectiveInterfaceType,
+    CollectiveSearchResultsType,
     CollectiveType,
     CollectiveStatsType,
     UserCollectiveType,


### PR DESCRIPTION
In conjunction with https://github.com/opencollective/frontend/pull/352, I've updated the `search` GraphQL query to use a custom `CollectiveSearchResultsType` which includes pagination information with the list of relevant collectives returned by Algolia. 