### PR TITLE
User Model: allow current user to view their own info

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -411,6 +411,7 @@ export default (Sequelize, DataTypes) => {
     if (!remoteUser) return Promise.resolve(this.public);
     return this.populateRoles()
       .then(() => {
+        if (this.id === remoteUser.id) return true;
         // all the CollectiveIds that the remoteUser is admin of.
         const adminOfCollectives = Object.keys(remoteUser.rolesByCollectiveId).filter(CollectiveId => remoteUser.isAdmin(CollectiveId));
         const memberOfCollectives = Object.keys(this.rolesByCollectiveId);


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/1124

When displaying personal info for a User, we make sure the logged in User has permission to view that data based on their role in overlapping collectives. By default, we should allow the logged in User to view their own data. This PR allows that. 