### PR TITLE
GraphQL Queries: allow allCollectives to order USER type by amountSent

### DIFF
--- a/server/graphql/queries.js
+++ b/server/graphql/queries.js
@@ -622,7 +622,8 @@ const queries = {
         return { total, collectives, limit: args.limit, offset: args.offset };
       }
 
-      if (args.orderBy === 'amountSent' && args.type === 'ORGANIZATION') {
+      if (args.orderBy === 'amountSent') {
+        // this will default returning ORGANIZATION collectives unless overwritten by the args.type
         const { total, collectives } = await rawQueries.getSponsors(query.where, args);
         return { total, collectives, limit: args.limit, offset: args.offset };
       }

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -398,6 +398,7 @@ const getTopSponsors = () => {
  * (excluding open source collective id 9805)
  */
 const getSponsors = async (where = {}, { orderDirection = 'ASC', limit = 0, offset = 0 }) => {
+  where.type = where.type || 'ORGANIZATION'; // setting the default type
   const whereStatement = Object.keys(where).reduce((statement, key) => `${statement} AND c."${key}"=$${key}`, '');
   const params = {
     bind: where,
@@ -410,8 +411,7 @@ const getSponsors = async (where = {}, { orderDirection = 'ASC', limit = 0, offs
       FROM "Transactions" t
       INNER JOIN "Collectives" c ON t."FromCollectiveId" = c.id
       WHERE
-        c.type = 'ORGANIZATION'
-        AND t.type = 'CREDIT'
+        t.type = 'CREDIT'
         AND c.id != 9805
         AND t."deletedAt" IS NULL
         AND c."isActive" IS TRUE


### PR DESCRIPTION
Adding on to https://github.com/opencollective/opencollective-api/pull/1339 in order to allow more flexibility in this query. Supports showing the top backers on the homepage. 