### PR TITLE
Install GraphicsMagick on the frontend docker container

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -3,3 +3,6 @@ FROM node:8.4.0
 VOLUME /usr/src/frontend
 
 WORKDIR /usr/src/frontend
+
+RUN apt-get update
+RUN apt-get install graphicsmagick --yes

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -4,5 +4,4 @@ VOLUME /usr/src/frontend
 
 WORKDIR /usr/src/frontend
 
-RUN apt-get update
-RUN apt-get install graphicsmagick --yes
+RUN apt-get update -y && apt-get install -y graphicsmagick


### PR DESCRIPTION
In the frontend README, installing GraphicsMagick is instructed, but then it's not happening in the docker container.

(Seems this was added 5 months ago, so seems that perhaps no one else is using docker, but i really appreciate it being supported!)

Thanks!