### PR TITLE
Slack Report: check for tags existence with new collectives

### DIFF
--- a/cron/weekly/slack-report.js
+++ b/cron/weekly/slack-report.js
@@ -128,10 +128,7 @@ Promise.props({
   newCollectives: Collective
     .findAll(_.merge({}, { attributes: ['slug', 'tags'], where: { type: 'COLLECTIVE' } }, createdLastWeek))
     .map(collective => {
-      let openSource = false;
-      if (collective.dataValues.tags.indexOf('open source') != -1) {
-        openSource = true;
-      }
+      const openSource = collective.dataValues.tags && collective.dataValues.tags.indexOf('open source') !== -1;
       return `${collective.dataValues.slug} (${openSource ? 'open source' : collective.dataValues.tags})`
     })
 


### PR DESCRIPTION
There was an error during the creation of the weekly slack report involving `null` tags for new collectives. Rather than add a default value of an empty array through a migration, the fix is just checking for the existence of `tags` values in the cron script. 