### PR TITLE
chore: Rename constants.transactions.{type,TransactionTypes}

### DIFF
--- a/server/constants/transactions.js
+++ b/server/constants/transactions.js
@@ -1,7 +1,13 @@
-export const type = {
+/** @module constants/transactions */
+
+/** Percentage that Open Collective charges per transaction: 5% */
+export const OC_FEE_PERCENT = 5;
+
+/** Default per transaction host fee percentage */
+export const HOST_FEE_PERCENT = 5;
+
+/** Types of Transactions */
+export const TransactionTypes = {
   CREDIT: 'CREDIT',
   DEBIT: 'DEBIT'
 };
-
-export const OC_FEE_PERCENT = 5;
-export const HOST_FEE_PERCENT = 5;

--- a/server/controllers/test.js
+++ b/server/controllers/test.js
@@ -1,7 +1,7 @@
 import config from 'config';
 import Sequelize from 'sequelize';
 import models, { setupModels } from '../models';
-import { type } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 import roles from '../constants/roles';
 import errors from '../lib/errors';
 import { exportToPDF } from '../lib/utils';
@@ -131,7 +131,7 @@ export const resetTestDatabase = function(req, res, next) {
       amount: 100,
       description: "Donation 1",
       CollectiveId: testGroup.id,
-      type: type.CREDIT,
+      type: TransactionTypes.CREDIT,
       currency: "EUR",
       CreatedByUserId: testBacker.id,
       OrderId: order.id,
@@ -148,7 +148,7 @@ export const resetTestDatabase = function(req, res, next) {
     .then(order => models.Transaction.create({
       amount: 200,
       description: "Donation 2",
-      type: type.CREDIT,
+      type: TransactionTypes.CREDIT,
       currency: "EUR",
       CreatedByUserId: testBacker2.id,
       OrderId: order.id,

--- a/server/graphql/loaders.js
+++ b/server/graphql/loaders.js
@@ -1,6 +1,6 @@
 import models, { sequelize, Op } from '../models';
 import { getListOfAccessibleMembers } from '../lib/auth';
-import { type } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 import DataLoader from 'dataloader';
 import { get, groupBy } from 'lodash';
 import debugLib from 'debug';
@@ -292,7 +292,7 @@ export const loaders = (req) => {
         where: {
           FromCollectiveId: { [Op.in]: keys.map(k => k.FromCollectiveId) },
           CollectiveId: { [Op.in]: keys.map(k => k.CollectiveId) },
-          type: type.CREDIT
+          type: TransactionTypes.CREDIT
         },
         group: ['FromCollectiveId', 'CollectiveId']
       })

--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -1,7 +1,7 @@
 import activities from '../constants/activities';
 import flatten from 'flat';
 import currencies from '../constants/currencies';
-import { type } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 
 export default {
 
@@ -95,7 +95,7 @@ export default {
 
       // Currently used for both new donation and expense
       case activities.COLLECTIVE_TRANSACTION_CREATED:
-        if (activity.data.transaction.type === type.CREDIT) {
+        if (activity.data.transaction.type === TransactionTypes.CREDIT) {
           return `New Donation: ${userString} gave ${currency} ${amount} to ${collective}!`;
         }
         break;
@@ -228,7 +228,7 @@ export default {
       case activities.COLLECTIVE_TRANSACTION_CREATED:
 
         switch (activity.data.transaction.type) {
-          case type.CREDIT:
+          case TransactionTypes.CREDIT:
             if (userTwitter) {
               tweet = encodeURIComponent(`@${userTwitter} thanks for your ${currencies[currency].format(recurringAmount)} donation to ${collectiveTwitter ? `@${collectiveTwitter}` : collectiveName} 👍 ${publicUrl}`);
               tweetLink = linkify(format, `https://twitter.com/intent/tweet?status=${tweet}`,"Thank that person on Twitter");
@@ -236,7 +236,7 @@ export default {
             }
             return `New Donation: ${userString} gave ${currency} ${amount} to ${collective}!${tweetThis}`;
 
-          case type.DEBIT:
+          case TransactionTypes.DEBIT:
             return `New Expense: ${userString} submitted an expense to ${collective}: ${currency} ${amount} for ${description}!`
         }
 

--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -1,7 +1,7 @@
 import Promise from 'bluebird';
 import models, { Op, sequelize } from '../models';
 import errors from '../lib/errors';
-import { type } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 import { getFxRate } from '../lib/currency';
 import { exportToCSV } from '../lib/utils';
 import { toNegative } from '../lib/math';
@@ -87,7 +87,7 @@ export function createFromPaidExpense(host, paymentMethod, expense, paymentRespo
     hostCurrency,
     paymentProcessorFeeInHostCurrency: toNegative(paymentProcessorFeeInHostCurrency),
     ExpenseId: expense.id,
-    type: type.DEBIT,
+    type: TransactionTypes.DEBIT,
     amount: -expense.amount,
     currency: expense.currency,
     description: expense.description,
@@ -130,7 +130,7 @@ export async function createTransactionFromInKindDonation(expenseTransaction) {
     amount: -expenseTransaction.amount,
     amountInHostCurrency: -expenseTransaction.amount,
     hostCurrency: expenseTransaction.hostCurrency,
-    type: type.DEBIT,
+    type: TransactionTypes.DEBIT,
     currency: expenseTransaction.currency,
     description: expenseTransaction.description,
     CreatedByUserId: expenseTransaction.CreatedByUserId,

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -1,8 +1,7 @@
 import Temporal from 'sequelize-temporal';
-import { type } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 
 import status from '../constants/expense_status';
-const expenseType = type.DEBIT;
 import CustomDataTypes from '../models/DataTypes';
 
 export default function (Sequelize, DataTypes) {
@@ -115,7 +114,7 @@ export default function (Sequelize, DataTypes) {
     getterMethods: {
       info() {
         return {
-          type: expenseType,
+          type: TransactionTypes.DEBIT,
           id: this.id,
           UserId: this.UserId,
           CollectiveId: this.CollectiveId,
@@ -136,7 +135,7 @@ export default function (Sequelize, DataTypes) {
       },
       public() {
         return {
-          type: expenseType,
+          type: TransactionTypes.DEBIT,
           id: this.id,
           UserId: this.UserId,
           CollectiveId: this.CollectiveId,

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -1,4 +1,4 @@
-import { type } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 import Promise from 'bluebird';
 import CustomDataTypes from './DataTypes';
 import Temporal from 'sequelize-temporal';
@@ -140,7 +140,7 @@ export default function(Sequelize, DataTypes) {
         return models.Transaction.sum('amount', {
           where: {
             OrderId: this.id,
-            type: type.CREDIT
+            type: TransactionTypes.CREDIT
           }
         })
       },
@@ -152,7 +152,7 @@ export default function(Sequelize, DataTypes) {
 
       info() {
         return {
-          type: type.CREDIT,
+          type: TransactionTypes.CREDIT,
           id: this.id,
           CreatedByUserId: this.CreatedByUserId,
           TierId: this.TierId,

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -2,7 +2,7 @@
 
 import * as stripe from '../paymentProviders/stripe/gateway';
 import { types as CollectiveTypes } from '../constants/collectives';
-import { type as TransactionTypes } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 import * as paymentProviders from '../paymentProviders';
 import debugLib from 'debug';
 const debug = debugLib('PaymentMethod');

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -2,7 +2,7 @@
 
 import Promise from 'bluebird';
 import activities from '../constants/activities';
-import { type } from '../constants/transactions';
+import { TransactionTypes } from '../constants/transactions';
 import CustomDataTypes from './DataTypes';
 import uuidv4 from 'uuid/v4';
 import debugLib from 'debug';
@@ -290,14 +290,14 @@ export default (Sequelize, DataTypes) => {
 
   Transaction.createDoubleEntry = (transaction) => {
 
-    transaction.type = (transaction.amount > 0) ? type.CREDIT : type.DEBIT;
+    transaction.type = (transaction.amount > 0) ? TransactionTypes.CREDIT : TransactionTypes.DEBIT;
     transaction.netAmountInCollectiveCurrency = transaction.netAmountInCollectiveCurrency || transaction.amount;
     transaction.TransactionGroup = uuidv4();
     transaction.hostCurrencyFxRate = transaction.hostCurrencyFxRate || 1;
 
     const oppositeTransaction = {
       ...transaction,
-      type: (-transaction.amount > 0) ? type.CREDIT : type.DEBIT,
+      type: (-transaction.amount > 0) ? TransactionTypes.CREDIT : TransactionTypes.DEBIT,
       FromCollectiveId: transaction.CollectiveId,
       CollectiveId: transaction.FromCollectiveId,
       amount: -transaction.netAmountInCollectiveCurrency,
@@ -344,7 +344,7 @@ export default (Sequelize, DataTypes) => {
         transaction.FromCollectiveId = FromCollectiveId;
         transaction.CollectiveId = CollectiveId;
         transaction.PaymentMethodId = transaction.PaymentMethodId || PaymentMethodId;
-        transaction.type = (transaction.amount > 0) ? type.CREDIT : type.DEBIT;
+        transaction.type = (transaction.amount > 0) ? TransactionTypes.CREDIT : TransactionTypes.DEBIT;
         transaction.platformFeeInHostCurrency =
           toNegative(transaction.platformFeeInHostCurrency);
         transaction.hostFeeInHostCurrency =

--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -1,5 +1,5 @@
 import models, { sequelize } from '../../models';
-import { type as TransactionTypes } from '../../constants/transactions';
+import { TransactionTypes } from '../../constants/transactions';
 import Promise from 'bluebird';
 import { getFxRate } from '../../lib/currency';
 import * as paymentsLib from '../../lib/payments';

--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -99,7 +99,7 @@ export async function createTransaction(order, paymentInfo) {
     PaymentMethodId: order.paymentMethod.id
   };
   payload.transaction = {
-    type: constants.type.CREDIT,
+    type: constants.TransactionTypes.CREDIT,
     OrderId: order.id,
     amount: order.totalAmount,
     currency: order.currency,

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -118,7 +118,7 @@ export default {
             PaymentMethodId: paymentMethod.id
           };
           payload.transaction = {
-            type: constants.type.CREDIT,
+            type: constants.TransactionTypes.CREDIT,
             OrderId: order.id,
             amount: order.totalAmount,
             currency: order.currency,

--- a/test/graphql.refundTransaction.test.js
+++ b/test/graphql.refundTransaction.test.js
@@ -77,7 +77,7 @@ async function setupTestObjects() {
     CollectiveId: collective.id,
     PaymentMethodId: paymentMethod.id,
     transaction: {
-      type: constants.type.CREDIT,
+      type: constants.TransactionTypes.CREDIT,
       OrderId: order.id,
       amount: order.totalAmount,
       currency: order.currency,


### PR DESCRIPTION
The name `type` is used in so many places that we started to alias
`type` to `TransactionTypes`. So this makes the code less verbose.