### PR TITLE
Slack Report: add env flags for running manually

### DIFF
--- a/cron/weekly/slack-report.js
+++ b/cron/weekly/slack-report.js
@@ -6,7 +6,10 @@ import models from '../../server/models';
 import activities from '../../server/constants/activities';
 import slackLib from '../../server/lib/slack';
 import expenseStatus from '../../server/constants/expense_status';
-onlyExecuteInProdOnMondays();
+
+if (!process.env.MANUAL) {
+  onlyExecuteInProdOnMondays();
+}
 
 const {
   Activity,
@@ -159,7 +162,7 @@ function onlyExecuteInProdOnMondays() {
 }
 
 function getTimeFrame(propName) {
-  const thisWeekStartRaw = moment()
+  const thisWeekStartRaw = moment(process.env.START_DATE) // will default to now if START_DATE is not set
     .tz('America/New_York')
     .startOf('isoWeek')
     .add(9, 'hours');


### PR DESCRIPTION
When the weekly slack report cron job fails to run, we should be able to run it manually and pass in a custom start date. 