### PR TITLE
Add INTERNAL_API_URL envvar for docker frontend

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       API_KEY: "dvl-1510egmf4a23d80342403fb599qd"
       WEBSITE_URL: "http://localhost:13000"
       API_URL: "http://localhost:13060"
+      INTERNAL_API_URL: "http://api:3060"
     volumes:
       - ../../frontend:/usr/src/frontend
     ports:

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -3,3 +3,6 @@ FROM node:8.4.0
 VOLUME /usr/src/frontend
 
 WORKDIR /usr/src/frontend
+
+RUN apt-get update
+RUN apt-get install graphicsmagick --yes


### PR DESCRIPTION
Builds on https://github.com/opencollective/opencollective-api/pull/1311

Related: https://github.com/opencollective/frontend/issues/467