### PR TITLE
Slack Report: use merge-options to support Symbol keys

### DIFF
--- a/cron/weekly/slack-report.js
+++ b/cron/weekly/slack-report.js
@@ -2,6 +2,7 @@ import config from 'config';
 import Promise from 'bluebird';
 import moment from 'moment-timezone';
 import _ from 'lodash';
+import merge from 'merge-options';
 import models, { Op } from '../../server/models';
 import activities from '../../server/constants/activities';
 import slackLib from '../../server/lib/slack';
@@ -45,13 +46,13 @@ const excludeOcTeam = { where: {
   }
 } };
 
-const lastWeekDonations = _.merge({}, createdLastWeek, donation, excludeOcTeam, credit);
-const lastWeekExpenses = _.merge({}, updatedLastWeek, excludeOcTeam);
+const lastWeekDonations = merge({}, createdLastWeek, donation, excludeOcTeam, credit);
+const lastWeekExpenses = merge({}, updatedLastWeek, excludeOcTeam);
 
-const pendingLastWeekExpenses = _.merge({}, lastWeekExpenses, pendingExpense);
-const approvedLastWeekExpenses = _.merge({}, lastWeekExpenses, approvedExpense);
-const rejectedLastWeekExpenses = _.merge({}, lastWeekExpenses, rejectedExpense);
-const paidLastWeekExpenses = _.merge({}, lastWeekExpenses, paidExpense);
+const pendingLastWeekExpenses = merge({}, lastWeekExpenses, pendingExpense);
+const approvedLastWeekExpenses = merge({}, lastWeekExpenses, approvedExpense);
+const rejectedLastWeekExpenses = merge({}, lastWeekExpenses, rejectedExpense);
+const paidLastWeekExpenses = merge({}, lastWeekExpenses, paidExpense);
 
 const collectiveByCurrency = {
   plain: false,
@@ -85,12 +86,12 @@ Promise.props({
   donationCount: Transaction.count(lastWeekDonations),
 
   donationAmount: Transaction
-    .aggregate('amount', 'SUM', _.merge({}, lastWeekDonations, collectiveByCurrency))
+    .aggregate('amount', 'SUM', merge({}, lastWeekDonations, collectiveByCurrency))
     .map(row => `${row.SUM/100} ${row.currency}`),
 
-  stripeReceivedCount: Activity.count(_.merge({}, createdLastWeek, stripeReceived)),
+  stripeReceivedCount: Activity.count(merge({}, createdLastWeek, stripeReceived)),
 
-  paypalReceivedCount: Activity.count(_.merge({}, createdLastWeek, paypalReceived)),
+  paypalReceivedCount: Activity.count(merge({}, createdLastWeek, paypalReceived)),
 
   // Expense statistics
 
@@ -103,33 +104,33 @@ Promise.props({
   paidExpenseCount: Expense.count(paidLastWeekExpenses),
 
   pendingExpenseAmount: Expense
-    .aggregate('amount', 'SUM', _.merge({}, pendingLastWeekExpenses, collectiveByCurrency))
+    .aggregate('amount', 'SUM', merge({}, pendingLastWeekExpenses, collectiveByCurrency))
     .map(row => `${-row.SUM/100} ${row.currency}`),
 
   approvedExpenseAmount: Expense
-    .aggregate('amount', 'SUM', _.merge({}, approvedLastWeekExpenses, collectiveByCurrency))
+    .aggregate('amount', 'SUM', merge({}, approvedLastWeekExpenses, collectiveByCurrency))
     .map(row => `${-row.SUM/100} ${row.currency}`),
 
   rejectedExpenseAmount: Expense
-    .aggregate('amount', 'SUM', _.merge({}, rejectedLastWeekExpenses, collectiveByCurrency))
+    .aggregate('amount', 'SUM', merge({}, rejectedLastWeekExpenses, collectiveByCurrency))
     .map(row => `${-row.SUM/100} ${row.currency}`),
 
   paidExpenseAmount: Expense
-    .aggregate('amount', 'SUM', _.merge({}, paidLastWeekExpenses, collectiveByCurrency))
+    .aggregate('amount', 'SUM', merge({}, paidLastWeekExpenses, collectiveByCurrency))
     .map(row => `${-row.SUM/100} ${row.currency}`),
 
   // Collective statistics
 
   activeCollectivesWithTransactions: Transaction
-    .findAll(_.merge({attributes: ['CollectiveId'] }, createdLastWeek, distinct, excludeOcTeam, onlyIncludeCollectiveType))
+    .findAll(merge({attributes: ['CollectiveId'] }, createdLastWeek, distinct, excludeOcTeam, onlyIncludeCollectiveType))
     .map(row => row.CollectiveId),
 
   activeCollectivesWithExpenses: Expense
-    .findAll(_.merge({attributes: ['CollectiveId'] }, updatedLastWeek, distinct, excludeOcTeam))
+    .findAll(merge({attributes: ['CollectiveId'] }, updatedLastWeek, distinct, excludeOcTeam))
     .map(row => row.CollectiveId),
 
   newCollectives: Collective
-    .findAll(_.merge({}, { attributes: ['slug', 'tags'], where: { type: 'COLLECTIVE' } }, createdLastWeek))
+    .findAll(merge({}, { attributes: ['slug', 'tags'], where: { type: 'COLLECTIVE' } }, createdLastWeek))
     .map(collective => {
       const openSource = collective.dataValues.tags && collective.dataValues.tags.indexOf('open source') !== -1;
       return `${collective.dataValues.slug} (${openSource ? 'open source' : collective.dataValues.tags})`

--- a/package-lock.json
+++ b/package-lock.json
@@ -6705,6 +6705,11 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -8070,6 +8075,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "requires": {
+        "is-plain-obj": "^1.1"
+      }
     },
     "methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "knox-mpu-alt": "0.2.2",
     "lodash": "3.10.1",
     "lru-cache": "4.1.1",
+    "merge-options": "^1.0.1",
     "mime": "2.2.2",
     "moment": "2.19.3",
     "moment-timezone": "0.5.14",


### PR DESCRIPTION
`lodash.merge` does not work with Symbol keys ([reference](https://github.com/lodash/lodash/issues/2088)), which Sequelize requires for query operators now. 

This PR fixes the issue by using a package called [`merge-options`](https://npmjs.com/package/merge-options).