### PR TITLE
GraphQL: allCollectives do not return null createdAt records

### DIFF
--- a/server/graphql/queries.js
+++ b/server/graphql/queries.js
@@ -632,6 +632,11 @@ const queries = {
 
       if (args.offset) query.offset = args.offset;
 
+      // this will elminate the odd test accounts and older data we need to cleanup
+      query.where.createdAt = {
+        [Op.not]: null,
+      };
+
       const result = await models.Collective.findAndCountAll(query);
 
       return {


### PR DESCRIPTION
When ordering by `createdAt` ascending NULL values come first, there should really be no records with `createdAt` or `updatedAt` as NULL but production still has some test collectives where this is the case. This PR adds a constraint has been added by default to avoid these records. 