### PR TITLE
GraphQL: add 'transactions' query to return all transactions with paginated results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha1-mlldxgJlS3FxiKKUUHCHpR55+6M=",
       "optional": true,
       "requires": {
-        "nan": "2.8.0"
+        "nan": "^2.4.0"
       }
     },
     "@types/debug": {
@@ -56,7 +56,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -71,7 +71,7 @@
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -88,7 +88,7 @@
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "optional": true,
       "requires": {
-        "acorn": "2.7.0"
+        "acorn": "^2.1.0"
       }
     },
     "acorn-jsx": {
@@ -96,7 +96,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -126,10 +126,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -143,21 +143,21 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.24.9.tgz",
       "integrity": "sha512-/jK/slMZBNfZB9TESqWs21IZD4i2ANvksYNU/PZwwqfsij56VHf6pvxeaQ0tQDM9YF49tdo7zsI620uDFEtXpA==",
       "requires": {
-        "agentkeepalive": "2.2.0",
-        "debug": "2.6.9",
-        "envify": "4.1.0",
-        "es6-promise": "4.2.2",
-        "events": "1.1.1",
-        "foreach": "2.0.5",
-        "global": "4.3.2",
-        "inherits": "2.0.3",
-        "isarray": "2.0.2",
-        "load-script": "1.0.0",
-        "object-keys": "1.0.11",
-        "querystring-es3": "0.2.1",
-        "reduce": "1.0.1",
-        "semver": "5.3.0",
-        "tunnel-agent": "0.6.0"
+        "agentkeepalive": "^2.2.0",
+        "debug": "^2.6.8",
+        "envify": "^4.0.0",
+        "es6-promise": "^4.1.0",
+        "events": "^1.1.0",
+        "foreach": "^2.0.5",
+        "global": "^4.3.2",
+        "inherits": "^2.0.1",
+        "isarray": "^2.0.1",
+        "load-script": "^1.0.0",
+        "object-keys": "^1.0.11",
+        "querystring-es3": "^0.2.1",
+        "reduce": "^1.0.1",
+        "semver": "^5.1.0",
+        "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
         "debug": {
@@ -173,8 +173,8 @@
           "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
           "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
           "requires": {
-            "esprima": "4.0.0",
-            "through": "2.3.8"
+            "esprima": "^4.0.0",
+            "through": "~2.3.4"
           }
         },
         "esprima": {
@@ -194,9 +194,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -215,7 +215,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -236,8 +236,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -246,7 +246,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -267,13 +267,18 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "apollo-errors": {
@@ -281,7 +286,7 @@
       "resolved": "https://registry.npmjs.org/apollo-errors/-/apollo-errors-1.5.1.tgz",
       "integrity": "sha512-gYAceMzNJfF+mUHH2/4UcZTkZtDY54arCTKGbKa7WU5IXnTJ4V+P94wHodcDkLLHWpHL8SW1hEgjN5ZINcPb1w==",
       "requires": {
-        "es6-error": "4.1.1"
+        "es6-error": "^4.0.0"
       }
     },
     "aproba": {
@@ -299,8 +304,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -308,7 +313,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -316,7 +321,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -335,8 +340,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-union": {
@@ -344,7 +349,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -379,9 +384,9 @@
       "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -403,6 +408,23 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
+    },
+    "assertion-error-formatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-2.0.1.tgz",
+      "integrity": "sha512-cjC3jUCh9spkroKue5PDSKH5RFQ/KNuZJhk3GwHYmB/8qqETxLOmMdLH+ohi/VukNzxDlMvIe7zScvLoOdhb6Q==",
+      "requires": {
+        "diff": "^3.0.0",
+        "pad-right": "^0.2.2",
+        "repeat-string": "^1.6.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        }
+      }
     },
     "async": {
       "version": "0.9.2",
@@ -439,21 +461,21 @@
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "commander": "2.12.2",
-        "convert-source-map": "1.5.1",
-        "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
+        "babel-core": "^6.26.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.6.1",
+        "commander": "^2.11.0",
+        "convert-source-map": "^1.5.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^4.17.4",
+        "output-file-sync": "^1.1.2",
+        "path-is-absolute": "^1.0.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6",
+        "v8flags": "^2.1.1"
       },
       "dependencies": {
         "lodash": {
@@ -468,9 +490,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -478,25 +500,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "debug": {
@@ -519,10 +541,10 @@
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
       }
     },
     "babel-generator": {
@@ -530,14 +552,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -552,9 +574,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -562,9 +584,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -572,10 +594,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -583,10 +605,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
@@ -601,9 +623,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-class": {
@@ -611,10 +633,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -622,11 +644,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -634,8 +656,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -643,8 +665,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -652,8 +674,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -661,9 +683,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
@@ -678,11 +700,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -690,12 +712,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -703,8 +725,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-loader": {
@@ -712,9 +734,9 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
       "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
       "requires": {
-        "find-cache-dir": "1.0.0",
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
+        "find-cache-dir": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1"
       }
     },
     "babel-messages": {
@@ -722,7 +744,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-add-module-exports": {
@@ -735,7 +757,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -744,9 +766,9 @@
       "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "test-exclude": "4.1.1"
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.7.2",
+        "test-exclude": "^4.1.1"
       }
     },
     "babel-plugin-lodash": {
@@ -754,8 +776,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz",
       "integrity": "sha1-Icj97J/hg176pzeHPjkCvdZtVwE=",
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4"
+        "glob": "^7.1.1",
+        "lodash": "^4.17.2"
       },
       "dependencies": {
         "lodash": {
@@ -830,9 +852,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -840,9 +862,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -850,9 +872,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "6.18.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -860,10 +882,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -871,11 +893,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-do-expressions": {
@@ -883,8 +905,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
       "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
       "requires": {
-        "babel-plugin-syntax-do-expressions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-do-expressions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -892,7 +914,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -900,7 +922,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -908,11 +930,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
@@ -927,15 +949,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -943,8 +965,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -952,7 +974,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -960,8 +982,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -969,7 +991,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -977,9 +999,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -987,7 +1009,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -995,9 +1017,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1005,10 +1027,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1016,9 +1038,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1026,9 +1048,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1036,8 +1058,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1045,12 +1067,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1058,8 +1080,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1067,7 +1089,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1075,9 +1097,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1085,7 +1107,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1093,7 +1115,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1101,9 +1123,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1111,9 +1133,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -1121,8 +1143,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "requires": {
-        "babel-plugin-syntax-export-extensions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-export-extensions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-function-bind": {
@@ -1130,8 +1152,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
       "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "requires": {
-        "babel-plugin-syntax-function-bind": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-function-bind": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1139,8 +1161,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1148,7 +1170,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1156,8 +1178,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -1165,9 +1187,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1182,30 +1204,30 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-stage-0": {
@@ -1213,9 +1235,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
       "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
       "requires": {
-        "babel-plugin-transform-do-expressions": "6.22.0",
-        "babel-plugin-transform-function-bind": "6.22.0",
-        "babel-preset-stage-1": "6.24.1"
+        "babel-plugin-transform-do-expressions": "^6.22.0",
+        "babel-plugin-transform-function-bind": "^6.22.0",
+        "babel-preset-stage-1": "^6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -1223,9 +1245,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "6.24.1",
-        "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-preset-stage-2": "6.24.1"
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1233,10 +1255,10 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1244,11 +1266,11 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -1256,13 +1278,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "lodash": {
@@ -1277,8 +1299,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1286,11 +1308,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
@@ -1305,15 +1327,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "debug": {
@@ -1336,10 +1358,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
         "lodash": {
@@ -1375,8 +1397,8 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
       "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
       "requires": {
-        "concat-stream": "1.4.10",
-        "meow": "2.0.0"
+        "concat-stream": "~1.4.7",
+        "meow": "~2.0.0"
       }
     },
     "basic-auth": {
@@ -1412,13 +1434,18 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
+    "becke-ch--regex--s0-0-v1--base--pl--lib": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/becke-ch--regex--s0-0-v1--base--pl--lib/-/becke-ch--regex--s0-0-v1--base--pl--lib-1.4.0.tgz",
+      "integrity": "sha1-Qpzuu/pffpNueNc/vcfacWKyDiA="
     },
     "big.js": {
       "version": "3.2.0",
@@ -1440,7 +1467,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -1460,15 +1487,15 @@
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
       "requires": {
         "bytes": "2.4.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.2",
         "debug": "2.6.7",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
         "iconv-lite": "0.4.15",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.4.0",
-        "raw-body": "2.2.0",
-        "type-is": "1.6.15"
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -1496,7 +1523,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "boxen": {
@@ -1505,13 +1532,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1526,7 +1553,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "camelcase": {
@@ -1541,9 +1568,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "has-flag": {
@@ -1564,8 +1591,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1574,7 +1601,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -1583,7 +1610,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -1593,7 +1620,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1602,9 +1629,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -1614,9 +1641,9 @@
       "dev": true
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "browserify-aes": {
@@ -1625,12 +1652,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -1639,9 +1666,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1650,9 +1677,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -1661,8 +1688,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -1671,13 +1698,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -1686,7 +1713,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "buffer": {
@@ -1695,9 +1722,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-crc32": {
@@ -1741,8 +1768,8 @@
       "resolved": "https://registry.npmjs.org/bufferstream/-/bufferstream-0.6.2.tgz",
       "integrity": "sha1-pfJ+ENPHYAhNFLNRJmFQBzGeNzE=",
       "requires": {
-        "bufferjs": "3.0.1",
-        "buffertools": "2.1.6"
+        "bufferjs": ">= 2.0.0",
+        "buffertools": ">= 1.0.3"
       }
     },
     "buffertools": {
@@ -1756,11 +1783,11 @@
       "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-2.0.0.tgz",
       "integrity": "sha1-8LewpZ6aShtQZrv6BR0kjzgy7s4=",
       "requires": {
-        "addressparser": "0.3.2",
-        "libbase64": "0.1.0",
-        "libmime": "1.2.0",
-        "libqp": "1.1.0",
-        "needle": "0.10.0"
+        "addressparser": "^0.3.2",
+        "libbase64": "^0.1.0",
+        "libmime": "^1.2.0",
+        "libqp": "^1.1.0",
+        "needle": "^0.10.0"
       },
       "dependencies": {
         "needle": {
@@ -1768,8 +1795,8 @@
           "resolved": "https://registry.npmjs.org/needle/-/needle-0.10.0.tgz",
           "integrity": "sha1-FqJNY/KmEVLrdMzh0Sr4XFB1d9Q=",
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.15"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4"
           },
           "dependencies": {
             "debug": {
@@ -1801,7 +1828,7 @@
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "requires": {
         "dicer": "0.2.5",
-        "readable-stream": "1.1.14"
+        "readable-stream": "1.1.x"
       },
       "dependencies": {
         "isarray": {
@@ -1814,10 +1841,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1837,7 +1864,7 @@
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -1855,8 +1882,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
       "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
       "requires": {
-        "camelcase": "1.2.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^1.0.1",
+        "map-obj": "^1.0.0"
       }
     },
     "camelize": {
@@ -1881,7 +1908,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "underscore-contrib": "~0.3.0"
       }
     },
     "center-align": {
@@ -1889,8 +1916,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -1919,11 +1946,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chance": {
@@ -1949,11 +1976,11 @@
       "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
       "dev": true,
       "requires": {
-        "css-select": "1.0.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.10.1"
+        "css-select": "~1.0.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.8.1",
+        "lodash": "^3.2.0"
       },
       "dependencies": {
         "css-select": {
@@ -1962,10 +1989,10 @@
           "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
           "dev": true,
           "requires": {
-            "boolbase": "1.0.0",
-            "css-what": "1.0.0",
-            "domutils": "1.4.3",
-            "nth-check": "1.0.1"
+            "boolbase": "~1.0.0",
+            "css-what": "1.0",
+            "domutils": "1.4",
+            "nth-check": "~1.0.0"
           }
         },
         "css-what": {
@@ -1980,7 +2007,7 @@
           "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         }
       }
@@ -1990,7 +2017,7 @@
       "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-1.1.0.tgz",
       "integrity": "sha1-Ex4BpwXxXtSgXVVN1eAy5SYSzzA=",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.1.2"
       }
     },
     "chokidar": {
@@ -1998,15 +2025,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "cipher-base": {
@@ -2015,8 +2042,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -2029,7 +2056,7 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-1.1.7.tgz",
       "integrity": "sha1-YB75z3ZCuYLLM+/JSIpkRMmGaG4=",
       "requires": {
-        "commander": "2.0.0"
+        "commander": "2.0.x"
       },
       "dependencies": {
         "commander": {
@@ -2044,9 +2071,9 @@
       "resolved": "https://registry.npmjs.org/clearbit/-/clearbit-1.2.1.tgz",
       "integrity": "sha1-nFKCJtq4lCKN7CtFRYZ+piR68Gc=",
       "requires": {
-        "bluebird": "2.11.0",
-        "create-error": "0.3.1",
-        "lodash": "2.4.2",
+        "bluebird": "2",
+        "create-error": "0.3",
+        "lodash": "2",
         "needle": "0.7.10"
       },
       "dependencies": {
@@ -2073,10 +2100,10 @@
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
       "integrity": "sha1-EtW90Vj/igsNtAEZiRPAPfBp9vU=",
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.37",
-        "memoizee": "0.3.10",
-        "timers-ext": "0.1.2"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.6",
+        "memoizee": "~0.3.8",
+        "timers-ext": "0.1"
       }
     },
     "cli-cursor": {
@@ -2085,7 +2112,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-table": {
@@ -2106,8 +2133,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -2128,8 +2155,8 @@
       "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
       "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
       "requires": {
-        "is-bluebird": "1.0.2",
-        "shimmer": "1.2.0"
+        "is-bluebird": "^1.0.2",
+        "shimmer": "^1.1.0"
       }
     },
     "co": {
@@ -2154,8 +2181,8 @@
       "integrity": "sha512-7YP956JubbWkmk9QqKy62CZgdGbEulHNJkz2/aUDTpsE1KrQtRrT9WzStJaxAOEX2k4wUOpojUX2ItPxa69kFA==",
       "dev": true,
       "requires": {
-        "graphql-language-service-interface": "1.1.0",
-        "graphql-language-service-parser": "0.1.14"
+        "graphql-language-service-interface": "^1.0.16",
+        "graphql-language-service-parser": "^0.1.14"
       }
     },
     "color-convert": {
@@ -2163,7 +2190,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -2181,7 +2208,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2205,8 +2232,8 @@
       "integrity": "sha512-8GBuTt6Q8ukt9XJ4Gka/PGAMHIZwtWgxN4kPnP+giUKUs9WFpCJGmEVk0Jij65UgoiVwC0hIHW5EQQghnIEUjQ==",
       "requires": {
         "@types/debug": "0.0.29",
-        "array-flatten": "2.1.1",
-        "debug": "3.1.0"
+        "array-flatten": "^2.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "array-flatten": {
@@ -2226,9 +2253,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.9",
+        "typedarray": "~0.0.5"
       },
       "dependencies": {
         "isarray": {
@@ -2241,10 +2268,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2274,8 +2301,8 @@
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "configstore": {
@@ -2284,12 +2311,12 @@
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "connect": {
@@ -2299,7 +2326,7 @@
       "requires": {
         "debug": "2.6.1",
         "finalhandler": "1.0.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.1",
         "utils-merge": "1.0.0"
       },
       "dependencies": {
@@ -2317,12 +2344,12 @@
           "integrity": "sha1-tWkcLAkSCS8YrCPpQWveXNfcZ1U=",
           "requires": {
             "debug": "2.6.1",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.1",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           }
         },
         "ms": {
@@ -2342,7 +2369,7 @@
       "resolved": "https://registry.npmjs.org/connect-session-sequelize/-/connect-session-sequelize-3.1.0.tgz",
       "integrity": "sha1-7D2Ylo2h+1Tzh+b2LeHY41JWVrA=",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.1.1"
       },
       "dependencies": {
         "debug": {
@@ -2361,7 +2388,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -2391,7 +2418,7 @@
       "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-1.1.0.tgz",
       "integrity": "sha1-2R8bB2I2wRmFDH3umSS/VeBXcrM=",
       "requires": {
-        "dashify": "0.2.2"
+        "dashify": "^0.2.0"
       }
     },
     "content-type": {
@@ -2443,7 +2470,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
       "integrity": "sha1-PC5QpYr574yJvuISJrCZvh8Cc5s=",
       "requires": {
-        "vary": "1.1.2"
+        "vary": "^1"
       }
     },
     "coveralls": {
@@ -2477,7 +2504,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -2492,7 +2519,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "form-data": {
@@ -2501,9 +2528,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -2512,10 +2539,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.12.2",
-            "is-my-json-valid": "2.17.1",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "hawk": {
@@ -2524,10 +2551,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -2542,9 +2569,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "minimist": {
@@ -2565,26 +2592,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -2593,7 +2620,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "tunnel-agent": {
@@ -2615,8 +2642,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-error": {
@@ -2630,7 +2657,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -2639,10 +2666,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.9"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2651,12 +2678,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cron": {
@@ -2664,7 +2691,7 @@
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.3.0.tgz",
       "integrity": "sha512-K/SF7JlgMmNjcThWxkKvsHhey2EDB4CeOEWJ9aXWj3fbQJppsvTPIeyLdHfNq5IbbsMUUjRW1nr5dSO95f2E4w==",
       "requires": {
-        "moment-timezone": "0.5.14"
+        "moment-timezone": "^0.5.x"
       }
     },
     "cross-fetch": {
@@ -2690,9 +2717,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cross-spawn-async": {
@@ -2700,8 +2727,8 @@
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.0",
+        "which": "^1.2.8"
       }
     },
     "crypt": {
@@ -2715,7 +2742,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -2723,7 +2750,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -2734,17 +2761,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5",
-        "randomfill": "1.0.3"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "crypto-random-string": {
@@ -2758,10 +2785,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-what": {
@@ -2780,7 +2807,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "optional": true,
       "requires": {
-        "cssom": "0.3.1"
+        "cssom": "0.3.x"
       }
     },
     "csv-stringify": {
@@ -2788,7 +2815,7 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
-        "lodash.get": "4.4.2"
+        "lodash.get": "^4.0.0"
       },
       "dependencies": {
         "lodash.get": {
@@ -2797,6 +2824,81 @@
           "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
         }
       }
+    },
+    "cucumber": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-4.2.1.tgz",
+      "integrity": "sha512-3gQ0Vv4kSHsvXEFC6b1c+TfLRDzWD1/kU7e5vm8Kh8j35b95k6favan9/4ixcBNqd7UsU1T6FYcawC87+DlNKw==",
+      "requires": {
+        "assertion-error-formatter": "^2.0.1",
+        "babel-runtime": "^6.11.6",
+        "bluebird": "^3.4.1",
+        "cli-table": "^0.3.1",
+        "colors": "^1.1.2",
+        "commander": "^2.9.0",
+        "cucumber-expressions": "^5.0.13",
+        "cucumber-tag-expressions": "^1.1.1",
+        "duration": "^0.2.0",
+        "escape-string-regexp": "^1.0.5",
+        "figures": "2.0.0",
+        "gherkin": "^5.0.0",
+        "glob": "^7.0.0",
+        "indent-string": "^3.1.0",
+        "is-generator": "^1.0.2",
+        "is-stream": "^1.1.0",
+        "knuth-shuffle-seeded": "^1.0.6",
+        "lodash": "^4.17.4",
+        "mz": "^2.4.0",
+        "progress": "^2.0.0",
+        "resolve": "^1.3.3",
+        "serialize-error": "^2.1.0",
+        "stack-chain": "^2.0.0",
+        "stacktrace-js": "^2.0.0",
+        "string-argv": "0.0.2",
+        "title-case": "^2.1.1",
+        "util-arity": "^1.0.2",
+        "verror": "^1.9.0"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        },
+        "colors": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.4.tgz",
+          "integrity": "sha512-6Y+iBnWmXL+AWtlOp2Vr6R2w5MUlNJRwR0ShVFaAb1CqWzhPOpQg4L0jxD+xpw/Nc8QJwaq3KM79QUCriY8CWQ=="
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+        }
+      }
+    },
+    "cucumber-expressions": {
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-5.0.17.tgz",
+      "integrity": "sha1-GS9p/JlKYFEnql33JFGbXLfftwg=",
+      "requires": {
+        "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.2.0"
+      }
+    },
+    "cucumber-tag-expressions": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cucumber-tag-expressions/-/cucumber-tag-expressions-1.1.1.tgz",
+      "integrity": "sha1-f1x7cACbwrZmWRv+ZIVFeL7e6Fo="
     },
     "cycle": {
       "version": "1.0.3",
@@ -2808,7 +2910,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "~0.10.2"
       }
     },
     "dashdash": {
@@ -2816,7 +2918,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "dasherize": {
@@ -2839,10 +2941,10 @@
       "resolved": "https://registry.npmjs.org/dataloader-sequelize/-/dataloader-sequelize-1.5.2.tgz",
       "integrity": "sha1-f4le2bV0FI0GFkysSpcYKo1+iFk=",
       "requires": {
-        "dataloader": "1.3.0",
-        "lodash": "4.17.4",
-        "lru-cache": "4.1.1",
-        "shimmer": "1.2.0"
+        "dataloader": "^1.2.0",
+        "lodash": "^4.15.0",
+        "lru-cache": "^4.0.1",
+        "shimmer": "^1.1.0"
       },
       "dependencies": {
         "lodash": {
@@ -2857,8 +2959,8 @@
       "resolved": "https://registry.npmjs.org/datauri/-/datauri-0.2.1.tgz",
       "integrity": "sha1-9Oit27PlTj3BLRyIVDuLCxv2kvo=",
       "requires": {
-        "mimer": "0.2.3",
-        "templayed": "0.2.3"
+        "mimer": "*",
+        "templayed": "*"
       }
     },
     "date-now": {
@@ -2923,10 +3025,10 @@
       "resolved": "https://registry.npmjs.org/deferred/-/deferred-0.7.1.tgz",
       "integrity": "sha1-9lzTwFaD899VS/XBU4UUlIEdAfQ=",
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.37",
-        "event-emitter": "0.3.5",
-        "next-tick": "0.2.2"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.2",
+        "event-emitter": "~0.3.1",
+        "next-tick": "~0.2.2"
       }
     },
     "define-properties": {
@@ -2935,8 +3037,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "del": {
@@ -2944,13 +3046,13 @@
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.5.4"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "pify": {
@@ -2981,8 +3083,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -2995,7 +3097,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "dicer": {
@@ -3003,7 +3105,7 @@
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "1.1.x",
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -3017,10 +3119,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3031,9 +3133,9 @@
       }
     },
     "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -3042,9 +3144,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dns-prefetch-control": {
@@ -3057,7 +3159,7 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
       "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-serializer": {
@@ -3065,8 +3167,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3097,7 +3199,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -3105,8 +3207,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dont-sniff-mimetype": {
@@ -3120,7 +3222,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "dotenv": {
@@ -3145,13 +3247,22 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "duration": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.0.tgz",
+      "integrity": "sha1-X5xN+q//ZV3phhEu/iXFl43YUUY=",
+      "requires": {
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.2"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -3159,8 +3270,8 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
       "requires": {
-        "base64url": "2.0.0",
-        "safe-buffer": "5.1.1"
+        "base64url": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       },
       "dependencies": {
         "base64url": {
@@ -3175,11 +3286,11 @@
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
       "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
       "requires": {
-        "bluebird": "3.4.0",
-        "commander": "2.12.2",
-        "lru-cache": "3.2.0",
-        "semver": "5.3.0",
-        "sigmund": "1.0.1"
+        "bluebird": "^3.0.5",
+        "commander": "^2.9.0",
+        "lru-cache": "^3.2.0",
+        "semver": "^5.1.0",
+        "sigmund": "^1.0.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -3187,7 +3298,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "requires": {
-            "pseudomap": "1.0.2"
+            "pseudomap": "^1.0.1"
           }
         }
       }
@@ -3203,13 +3314,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -3227,7 +3338,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.15"
+        "iconv-lite": "~0.4.13"
       }
     },
     "enhanced-resolve": {
@@ -3236,10 +3347,10 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "entities": {
@@ -3252,7 +3363,7 @@
       "resolved": "https://registry.npmjs.org/eraro/-/eraro-0.4.1.tgz",
       "integrity": "sha1-ZThzB2mh6J/8Pwx+LJTVofhmYp0=",
       "requires": {
-        "lodash": "2.4.2"
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "lodash": {
@@ -3268,7 +3379,7 @@
       "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -3276,7 +3387,15 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
+      "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
+      "requires": {
+        "stackframe": "^1.0.3"
       }
     },
     "errorhandler": {
@@ -3284,8 +3403,8 @@
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
       "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
       "requires": {
-        "accepts": "1.3.4",
-        "escape-html": "1.0.3"
+        "accepts": "~1.3.0",
+        "escape-html": "~1.0.3"
       }
     },
     "es-abstract": {
@@ -3294,11 +3413,11 @@
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3307,9 +3426,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -3317,8 +3436,8 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
       "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-error": {
@@ -3331,9 +3450,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       },
       "dependencies": {
         "d": {
@@ -3341,7 +3460,7 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "0.10.37"
+            "es5-ext": "^0.10.9"
           }
         }
       }
@@ -3356,8 +3475,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       },
       "dependencies": {
         "d": {
@@ -3365,7 +3484,7 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "0.10.37"
+            "es5-ext": "^0.10.9"
           }
         }
       }
@@ -3375,10 +3494,10 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
       "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "0.1.3",
-        "es6-symbol": "2.0.1"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.6",
+        "es6-iterator": "~0.1.3",
+        "es6-symbol": "~2.0.1"
       },
       "dependencies": {
         "es6-iterator": {
@@ -3386,9 +3505,9 @@
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
           "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.37",
-            "es6-symbol": "2.0.1"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.5",
+            "es6-symbol": "~2.0.1"
           }
         },
         "es6-symbol": {
@@ -3396,8 +3515,8 @@
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
           "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.37"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.5"
           }
         }
       }
@@ -3418,11 +3537,11 @@
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "optional": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.5.6"
       }
     },
     "eslint": {
@@ -3431,44 +3550,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.1",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.5.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.0.1",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.3.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
-        "text-table": "0.2.0"
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "acorn": {
@@ -3489,7 +3608,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3498,9 +3617,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "concat-stream": {
@@ -3509,10 +3628,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "doctrine": {
@@ -3521,7 +3640,7 @@
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2"
+            "esutils": "^2.0.2"
           }
         },
         "espree": {
@@ -3530,8 +3649,8 @@
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "dev": true,
           "requires": {
-            "acorn": "5.5.3",
-            "acorn-jsx": "3.0.1"
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
           }
         },
         "esprima": {
@@ -3558,8 +3677,8 @@
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "lodash": {
@@ -3580,7 +3699,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -3589,7 +3708,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -3606,8 +3725,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.7.1"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -3627,8 +3746,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3646,8 +3765,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -3656,7 +3775,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -3665,7 +3784,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -3676,16 +3795,16 @@
       "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
       "dev": true,
       "requires": {
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.2.0",
-        "has": "1.0.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.7.1"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
       },
       "dependencies": {
         "debug": {
@@ -3703,8 +3822,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -3713,10 +3832,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "lodash": {
@@ -3731,7 +3850,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "pify": {
@@ -3746,9 +3865,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -3757,8 +3876,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -3775,7 +3894,7 @@
       "integrity": "sha512-mpRWWsjxRco2bY4qE5DL8SmGoVF0Onb6DZrbgOjFoNo1YNN299K2voIozd8Kce3qC/neWNr2XF27E1ZDMl1yZg==",
       "dev": true,
       "requires": {
-        "ramda": "0.25.0"
+        "ramda": "^0.25.0"
       }
     },
     "eslint-plugin-node": {
@@ -3784,10 +3903,10 @@
       "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
       "dev": true,
       "requires": {
-        "ignore": "3.3.7",
-        "minimatch": "3.0.4",
-        "resolve": "1.7.1",
-        "semver": "5.5.0"
+        "ignore": "^3.3.6",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.3",
+        "semver": "^5.4.1"
       },
       "dependencies": {
         "semver": {
@@ -3804,10 +3923,10 @@
       "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
       "dev": true,
       "requires": {
-        "doctrine": "2.0.2",
-        "has": "1.0.1",
-        "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.1"
+        "doctrine": "^2.0.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^2.0.1",
+        "prop-types": "^15.6.0"
       }
     },
     "eslint-scope": {
@@ -3815,8 +3934,8 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -3830,8 +3949,8 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "requires": {
-        "acorn": "5.3.0",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.2.1",
+        "acorn-jsx": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -3852,7 +3971,7 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -3860,8 +3979,8 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -3884,8 +4003,8 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       },
       "dependencies": {
         "d": {
@@ -3893,24 +4012,24 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "0.10.37"
+            "es5-ext": "^0.10.9"
           }
         }
       }
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       },
       "dependencies": {
         "split": {
@@ -3919,7 +4038,7 @@
           "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
           "dev": true,
           "requires": {
-            "through": "2.3.8"
+            "through": "2"
           }
         }
       }
@@ -3935,8 +4054,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -3944,13 +4063,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -3958,7 +4077,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -3966,7 +4085,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "express": {
@@ -3974,32 +4093,32 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.3",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.1",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.2.0",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.7.0",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
         "finalhandler": "0.5.0",
         "fresh": "0.3.0",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
+        "proxy-addr": "~1.1.2",
         "qs": "6.2.0",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "send": "0.14.1",
-        "serve-static": "1.11.2",
-        "type-is": "1.6.15",
+        "serve-static": "~1.11.1",
+        "type-is": "~1.6.13",
         "utils-merge": "1.0.0",
-        "vary": "1.1.2"
+        "vary": "~1.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4027,10 +4146,10 @@
       "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.6.11.tgz",
       "integrity": "sha512-dC/FAun5rqcRxhDe78047hqc048mo3xZpBDS0Z7RZOw9UleO9mZE0rHMS9yrVSaYzsLiz+q4PldKu6Oaqop+CA==",
       "requires": {
-        "accepts": "1.3.4",
-        "content-type": "1.0.4",
-        "http-errors": "1.6.2",
-        "raw-body": "2.2.0"
+        "accepts": "^1.3.0",
+        "content-type": "^1.0.2",
+        "http-errors": "^1.3.0",
+        "raw-body": "^2.1.0"
       }
     },
     "express-jwt": {
@@ -4038,10 +4157,10 @@
       "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
       "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
       "requires": {
-        "async": "1.5.2",
-        "express-unless": "0.3.1",
-        "jsonwebtoken": "8.2.1",
-        "lodash.set": "4.3.2"
+        "async": "^1.5.0",
+        "express-unless": "^0.3.0",
+        "jsonwebtoken": "^8.1.0",
+        "lodash.set": "^4.0.0"
       },
       "dependencies": {
         "async": {
@@ -4054,16 +4173,16 @@
           "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
           "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
           "requires": {
-            "jws": "3.1.4",
-            "lodash.includes": "4.3.0",
-            "lodash.isboolean": "3.0.3",
-            "lodash.isinteger": "4.0.4",
-            "lodash.isnumber": "3.0.3",
-            "lodash.isplainobject": "4.0.6",
-            "lodash.isstring": "4.0.1",
-            "lodash.once": "4.1.1",
-            "ms": "2.1.1",
-            "xtend": "4.0.1"
+            "jws": "^3.1.4",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "xtend": "^4.0.1"
           }
         },
         "ms": {
@@ -4078,8 +4197,8 @@
       "resolved": "https://registry.npmjs.org/express-server-status/-/express-server-status-1.0.3.tgz",
       "integrity": "sha1-O5Gf7c0HEUZ+Cx628F88uRT7mRY=",
       "requires": {
-        "express": "4.14.0",
-        "moment": "2.19.3"
+        "express": "^4.13.3",
+        "moment": "^2.11.1"
       }
     },
     "express-session": {
@@ -4090,11 +4209,11 @@
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "crc": "3.4.0",
-        "debug": "2.2.0",
-        "depd": "1.1.1",
-        "on-headers": "1.0.1",
-        "parseurl": "1.3.2",
-        "uid-safe": "2.1.5",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "on-headers": "~1.0.1",
+        "parseurl": "~1.3.1",
+        "uid-safe": "~2.1.1",
         "utils-merge": "1.0.0"
       },
       "dependencies": {
@@ -4128,9 +4247,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       },
       "dependencies": {
         "iconv-lite": {
@@ -4138,7 +4257,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         }
       }
@@ -4148,7 +4267,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -4169,9 +4288,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "optional": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "debug": {
@@ -4225,13 +4344,13 @@
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "dev": true,
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       },
       "dependencies": {
         "core-js": {
@@ -4248,16 +4367,15 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "optional": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4265,8 +4383,8 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -4279,11 +4397,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -4291,11 +4409,11 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
       "requires": {
-        "debug": "2.2.0",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "statuses": "~1.3.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -4323,9 +4441,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.1.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-up": {
@@ -4333,7 +4451,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat": {
@@ -4341,7 +4459,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.0.tgz",
       "integrity": "sha1-1Vagvjak5gG78QdpsFaC9FPSQBM=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "~1.1.2"
       }
     },
     "flat-cache": {
@@ -4349,10 +4467,10 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "follow-redirects": {
@@ -4360,8 +4478,8 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
       "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
       "requires": {
-        "debug": "2.6.9",
-        "stream-consume": "0.1.0"
+        "debug": "^2.2.0",
+        "stream-consume": "^0.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4384,7 +4502,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -4428,15 +4546,15 @@
           "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.1",
-            "http-errors": "1.6.2",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
             "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "1.6.15"
+            "type-is": "~1.6.15"
           }
         },
         "bytes": {
@@ -4449,7 +4567,7 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "content-disposition": {
@@ -4462,8 +4580,8 @@
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
           "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
           "requires": {
-            "object-assign": "4.1.1",
-            "vary": "1.1.2"
+            "object-assign": "^4",
+            "vary": "^1"
           }
         },
         "debug": {
@@ -4484,36 +4602,36 @@
           "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
           "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
           "requires": {
-            "accepts": "1.3.4",
+            "accepts": "~1.3.4",
             "array-flatten": "1.1.1",
             "body-parser": "1.18.2",
             "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "1.1.1",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "finalhandler": "1.1.0",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.3",
+            "proxy-addr": "~2.0.2",
             "qs": "6.5.1",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "safe-buffer": "5.1.1",
             "send": "0.16.1",
             "serve-static": "1.13.1",
             "setprototypeof": "1.1.0",
-            "statuses": "1.3.1",
-            "type-is": "1.6.15",
+            "statuses": "~1.3.1",
+            "type-is": "~1.6.15",
             "utils-merge": "1.0.1",
-            "vary": "1.1.2"
+            "vary": "~1.1.2"
           }
         },
         "finalhandler": {
@@ -4522,12 +4640,12 @@
           "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           }
         },
         "form-data": {
@@ -4535,9 +4653,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.17"
+            "mime-types": "^2.1.12"
           }
         },
         "fresh": {
@@ -4560,16 +4678,16 @@
           "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.1.tgz",
           "integrity": "sha512-+ijVOtfLMlCII8LJkvabaKX3+8tGrGjiCTfzoed2D1b/ebKTO1hIYBQUJHbd9dJ9Fa4kH+dhYEd1qDwyzDLUUw==",
           "requires": {
-            "jws": "3.1.4",
-            "lodash.includes": "4.3.0",
-            "lodash.isboolean": "3.0.3",
-            "lodash.isinteger": "4.0.4",
-            "lodash.isnumber": "3.0.3",
-            "lodash.isplainobject": "4.0.6",
-            "lodash.isstring": "4.0.1",
-            "lodash.once": "4.1.1",
-            "ms": "2.1.1",
-            "xtend": "4.0.1"
+            "jws": "^3.1.4",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "xtend": "^4.0.1"
           },
           "dependencies": {
             "ms": {
@@ -4599,7 +4717,7 @@
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
           "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
           "requires": {
-            "forwarded": "0.1.2",
+            "forwarded": "~0.1.2",
             "ipaddr.js": "1.6.0"
           }
         },
@@ -4620,18 +4738,18 @@
           "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.1"
           }
         },
         "serve-static": {
@@ -4639,9 +4757,9 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
           "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
           "requires": {
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
             "send": "0.16.1"
           }
         },
@@ -4660,16 +4778,16 @@
           "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
           "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
           "requires": {
-            "component-emitter": "1.2.1",
-            "cookiejar": "2.1.1",
-            "debug": "3.1.0",
-            "extend": "3.0.1",
-            "form-data": "2.3.2",
-            "formidable": "1.1.1",
-            "methods": "1.1.2",
-            "mime": "1.4.1",
-            "qs": "6.5.1",
-            "readable-stream": "2.3.3"
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.1.1",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.0.5"
           },
           "dependencies": {
             "debug": {
@@ -4715,10 +4833,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^3.0.2"
           }
         },
         "ajv-keywords": {
@@ -4741,7 +4859,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "bluebird": {
@@ -4754,7 +4872,7 @@
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "concat-stream": {
@@ -4762,10 +4880,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
-            "buffer-from": "1.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "debug": {
@@ -4786,39 +4904,39 @@
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.1.1.tgz",
           "integrity": "sha1-+svfz+Pg+s06i4DcmMTmwTrlgt8=",
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.2",
-            "debug": "2.6.9",
-            "doctrine": "2.0.2",
-            "eslint-scope": "3.7.1",
-            "espree": "3.5.2",
-            "esquery": "1.0.0",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "2.0.0",
-            "glob": "7.1.2",
-            "globals": "9.18.0",
-            "ignore": "3.3.7",
-            "imurmurhash": "0.1.4",
-            "inquirer": "3.3.0",
-            "is-my-json-valid": "2.17.1",
-            "is-resolvable": "1.0.1",
-            "js-yaml": "3.11.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.10",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.2",
-            "path-is-inside": "1.0.2",
-            "pluralize": "4.0.0",
-            "progress": "2.0.0",
-            "require-uncached": "1.0.3",
-            "strip-json-comments": "2.0.1",
-            "table": "4.0.3",
-            "text-table": "0.2.0"
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^1.1.3",
+            "concat-stream": "^1.6.0",
+            "debug": "^2.6.8",
+            "doctrine": "^2.0.0",
+            "eslint-scope": "^3.7.1",
+            "espree": "^3.4.3",
+            "esquery": "^1.0.0",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "glob": "^7.1.2",
+            "globals": "^9.17.0",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-my-json-valid": "^2.16.0",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.8.4",
+            "json-stable-stringify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^4.0.0",
+            "progress": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "strip-json-comments": "~2.0.1",
+            "table": "^4.0.1",
+            "text-table": "~0.2.0"
           },
           "dependencies": {
             "lodash": {
@@ -4838,7 +4956,7 @@
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "has-flag": {
@@ -4854,7 +4972,7 @@
             "depd": "1.1.0",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "inquirer": {
@@ -4862,20 +4980,20 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.2.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.10",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           },
           "dependencies": {
             "chalk": {
@@ -4883,9 +5001,9 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "lodash": {
@@ -4905,8 +5023,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "lodash": {
@@ -4929,7 +5047,7 @@
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "pluralize": {
@@ -4947,8 +5065,8 @@
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "run-async": {
@@ -4956,7 +5074,7 @@
           "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "rx-lite": {
@@ -4974,7 +5092,7 @@
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
           "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0"
+            "is-fullwidth-code-point": "^2.0.0"
           }
         },
         "string-width": {
@@ -4982,8 +5100,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -4991,7 +5109,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -4999,7 +5117,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "table": {
@@ -5007,12 +5125,12 @@
           "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "requires": {
-            "ajv": "6.4.0",
-            "ajv-keywords": "3.1.0",
-            "chalk": "2.4.1",
-            "lodash": "4.17.10",
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
             "slice-ansi": "1.0.0",
-            "string-width": "2.1.1"
+            "string-width": "^2.1.1"
           },
           "dependencies": {
             "chalk": {
@@ -5020,9 +5138,9 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "lodash": {
@@ -5044,9 +5162,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
       "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
       "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime-types": "2.0.14"
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime-types": "~2.0.3"
       },
       "dependencies": {
         "combined-stream": {
@@ -5072,7 +5190,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "requires": {
-            "mime-db": "1.12.0"
+            "mime-db": "~1.12.0"
           }
         }
       }
@@ -5083,7 +5201,7 @@
       "integrity": "sha1-55kcoUT/fYz/B7uayGqbeca6R+8=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.3"
+        "samsam": "~1.1"
       }
     },
     "formidable": {
@@ -5118,9 +5236,9 @@
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
       }
     },
     "fs-readdir-recursive": {
@@ -5139,8 +5257,8 @@
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -5155,8 +5273,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -5176,8 +5294,8 @@
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -5221,7 +5339,7 @@
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
@@ -5229,7 +5347,7 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -5237,7 +5355,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -5245,7 +5363,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -5276,7 +5394,7 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -5299,7 +5417,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -5308,7 +5426,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -5357,7 +5475,7 @@
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -5383,9 +5501,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -5398,10 +5516,10 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -5410,9 +5528,9 @@
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -5421,14 +5539,14 @@
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -5437,7 +5555,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -5453,12 +5571,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -5478,8 +5596,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -5493,10 +5611,10 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -5510,9 +5628,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -5520,8 +5638,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -5540,7 +5658,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -5566,7 +5684,7 @@
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -5587,7 +5705,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -5632,7 +5750,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -5640,7 +5758,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5668,17 +5786,17 @@
           "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -5687,8 +5805,8 @@
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -5697,10 +5815,10 @@
           "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5725,7 +5843,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -5746,8 +5864,8 @@
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -5784,10 +5902,10 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5803,13 +5921,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -5818,28 +5936,28 @@
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
@@ -5847,7 +5965,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -5878,7 +5996,7 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -5887,15 +6005,15 @@
           "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -5911,9 +6029,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -5921,7 +6039,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -5935,7 +6053,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -5949,9 +6067,9 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -5960,14 +6078,14 @@
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -5976,7 +6094,7 @@
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -5985,7 +6103,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -6026,7 +6144,7 @@
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -6041,10 +6159,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.5.4"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "fstream-ignore": {
@@ -6052,9 +6170,9 @@
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
       }
     },
     "function-bind": {
@@ -6096,14 +6214,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "generate-function": {
@@ -6116,7 +6234,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "generic-pool": {
@@ -6144,7 +6262,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gex": {
@@ -6162,14 +6280,19 @@
         }
       }
     },
+    "gherkin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-5.0.0.tgz",
+      "integrity": "sha1-lt70EZjsOQgli1Ea909lWidk0qE="
+    },
     "github4": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/github4/-/github4-1.1.1.tgz",
       "integrity": "sha1-OtaomntZBHWpCRmIcGhSOgQPxS4=",
       "requires": {
         "follow-redirects": "0.0.7",
-        "https-proxy-agent": "1.0.0",
-        "mime": "1.6.0"
+        "https-proxy-agent": "^1.0.0",
+        "mime": "^1.2.11"
       },
       "dependencies": {
         "agent-base": {
@@ -6177,8 +6300,8 @@
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "requires": {
-            "extend": "3.0.1",
-            "semver": "5.0.3"
+            "extend": "~3.0.0",
+            "semver": "~5.0.1"
           }
         },
         "https-proxy-agent": {
@@ -6186,9 +6309,9 @@
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "requires": {
-            "agent-base": "2.1.1",
-            "debug": "2.6.9",
-            "extend": "3.0.1"
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3"
           },
           "dependencies": {
             "debug": {
@@ -6218,12 +6341,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -6231,8 +6354,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -6240,7 +6363,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global": {
@@ -6248,8 +6371,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       },
       "dependencies": {
         "process": {
@@ -6265,7 +6388,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -6278,12 +6401,12 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6299,17 +6422,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -6328,9 +6451,9 @@
       "integrity": "sha512-+r8qY2JRRs+uaZcrZOxpNhdlCZoS8yS5KQ6X53Twc8WecZ6VtAn+MVHroLOd4u9HVPxTXZ9RUd9+556EpTc0xA==",
       "dev": true,
       "requires": {
-        "codemirror": "5.37.0",
-        "codemirror-graphql": "0.6.12",
-        "markdown-it": "8.4.1"
+        "codemirror": "^5.26.0",
+        "codemirror-graphql": "^0.6.11",
+        "markdown-it": "^8.4.0"
       }
     },
     "graphql": {
@@ -6347,12 +6470,12 @@
       "integrity": "sha512-OwDrKrYc1h7HHhEVInQrKInl7/ZgfT4ftjjBJDahBiiHi/mEstnn0mVlSb7B06SF+PZt/FgkE3q+RX+rqavvWQ==",
       "dev": true,
       "requires": {
-        "graphql": "0.12.3",
-        "graphql-import": "0.1.9",
-        "graphql-request": "1.5.2",
-        "js-yaml": "3.11.0",
-        "minimatch": "3.0.4",
-        "rimraf": "2.6.2"
+        "graphql": "^0.12.3",
+        "graphql-import": "^0.1.7",
+        "graphql-request": "^1.4.0",
+        "js-yaml": "^3.10.0",
+        "minimatch": "^3.0.4",
+        "rimraf": "^2.6.2"
       },
       "dependencies": {
         "esprima": {
@@ -6376,8 +6499,8 @@
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "rimraf": {
@@ -6386,7 +6509,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -6398,9 +6521,9 @@
       "dev": true,
       "requires": {
         "@types/graphql": "0.11.7",
-        "@types/lodash": "4.14.108",
-        "graphql": "0.12.3",
-        "lodash": "4.17.10"
+        "@types/lodash": "^4.14.85",
+        "graphql": "^0.12.3",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "graphql": {
@@ -6427,9 +6550,9 @@
       "dev": true,
       "requires": {
         "graphql-config": "1.1.4",
-        "graphql-language-service-parser": "1.1.0",
-        "graphql-language-service-types": "1.1.0",
-        "graphql-language-service-utils": "1.1.0"
+        "graphql-language-service-parser": "^1.1.0",
+        "graphql-language-service-types": "^1.1.0",
+        "graphql-language-service-utils": "^1.1.0"
       },
       "dependencies": {
         "graphql-language-service-parser": {
@@ -6439,7 +6562,7 @@
           "dev": true,
           "requires": {
             "graphql-config": "1.1.4",
-            "graphql-language-service-types": "1.1.0"
+            "graphql-language-service-types": "^1.1.0"
           }
         }
       }
@@ -6450,7 +6573,7 @@
       "integrity": "sha512-72M4OksONeqT5slfdfODmlPBFlUQQkcnRhjgmPt9H2n8/DUcf4XzDkGXudBWpzNfjVU35+IADYW6x13wKw/fOg==",
       "dev": true,
       "requires": {
-        "graphql-language-service-types": "0.1.14"
+        "graphql-language-service-types": "^0.1.14"
       },
       "dependencies": {
         "graphql-language-service-types": {
@@ -6477,7 +6600,7 @@
       "dev": true,
       "requires": {
         "graphql-config": "1.1.4",
-        "graphql-language-service-types": "1.1.0"
+        "graphql-language-service-types": "^1.1.0"
       }
     },
     "graphql-request": {
@@ -6495,9 +6618,9 @@
       "integrity": "sha1-ifE/XTLOCMmnbHn9+cGWg4TYGk4="
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "handlebars": {
@@ -6505,10 +6628,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
       "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -6521,7 +6644,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -6536,8 +6659,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -6546,7 +6669,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -6554,7 +6677,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -6574,7 +6697,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -6583,8 +6706,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hasha": {
@@ -6593,8 +6716,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "optional": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hawk": {
@@ -6602,10 +6725,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -6655,9 +6778,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -6670,8 +6793,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -6697,7 +6820,7 @@
       "resolved": "https://registry.npmjs.org/html-pdf/-/html-pdf-2.2.0.tgz",
       "integrity": "sha1-S8+Rwky1YOR6o/rP0DPg4b8kG5E=",
       "requires": {
-        "phantomjs-prebuilt": "2.1.16"
+        "phantomjs-prebuilt": "^2.1.4"
       }
     },
     "htmlparser2": {
@@ -6705,11 +6828,11 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       },
       "dependencies": {
         "entities": {
@@ -6727,10 +6850,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6748,7 +6871,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.3.1 < 2"
       }
     },
     "http-signature": {
@@ -6756,9 +6879,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6772,9 +6895,9 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
       "integrity": "sha1-cT+jjl01P1DrFKNC/r4pAz7RYZs=",
       "requires": {
-        "agent-base": "1.0.2",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "~1.0.1",
+        "debug": "2",
+        "extend": "3"
       },
       "dependencies": {
         "debug": {
@@ -6836,9 +6959,9 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
       "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
       "requires": {
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "repeating": "1.1.3"
+        "get-stdin": "^4.0.1",
+        "minimist": "^1.1.0",
+        "repeating": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -6851,7 +6974,7 @@
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         }
       }
@@ -6877,8 +7000,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -6897,20 +7020,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6925,7 +7048,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -6934,9 +7057,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -6969,8 +7092,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6979,7 +7102,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -6988,7 +7111,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7017,7 +7140,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -7031,11 +7154,11 @@
       "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash.find": "4.6.0",
-        "lodash.max": "4.0.1",
-        "lodash.merge": "4.6.1",
-        "lodash.padstart": "4.6.1",
-        "lodash.repeat": "4.1.0",
+        "lodash.find": "^4.6.0",
+        "lodash.max": "^4.0.1",
+        "lodash.merge": "^4.6.0",
+        "lodash.padstart": "^4.6.1",
+        "lodash.repeat": "^4.1.0",
         "sprintf-js": "1.1.0"
       },
       "dependencies": {
@@ -7053,9 +7176,10 @@
     },
     "ip-utils": {
       "version": "git+https://github.com/ForestAdmin/ip-utils.git#5f88562ba53fedcdc0374937fca0fdb71fa4923c",
+      "from": "git+https://github.com/ForestAdmin/ip-utils.git#5f88562ba53fedcdc0374937fca0fdb71fa4923c",
       "requires": {
-        "ip-address": "5.8.9",
-        "range_check": "1.4.0"
+        "ip-address": "^5.8.9",
+        "range_check": "^1.4.0"
       }
     },
     "ip6": {
@@ -7078,7 +7202,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-bluebird": {
@@ -7096,7 +7220,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -7121,7 +7245,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -7139,7 +7263,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -7147,15 +7271,20 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
+    },
+    "is-generator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM="
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-installed-globally": {
@@ -7164,8 +7293,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -7173,10 +7302,10 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
       "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-npm": {
@@ -7190,7 +7319,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -7209,7 +7338,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -7217,7 +7346,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -7252,7 +7381,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -7315,8 +7444,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -7336,13 +7465,13 @@
       "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.3.0"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.1.1",
+        "semver": "^5.3.0"
       }
     },
     "iterall": {
@@ -7533,10 +7662,10 @@
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
       "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
       "requires": {
-        "config-chain": "1.1.11",
-        "editorconfig": "0.13.3",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6"
+        "config-chain": "~1.1.5",
+        "editorconfig": "^0.13.2",
+        "mkdirp": "~0.5.0",
+        "nopt": "~3.0.1"
       }
     },
     "js-string-escape": {
@@ -7555,8 +7684,8 @@
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
       },
       "dependencies": {
         "esprima": {
@@ -7573,7 +7702,7 @@
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
       "dev": true,
       "requires": {
-        "xmlcreate": "1.0.2"
+        "xmlcreate": "^1.0.1"
       }
     },
     "jsbn": {
@@ -7589,17 +7718,17 @@
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.1",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "js2xmlparser": "3.0.0",
-        "klaw": "2.0.0",
-        "marked": "0.3.9",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.8.3"
       },
       "dependencies": {
         "babylon": {
@@ -7620,7 +7749,7 @@
           "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.9"
           }
         }
       }
@@ -7631,8 +7760,8 @@
       "integrity": "sha1-Ri+p+bSiqwag9NBiQUPQLlui0F8=",
       "dev": true,
       "requires": {
-        "in-publish": "2.0.0",
-        "lodash": "4.17.10"
+        "in-publish": "^2.0.0",
+        "lodash": "^4.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -7655,9 +7784,9 @@
       "integrity": "sha1-ZtbxO8OuXZt5DL94Zk6NHdUmNNo=",
       "dev": true,
       "requires": {
-        "jsdoc-export-default-interop": "0.3.1",
-        "jsdoc-ignore-code": "1.0.1",
-        "jsdoc-sourcecode-tag": "1.0.2"
+        "jsdoc-export-default-interop": "^0.3.1",
+        "jsdoc-ignore-code": "^1.0.1",
+        "jsdoc-sourcecode-tag": "^1.0.2"
       }
     },
     "jsdoc-sourcecode-tag": {
@@ -7672,21 +7801,21 @@
       "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
       "optional": true,
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "2.7.0",
-        "acorn-globals": "1.0.9",
-        "cssom": "0.3.1",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.9.0",
-        "nwmatcher": "1.4.3",
-        "parse5": "1.5.1",
-        "request": "2.83.0",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "2.0.1",
-        "whatwg-url-compat": "0.6.5",
-        "xml-name-validator": "2.0.1"
+        "abab": "^1.0.0",
+        "acorn": "^2.4.0",
+        "acorn-globals": "^1.0.4",
+        "cssom": ">= 0.3.0 < 0.4.0",
+        "cssstyle": ">= 0.2.29 < 0.3.0",
+        "escodegen": "^1.6.1",
+        "nwmatcher": ">= 1.3.7 < 2.0.0",
+        "parse5": "^1.5.1",
+        "request": "^2.55.0",
+        "sax": "^1.1.4",
+        "symbol-tree": ">= 3.1.0 < 4.0.0",
+        "tough-cookie": "^2.2.0",
+        "webidl-conversions": "^2.0.0",
+        "whatwg-url-compat": "~0.6.5",
+        "xml-name-validator": ">= 2.0.1 < 3.0.0"
       }
     },
     "jsesc": {
@@ -7715,7 +7844,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -7734,12 +7863,12 @@
       "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-3.4.2.tgz",
       "integrity": "sha1-7v1r47EH+kcJR483MZ2KGCdOacA=",
       "requires": {
-        "cli-table": "0.3.1",
-        "commander": "2.12.2",
-        "debug": "2.6.9",
-        "flat": "1.6.1",
-        "lodash.get": "3.7.0",
-        "path-is-absolute": "1.0.1"
+        "cli-table": "^0.3.1",
+        "commander": "^2.8.1",
+        "debug": "^2.2.0",
+        "flat": "^1.6.0",
+        "lodash.get": "^3.7.0",
+        "path-is-absolute": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7755,7 +7884,7 @@
           "resolved": "https://registry.npmjs.org/flat/-/flat-1.6.1.tgz",
           "integrity": "sha1-R2udu3DV6TQNu8A4veCEoglFkhw=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "~1.1.2"
           }
         }
       }
@@ -7776,9 +7905,9 @@
       "resolved": "https://registry.npmjs.org/jsonapi-serializer/-/jsonapi-serializer-3.4.1.tgz",
       "integrity": "sha1-YfW0pmq6kAPzmkeA6gkeAc6HpZ8=",
       "requires": {
-        "bluebird": "2.11.0",
-        "inflected": "1.1.7",
-        "lodash": "3.10.1"
+        "bluebird": "^2.10.2",
+        "inflected": "^1.1.6",
+        "lodash": "^3.9.3"
       },
       "dependencies": {
         "bluebird": {
@@ -7799,7 +7928,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonic": {
@@ -7822,9 +7951,9 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
       "integrity": "sha1-HJD5qGzlt0j1+XnBK3BAK0r83bQ=",
       "requires": {
-        "jws": "3.1.4",
-        "ms": "0.7.3",
-        "xtend": "4.0.1"
+        "jws": "^3.0.0",
+        "ms": "^0.7.1",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "ms": {
@@ -7851,7 +7980,7 @@
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "dev": true,
       "requires": {
-        "array-includes": "3.0.3"
+        "array-includes": "^3.0.3"
       }
     },
     "juice": {
@@ -7862,9 +7991,9 @@
         "batch": "0.5.3",
         "cheerio": "0.20.0",
         "commander": "2.9.0",
-        "cross-spawn-async": "2.2.5",
+        "cross-spawn-async": "^2.1.8",
         "cssom": "0.3.1",
-        "deep-extend": "0.4.2",
+        "deep-extend": "^0.4.0",
         "slick": "1.12.2",
         "web-resource-inliner": "2.0.0"
       },
@@ -7874,12 +8003,12 @@
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
           "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
           "requires": {
-            "css-select": "1.2.0",
-            "dom-serializer": "0.1.0",
-            "entities": "1.1.1",
-            "htmlparser2": "3.8.3",
-            "jsdom": "7.2.2",
-            "lodash": "4.17.4"
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "~3.8.1",
+            "jsdom": "^7.0.2",
+            "lodash": "^4.1.0"
           }
         },
         "commander": {
@@ -7887,7 +8016,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "lodash": {
@@ -7905,7 +8034,7 @@
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.9",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       },
       "dependencies": {
         "base64url": {
@@ -7920,9 +8049,9 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
       "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
       "requires": {
-        "base64url": "2.0.0",
-        "jwa": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "base64url": "^2.0.0",
+        "jwa": "^1.1.4",
+        "safe-buffer": "^5.0.1"
       },
       "dependencies": {
         "base64url": {
@@ -7943,7 +8072,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -7952,17 +8081,18 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "knox": {
       "version": "github:automattic/knox#278337d7673341658efcc81e631c3f63fa53d374",
+      "from": "github:automattic/knox#278337d7673341658efcc81e631c3f63fa53d374",
       "requires": {
-        "debug": "2.6.9",
-        "mime": "2.2.2",
-        "once": "1.4.0",
-        "stream-counter": "1.0.0",
-        "xml2js": "0.4.19"
+        "debug": "^2.2.0",
+        "mime": "*",
+        "once": "^1.3.0",
+        "stream-counter": "^1.0.0",
+        "xml2js": "^0.4.4"
       },
       "dependencies": {
         "debug": {
@@ -7980,10 +8110,10 @@
       "resolved": "https://registry.npmjs.org/knox-mpu-alt/-/knox-mpu-alt-0.2.2.tgz",
       "integrity": "sha1-KZ4EP7peAa17kg29yOpRoVFtImg=",
       "requires": {
-        "async": "0.9.2",
-        "fs-extra": "0.10.0",
-        "lodash": "2.4.2",
-        "xml2js": "0.2.8"
+        "async": "~0.9.0",
+        "fs-extra": "~0.10.0",
+        "lodash": "~2.4.0",
+        "xml2js": "~0.2.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -7991,10 +8121,10 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
           "integrity": "sha1-mcDsL9XqqtnWRiReSwFLVnKZgq8=",
           "requires": {
-            "jsonfile": "1.2.0",
-            "mkdirp": "0.5.1",
-            "ncp": "0.5.1",
-            "rimraf": "2.5.4"
+            "jsonfile": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "ncp": "^0.5.1",
+            "rimraf": "^2.2.8"
           }
         },
         "jsonfile": {
@@ -8017,9 +8147,17 @@
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
           "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
           "requires": {
-            "sax": "0.5.8"
+            "sax": "0.5.x"
           }
         }
+      }
+    },
+    "knuth-shuffle-seeded": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle-seeded/-/knuth-shuffle-seeded-1.0.6.tgz",
+      "integrity": "sha1-AfG2VzOqdUDuCNiwF0Fk0iCB5OE=",
+      "requires": {
+        "seed-random": "~2.2.0"
       }
     },
     "latest-version": {
@@ -8028,7 +8166,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lazy-cache": {
@@ -8041,7 +8179,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -8055,8 +8193,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "libbase64": {
@@ -8069,9 +8207,9 @@
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-1.2.0.tgz",
       "integrity": "sha1-jYS087Ils3BEECNu9JSQZDa6dCs=",
       "requires": {
-        "iconv-lite": "0.4.15",
-        "libbase64": "0.1.0",
-        "libqp": "1.1.0"
+        "iconv-lite": "^0.4.13",
+        "libbase64": "^0.1.0",
+        "libqp": "^1.1.0"
       }
     },
     "libqp": {
@@ -8085,7 +8223,7 @@
       "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
       "dev": true,
       "requires": {
-        "uc.micro": "1.0.5"
+        "uc.micro": "^1.0.1"
       }
     },
     "load-json-file": {
@@ -8093,11 +8231,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8123,9 +8261,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -8133,8 +8271,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -8148,8 +8286,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -8181,9 +8319,9 @@
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash._getnative": {
@@ -8203,7 +8341,7 @@
       "resolved": "https://registry.npmjs.org/lodash._topath/-/lodash._topath-3.8.1.tgz",
       "integrity": "sha1-PsXiYGAU9MuX91X+aRTt2L/ADqw=",
       "requires": {
-        "lodash.isarray": "3.0.4"
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.assign": {
@@ -8217,9 +8355,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.defaults": {
@@ -8228,8 +8366,8 @@
       "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
       "dev": true,
       "requires": {
-        "lodash.assign": "3.2.0",
-        "lodash.restparam": "3.6.1"
+        "lodash.assign": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       },
       "dependencies": {
         "lodash.assign": {
@@ -8238,9 +8376,9 @@
           "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
           "dev": true,
           "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash.keys": "3.1.2"
+            "lodash._baseassign": "^3.0.0",
+            "lodash._createassigner": "^3.0.0",
+            "lodash.keys": "^3.0.0"
           }
         }
       }
@@ -8255,8 +8393,8 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-3.7.0.tgz",
       "integrity": "sha1-POaK4skWg7KBzFOUEoMDy/deaR8=",
       "requires": {
-        "lodash._baseget": "3.7.2",
-        "lodash._topath": "3.8.1"
+        "lodash._baseget": "^3.0.0",
+        "lodash._topath": "^3.0.0"
       }
     },
     "lodash.includes": {
@@ -8306,9 +8444,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.max": {
@@ -8384,8 +8522,13 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -8398,8 +8541,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "lru-queue": {
@@ -8407,7 +8550,7 @@
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "~0.10.2"
       }
     },
     "mailcomposer": {
@@ -8415,8 +8558,8 @@
       "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-2.1.0.tgz",
       "integrity": "sha1-plMYIomWFP7omckiJtgeK5y7GD0=",
       "requires": {
-        "buildmail": "2.0.0",
-        "libmime": "1.2.0"
+        "buildmail": "^2.0.0",
+        "libmime": "^1.2.0"
       }
     },
     "make-dir": {
@@ -8424,7 +8567,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "map-obj": {
@@ -8444,11 +8587,11 @@
       "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.5"
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
       }
     },
     "marked": {
@@ -8463,9 +8606,9 @@
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "1.1.6"
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "md5.js": {
@@ -8474,8 +8617,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -8484,8 +8627,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -8506,7 +8649,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memoizee": {
@@ -8514,13 +8657,13 @@
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
       "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.37",
-        "es6-weak-map": "0.1.4",
-        "event-emitter": "0.3.5",
-        "lru-queue": "0.1.0",
-        "next-tick": "0.2.2",
-        "timers-ext": "0.1.2"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.11",
+        "es6-weak-map": "~0.1.4",
+        "event-emitter": "~0.3.4",
+        "lru-queue": "0.1",
+        "next-tick": "~0.2.2",
+        "timers-ext": "0.1"
       }
     },
     "memory-fs": {
@@ -8529,8 +8672,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -8538,10 +8681,10 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
       "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
       "requires": {
-        "camelcase-keys": "1.0.0",
-        "indent-string": "1.2.2",
-        "minimist": "1.2.0",
-        "object-assign": "1.0.0"
+        "camelcase-keys": "^1.0.0",
+        "indent-string": "^1.1.0",
+        "minimist": "^1.1.0",
+        "object-assign": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -8571,19 +8714,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -8592,8 +8735,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -8611,7 +8754,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimer": {
@@ -8629,7 +8772,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -8649,7 +8792,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -8666,69 +8809,43 @@
       }
     },
     "mocha": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.0.2.tgz",
-      "integrity": "sha1-Y6l/Phj00+ZZ1HphdnfQiYdFV/A=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
+      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.0.5",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
         },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "glob": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -8739,8 +8856,89 @@
       "integrity": "sha1-bLs/GhkRziNl55RhoVY3C2N5DH4=",
       "dev": true,
       "requires": {
-        "mocha": "3.0.2",
-        "mocha-junit-reporter": "1.15.0"
+        "mocha": "^3.0.0",
+        "mocha-junit-reporter": "^1.12.0"
+      },
+      "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
+        },
+        "mocha": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+          "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+          "dev": true,
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.9.0",
+            "debug": "2.6.8",
+            "diff": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.1",
+            "growl": "1.9.2",
+            "he": "1.1.1",
+            "json3": "3.3.2",
+            "lodash.create": "3.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "3.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "mocha-junit-reporter": {
@@ -8749,10 +8947,10 @@
       "integrity": "sha1-MJ9LeiD82ibQrWnJt9CAjXcjAsI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "md5": "2.2.1",
-        "mkdirp": "0.5.1",
-        "xml": "1.0.1"
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "xml": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -8782,7 +8980,7 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
       "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
       "requires": {
-        "moment": "2.19.3"
+        "moment": ">= 2.9.0"
       }
     },
     "morgan": {
@@ -8790,11 +8988,11 @@
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
       "integrity": "sha1-6xDKjlDRq+D409rVwCAdBS2YHGI=",
       "requires": {
-        "basic-auth": "1.0.4",
-        "debug": "2.2.0",
-        "depd": "1.1.1",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "basic-auth": "~1.0.3",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -8827,10 +9025,10 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
       "integrity": "sha1-VRuKYBUJNwG8rMlkkWsa4GV483s=",
       "requires": {
-        "busboy": "0.2.14",
-        "mkdirp": "0.3.5",
-        "qs": "1.2.2",
-        "type-is": "1.5.7"
+        "busboy": "~0.2.9",
+        "mkdirp": "~0.3.5",
+        "qs": "~1.2.2",
+        "type-is": "~1.5.2"
       },
       "dependencies": {
         "mime-db": {
@@ -8843,7 +9041,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "requires": {
-            "mime-db": "1.12.0"
+            "mime-db": "~1.12.0"
           }
         },
         "mkdirp": {
@@ -8862,7 +9060,7 @@
           "integrity": "sha1-uTaKWTzG730GReeLL0xky+zQXpA=",
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.0.14"
+            "mime-types": "~2.0.9"
           }
         }
       }
@@ -8872,6 +9070,16 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "nan": {
       "version": "2.8.0",
@@ -8894,9 +9102,9 @@
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.4.4.tgz",
       "integrity": "sha1-eCAmc24Uaf7m7qED6IVxM2xyw3E=",
       "requires": {
-        "minimist": "1.2.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -8911,7 +9119,7 @@
       "resolved": "https://registry.npmjs.org/needle/-/needle-0.7.10.tgz",
       "integrity": "sha1-4cLbkgufr95GcJzF6fSqh8JZZW0=",
       "requires": {
-        "iconv-lite": "0.4.15"
+        "iconv-lite": "^0.4.4"
       }
     },
     "negotiator": {
@@ -8924,13 +9132,13 @@
       "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-2.4.2.tgz",
       "integrity": "sha1-zmMji5ifj6J9rmDqJP48L62Wnlw=",
       "requires": {
-        "@newrelic/native-metrics": "2.1.2",
-        "async": "2.6.0",
-        "concat-stream": "1.6.0",
-        "https-proxy-agent": "0.3.6",
-        "json-stringify-safe": "5.0.1",
-        "readable-stream": "2.3.3",
-        "semver": "5.3.0"
+        "@newrelic/native-metrics": "^2.1.0",
+        "async": "^2.1.4",
+        "concat-stream": "^1.5.0",
+        "https-proxy-agent": "^0.3.5",
+        "json-stringify-safe": "^5.0.0",
+        "readable-stream": "^2.1.4",
+        "semver": "^5.3.0"
       },
       "dependencies": {
         "async": {
@@ -8938,7 +9146,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "concat-stream": {
@@ -8946,9 +9154,9 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "lodash": {
@@ -8968,6 +9176,14 @@
       "resolved": "https://registry.npmjs.org/nid/-/nid-0.3.2.tgz",
       "integrity": "sha1-l3qTGO1cKjjt1mJj8+r9gUPyJRo="
     },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "nocache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
@@ -8979,15 +9195,15 @@
       "integrity": "sha1-IhFVAlMXPOKYvNifyoJeg4E8pys=",
       "dev": true,
       "requires": {
-        "chai": "3.5.0",
-        "debug": "2.6.9",
-        "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
+        "chai": ">=1.9.2 <4.0.0",
+        "debug": "^2.2.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "~4.17.2",
+        "mkdirp": "^0.5.0",
         "propagate": "0.4.0",
-        "qs": "6.5.1",
-        "semver": "5.3.0"
+        "qs": "^6.0.2",
+        "semver": "^5.3.0"
       },
       "dependencies": {
         "debug": {
@@ -9012,8 +9228,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-libs-browser": {
@@ -9022,28 +9238,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.4",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       }
     },
@@ -9052,15 +9268,15 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
       "integrity": "sha1-/EUrN25zGbPSVfXzSFPvb9j+H9U=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "rc": "1.1.7",
-        "request": "2.83.0",
-        "rimraf": "2.5.4",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "tar-pack": "3.3.0"
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "npmlog": "^4.0.1",
+        "rc": "~1.1.6",
+        "request": "^2.79.0",
+        "rimraf": "~2.5.4",
+        "semver": "~5.3.0",
+        "tar": "~2.2.1",
+        "tar-pack": "~3.3.0"
       }
     },
     "node-slack": {
@@ -9069,7 +9285,7 @@
       "integrity": "sha1-KgItO1tH6qppP7Fn/L+8rXaXrOc=",
       "requires": {
         "deferred": "0.7.1",
-        "request": "2.83.0"
+        "request": "~2.x"
       }
     },
     "node-slug": {
@@ -9077,7 +9293,7 @@
       "resolved": "https://registry.npmjs.org/node-slug/-/node-slug-0.0.2.tgz",
       "integrity": "sha1-zdCgkgOBkBq/w2nrV6biSx7W3co=",
       "requires": {
-        "unidecode": "0.1.8"
+        "unidecode": "^0.1.3"
       }
     },
     "node-uuid": {
@@ -9090,11 +9306,11 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-1.11.0.tgz",
       "integrity": "sha1-TmnLObAwFbHR7wx4qBVBK56Xb3k=",
       "requires": {
-        "libmime": "1.2.0",
-        "mailcomposer": "2.1.0",
-        "needle": "0.11.0",
-        "nodemailer-direct-transport": "1.1.0",
-        "nodemailer-smtp-transport": "1.1.0"
+        "libmime": "^1.2.0",
+        "mailcomposer": "^2.1.0",
+        "needle": "^0.11.0",
+        "nodemailer-direct-transport": "^1.1.0",
+        "nodemailer-smtp-transport": "^1.1.0"
       },
       "dependencies": {
         "needle": {
@@ -9102,8 +9318,8 @@
           "resolved": "https://registry.npmjs.org/needle/-/needle-0.11.0.tgz",
           "integrity": "sha1-AqcbAI6vfVWuifuf12hbe4jXvCk=",
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.15"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4"
           },
           "dependencies": {
             "debug": {
@@ -9123,7 +9339,7 @@
       "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-1.1.0.tgz",
       "integrity": "sha1-oveHCO5vFuoFc/yClJ0Tj/Fy9iQ=",
       "requires": {
-        "smtp-connection": "1.3.8"
+        "smtp-connection": "^1.3.1"
       }
     },
     "nodemailer-smtp-transport": {
@@ -9131,9 +9347,9 @@
       "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-1.1.0.tgz",
       "integrity": "sha1-5sN/MYhaswgOfe089SjErX5pE5g=",
       "requires": {
-        "clone": "1.0.3",
-        "nodemailer-wellknown": "0.1.10",
-        "smtp-connection": "1.3.8"
+        "clone": "^1.0.2",
+        "nodemailer-wellknown": "^0.1.7",
+        "smtp-connection": "^1.3.7"
       }
     },
     "nodemailer-wellknown": {
@@ -9147,16 +9363,16 @@
       "integrity": "sha512-Kwx492h2buPPOie50cht/PdV+jXLqk28l79Nzs1udrFWIXpYHKCskLict1hTrln4ux61azehZcwm8M5McmiuAw==",
       "dev": true,
       "requires": {
-        "chokidar": "1.7.0",
-        "debug": "2.6.9",
-        "es6-promise": "3.3.1",
-        "ignore-by-default": "1.0.1",
-        "lodash.defaults": "3.1.2",
-        "minimatch": "3.0.4",
-        "ps-tree": "1.1.0",
-        "touch": "3.1.0",
+        "chokidar": "^1.7.0",
+        "debug": "^2.6.8",
+        "es6-promise": "^3.3.1",
+        "ignore-by-default": "^1.0.1",
+        "lodash.defaults": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "ps-tree": "^1.1.0",
+        "touch": "^3.1.0",
         "undefsafe": "0.0.3",
-        "update-notifier": "2.3.0"
+        "update-notifier": "^2.3.0"
       },
       "dependencies": {
         "debug": {
@@ -9181,7 +9397,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "norma": {
@@ -9189,8 +9405,8 @@
       "resolved": "https://registry.npmjs.org/norma/-/norma-0.3.0.tgz",
       "integrity": "sha1-JyZcNBEBjDLJPucZ9pLPkN7Fq2Q=",
       "requires": {
-        "eraro": "0.4.1",
-        "lodash": "2.4.2"
+        "eraro": "~0.4.1",
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "lodash": {
@@ -9205,10 +9421,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -9216,7 +9432,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -9224,7 +9440,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -9232,10 +9448,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nsp": {
@@ -9244,16 +9460,16 @@
       "integrity": "sha1-6WS0KR1GjhGHOe6UEVQP97jysPI=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "https-proxy-agent": "1.0.0",
-        "joi": "6.10.1",
-        "nodesecurity-npm-utils": "5.0.0",
-        "path-is-absolute": "1.0.0",
-        "rc": "1.1.6",
-        "semver": "5.1.0",
-        "subcommand": "2.0.3",
-        "wreck": "6.3.0"
+        "chalk": "^1.1.1",
+        "cli-table": "^0.3.1",
+        "https-proxy-agent": "^1.0.0",
+        "joi": "^6.9.1",
+        "nodesecurity-npm-utils": "^5.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rc": "^1.1.2",
+        "semver": "^5.0.3",
+        "subcommand": "^2.0.3",
+        "wreck": "^6.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -9262,11 +9478,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -9287,7 +9503,7 @@
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -9304,7 +9520,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -9346,9 +9562,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2.0.1",
-            "debug": "2.2.0",
-            "extend": "3.0.0"
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3"
           },
           "dependencies": {
             "agent-base": {
@@ -9357,8 +9573,8 @@
               "integrity": "sha1-vY+ehqjrIh//oHvRS+/VXfFCgV4=",
               "dev": true,
               "requires": {
-                "extend": "3.0.0",
-                "semver": "5.0.3"
+                "extend": "~3.0.0",
+                "semver": "~5.0.1"
               },
               "dependencies": {
                 "semver": {
@@ -9400,10 +9616,10 @@
           "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3",
-            "isemail": "1.2.0",
-            "moment": "2.12.0",
-            "topo": "1.1.0"
+            "hoek": "2.x.x",
+            "isemail": "1.x.x",
+            "moment": "2.x.x",
+            "topo": "1.x.x"
           },
           "dependencies": {
             "hoek": {
@@ -9430,7 +9646,7 @@
               "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
               "dev": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             }
           }
@@ -9453,10 +9669,10 @@
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
           "dev": true,
           "requires": {
-            "deep-extend": "0.4.1",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "1.0.4"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~1.0.4"
           },
           "dependencies": {
             "deep-extend": {
@@ -9497,10 +9713,10 @@
           "integrity": "sha1-mz/Rp1PjxEHwBBDLRBMdhlX1LDI=",
           "dev": true,
           "requires": {
-            "cliclopts": "1.1.1",
-            "debug": "2.2.0",
-            "minimist": "1.2.0",
-            "xtend": "4.0.1"
+            "cliclopts": "^1.1.0",
+            "debug": "^2.1.3",
+            "minimist": "^1.2.0",
+            "xtend": "^4.0.0"
           },
           "dependencies": {
             "cliclopts": {
@@ -9546,8 +9762,8 @@
           "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "hoek": "2.16.3"
+            "boom": "2.x.x",
+            "hoek": "2.x.x"
           },
           "dependencies": {
             "boom": {
@@ -9556,7 +9772,7 @@
               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
               "dev": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "hoek": {
@@ -9574,7 +9790,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "number-is-nan": {
@@ -9594,33 +9810,33 @@
       "integrity": "sha1-6nrKogojUhAQFgT059VtKEU7AnQ=",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.3.0",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "1.1.2",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.1",
-        "istanbul-lib-coverage": "1.0.1",
-        "istanbul-lib-hook": "1.0.0",
-        "istanbul-lib-instrument": "1.4.2",
-        "istanbul-lib-report": "1.0.0-alpha.3",
-        "istanbul-lib-source-maps": "1.1.0",
-        "istanbul-reports": "1.0.0",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.3",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.5.4",
-        "signal-exit": "3.0.2",
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.3.0",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^1.1.2",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.0.1",
+        "istanbul-lib-hook": "^1.0.0",
+        "istanbul-lib-instrument": "^1.4.2",
+        "istanbul-lib-report": "^1.0.0-alpha.3",
+        "istanbul-lib-source-maps": "^1.1.0",
+        "istanbul-reports": "^1.0.0",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.0.2",
+        "micromatch": "^2.3.11",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.4",
+        "signal-exit": "^3.0.1",
         "spawn-wrap": "1.2.4",
-        "test-exclude": "3.3.0",
-        "yargs": "6.6.0",
-        "yargs-parser": "4.2.1"
+        "test-exclude": "^3.3.0",
+        "yargs": "^6.6.0",
+        "yargs-parser": "^4.0.2"
       },
       "dependencies": {
         "align-text": {
@@ -9629,9 +9845,9 @@
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
-            "kind-of": "3.1.0",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -9658,7 +9874,7 @@
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
@@ -9673,7 +9889,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.0.1"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -9706,9 +9922,9 @@
           "integrity": "sha1-uWj4OQkPmovG1Bk4+5bLhPc4eyY=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "2.0.0"
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^2.0.0"
           }
         },
         "babel-generator": {
@@ -9717,13 +9933,13 @@
           "integrity": "sha1-YF8SacSJocdd7sp+oW1D1GVshJQ=",
           "dev": true,
           "requires": {
-            "babel-messages": "6.8.0",
-            "babel-runtime": "6.20.0",
-            "babel-types": "6.21.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.6"
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.20.0",
+            "babel-types": "^6.21.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0"
           }
         },
         "babel-messages": {
@@ -9732,7 +9948,7 @@
           "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.20.0"
+            "babel-runtime": "^6.0.0"
           }
         },
         "babel-runtime": {
@@ -9741,8 +9957,8 @@
           "integrity": "sha1-hzAL3PTNdw8JvwBIxkIE4XgG0W8=",
           "dev": true,
           "requires": {
-            "core-js": "2.4.1",
-            "regenerator-runtime": "0.10.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
           }
         },
         "babel-template": {
@@ -9751,11 +9967,11 @@
           "integrity": "sha1-4UndGp8Do1+BfdvE0EgZiOfryMo=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.20.0",
-            "babel-traverse": "6.21.0",
-            "babel-types": "6.21.0",
-            "babylon": "6.15.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.9.0",
+            "babel-traverse": "^6.16.0",
+            "babel-types": "^6.16.0",
+            "babylon": "^6.11.0",
+            "lodash": "^4.2.0"
           }
         },
         "babel-traverse": {
@@ -9764,15 +9980,15 @@
           "integrity": "sha1-acY2WATxpPaesSE/hbAKgYuMIa0=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.20.0",
-            "babel-messages": "6.8.0",
-            "babel-runtime": "6.20.0",
-            "babel-types": "6.21.0",
-            "babylon": "6.15.0",
-            "debug": "2.6.0",
-            "globals": "9.14.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.20.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.20.0",
+            "babel-types": "^6.21.0",
+            "babylon": "^6.11.0",
+            "debug": "^2.2.0",
+            "globals": "^9.0.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
           }
         },
         "babel-types": {
@@ -9781,10 +9997,10 @@
           "integrity": "sha1-MUuSFoiR7204Brf3qRf9+HwRpLI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.20.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.2"
+            "babel-runtime": "^6.20.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^1.0.1"
           }
         },
         "babylon": {
@@ -9805,7 +10021,7 @@
           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -9815,9 +10031,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "builtin-modules": {
@@ -9832,9 +10048,9 @@
           "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.1"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           }
         },
         "camelcase": {
@@ -9851,8 +10067,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -9861,11 +10077,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cliui": {
@@ -9875,8 +10091,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -9925,8 +10141,8 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.0.2",
-            "which": "1.2.12"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -9956,7 +10172,7 @@
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           }
         },
         "detect-indent": {
@@ -9965,7 +10181,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "error-ex": {
@@ -9974,7 +10190,7 @@
           "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -9995,7 +10211,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -10004,7 +10220,7 @@
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -10013,7 +10229,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
@@ -10028,11 +10244,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.6",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "find-cache-dir": {
@@ -10041,9 +10257,9 @@
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -10052,8 +10268,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "for-in": {
@@ -10068,7 +10284,7 @@
           "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
           "dev": true,
           "requires": {
-            "for-in": "0.1.6"
+            "for-in": "^0.1.5"
           }
         },
         "foreground-child": {
@@ -10077,8 +10293,8 @@
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -10099,12 +10315,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -10113,8 +10329,8 @@
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -10123,7 +10339,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -10144,10 +10360,10 @@
           "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.7.5"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -10156,7 +10372,7 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -10167,7 +10383,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -10194,8 +10410,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -10210,7 +10426,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -10237,7 +10453,7 @@
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-dotfile": {
@@ -10252,7 +10468,7 @@
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -10273,7 +10489,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -10282,7 +10498,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-glob": {
@@ -10291,7 +10507,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -10300,7 +10516,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.1.0"
+            "kind-of": "^3.0.2"
           }
         },
         "is-posix-bracket": {
@@ -10354,7 +10570,7 @@
           "integrity": "sha1-/FNn7if1kmjo8GCwx6rwUdnEJcU=",
           "dev": true,
           "requires": {
-            "append-transform": "0.4.0"
+            "append-transform": "^0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -10363,13 +10579,13 @@
           "integrity": "sha1-Di/frJPB2r8uMVeGN9x4oZCJ9D4=",
           "dev": true,
           "requires": {
-            "babel-generator": "6.21.0",
-            "babel-template": "6.16.0",
-            "babel-traverse": "6.21.0",
-            "babel-types": "6.21.0",
-            "babylon": "6.15.0",
-            "istanbul-lib-coverage": "1.0.1",
-            "semver": "5.3.0"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.13.0",
+            "istanbul-lib-coverage": "^1.0.0",
+            "semver": "^5.3.0"
           }
         },
         "istanbul-lib-report": {
@@ -10378,12 +10594,12 @@
           "integrity": "sha1-MtX27H8zyjpgIgnieLLm/xQ0mK8=",
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "istanbul-lib-coverage": "1.0.1",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "rimraf": "2.5.4",
-            "supports-color": "3.2.3"
+            "async": "^1.4.2",
+            "istanbul-lib-coverage": "^1.0.0-alpha",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "rimraf": "^2.4.3",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "supports-color": {
@@ -10392,7 +10608,7 @@
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -10403,10 +10619,10 @@
           "integrity": "sha1-nUKSGPNbgjVg6jAKlv8MO72reF8=",
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.0.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.5.4",
-            "source-map": "0.5.6"
+            "istanbul-lib-coverage": "^1.0.0-alpha.0",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.4.4",
+            "source-map": "^0.5.3"
           }
         },
         "istanbul-reports": {
@@ -10415,7 +10631,7 @@
           "integrity": "sha1-JLTrKx0p1Q8QOzab1CL25kCqB3c=",
           "dev": true,
           "requires": {
-            "handlebars": "4.0.6"
+            "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
@@ -10436,7 +10652,7 @@
           "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.4"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -10452,7 +10668,7 @@
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -10461,11 +10677,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "lodash": {
@@ -10486,7 +10702,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.0"
+            "js-tokens": "^3.0.0"
           },
           "dependencies": {
             "js-tokens": {
@@ -10503,8 +10719,8 @@
           "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.0.0"
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
           }
         },
         "md5-hex": {
@@ -10513,7 +10729,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
@@ -10528,7 +10744,7 @@
           "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.6"
+            "source-map": "^0.5.3"
           }
         },
         "micromatch": {
@@ -10537,19 +10753,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.0",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.1.0",
-            "normalize-path": "2.0.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.3"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "minimatch": {
@@ -10558,7 +10774,7 @@
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.6"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -10588,10 +10804,10 @@
           "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.3.0",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -10618,8 +10834,8 @@
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
-            "for-own": "0.1.4",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "once": {
@@ -10628,7 +10844,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimist": {
@@ -10637,8 +10853,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-homedir": {
@@ -10653,7 +10869,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "parse-glob": {
@@ -10662,10 +10878,10 @@
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.2",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -10674,7 +10890,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.0"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -10683,7 +10899,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -10704,9 +10920,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -10727,7 +10943,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -10736,7 +10952,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         },
         "preserve": {
@@ -10757,8 +10973,8 @@
           "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "kind-of": "3.1.0"
+            "is-number": "^2.0.2",
+            "kind-of": "^3.0.2"
           }
         },
         "read-pkg": {
@@ -10767,9 +10983,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.3.5",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -10778,8 +10994,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "regenerator-runtime": {
@@ -10794,8 +11010,8 @@
           "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3",
-            "is-primitive": "2.0.0"
+            "is-equal-shallow": "^0.1.3",
+            "is-primitive": "^2.0.0"
           }
         },
         "repeat-element": {
@@ -10816,7 +11032,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
@@ -10844,7 +11060,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -10853,7 +11069,7 @@
           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
           "dev": true,
           "requires": {
-            "glob": "7.1.1"
+            "glob": "^7.0.5"
           }
         },
         "semver": {
@@ -10892,12 +11108,12 @@
           "integrity": "sha1-kg6yEadpwJPuv71bDnpdLmirLkA=",
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.5.4",
-            "signal-exit": "2.1.2",
-            "which": "1.2.12"
+            "foreground-child": "^1.3.3",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.3.3",
+            "signal-exit": "^2.0.0",
+            "which": "^1.2.4"
           },
           "dependencies": {
             "signal-exit": {
@@ -10914,7 +11130,7 @@
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -10935,9 +11151,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -10946,7 +11162,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -10955,7 +11171,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "supports-color": {
@@ -10970,11 +11186,11 @@
           "integrity": "sha1-ehfKEjmYjJg2ewYhRW27fUvDiXc=",
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           }
         },
         "to-fast-properties": {
@@ -10990,10 +11206,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "0.2.10",
-            "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "async": {
@@ -11010,9 +11226,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -11031,8 +11247,8 @@
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "which": {
@@ -11041,7 +11257,7 @@
           "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
           "dev": true,
           "requires": {
-            "isexe": "1.1.2"
+            "isexe": "^1.1.1"
           }
         },
         "which-module": {
@@ -11069,8 +11285,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           }
         },
         "wrappy": {
@@ -11085,9 +11301,9 @@
           "integrity": "sha1-fUW6MjFjKN0ex9kPYOvA2EW7dZo=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "y18n": {
@@ -11108,19 +11324,19 @@
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           },
           "dependencies": {
             "camelcase": {
@@ -11135,9 +11351,9 @@
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
               }
             }
           }
@@ -11148,7 +11364,7 @@
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           },
           "dependencies": {
             "camelcase": {
@@ -11186,8 +11402,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "on-finished": {
@@ -11208,7 +11424,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -11217,23 +11433,24 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opencollective-jobs": {
       "version": "github:opencollective/opencollective-jobs#2a73279702f34461fcef7c81d47bdeb374339faf",
+      "from": "github:opencollective/opencollective-jobs#v0.3.1",
       "requires": {
-        "bluebird": "3.4.0",
-        "dotenv": "2.0.0",
-        "github4": "1.1.1",
-        "lodash": "4.17.10",
-        "npmlog": "2.0.4",
-        "seneca": "2.1.0",
+        "bluebird": "^3.4.0",
+        "dotenv": "^2.0.0",
+        "github4": "^1.1.0",
+        "lodash": "^4.12.0",
+        "npmlog": "^2.0.4",
+        "seneca": "^2.0.1",
         "seneca-cron": "0.0.5",
-        "seneca-postgres-store": "2.3.0",
-        "seneca-queue": "0.3.0",
-        "stampit": "2.1.2",
-        "yargs": "4.8.1"
+        "seneca-postgres-store": "^2.0.0",
+        "seneca-queue": "^0.3.0",
+        "stampit": "^2.1.1",
+        "yargs": "^4.7.1"
       },
       "dependencies": {
         "cliui": {
@@ -11241,9 +11458,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "dotenv": {
@@ -11256,11 +11473,11 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
           "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
           "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
+            "ansi": "^0.3.0",
+            "has-unicode": "^2.0.0",
+            "lodash.pad": "^4.1.0",
+            "lodash.padend": "^4.1.0",
+            "lodash.padstart": "^4.1.0"
           }
         },
         "lodash": {
@@ -11273,9 +11490,9 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
           "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
+            "ansi": "~0.3.1",
+            "are-we-there-yet": "~1.1.2",
+            "gauge": "~1.2.5"
           }
         },
         "window-size": {
@@ -11288,20 +11505,20 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "lodash.assign": "4.2.0",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "2.4.1"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
           }
         }
       }
@@ -11311,8 +11528,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -11320,12 +11537,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -11351,7 +11568,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -11364,9 +11581,9 @@
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
       }
     },
     "p-finally": {
@@ -11384,7 +11601,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "package-json": {
@@ -11393,16 +11610,24 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.3.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "packet-reader": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
       "integrity": "sha1-gZ300BC4LV6lZx+KGjrPA5vNdwA="
+    },
+    "pad-right": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+      "requires": {
+        "repeat-string": "^1.5.2"
+      }
     },
     "pako": {
       "version": "1.0.6",
@@ -11433,11 +11658,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.2",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -11445,10 +11670,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -11456,7 +11681,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse5": {
@@ -11475,7 +11700,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
       "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
       "requires": {
-        "passport-strategy": "1.0.0",
+        "passport-strategy": "1.x.x",
         "pause": "0.0.1"
       }
     },
@@ -11484,7 +11709,7 @@
       "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
       "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
       "requires": {
-        "passport-oauth2": "1.4.0"
+        "passport-oauth2": "1.x.x"
       }
     },
     "passport-meetup-oauth2": {
@@ -11492,8 +11717,8 @@
       "resolved": "https://registry.npmjs.org/passport-meetup-oauth2/-/passport-meetup-oauth2-0.0.2.tgz",
       "integrity": "sha1-peppjBfRxeaHWOf49y7iRJolgFs=",
       "requires": {
-        "passport-oauth2": "1.4.0",
-        "pkginfo": "0.3.1"
+        "passport-oauth2": "^1.1.2",
+        "pkginfo": "~0.3.0"
       }
     },
     "passport-oauth1": {
@@ -11501,9 +11726,9 @@
       "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.1.0.tgz",
       "integrity": "sha1-p96YiiEfnPRoc3cTDqdN8ycwyRg=",
       "requires": {
-        "oauth": "0.9.15",
-        "passport-strategy": "1.0.0",
-        "utils-merge": "1.0.0"
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-oauth2": {
@@ -11511,10 +11736,10 @@
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
       "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
       "requires": {
-        "oauth": "0.9.15",
-        "passport-strategy": "1.0.0",
-        "uid2": "0.0.3",
-        "utils-merge": "1.0.0"
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
@@ -11527,8 +11752,8 @@
       "resolved": "https://registry.npmjs.org/passport-twitter/-/passport-twitter-1.0.4.tgz",
       "integrity": "sha1-AaeZ4fdgvy3knyul+6MigvGJMtc=",
       "requires": {
-        "passport-oauth1": "1.1.0",
-        "xtraverse": "0.1.0"
+        "passport-oauth1": "1.x.x",
+        "xtraverse": "0.1.x"
       }
     },
     "path-browserify": {
@@ -11572,9 +11797,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -11611,7 +11836,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "paypal-adaptive": {
@@ -11624,9 +11849,9 @@
       "resolved": "https://registry.npmjs.org/paypal-rest-sdk/-/paypal-rest-sdk-1.6.8.tgz",
       "integrity": "sha1-+3KpnW7ggDh/95s3DuE+q0tQx9Y=",
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "semver": "5.3.0",
-        "uuid": "2.0.3"
+        "buffer-crc32": "^0.2.3",
+        "semver": "^5.0.3",
+        "uuid": "^2.0.1"
       },
       "dependencies": {
         "uuid": {
@@ -11642,11 +11867,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pend": {
@@ -11669,9 +11894,9 @@
         "js-string-escape": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "2.0.3",
-        "pg-types": "1.12.1",
-        "pgpass": "1.0.2",
+        "pg-pool": "~2.0.3",
+        "pg-types": "~1.12.1",
+        "pgpass": "1.x",
         "semver": "4.3.2"
       },
       "dependencies": {
@@ -11685,10 +11910,10 @@
           "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
           "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
           "requires": {
-            "postgres-array": "1.0.2",
-            "postgres-bytea": "1.0.0",
-            "postgres-date": "1.0.3",
-            "postgres-interval": "1.1.1"
+            "postgres-array": "~1.0.0",
+            "postgres-bytea": "~1.0.0",
+            "postgres-date": "~1.0.0",
+            "postgres-interval": "^1.1.0"
           }
         },
         "pgpass": {
@@ -11696,7 +11921,7 @@
           "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
           "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
           "requires": {
-            "split": "1.0.1"
+            "split": "^1.0.0"
           }
         },
         "semver": {
@@ -11721,7 +11946,7 @@
       "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.2.tgz",
       "integrity": "sha1-9+8FPnubiSrphq8vfL6GQy388k8=",
       "requires": {
-        "underscore": "1.8.3"
+        "underscore": "^1.7.0"
       }
     },
     "pg-int8": {
@@ -11740,10 +11965,10 @@
       "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
       "requires": {
         "pg-int8": "1.0.1",
-        "postgres-array": "1.0.2",
-        "postgres-bytea": "1.0.0",
-        "postgres-date": "1.0.3",
-        "postgres-interval": "1.1.1"
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
       }
     },
     "pgpass": {
@@ -11751,7 +11976,7 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.6.tgz",
       "integrity": "sha1-9idiANAXOdoe6mMTi9yjX/S9coA=",
       "requires": {
-        "split": "1.0.1"
+        "split": "^1.0.0"
       }
     },
     "phantomjs-prebuilt": {
@@ -11760,15 +11985,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "optional": true,
       "requires": {
-        "es6-promise": "4.2.2",
-        "extract-zip": "1.6.6",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.83.0",
-        "request-progress": "2.0.1",
-        "which": "1.3.0"
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
       }
     },
     "pify": {
@@ -11786,7 +12011,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -11794,7 +12019,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pkginfo": {
@@ -11833,7 +12058,7 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
       "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "^4.0.0"
       }
     },
     "prelude-ls": {
@@ -11850,6 +12075,33 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
     },
     "private": {
       "version": "0.1.8",
@@ -11879,7 +12131,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -11888,9 +12140,9 @@
       "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       },
       "dependencies": {
         "core-js": {
@@ -11905,13 +12157,13 @@
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "dev": true,
           "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.9"
           }
         }
       }
@@ -11932,7 +12184,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
       "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.0",
         "ipaddr.js": "1.4.0"
       }
     },
@@ -11948,7 +12200,7 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "3.3.4"
+        "event-stream": "~3.3.0"
       }
     },
     "pseudomap": {
@@ -11962,11 +12214,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -12010,8 +12262,8 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -12019,7 +12271,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12027,7 +12279,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -12037,7 +12289,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -12048,7 +12300,7 @@
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -12057,8 +12309,8 @@
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.5",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -12072,7 +12324,7 @@
       "integrity": "sha1-zYfHrGLEC6nfabhwPGBPYMN0hjU=",
       "requires": {
         "ip6": "0.0.4",
-        "ipaddr.js": "1.2.0"
+        "ipaddr.js": "1.2"
       },
       "dependencies": {
         "ipaddr.js": {
@@ -12097,10 +12349,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
       "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -12116,10 +12368,10 @@
       "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-dom": {
@@ -12128,10 +12380,10 @@
       "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "read-pkg": {
@@ -12139,9 +12391,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -12149,8 +12401,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -12158,8 +12410,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -12167,7 +12419,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -12177,13 +12429,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -12191,10 +12443,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "reconnect-core": {
@@ -12202,7 +12454,7 @@
       "resolved": "https://registry.npmjs.org/reconnect-core/-/reconnect-core-1.1.0.tgz",
       "integrity": "sha1-W7Ngs1sZfqVT8JK2BXUzqkHyhow=",
       "requires": {
-        "backoff": "2.3.0"
+        "backoff": "~2.3.0"
       }
     },
     "reduce": {
@@ -12210,7 +12462,7 @@
       "resolved": "https://registry.npmjs.org/reduce/-/reduce-1.0.1.tgz",
       "integrity": "sha1-FPouX/H8VgcDoCDLtfuqtpFWWAQ=",
       "requires": {
-        "object-keys": "1.0.11"
+        "object-keys": "~1.0.0"
       }
     },
     "referrer-policy": {
@@ -12233,9 +12485,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -12243,7 +12495,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexp-quote": {
@@ -12262,9 +12514,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -12273,8 +12525,8 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.1.7",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -12283,7 +12535,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.1.7"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -12296,7 +12548,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -12326,7 +12578,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -12334,28 +12586,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "form-data": {
@@ -12363,9 +12615,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "uuid": {
@@ -12386,7 +12638,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "optional": true,
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "request-promise": {
@@ -12394,9 +12646,9 @@
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.1.1.tgz",
       "integrity": "sha1-JgIeT29W/Uwwn2vx69jJepWsH7U=",
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "^3.4.1",
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1"
+        "stealthy-require": "^1.0.0"
       },
       "dependencies": {
         "bluebird": {
@@ -12411,7 +12663,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.13.1"
       },
       "dependencies": {
         "lodash": {
@@ -12436,8 +12688,8 @@
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "requizzle": {
@@ -12446,7 +12698,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -12462,7 +12714,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -12476,8 +12728,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "retry-as-promised": {
@@ -12485,8 +12737,8 @@
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.2.tgz",
       "integrity": "sha1-zZdO5P2bX+A8vzGHHuSCIcB3N7c=",
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "2.6.9"
+        "bluebird": "^3.4.6",
+        "debug": "^2.6.9"
       },
       "dependencies": {
         "bluebird": {
@@ -12509,7 +12761,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -12517,7 +12769,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -12526,8 +12778,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rolling-stats": {
@@ -12541,7 +12793,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -12554,7 +12806,7 @@
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
-        "rx-lite": "3.1.2"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -12578,9 +12830,9 @@
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.14.1.tgz",
       "integrity": "sha1-cw/6Ikm98YMz7/5FsoYXPJxa0Lg=",
       "requires": {
-        "htmlparser2": "3.9.2",
+        "htmlparser2": "^3.9.0",
         "regexp-quote": "0.0.0",
-        "xtend": "4.0.1"
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "htmlparser2": {
@@ -12588,12 +12840,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.3.0",
-            "domutils": "1.5.1",
-            "entities": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3"
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
           }
         }
       }
@@ -12602,6 +12854,11 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "seed-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
     },
     "semver": {
       "version": "5.3.0",
@@ -12614,7 +12871,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.3.0"
+        "semver": "^5.0.3"
       }
     },
     "send": {
@@ -12622,19 +12879,19 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
       "requires": {
-        "debug": "2.2.0",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.7.0",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
         "fresh": "0.3.0",
-        "http-errors": "1.5.1",
+        "http-errors": "~1.5.0",
         "mime": "1.3.4",
         "ms": "0.7.1",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.0"
       },
       "dependencies": {
         "debug": {
@@ -12652,7 +12909,7 @@
           "requires": {
             "inherits": "2.0.3",
             "setprototypeof": "1.0.2",
-            "statuses": "1.3.1"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "mime": {
@@ -12717,8 +12974,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
           "integrity": "sha1-tcvwFVbBaWb+vlTO7A+03JDfbCg=",
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
           }
         },
         "minimist": {
@@ -12760,8 +13017,8 @@
       "resolved": "https://registry.npmjs.org/seneca-cluster/-/seneca-cluster-0.0.1.tgz",
       "integrity": "sha1-1qK0SCyLzUnM8Obhol+F70Cl9tM=",
       "requires": {
-        "eraro": "0.4.1",
-        "semver": "5.1.1"
+        "eraro": "0.4.x",
+        "semver": "5.1.x"
       },
       "dependencies": {
         "semver": {
@@ -12776,10 +13033,10 @@
       "resolved": "https://registry.npmjs.org/seneca-cron/-/seneca-cron-0.0.5.tgz",
       "integrity": "sha1-kmSPfLVrul1lS3miekzzjo2Zlvo=",
       "requires": {
-        "cron": "1.3.0",
-        "lodash": "3.10.1",
-        "seneca": "2.1.0",
-        "uuid": "2.0.3"
+        "cron": ">= 1.0.0",
+        "lodash": "^3.10.1",
+        "seneca": ">= 0.8.0",
+        "uuid": "~2.0.1"
       },
       "dependencies": {
         "uuid": {
@@ -12832,7 +13089,7 @@
             "generic-pool": "2.4.2",
             "packet-reader": "0.2.0",
             "pg-connection-string": "0.1.3",
-            "pg-types": "1.13.0",
+            "pg-types": "1.*",
             "pgpass": "0.0.6",
             "semver": "4.3.2"
           }
@@ -12849,8 +13106,8 @@
       "resolved": "https://registry.npmjs.org/seneca-queue/-/seneca-queue-0.3.0.tgz",
       "integrity": "sha1-bj2K18his8tRJzwGlm1RpcoAWGM=",
       "requires": {
-        "async": "1.5.2",
-        "lodash": "3.10.1"
+        "async": "^1.5.0",
+        "lodash": "^3.2.0"
       },
       "dependencies": {
         "async": {
@@ -12865,8 +13122,8 @@
       "resolved": "https://registry.npmjs.org/seneca-repl/-/seneca-repl-0.2.0.tgz",
       "integrity": "sha1-fQdtEOshvax52aibm7kyhlQlSu4=",
       "requires": {
-        "jsonic": "0.2.2",
-        "lodash": "4.5.1"
+        "jsonic": "0.2.x",
+        "lodash": "4.5.x"
       },
       "dependencies": {
         "lodash": {
@@ -12890,17 +13147,17 @@
       "resolved": "https://registry.npmjs.org/seneca-transport/-/seneca-transport-1.2.0.tgz",
       "integrity": "sha1-A2fOuKjxV9ljfAqiKH+C9rJ6gao=",
       "requires": {
-        "eraro": "0.4.1",
-        "gex": "0.2.2",
-        "jsonic": "0.2.2",
+        "eraro": "0.4.x",
+        "gex": "0.2.x",
+        "jsonic": "0.2.x",
         "lodash": "4.5.1",
-        "lru-cache": "3.2.0",
-        "ndjson": "1.4.4",
+        "lru-cache": "3.2.x",
+        "ndjson": "1.4.x",
         "nid": "0.3.2",
-        "patrun": "0.5.0",
+        "patrun": "0.5.x",
         "qs": "5.2.0",
-        "reconnect-core": "1.1.0",
-        "wreck": "6.3.0"
+        "reconnect-core": "1.1.x",
+        "wreck": "6.3.x"
       },
       "dependencies": {
         "lodash": {
@@ -12913,7 +13170,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "requires": {
-            "pseudomap": "1.0.2"
+            "pseudomap": "^1.0.1"
           }
         },
         "qs": {
@@ -12933,7 +13190,7 @@
         "eraro": "0.4.1",
         "json-stringify-safe": "5.0.1",
         "lodash": "4.2.1",
-        "methods": "1.1.2",
+        "methods": "^1.1.1",
         "mstring": "0.1.2",
         "nid": "0.3.2",
         "norma": "0.3.0",
@@ -12952,9 +13209,9 @@
           "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
           "integrity": "sha1-ohNh0/QJnvdhzabcSpc7seuwo00=",
           "requires": {
-            "debug": "2.2.0",
+            "debug": "~2.2.0",
             "finalhandler": "0.4.1",
-            "parseurl": "1.3.2",
+            "parseurl": "~1.3.1",
             "utils-merge": "1.0.0"
           },
           "dependencies": {
@@ -12973,10 +13230,10 @@
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
           "requires": {
-            "debug": "2.2.0",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "unpipe": "1.0.0"
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "unpipe": "~1.0.0"
           },
           "dependencies": {
             "debug": {
@@ -12994,7 +13251,7 @@
           "resolved": "https://registry.npmjs.org/gex/-/gex-0.2.0.tgz",
           "integrity": "sha1-5f9BdNZstlaq7bYk76LjV/YR5og=",
           "requires": {
-            "lodash": "2.4.2"
+            "lodash": "~2.4.1"
           },
           "dependencies": {
             "lodash": {
@@ -13009,8 +13266,8 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "requires": {
-            "inherits": "2.0.3",
-            "statuses": "1.2.1"
+            "inherits": "~2.0.1",
+            "statuses": "1"
           }
         },
         "jsonic": {
@@ -13055,18 +13312,18 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "integrity": "sha1-ow1fTILIqbrprQCh2bG9vm8Zntc=",
           "requires": {
-            "debug": "2.2.0",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "destroy": "~1.0.4",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
             "fresh": "0.3.0",
-            "http-errors": "1.3.1",
+            "http-errors": "~1.3.1",
             "mime": "1.3.4",
             "ms": "0.7.1",
-            "on-finished": "2.3.0",
-            "range-parser": "1.0.3",
-            "statuses": "1.2.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.0.3",
+            "statuses": "~1.2.1"
           },
           "dependencies": {
             "debug": {
@@ -13089,8 +13346,8 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
           "integrity": "sha1-/rgA0OciEk3QsAMzFgwW6cqovLM=",
           "requires": {
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.1",
             "send": "0.13.1"
           }
         },
@@ -13106,23 +13363,23 @@
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.37.5.tgz",
       "integrity": "sha512-Sf9wmO6nBIjb2fBWQapmQ4W9/fUyhwKQsMcvbnVey7v6qmIjSrz8FtAqiym9wKmp1u1qoRld+C2PJmtS2poopg==",
       "requires": {
-        "bluebird": "3.5.1",
-        "cls-bluebird": "2.1.0",
-        "debug": "3.1.0",
-        "depd": "1.1.1",
-        "dottie": "2.0.0",
-        "generic-pool": "3.4.2",
+        "bluebird": "^3.5.0",
+        "cls-bluebird": "^2.1.0",
+        "debug": "^3.1.0",
+        "depd": "^1.1.0",
+        "dottie": "^2.0.0",
+        "generic-pool": "^3.4.0",
         "inflection": "1.12.0",
-        "lodash": "4.17.10",
-        "moment": "2.22.1",
-        "moment-timezone": "0.5.14",
-        "retry-as-promised": "2.3.2",
-        "semver": "5.5.0",
-        "terraformer-wkt-parser": "1.1.2",
-        "toposort-class": "1.0.1",
-        "uuid": "3.2.1",
-        "validator": "9.4.1",
-        "wkx": "0.4.4"
+        "lodash": "^4.17.1",
+        "moment": "^2.20.0",
+        "moment-timezone": "^0.5.14",
+        "retry-as-promised": "^2.3.2",
+        "semver": "^5.5.0",
+        "terraformer-wkt-parser": "^1.1.2",
+        "toposort-class": "^1.0.1",
+        "uuid": "^3.2.1",
+        "validator": "^9.4.1",
+        "wkx": "^0.4.1"
       },
       "dependencies": {
         "bluebird": {
@@ -13157,14 +13414,14 @@
       "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-4.0.0.tgz",
       "integrity": "sha1-TWQd+1iwNwq0QPc34bC/c38V7KU=",
       "requires": {
-        "bluebird": "3.5.1",
-        "cli-color": "1.2.0",
-        "fs-extra": "5.0.0",
-        "js-beautify": "1.7.5",
-        "lodash": "4.17.10",
-        "resolve": "1.7.1",
-        "umzug": "2.1.0",
-        "yargs": "8.0.2"
+        "bluebird": "^3.5.1",
+        "cli-color": "^1.2.0",
+        "fs-extra": "^5.0.0",
+        "js-beautify": "^1.7.4",
+        "lodash": "^4.17.5",
+        "resolve": "^1.5.0",
+        "umzug": "^2.1.0",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "bluebird": {
@@ -13182,12 +13439,12 @@
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
           "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE=",
           "requires": {
-            "ansi-regex": "2.1.1",
-            "d": "1.0.0",
-            "es5-ext": "0.10.37",
-            "es6-iterator": "2.0.3",
-            "memoizee": "0.4.12",
-            "timers-ext": "0.1.2"
+            "ansi-regex": "^2.1.1",
+            "d": "1",
+            "es5-ext": "^0.10.12",
+            "es6-iterator": "2",
+            "memoizee": "^0.4.3",
+            "timers-ext": "0.1"
           }
         },
         "cliui": {
@@ -13195,9 +13452,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -13205,9 +13462,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -13217,7 +13474,7 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "0.10.37"
+            "es5-ext": "^0.10.9"
           }
         },
         "es6-weak-map": {
@@ -13225,10 +13482,10 @@
           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
           "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.37",
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.14",
+            "es6-iterator": "^2.0.1",
+            "es6-symbol": "^3.1.1"
           }
         },
         "fs-extra": {
@@ -13236,9 +13493,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "jsonfile": {
@@ -13246,7 +13503,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "load-json-file": {
@@ -13254,10 +13511,10 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "lodash": {
@@ -13270,14 +13527,14 @@
           "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.12.tgz",
           "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.37",
-            "es6-weak-map": "2.0.2",
-            "event-emitter": "0.3.5",
-            "is-promise": "2.1.0",
-            "lru-queue": "0.1.0",
-            "next-tick": "1.0.0",
-            "timers-ext": "0.1.2"
+            "d": "1",
+            "es5-ext": "^0.10.30",
+            "es6-weak-map": "^2.0.2",
+            "event-emitter": "^0.3.5",
+            "is-promise": "^2.1",
+            "lru-queue": "0.1",
+            "next-tick": "1",
+            "timers-ext": "^0.1.2"
           }
         },
         "next-tick": {
@@ -13290,9 +13547,9 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "path-type": {
@@ -13300,7 +13557,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "pify": {
@@ -13313,9 +13570,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -13323,8 +13580,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "string-width": {
@@ -13332,8 +13589,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -13351,7 +13608,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -13371,19 +13628,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         },
         "yargs-parser": {
@@ -13391,7 +13648,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -13401,10 +13658,10 @@
       "resolved": "https://registry.npmjs.org/sequelize-fixtures/-/sequelize-fixtures-0.6.0.tgz",
       "integrity": "sha1-vE3mBvQQLzlqwOiSXBw/Yg3eFHE=",
       "requires": {
-        "bluebird": "2.11.0",
-        "glob": "7.0.6",
-        "js-yaml": "2.1.3",
-        "object-assign": "4.1.1"
+        "bluebird": "^2.4.2",
+        "glob": "~7.0.5",
+        "js-yaml": "~2.1.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "argparse": {
@@ -13412,8 +13669,8 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "requires": {
-            "underscore": "1.7.0",
-            "underscore.string": "2.4.0"
+            "underscore": "~1.7.0",
+            "underscore.string": "~2.4.0"
           }
         },
         "bluebird": {
@@ -13431,12 +13688,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "js-yaml": {
@@ -13444,8 +13701,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "integrity": "sha1-D/tWF75VUlh4Bj16Fq7n/dKC6Ew=",
           "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
+            "argparse": "~ 0.1.11",
+            "esprima": "~ 1.0.2"
           }
         },
         "underscore": {
@@ -13460,17 +13717,22 @@
       "resolved": "https://registry.npmjs.org/sequelize-temporal/-/sequelize-temporal-1.0.4.tgz",
       "integrity": "sha512-W/WrG5JqeMDZXZ8+cSR/GiI/gyArD72zdAR9jyx07P00984pkK70ZNnc6AiX/YMd3x8CdK7NmjPMZFGRcc6tLA==",
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.10.1"
       }
+    },
+    "serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serve-static": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
       "integrity": "sha1-LPmIm9RDWjIMw2iVyapXvWYuasc=",
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
         "send": "0.14.2"
       },
       "dependencies": {
@@ -13481,7 +13743,7 @@
           "requires": {
             "inherits": "2.0.3",
             "setprototypeof": "1.0.2",
-            "statuses": "1.3.1"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "ms": {
@@ -13494,19 +13756,19 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
           "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
           "requires": {
-            "debug": "2.2.0",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
             "fresh": "0.3.0",
-            "http-errors": "1.5.1",
+            "http-errors": "~1.5.1",
             "mime": "1.3.4",
             "ms": "0.7.2",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.1"
           },
           "dependencies": {
             "debug": {
@@ -13570,8 +13832,8 @@
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -13579,7 +13841,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -13597,7 +13859,7 @@
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
       "integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
       "requires": {
-        "yargs": "10.1.2"
+        "yargs": "^10.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13615,9 +13877,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -13630,9 +13892,9 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "string-width": {
@@ -13640,8 +13902,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -13649,7 +13911,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "which-module": {
@@ -13662,18 +13924,18 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.1.0"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^8.1.0"
           }
         },
         "yargs-parser": {
@@ -13681,7 +13943,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -13702,8 +13964,8 @@
       "integrity": "sha1-wGPg6Z2DJ9wZkROqtS64Oi6ePCw=",
       "dev": true,
       "requires": {
-        "formatio": "1.0.2",
-        "util": "0.10.3"
+        "formatio": "~1.0",
+        "util": ">=0.10.3 <1"
       }
     },
     "slash": {
@@ -13717,7 +13979,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -13738,7 +14000,7 @@
       "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
       "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o=",
       "requires": {
-        "unicode": "0.6.1"
+        "unicode": ">= 0.3.1"
       }
     },
     "smtp-connection": {
@@ -13751,7 +14013,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "source-list-map": {
@@ -13770,7 +14032,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "spdx-correct": {
@@ -13778,7 +14040,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -13796,7 +14058,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split2": {
@@ -13804,7 +14066,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -13817,14 +14079,27 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stack-chain": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
+      "integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg=="
+    },
+    "stack-generator": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.2.tgz",
+      "integrity": "sha512-Qj3X+vY7qQ0OOLQomEihHk5SSnSPCI3z4RfB8kDk9lnzwznBODlkWODitEo8sHpp0a2VdSy3yuJkabNsQN5RGA==",
+      "requires": {
+        "stackframe": "^1.0.4"
       }
     },
     "stack-trace": {
@@ -13832,13 +14107,44 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
+    "stackframe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
+      "integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.0.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.0.tgz",
+      "integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
+      "requires": {
+        "error-stack-parser": "^2.0.1",
+        "stack-generator": "^2.0.1",
+        "stacktrace-gps": "^3.0.1"
+      }
+    },
     "stampit": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/stampit/-/stampit-2.1.2.tgz",
       "integrity": "sha1-3odBo+HwaBXonI7Rx1MpW7ooNWo=",
       "requires": {
-        "lodash": "3.10.1",
-        "supermixer": "1.0.3"
+        "lodash": "^3.9.1",
+        "supermixer": "^1.0.3"
       }
     },
     "statuses": {
@@ -13857,8 +14163,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner": {
@@ -13867,7 +14173,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-consume": {
@@ -13886,11 +14192,11 @@
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "streamsearch": {
@@ -13898,14 +14204,19 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
+    "string-argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+      "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY="
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -13913,7 +14224,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -13926,7 +14237,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -13934,7 +14245,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-eof": {
@@ -13952,9 +14263,9 @@
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-4.8.0.tgz",
       "integrity": "sha1-fb46EUSHelncmLMJNVlG/RKgskY=",
       "requires": {
-        "bluebird": "2.11.0",
-        "lodash": "4.17.4",
-        "qs": "2.4.2"
+        "bluebird": "^2.10.2",
+        "lodash": "^4.11.1",
+        "qs": "^2.4.2"
       },
       "dependencies": {
         "bluebird": {
@@ -13980,16 +14291,16 @@
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "debug": {
@@ -14007,9 +14318,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "mime": {
@@ -14025,7 +14336,7 @@
       "resolved": "https://registry.npmjs.org/supermixer/-/supermixer-1.0.3.tgz",
       "integrity": "sha1-oWweTe+an0x18IkGZw8DERd5A+U=",
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.8.0"
       }
     },
     "supertest": {
@@ -14034,8 +14345,8 @@
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
       "dev": true,
       "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.2"
+        "methods": "~1.1.2",
+        "superagent": "^3.0.0"
       }
     },
     "supertest-as-promised": {
@@ -14044,8 +14355,8 @@
       "integrity": "sha1-BGTyvSVlaNSlm86EJpwFSPaHnxo=",
       "dev": true,
       "requires": {
-        "bluebird": "3.4.0",
-        "methods": "1.1.2"
+        "bluebird": "^3.3.1",
+        "methods": "^1.1.1"
       }
     },
     "supports-color": {
@@ -14065,12 +14376,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.1",
-        "lodash": "4.17.10",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ajv-keywords": {
@@ -14091,7 +14402,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -14100,9 +14411,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -14129,8 +14440,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -14139,7 +14450,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -14148,7 +14459,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -14170,9 +14481,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-pack": {
@@ -14180,14 +14491,14 @@
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
       "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
       "requires": {
-        "debug": "2.2.0",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.3.3",
-        "readable-stream": "2.1.5",
-        "rimraf": "2.5.4",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
+        "debug": "~2.2.0",
+        "fstream": "~1.0.10",
+        "fstream-ignore": "~1.0.5",
+        "once": "~1.3.3",
+        "readable-stream": "~2.1.4",
+        "rimraf": "~2.5.1",
+        "tar": "~2.2.1",
+        "uid-number": "~0.0.6"
       },
       "dependencies": {
         "debug": {
@@ -14208,7 +14519,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "readable-stream": {
@@ -14216,13 +14527,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -14243,7 +14554,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "terraformer": {
@@ -14251,7 +14562,7 @@
       "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
       "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM=",
       "requires": {
-        "@types/geojson": "1.0.6"
+        "@types/geojson": "^1.0.0"
       }
     },
     "terraformer-wkt-parser": {
@@ -14259,7 +14570,7 @@
       "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
       "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww=",
       "requires": {
-        "terraformer": "1.0.8"
+        "terraformer": "~1.0.5"
       }
     },
     "test-exclude": {
@@ -14268,17 +14579,33 @@
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       }
     },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
     },
     "throttleit": {
       "version": "1.0.0",
@@ -14296,8 +14623,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timed-out": {
@@ -14312,7 +14639,7 @@
       "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "timers-ext": {
@@ -14320,8 +14647,8 @@
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "requires": {
-        "es5-ext": "0.10.37",
-        "next-tick": "1.0.0"
+        "es5-ext": "~0.10.14",
+        "next-tick": "1"
       },
       "dependencies": {
         "next-tick": {
@@ -14331,12 +14658,21 @@
         }
       }
     },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -14355,7 +14691,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "toposort-class": {
@@ -14369,7 +14705,7 @@
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
-        "nopt": "1.0.10"
+        "nopt": "~1.0.10"
       },
       "dependencies": {
         "nopt": {
@@ -14378,7 +14714,7 @@
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         }
       }
@@ -14388,7 +14724,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tr46": {
@@ -14413,7 +14749,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -14427,8 +14763,8 @@
       "resolved": "https://registry.npmjs.org/twitter/-/twitter-1.3.0.tgz",
       "integrity": "sha1-IYDwpKAdHLKqncip4LwRIkWLhQc=",
       "requires": {
-        "deep-extend": "0.3.3",
-        "request": "2.83.0"
+        "deep-extend": "^0.3.2",
+        "request": "^2.51.0"
       },
       "dependencies": {
         "deep-extend": {
@@ -14443,7 +14779,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -14458,7 +14794,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "~2.1.15"
       }
     },
     "typedarray": {
@@ -14483,9 +14819,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -14504,7 +14840,7 @@
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
       "requires": {
-        "random-bytes": "1.0.0"
+        "random-bytes": "~1.0.0"
       }
     },
     "uid2": {
@@ -14517,10 +14853,10 @@
       "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.1.0.tgz",
       "integrity": "sha512-BgT+ekpItEWaG+3JjLLj6yVTxw2wIH8Cr6JyKYIzukWAx9nzGhC6BGHb/IRMjpobMM1qtIrReATwLUjKpU2iOQ==",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "bluebird": "3.5.1",
-        "lodash": "4.17.10",
-        "resolve": "1.7.1"
+        "babel-runtime": "^6.23.0",
+        "bluebird": "^3.4.1",
+        "lodash": "^4.17.0",
+        "resolve": "^1.0.0"
       },
       "dependencies": {
         "bluebird": {
@@ -14573,7 +14909,7 @@
       "resolved": "https://registry.npmjs.org/unicode/-/unicode-0.6.1.tgz",
       "integrity": "sha1-7GnjxFN+K5ZQuCYTO8sGjwRF0Lw=",
       "requires": {
-        "bufferstream": "0.6.2"
+        "bufferstream": ">= 0.6.2"
       }
     },
     "unidecode": {
@@ -14587,7 +14923,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "universalify": {
@@ -14612,15 +14948,15 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.0",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14629,7 +14965,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -14638,9 +14974,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "has-flag": {
@@ -14655,17 +14991,22 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -14699,7 +15040,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       },
       "dependencies": {
         "prepend-http": {
@@ -14715,10 +15056,10 @@
       "resolved": "https://registry.npmjs.org/use-plugin/-/use-plugin-0.3.1.tgz",
       "integrity": "sha1-XZafuZq1XOTxr5BsmXgjKnWJIa8=",
       "requires": {
-        "eraro": "0.4.1",
-        "lodash": "2.4.2",
-        "nid": "0.3.2",
-        "norma": "0.3.0"
+        "eraro": "~0.4.1",
+        "lodash": "~2.4.1",
+        "nid": "~0.3.2",
+        "norma": "~0.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -14738,8 +15079,8 @@
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
       "integrity": "sha1-u6Q+iqJNXOuDwpN0c+EC4h33TBA=",
       "requires": {
-        "lru-cache": "2.2.4",
-        "tmp": "0.0.33"
+        "lru-cache": "2.2.x",
+        "tmp": "0.0.x"
       },
       "dependencies": {
         "lru-cache": {
@@ -14766,6 +15107,11 @@
         }
       }
     },
+    "util-arity": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz",
+      "integrity": "sha1-WdAa8f2z/t4KxOYysKtfbOl8kzA="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14786,7 +15132,7 @@
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "^1.1.1"
       }
     },
     "validate-npm-package-license": {
@@ -14794,8 +15140,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "validator": {
@@ -14813,9 +15159,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -14833,9 +15179,9 @@
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "async": "^2.1.2",
+        "chokidar": "^1.7.0",
+        "graceful-fs": "^4.1.2"
       },
       "dependencies": {
         "async": {
@@ -14844,7 +15190,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "lodash": {
@@ -14860,15 +15206,15 @@
       "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-2.0.0.tgz",
       "integrity": "sha1-q/k0/Ia+ZluApW7PLwTy7hTmdGw=",
       "requires": {
-        "async": "0.9.2",
+        "async": "^0.9.0",
         "clean-css": "1.1.7",
-        "cli-color": "0.3.3",
-        "datauri": "0.2.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "3.10.1",
-        "request": "2.83.0",
-        "uglify-js": "2.8.29",
-        "xtend": "4.0.1"
+        "cli-color": "^0.3.2",
+        "datauri": "~0.2.0",
+        "htmlparser2": "^3.9.0",
+        "lodash": "^3.10.1",
+        "request": "^2.49.0",
+        "uglify-js": "^2.4.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "htmlparser2": {
@@ -14876,12 +15222,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.3.0",
-            "domutils": "1.5.1",
-            "entities": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3"
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
           }
         }
       }
@@ -14898,26 +15244,26 @@
       "integrity": "sha1-CSRjNrVYHJACNT91vK21mKZI+Xc=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "loader-runner": "2.3.0",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3",
-        "tapable": "0.2.8",
-        "uglify-js": "2.8.29",
-        "watchpack": "1.4.0",
-        "webpack-sources": "0.1.5",
-        "yargs": "6.6.0"
+        "acorn": "^4.0.4",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.1.1",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.0.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "loader-runner": "^2.2.0",
+        "loader-utils": "^0.2.16",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.2.5",
+        "uglify-js": "^2.7.5",
+        "watchpack": "^1.2.0",
+        "webpack-sources": "^0.1.4",
+        "yargs": "^6.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -14932,8 +15278,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "async": {
@@ -14942,7 +15288,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "camelcase": {
@@ -14957,9 +15303,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "loader-utils": {
@@ -14968,10 +15314,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         },
         "lodash": {
@@ -14986,7 +15332,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "yargs": {
@@ -14995,19 +15341,19 @@
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           }
         },
         "yargs-parser": {
@@ -15016,7 +15362,7 @@
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -15027,8 +15373,8 @@
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
       "dev": true,
       "requires": {
-        "source-list-map": "0.1.8",
-        "source-map": "0.5.7"
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.5.3"
       }
     },
     "whatwg-fetch": {
@@ -15042,7 +15388,7 @@
       "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
       "optional": true,
       "requires": {
-        "tr46": "0.0.3"
+        "tr46": "~0.0.1"
       }
     },
     "which": {
@@ -15050,7 +15396,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -15063,7 +15409,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "widest-line": {
@@ -15072,7 +15418,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15093,8 +15439,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -15103,7 +15449,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -15118,13 +15464,13 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
       "integrity": "sha1-LIU92Hq1UqjoSF1yy7+aIobwKbc=",
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "pkginfo": "0.3.1",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -15139,7 +15485,7 @@
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.4.tgz",
       "integrity": "sha512-eVVHka2jRaAp9QanKhLpxWs3AGDV0b8cijlavxBnn4ryXzq5N/3Xe3nkQsI0XMRA16RURwviCWuOCj4mXCmrxw==",
       "requires": {
-        "@types/node": "10.0.0"
+        "@types/node": "*"
       }
     },
     "wordwrap": {
@@ -15152,8 +15498,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -15166,8 +15512,8 @@
       "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
       "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
       "requires": {
-        "boom": "2.10.1",
-        "hoek": "2.16.3"
+        "boom": "2.x.x",
+        "hoek": "2.x.x"
       },
       "dependencies": {
         "boom": {
@@ -15175,7 +15521,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "hoek": {
@@ -15190,7 +15536,7 @@
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -15199,9 +15545,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "x-xss-protection": {
@@ -15232,8 +15578,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -15262,7 +15608,7 @@
       "resolved": "https://registry.npmjs.org/xtraverse/-/xtraverse-0.1.0.tgz",
       "integrity": "sha1-t0G60BjveNip0ug63gB7P3lZxzI=",
       "requires": {
-        "xmldom": "0.1.27"
+        "xmldom": "0.1.x"
       }
     },
     "y18n": {
@@ -15280,9 +15626,9 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -15291,8 +15637,8 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "requires": {
-        "camelcase": "3.0.0",
-        "lodash.assign": "4.2.0"
+        "camelcase": "^3.0.0",
+        "lodash.assign": "^4.0.6"
       },
       "dependencies": {
         "camelcase": {
@@ -15308,7 +15654,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "optional": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "zig": {
@@ -15316,7 +15662,7 @@
       "resolved": "https://registry.npmjs.org/zig/-/zig-0.1.1.tgz",
       "integrity": "sha1-gBGFWUx9EzjxTD6/vgunTwuWnMs=",
       "requires": {
-        "lodash": "2.4.2"
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,9 +1899,19 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "chai-jest-snapshot": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chai-jest-snapshot/-/chai-jest-snapshot-2.0.0.tgz",
+      "integrity": "sha512-u8jZZjw/0G1t5A8wDfH6K7DAVfMg3g0dsw9wKQURNUyrZX96VojHNrFMmLirq1m0kOvC5icgL/Qh/fu1MZyvUw==",
+      "dev": true,
+      "requires": {
+        "jest-snapshot": "21.2.1",
+        "lodash.values": "^4.3.0"
       }
     },
     "chalk": {
@@ -7340,15 +7350,175 @@
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
       "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
     },
+    "jest-diff": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
+      "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^21.2.0",
+        "pretty-format": "^21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-matcher-utils": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
+      "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-get-type": "^21.2.0",
+        "pretty-format": "^21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-snapshot": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
+      "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-diff": "^21.2.1",
+        "jest-matcher-utils": "^21.2.1",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "joi": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-7.3.0.tgz",
       "integrity": "sha1-TZyfGBgwRECDZltbbNW4ymd5pek=",
       "requires": {
-        "hoek": "3.0.4",
-        "isemail": "2.2.1",
-        "moment": "2.19.3",
-        "topo": "2.0.2"
+        "hoek": "3.x.x",
+        "isemail": "2.x.x",
+        "moment": "2.x.x",
+        "topo": "2.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -8191,6 +8361,12 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
+      "dev": true
     },
     "log-driver": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "devDependencies": {
     "babel-plugin-istanbul": "4.1.4",
     "chai": "3.5.0",
+    "chai-jest-snapshot": "^2.0.0",
     "chance": "0.8.0",
     "cheerio": "0.19.0",
     "coveralls": "2.11.16",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "graphiql": "0.11.11",
     "jsdoc": "3.5.5",
     "jsdoc-simple-theme": "1.2.6",
-    "mocha": "3.0.2",
+    "mocha": "5.1.1",
     "mocha-circleci-reporter": "0.0.2",
     "mocha-lcov-reporter": "1.3.0",
     "nock": "9.0.14",

--- a/server/graphql/TransactionInterface.js
+++ b/server/graphql/TransactionInterface.js
@@ -3,7 +3,10 @@ import {
   GraphQLFloat,
   GraphQLString,
   GraphQLInterfaceType,
-  GraphQLObjectType
+  GraphQLObjectType,
+  GraphQLList,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
 } from 'graphql';
 
 import {
@@ -255,4 +258,62 @@ export const TransactionOrderType = new GraphQLObjectType({
       }
     }
   }
+});
+
+export const TransactionType = new GraphQLEnumType({
+  name: 'TransactionType',
+  description: 'Type of transaction in the ledger',
+  values: {
+    CREDIT: {},
+    DEBIT: {},
+  },
+});
+
+export const TransactionOrder = new GraphQLInputObjectType({
+  name: 'TransactionOrder',
+  description: 'Ordering options for transactions',
+  fields: {
+    field: {
+      description: 'The field to order transactions by.',
+      defaultValue: 'createdAt',
+      type: new GraphQLEnumType({
+        name: 'TransactionOrderField',
+        description: 'Properties by which transactions can be ordered.',
+        values: {
+          CREATED_AT: {
+            value: 'createdAt',
+            description: 'Order transactions by creation time.',
+          },
+        },
+      }),
+    },
+    direction: {
+      description: 'The ordering direction.',
+      defaultValue: 'DESC',
+      type: new GraphQLEnumType({
+        name: 'OrderDirection',
+        description: 'Possible directions in which to order a list of items when provided an orderBy argument.',
+        values: {
+          ASC: {},
+          DESC: {},
+        },
+      }),
+    },
+  },
+});
+
+TransactionOrder.defaultValue = Object.entries(TransactionOrder.getFields()).reduce((values, [key, value]) => ({
+  ...values,
+  [key]: value.defaultValue,
+}), {});
+
+export const PaginatedTransactionsType = new GraphQLObjectType({
+  name: 'PaginatedTransactions',
+  description: 'List of transactions with pagination data', 
+  fields: () => ({
+    transactions: { type: new GraphQLList(TransactionInterfaceType) },
+    limit: { type: GraphQLInt },
+    offset: { type: GraphQLInt },
+    total: { type: GraphQLInt },
+  }),
 });

--- a/test/graphql.transaction.test.js.snap
+++ b/test/graphql.transaction.test.js.snap
@@ -1,0 +1,4484 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graphql.transaction.test.js return collective.transactions when given a collective slug (case insensitive) 1`] = `
+Object {
+  "data": Object {
+    "Collective": Object {
+      "id": 2,
+      "slug": "wwcodeaustin",
+      "transactions": Array [
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Craft",
+            "id": 4348,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48146,
+          "paymentMethod": Object {
+            "id": 5401,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 3689,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Craft",
+            "id": 4348,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 43331,
+          "paymentMethod": Object {
+            "id": 5401,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 3689,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Holly",
+            "id": 28,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 42072,
+          "type": "DEBIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Craft",
+            "id": 4348,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 41472,
+          "paymentMethod": Object {
+            "id": 5401,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 3689,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Holly",
+            "id": 28,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 20083,
+          "type": "DEBIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Geoff",
+            "id": 896,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 18022,
+          "paymentMethod": Object {
+            "id": 4602,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "MaxPoint",
+            "id": 7142,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 17706,
+          "paymentMethod": Object {
+            "id": 4405,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 17449,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 16250,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Praxent",
+            "id": 6512,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 15621,
+          "paymentMethod": Object {
+            "id": 4044,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 15309,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Eric",
+            "id": 6100,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 13821,
+          "paymentMethod": Object {
+            "id": 3779,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Rackspace",
+            "id": 6030,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 13681,
+          "paymentMethod": Object {
+            "id": 3734,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 13265,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Bazaarvoice",
+            "id": 5754,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 12392,
+          "paymentMethod": Object {
+            "id": 3550,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 12075,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Ojo",
+            "id": 5356,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 11754,
+          "paymentMethod": Object {
+            "id": 3280,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Serverless",
+            "id": 571,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 11369,
+          "paymentMethod": Object {
+            "id": 3144,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 11311,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Nicole",
+            "id": 4720,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 9879,
+          "paymentMethod": Object {
+            "id": 2860,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 9595,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 8705,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Allie",
+            "id": 3999,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 8210,
+          "paymentMethod": Object {
+            "id": 2438,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 8038,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 7661,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Holly",
+            "id": 28,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 7071,
+          "type": "DEBIT",
+        },
+        Object {
+          "attachment": null,
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Holly",
+            "id": 28,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 7070,
+          "type": "DEBIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 6709,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 5578,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 5026,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Kelly",
+            "id": 2416,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 4655,
+          "paymentMethod": Object {
+            "id": 1553,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 4586,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 4190,
+          "type": "DEBIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 4188,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 3669,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Maddy",
+            "id": 1957,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 3590,
+          "paymentMethod": Object {
+            "id": 1296,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Jamie",
+            "id": 1890,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 3471,
+          "paymentMethod": Object {
+            "id": 1249,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Holly",
+            "id": 28,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 3284,
+          "type": "DEBIT",
+        },
+        Object {
+          "attachment": null,
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Holly",
+            "id": 28,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 3234,
+          "type": "DEBIT",
+        },
+        Object {
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 686,
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 2887,
+          "paymentMethod": Object {
+            "id": 461,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 286,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions \`transactions\` query accepts orderBy argument to order transactions 1`] = `
+Object {
+  "data": Object {
+    "transactions": Object {
+      "limit": 5,
+      "offset": 0,
+      "total": 2184,
+      "transactions": Array [
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 668,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 33190,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 33189,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 865,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 33078,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions \`transactions\` query accepts pagination arguments: limit & offset 1`] = `
+Object {
+  "data": Object {
+    "transactions": Object {
+      "limit": 5,
+      "offset": 10,
+      "total": 2184,
+      "transactions": Array [
+        Object {
+          "collective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50788,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50787,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50786,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50785,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50784,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions \`transactions\` query accepts type argument to filter transactions by type 1`] = `
+Object {
+  "data": Object {
+    "transactions": Object {
+      "limit": 5,
+      "offset": 0,
+      "total": 1092,
+      "transactions": Array [
+        Object {
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50860,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 1115,
+            "slug": "beth",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "beth",
+            "id": 70,
+            "lastName": "laing",
+          },
+          "fromCollective": Object {
+            "id": 12,
+            "slug": "wwcodeatl",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50846,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 264,
+            "slug": "wwcodebelfast",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50836,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50824,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50790,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions \`transactions\` query default returns list of transactions with pagination data 1`] = `
+Object {
+  "data": Object {
+    "transactions": Object {
+      "limit": 100,
+      "offset": 0,
+      "total": 2184,
+      "transactions": Array [
+        Object {
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50860,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50859,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 1115,
+            "slug": "beth",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "beth",
+            "id": 70,
+            "lastName": "laing",
+          },
+          "fromCollective": Object {
+            "id": 12,
+            "slug": "wwcodeatl",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50846,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 12,
+            "slug": "wwcodeatl",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "beth",
+            "id": 70,
+            "lastName": "laing",
+          },
+          "fromCollective": Object {
+            "id": 1115,
+            "slug": "beth",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50845,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 264,
+            "slug": "wwcodebelfast",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50836,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 264,
+            "slug": "wwcodebelfast",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50835,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50824,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50823,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50790,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50789,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50788,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50787,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50786,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50785,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50784,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50783,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50774,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50773,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 522,
+            "slug": "wwcodevancouver",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50618,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 522,
+            "slug": "wwcodevancouver",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50617,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 522,
+            "slug": "wwcodevancouver",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50616,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 522,
+            "slug": "wwcodevancouver",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50615,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 522,
+            "slug": "wwcodevancouver",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50614,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 522,
+            "slug": "wwcodevancouver",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50613,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50612,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 50611,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 516,
+            "slug": "wwcodehuntsville",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 8512,
+            "lastName": null,
+          },
+          "fromCollective": Object {
+            "id": 9451,
+            "slug": "emilypmendez",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49610,
+          "paymentMethod": Object {
+            "id": 5832,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 3802,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9451,
+            "slug": "emilypmendez",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 8512,
+            "lastName": null,
+          },
+          "fromCollective": Object {
+            "id": 516,
+            "slug": "wwcodehuntsville",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49609,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 271,
+            "slug": "wwcodedallas",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 2906,
+            "lastName": null,
+          },
+          "fromCollective": Object {
+            "id": 4881,
+            "slug": "androidchick88",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49514,
+          "paymentMethod": Object {
+            "id": 1804,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 1366,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 4881,
+            "slug": "androidchick88",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": null,
+            "id": 2906,
+            "lastName": null,
+          },
+          "fromCollective": Object {
+            "id": 271,
+            "slug": "wwcodedallas",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49513,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 516,
+            "slug": "wwcodehuntsville",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Lacey",
+            "id": 4550,
+            "lastName": "Reinoehl",
+          },
+          "fromCollective": Object {
+            "id": 1788,
+            "slug": "laceyreinoehl",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49410,
+          "paymentMethod": Object {
+            "id": 2757,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 2039,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 1788,
+            "slug": "laceyreinoehl",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Lacey",
+            "id": 4550,
+            "lastName": "Reinoehl",
+          },
+          "fromCollective": Object {
+            "id": 516,
+            "slug": "wwcodehuntsville",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49409,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "chase",
+            "id": 9055,
+            "lastName": "morrow",
+          },
+          "fromCollective": Object {
+            "id": 10344,
+            "slug": "fetchtalent1",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49022,
+          "paymentMethod": Object {
+            "id": 8458,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 4033,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10344,
+            "slug": "fetchtalent1",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "chase",
+            "id": 9055,
+            "lastName": "morrow",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 49021,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Fair",
+            "id": 7136,
+            "lastName": "Inso",
+          },
+          "fromCollective": Object {
+            "id": 3022,
+            "slug": "fairlaneinso",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48566,
+          "paymentMethod": Object {
+            "id": 4403,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 3229,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 3022,
+            "slug": "fairlaneinso",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Fair",
+            "id": 7136,
+            "lastName": "Inso",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48565,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Tamouse",
+            "id": 2594,
+            "lastName": "Temple",
+          },
+          "fromCollective": Object {
+            "id": 3116,
+            "slug": "tamouse1",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48490,
+          "paymentMethod": Object {
+            "id": 8690,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 4156,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 3116,
+            "slug": "tamouse1",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Tamouse",
+            "id": 2594,
+            "lastName": "Temple",
+          },
+          "fromCollective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48489,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 2,
+            "slug": "wwcodeaustin",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Craft",
+            "id": 4348,
+            "lastName": "CMS",
+          },
+          "fromCollective": Object {
+            "id": 6965,
+            "slug": "craftcms",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48146,
+          "paymentMethod": Object {
+            "id": 5401,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 3689,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 6965,
+            "slug": "craftcms",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Craft",
+            "id": 4348,
+            "lastName": "CMS",
+          },
+          "fromCollective": Object {
+            "id": 2,
+            "slug": "wwcodeaustin",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48145,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Craft",
+            "id": 4348,
+            "lastName": "CMS",
+          },
+          "fromCollective": Object {
+            "id": 6965,
+            "slug": "craftcms",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48136,
+          "paymentMethod": Object {
+            "id": 5401,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 3688,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 6965,
+            "slug": "craftcms",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Craft",
+            "id": 4348,
+            "lastName": "CMS",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 48135,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Kristine",
+            "id": 4711,
+            "lastName": "Paas",
+          },
+          "fromCollective": Object {
+            "id": 3178,
+            "slug": "kjcpaas",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47956,
+          "paymentMethod": Object {
+            "id": 2855,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 2103,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 3178,
+            "slug": "kjcpaas",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Kristine",
+            "id": 4711,
+            "lastName": "Paas",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47955,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 273,
+            "slug": "wwcodegreenville",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Pamela",
+            "id": 1325,
+            "lastName": "Wood Browne",
+          },
+          "fromCollective": Object {
+            "id": 3210,
+            "slug": "pamelawoodbrowne",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47884,
+          "paymentMethod": Object {
+            "id": 3951,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 2888,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 3210,
+            "slug": "pamelawoodbrowne",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Pamela",
+            "id": 1325,
+            "lastName": "Wood Browne",
+          },
+          "fromCollective": Object {
+            "id": 273,
+            "slug": "wwcodegreenville",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47883,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 516,
+            "slug": "wwcodehuntsville",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Erin",
+            "id": 3419,
+            "lastName": "Spiceland",
+          },
+          "fromCollective": Object {
+            "id": 3898,
+            "slug": "erin",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47418,
+          "paymentMethod": Object {
+            "id": 2749,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 2031,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 3898,
+            "slug": "erin",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Erin",
+            "id": 3419,
+            "lastName": "Spiceland",
+          },
+          "fromCollective": Object {
+            "id": 516,
+            "slug": "wwcodehuntsville",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47417,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 291,
+            "slug": "wwcodetoronto",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47290,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 291,
+            "slug": "wwcodetoronto",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47289,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 12,
+            "slug": "wwcodeatl",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Dionne ",
+            "id": 9296,
+            "lastName": "Toussaint",
+          },
+          "fromCollective": Object {
+            "id": 10660,
+            "slug": "dionnetoussaint",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47248,
+          "paymentMethod": Object {
+            "id": 8646,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10660,
+            "slug": "dionnetoussaint",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Dionne ",
+            "id": 9296,
+            "lastName": "Toussaint",
+          },
+          "fromCollective": Object {
+            "id": 12,
+            "slug": "wwcodeatl",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47247,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47234,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47233,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 51,
+            "slug": "wwcode-collective",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47200,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 51,
+            "slug": "wwcode-collective",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47199,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 51,
+            "slug": "wwcode-collective",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47198,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 51,
+            "slug": "wwcode-collective",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47197,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 51,
+            "slug": "wwcode-collective",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47196,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 51,
+            "slug": "wwcode-collective",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47195,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47194,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47193,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47188,
+          "paymentMethod": Object {
+            "id": 8392,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47187,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47184,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47183,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47182,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Caterina",
+            "id": 171,
+            "lastName": "Paun",
+          },
+          "fromCollective": Object {
+            "id": 6057,
+            "slug": "cpaun",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47181,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47154,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47153,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47152,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47151,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9564,
+            "slug": "richa-khandelwal",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Richa",
+            "id": 8600,
+            "lastName": "Khandelwal",
+          },
+          "fromCollective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47060,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 59,
+            "slug": "wwcodeportland",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Richa",
+            "id": 8600,
+            "lastName": "Khandelwal",
+          },
+          "fromCollective": Object {
+            "id": 9564,
+            "slug": "richa-khandelwal",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47059,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 8405,
+            "slug": "snehalpatil",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Snehal",
+            "id": 1374,
+            "lastName": "Patil",
+          },
+          "fromCollective": Object {
+            "id": 300,
+            "slug": "wwcodesv",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47054,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 300,
+            "slug": "wwcodesv",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Snehal",
+            "id": 1374,
+            "lastName": "Patil",
+          },
+          "fromCollective": Object {
+            "id": 8405,
+            "slug": "snehalpatil",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47053,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47052,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 47051,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Ed",
+            "id": 9159,
+            "lastName": "McLain",
+          },
+          "fromCollective": Object {
+            "id": 10475,
+            "slug": "daxko",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46886,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10475,
+            "slug": "daxko",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Ed",
+            "id": 9159,
+            "lastName": "McLain",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46885,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 430,
+            "slug": "wwcodekyiv",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Kate",
+            "id": 9152,
+            "lastName": "Ageenko",
+          },
+          "fromCollective": Object {
+            "id": 10465,
+            "slug": "kate-ageenko",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46872,
+          "paymentMethod": Object {
+            "id": 8533,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10465,
+            "slug": "kate-ageenko",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Kate",
+            "id": 9152,
+            "lastName": "Ageenko",
+          },
+          "fromCollective": Object {
+            "id": 430,
+            "slug": "wwcodekyiv",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46871,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "",
+            "id": 9079,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 10376,
+            "slug": "wrady-and-michel-llc",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46640,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10376,
+            "slug": "wrady-and-michel-llc",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "",
+            "id": 9079,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46639,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Eric",
+            "id": 9061,
+            "lastName": "Kramlinger",
+          },
+          "fromCollective": Object {
+            "id": 10354,
+            "slug": "daughertytweets",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46628,
+          "paymentMethod": Object {
+            "id": 8463,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10354,
+            "slug": "daughertytweets",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Eric",
+            "id": 9061,
+            "lastName": "Kramlinger",
+          },
+          "fromCollective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46627,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "chase",
+            "id": 9055,
+            "lastName": "morrow",
+          },
+          "fromCollective": Object {
+            "id": 10344,
+            "slug": "fetchtalent1",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46622,
+          "paymentMethod": Object {
+            "id": 8458,
+            "name": "*****",
+          },
+          "subscription": Object {
+            "id": 4033,
+            "interval": "month",
+          },
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10344,
+            "slug": "fetchtalent1",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "chase",
+            "id": 9055,
+            "lastName": "morrow",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46621,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Sarah",
+            "id": 142,
+            "lastName": "Olson",
+          },
+          "fromCollective": Object {
+            "id": 8492,
+            "slug": "saraholson",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46598,
+          "paymentMethod": Object {
+            "id": 8451,
+            "name": "*****",
+          },
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 8492,
+            "slug": "saraholson",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Sarah",
+            "id": 142,
+            "lastName": "Olson",
+          },
+          "fromCollective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46597,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46504,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 48,
+            "slug": "wwcodetwincities",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46503,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 195,
+            "slug": "wwcodeboston",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46502,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 195,
+            "slug": "wwcodeboston",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46501,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46498,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 517,
+            "slug": "wwcodemanila",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46497,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 195,
+            "slug": "wwcodeboston",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46492,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 9814,
+            "slug": "wwcodeuser",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "WWCode",
+            "id": 3,
+            "lastName": "",
+          },
+          "fromCollective": Object {
+            "id": 195,
+            "slug": "wwcodeboston",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46491,
+          "type": "DEBIT",
+        },
+        Object {
+          "collective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Melondy",
+            "id": 8983,
+            "lastName": "Snider",
+          },
+          "fromCollective": Object {
+            "id": 10291,
+            "slug": "vulcan-materials-company3",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46488,
+          "paymentMethod": null,
+          "subscription": null,
+          "type": "CREDIT",
+        },
+        Object {
+          "attachment": null,
+          "collective": Object {
+            "id": 10291,
+            "slug": "vulcan-materials-company3",
+          },
+          "createdByUser": Object {
+            "email": null,
+            "firstName": "Melondy",
+            "id": 8983,
+            "lastName": "Snider",
+          },
+          "fromCollective": Object {
+            "id": 259,
+            "slug": "wwcodebirmingham",
+          },
+          "host": Object {
+            "id": 9804,
+            "slug": "wwcode",
+          },
+          "id": 46487,
+          "type": "DEBIT",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions returns one transaction  1`] = `
+Object {
+  "data": Object {
+    "Transaction": Object {
+      "attachment": null,
+      "createdByUser": Object {
+        "email": null,
+        "firstName": "Holly",
+        "id": 28,
+      },
+      "host": Object {
+        "id": 9804,
+        "slug": "wwcode",
+      },
+      "id": 7071,
+      "type": "DEBIT",
+    },
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions with dateFrom 1`] = `
+Object {
+  "data": Object {
+    "allTransactions": Array [
+      Object {
+        "id": 48146,
+      },
+      Object {
+        "id": 43331,
+      },
+      Object {
+        "id": 42072,
+      },
+      Object {
+        "id": 41472,
+      },
+      Object {
+        "id": 20083,
+      },
+    ],
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions with dateTo 1`] = `
+Object {
+  "data": Object {
+    "allTransactions": Array [
+      Object {
+        "id": 18022,
+      },
+      Object {
+        "id": 17706,
+      },
+      Object {
+        "id": 17449,
+      },
+      Object {
+        "id": 16250,
+      },
+      Object {
+        "id": 15621,
+      },
+      Object {
+        "id": 15309,
+      },
+      Object {
+        "id": 13821,
+      },
+      Object {
+        "id": 13681,
+      },
+      Object {
+        "id": 13265,
+      },
+      Object {
+        "id": 12392,
+      },
+      Object {
+        "id": 12075,
+      },
+      Object {
+        "id": 11754,
+      },
+      Object {
+        "id": 11369,
+      },
+      Object {
+        "id": 11311,
+      },
+      Object {
+        "id": 9879,
+      },
+      Object {
+        "id": 9595,
+      },
+      Object {
+        "id": 8705,
+      },
+      Object {
+        "id": 8210,
+      },
+      Object {
+        "id": 8038,
+      },
+      Object {
+        "id": 7661,
+      },
+      Object {
+        "id": 7071,
+      },
+      Object {
+        "id": 7070,
+      },
+      Object {
+        "id": 6709,
+      },
+      Object {
+        "id": 5578,
+      },
+      Object {
+        "id": 5026,
+      },
+      Object {
+        "id": 4655,
+      },
+      Object {
+        "id": 4586,
+      },
+      Object {
+        "id": 4190,
+      },
+      Object {
+        "id": 4188,
+      },
+      Object {
+        "id": 3669,
+      },
+      Object {
+        "id": 3590,
+      },
+      Object {
+        "id": 3471,
+      },
+      Object {
+        "id": 3284,
+      },
+      Object {
+        "id": 3234,
+      },
+      Object {
+        "id": 2887,
+      },
+      Object {
+        "id": 2824,
+      },
+      Object {
+        "id": 2820,
+      },
+      Object {
+        "id": 2817,
+      },
+      Object {
+        "id": 2816,
+      },
+      Object {
+        "id": 2815,
+      },
+      Object {
+        "id": 2814,
+      },
+      Object {
+        "id": 2813,
+      },
+      Object {
+        "id": 2812,
+      },
+      Object {
+        "id": 2811,
+      },
+      Object {
+        "id": 2739,
+      },
+      Object {
+        "id": 2522,
+      },
+      Object {
+        "id": 2310,
+      },
+      Object {
+        "id": 2257,
+      },
+      Object {
+        "id": 2256,
+      },
+      Object {
+        "id": 2253,
+      },
+      Object {
+        "id": 2189,
+      },
+      Object {
+        "id": 2143,
+      },
+      Object {
+        "id": 1918,
+      },
+      Object {
+        "id": 1792,
+      },
+      Object {
+        "id": 1787,
+      },
+      Object {
+        "id": 1461,
+      },
+      Object {
+        "id": 1395,
+      },
+      Object {
+        "id": 1392,
+      },
+      Object {
+        "id": 1391,
+      },
+      Object {
+        "id": 1080,
+      },
+      Object {
+        "id": 995,
+      },
+      Object {
+        "id": 837,
+      },
+      Object {
+        "id": 822,
+      },
+      Object {
+        "id": 821,
+      },
+      Object {
+        "id": 645,
+      },
+      Object {
+        "id": 639,
+      },
+      Object {
+        "id": 637,
+      },
+      Object {
+        "id": 638,
+      },
+      Object {
+        "id": 640,
+      },
+      Object {
+        "id": 616,
+      },
+      Object {
+        "id": 478,
+      },
+      Object {
+        "id": 337,
+      },
+      Object {
+        "id": 261,
+      },
+      Object {
+        "id": 228,
+      },
+      Object {
+        "id": 229,
+      },
+      Object {
+        "id": 231,
+      },
+      Object {
+        "id": 130,
+      },
+      Object {
+        "id": 103,
+      },
+    ],
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions with filter on type 1`] = `
+Object {
+  "data": Object {
+    "allTransactions": Array [
+      Object {
+        "id": 17449,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 16250,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 15621,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 15309,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 13821,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 13681,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 13265,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 12392,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 12075,
+        "type": "CREDIT",
+      },
+      Object {
+        "id": 11754,
+        "type": "CREDIT",
+      },
+    ],
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions with pagination 1`] = `
+Object {
+  "data": Object {
+    "allTransactions": Array [
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": null,
+          "id": 686,
+          "lastName": null,
+        },
+        "fromCollective": Object {
+          "id": 6616,
+          "slug": "pkmass",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 9595,
+        "paymentMethod": Object {
+          "id": 461,
+          "name": "*****",
+        },
+        "subscription": Object {
+          "id": 286,
+          "interval": "month",
+        },
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "WWCode",
+          "id": 3,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 8705,
+        "paymentMethod": null,
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Allie",
+          "id": 3999,
+          "lastName": "Winkelman",
+        },
+        "fromCollective": Object {
+          "id": 2977,
+          "slug": "lwinkelman",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 8210,
+        "paymentMethod": Object {
+          "id": 2438,
+          "name": "*****",
+        },
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": null,
+          "id": 686,
+          "lastName": null,
+        },
+        "fromCollective": Object {
+          "id": 6616,
+          "slug": "pkmass",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 8038,
+        "paymentMethod": Object {
+          "id": 461,
+          "name": "*****",
+        },
+        "subscription": Object {
+          "id": 286,
+          "interval": "month",
+        },
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "WWCode",
+          "id": 3,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 7661,
+        "paymentMethod": null,
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "attachment": null,
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Holly",
+          "id": 28,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 6280,
+          "slug": "ogibson",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 7071,
+        "type": "DEBIT",
+      },
+      Object {
+        "attachment": null,
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Holly",
+          "id": 28,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 6280,
+          "slug": "ogibson",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 7070,
+        "type": "DEBIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": null,
+          "id": 686,
+          "lastName": null,
+        },
+        "fromCollective": Object {
+          "id": 6616,
+          "slug": "pkmass",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 6709,
+        "paymentMethod": Object {
+          "id": 461,
+          "name": "*****",
+        },
+        "subscription": Object {
+          "id": 286,
+          "interval": "month",
+        },
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": null,
+          "id": 686,
+          "lastName": null,
+        },
+        "fromCollective": Object {
+          "id": 6616,
+          "slug": "pkmass",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 5578,
+        "paymentMethod": Object {
+          "id": 461,
+          "name": "*****",
+        },
+        "subscription": Object {
+          "id": 286,
+          "interval": "month",
+        },
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "WWCode",
+          "id": 3,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 5026,
+        "paymentMethod": null,
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Kelly",
+          "id": 2416,
+          "lastName": "Erickson",
+        },
+        "fromCollective": Object {
+          "id": 3538,
+          "slug": "kellyerickson",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 4655,
+        "paymentMethod": Object {
+          "id": 1553,
+          "name": "*****",
+        },
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": null,
+          "id": 686,
+          "lastName": null,
+        },
+        "fromCollective": Object {
+          "id": 6616,
+          "slug": "pkmass",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 4586,
+        "paymentMethod": Object {
+          "id": 461,
+          "name": "*****",
+        },
+        "subscription": Object {
+          "id": 286,
+          "interval": "month",
+        },
+        "type": "CREDIT",
+      },
+      Object {
+        "attachment": null,
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "WWCode",
+          "id": 3,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 4190,
+        "type": "DEBIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "WWCode",
+          "id": 3,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 4188,
+        "paymentMethod": null,
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": null,
+          "id": 686,
+          "lastName": null,
+        },
+        "fromCollective": Object {
+          "id": 6616,
+          "slug": "pkmass",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 3669,
+        "paymentMethod": Object {
+          "id": 461,
+          "name": "*****",
+        },
+        "subscription": Object {
+          "id": 286,
+          "interval": "month",
+        },
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Maddy",
+          "id": 1957,
+          "lastName": "Lau",
+        },
+        "fromCollective": Object {
+          "id": 4960,
+          "slug": "maddylau",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 3590,
+        "paymentMethod": Object {
+          "id": 1296,
+          "name": "*****",
+        },
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Jamie",
+          "id": 1890,
+          "lastName": "Lu",
+        },
+        "fromCollective": Object {
+          "id": 6014,
+          "slug": "jamielu",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 3471,
+        "paymentMethod": Object {
+          "id": 1249,
+          "name": "*****",
+        },
+        "subscription": null,
+        "type": "CREDIT",
+      },
+      Object {
+        "attachment": null,
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Holly",
+          "id": 28,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 6280,
+          "slug": "ogibson",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 3284,
+        "type": "DEBIT",
+      },
+      Object {
+        "attachment": null,
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": "Holly",
+          "id": 28,
+          "lastName": "",
+        },
+        "fromCollective": Object {
+          "id": 6280,
+          "slug": "ogibson",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 3234,
+        "type": "DEBIT",
+      },
+      Object {
+        "collective": Object {
+          "id": 2,
+          "slug": "wwcodeaustin",
+        },
+        "createdByUser": Object {
+          "email": null,
+          "firstName": null,
+          "id": 686,
+          "lastName": null,
+        },
+        "fromCollective": Object {
+          "id": 6616,
+          "slug": "pkmass",
+        },
+        "host": Object {
+          "id": 9804,
+          "slug": "wwcode",
+        },
+        "id": 2887,
+        "paymentMethod": Object {
+          "id": 461,
+          "name": "*****",
+        },
+        "subscription": Object {
+          "id": 286,
+          "interval": "month",
+        },
+        "type": "CREDIT",
+      },
+    ],
+  },
+}
+`;

--- a/test/lib.imageUrlToAmazonUrl.js
+++ b/test/lib.imageUrlToAmazonUrl.js
@@ -28,6 +28,7 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
 
     beforeEach(() => {
       const s = stream.Readable();
+      s.read = () => null;
       s.write = function(){};
       s.end = function(){
         s.emit('response', {statusCode: 200, statusMessage: 'OK'});
@@ -41,7 +42,7 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
       uuid.v1.restore();
     })
 
-    it('returns an error if the image url is not found', () => {
+    it('returns an error if the image url is not found', (done) => {
       nocks['cloudfront.head'] = nock(imageUrl)
         .head('')
         .reply(404);
@@ -50,7 +51,8 @@ describe('lib.imageUrlToAmazonUrl.js', () => {
         knox,
         imageUrl,
         (e) => {
-          expect(e).to.equal('Image not found');
+          expect(e.toString()).to.include('Image not found');
+          done();
         })
     });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,5 +3,5 @@
 --reporter mocha-circleci-reporter
 --require babel-core/register
 --require babel-polyfill
---require=./test/setup.js
-
+--file ./test/setup.js
+--exit

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,15 @@
-if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'test';
-}
+import chai from 'chai';
+import chaiJestSnapshot from 'chai-jest-snapshot';
+
+chai.use(chaiJestSnapshot);
+
+before(() => {
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'test';
+  }
+  chaiJestSnapshot.resetSnapshotRegistry();
+});
+
+beforeEach(function() {
+  chaiJestSnapshot.configureUsingMochaContext(this);
+});


### PR DESCRIPTION
To support the new homepage design, I'm working on creating and updating graphql queries to provide the necessary data. Most of the API design decisions are inspired by the [GitHub GraphQL API](https://developer.github.com/v4/explorer/) as it seems to be one of the more mature, real-world examples. 

This PR adds a `transactions` query to eventually replace the `allTransactions` query to support a paginated return value that includes `total, limit, offset, transactions` fields. `transactions` also does not require `CollectiveId` or `CollectiveSlug` arguments. In reality, the use of `allTransactions` should be replaced by using the `Collective` query and selecting the `transactions` field off that relationship. 

This PR is also using snapshot testing for verifying the result of graphql queries to simplify testing. Interested in feedback on this pattern. cc: @znarf @clarete 