### PR TITLE
BDD tests that create new orders

### DIFF
--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -182,7 +182,7 @@ export function difference(tr) {
  * @return the sum of the column `amount`.
  */
 export async function sum(where) {
-  const totalAttr = sequelize.fn('COALESCE', sequelize.fn('SUM', sequelize.col('amount')), 0);
+  const totalAttr = sequelize.fn('COALESCE', sequelize.fn('SUM', sequelize.col('netAmountInCollectiveCurrency')), 0);
   const attributes = [[ totalAttr, 'total' ]];
   const result = await models.Transaction.find({ attributes, where });
   return result.dataValues.total;

--- a/test/features/orders.stripe.feature
+++ b/test/features/orders.stripe.feature
@@ -1,0 +1,21 @@
+Feature: Place orders via Stripe
+
+  Background:
+    Given a Host "Open Source Collective" in "USD" and charges "5%" of fee
+    And "Open Source Collective" connects a "Stripe" account
+    And "Stripe" payment processor fee is "3%"
+    And platform fee is "5%"
+
+  Scenario: User makes a donation to Collective
+    Given a Collective "Apex" in "USD" hosted by "Open Source Collective"
+    And a User "Sherman"
+    When "Sherman" donates "1000 USD" to "Apex" via "Stripe"
+    Then "Apex" should have "870 USD" in their balance
+    And "Sherman" should have "-1000 USD" in their balance
+
+    # Host Fee:
+    #And "Open Source Collective" should have "50 USD" in their balance
+    # Platform Fee
+    #And "Platform" should have "50 USD" in their balance
+    # Payment Method Fee
+    #And "Stripe" should have "30 USD" in their balance

--- a/test/features/support/steps/README.md
+++ b/test/features/support/steps/README.md
@@ -34,6 +34,23 @@ most likely broken.
  * `Given a Collective {name} with a host in {currency}, {fee%} fee`:
    Same as above but also sets the host fee percentage.
 
+ * `Given {hostCollective} connects a {paymentProcessor} account`:
+   Create a connected account for a host collective with the payment
+   provider name informed in `<paymentProcessor>`.
+
+ * `Given {payemntProcessor} payment processor fee is {fee%}`: Set the
+   fee of a payment processor.
+
+ * `Given platform fee is {fee}`: Set the platform fee (how much Open
+   Collective) charges per transaction.
+
+ * `When {name} donates {value} to {collective} via {paymentMethod}`:
+   This **action** creates and executes a one time order from the user
+   `<name>` to the `<collective>`. The value of the transactions is
+   specified in `<value>` and uses the format `AMOUNT CURRENCY`. E.g.:
+   `10 USD`. The `<paymentMethod>` is a string containing `stripe` for
+   now.
+
  * `When {name} expenses {value} for {description} to {collective} via {method}`:
    This **action** creates an expense from the user `<name>` to the
    collective. The `<value>` is how much the expense is worth. It

--- a/test/features/support/steps/users-and-collectives.js
+++ b/test/features/support/steps/users-and-collectives.js
@@ -23,10 +23,13 @@ import * as utils from '../../../utils';
  *  percentage.
  */
 const readFee = (amount, feeStr) => {
-  if (feeStr.endsWith('%')) {
+  if (!feeStr) {
+    return 0;
+  } else if (feeStr.endsWith('%')) {
     const asFloat = parseFloat(feeStr.replace('%', ''));
     return asFloat > 0 ? libpayments.calcFee(amount, asFloat) : asFloat;
   } else {
+    /* The `* 100` is for converting from cents */
     return parseFloat(feeStr) * 100;
   }
 };

--- a/test/features/support/stores/index.js
+++ b/test/features/support/stores/index.js
@@ -90,7 +90,8 @@ export async function newHost(name, currency, hostFee) {
 export async function newCollectiveWithHost(name, currency, hostCurrency, hostFee) {
   const { hostAdmin, hostCollective } = await newHost(`${name} Host`, hostCurrency, hostFee);
   const slug = slugify(name);
-  const collective = await models.Collective.create({ name, slug, currency });
+  const { hostFeePercent } = hostCollective;
+  const collective = await models.Collective.create({ name, slug, currency, hostFeePercent });
   await collective.addHost(hostCollective);
   return { hostCollective, hostAdmin, collective };
 }
@@ -105,7 +106,8 @@ export async function newCollectiveWithHost(name, currency, hostCurrency, hostFe
  */
 export async function newCollectiveInHost(name, currency, hostCollective) {
   const slug = slugify(name);
-  const collective = await models.Collective.create({ name, slug, currency });
+  const { hostFeePercent } = hostCollective;
+  const collective = await models.Collective.create({ name, slug, currency, hostFeePercent });
   await collective.addHost(hostCollective);
   return { collective };
 }

--- a/test/features/support/stores/index.js
+++ b/test/features/support/stores/index.js
@@ -188,9 +188,15 @@ export async function stripeConnectedAccount(hostId) {
  * @param {Number} opt.amount is the amount of the order in cents.
  * @param {String} opt.currency is the currency of the user making the
  *  order.
+ * @param {Number} opt.appFee is the application fee to be subtracted
+ *  from the order's total amount. It must be the absolute
+ *  value. Not a percentage.
+ * @param {Number} opt.ppFee is the payment processor fee to be
+ *  subtracted from the order's total amount. It must be the absolute
+ *  value. Not a percentage.
  */
 export async function stripeOneTimeDonation(opt) {
-  const { userCollective, collective, amount, currency } = opt;
+  const { userCollective, collective, amount, currency, appFee, ppFee } = opt;
   const params = { from: userCollective, to: collective, amount, currency };
   const { order } = await newOrder(params)
   const user = await models.User.findById(userCollective.CreatedByUserId);
@@ -200,7 +206,7 @@ export async function stripeOneTimeDonation(opt) {
   const sandbox = sinon.sandbox.create();
   try {
     utils.stubStripeCreate(sandbox);
-    utils.stubStripeBalance(sandbox, order.totalAmount, order.currency)
+    utils.stubStripeBalance(sandbox, amount, currency, appFee, ppFee);
     // Although it's supposed to be OK to omit `await' when returning
     // a promise, it's causing this next call to fail so I'm keeping
     // it here.

--- a/test/utils.js
+++ b/test/utils.js
@@ -186,9 +186,9 @@ export function stubStripeCreate(sandbox, overloadDefaults) {
 export function stubStripeBalance(sandbox, amount, currency, applicationFee=0, stripeFee=0) {
   const fee_details = [];
   const fee = applicationFee + stripeFee;
-  if (applicationFee > 0)
+  if (applicationFee && applicationFee > 0)
     fee_details.push({ type: 'application_fee', amount: applicationFee });
-  if (stripeFee > 0)
+  if (stripeFee && stripeFee > 0)
     fee_details.push({ type: 'stripe_fee', amount: stripeFee });
   return sandbox.stub(stripeGateway, "retrieveBalanceTransaction", async () => ({
     id: "txn_1Bs9EEBYycQg1OMfTR33Y5Xr",


### PR DESCRIPTION
The BDD tests we've been working on are supposed to cover the most critical paths of our application. Creating orders is definitely the hottest code path we have in our app so it should be easy to write these types of tests.

This change adds new steps that make it easier to setup the environment to test the creation of the transactions when an order is executed.