### PR TITLE
GraphQL: add ability to order allCollectives by amountSent

### DIFF
--- a/server/graphql/CollectiveInterface.js
+++ b/server/graphql/CollectiveInterface.js
@@ -47,6 +47,9 @@ export const CollectiveOrderFieldType = new GraphQLEnumType({
   name: 'CollectiveOrderField',
   description: 'Properties by which collectives can be ordered.',
   values: {
+    amountSent: {
+      description: 'Order collective organizations by total money sent to collectives',
+    },
     balance: {
       description: 'Order collectives by total balance.',
     },

--- a/server/graphql/queries.js
+++ b/server/graphql/queries.js
@@ -622,6 +622,11 @@ const queries = {
         return { total, collectives, limit: args.limit, offset: args.offset };
       }
 
+      if (args.orderBy === 'amountSent' && args.type === 'ORGANIZATION') {
+        const { total, collectives } = await rawQueries.getSponsors(query.where, args);
+        return { total, collectives, limit: args.limit, offset: args.offset };
+      }
+
       query.order = [[args.orderBy, args.orderDirection]];
 
       if (args.offset) query.offset = args.offset;


### PR DESCRIPTION
To support the ability to display the top sponsors on the new home page design, this PR adds an option to order `allCollectives` by `amountSent`, which is equivalent to the amount of money donated to other collectives. 

Included in this PR is a generalized `getSponsors` query in the `server/lib/queries` module that could eventually replace the `getTopSponsors` query, which is only used by the API endpoint for the current home page. 