### PR TITLE
Fix host report

### DIFF
--- a/cron/monthly/host-report.js
+++ b/cron/monthly/host-report.js
@@ -2,7 +2,7 @@
 
 // Only run on the first of the month
 const today = new Date();
-if (process.env.NODE_ENV === 'production' && today.getDate() !== 2 && !process.env.OFFCYCLE) {
+if (process.env.NODE_ENV === 'production' && today.getDate() !== 1 && !process.env.OFFCYCLE) {
   console.log('NODE_ENV is production and today is not the first of month, script aborted!');
   process.exit();
 }

--- a/cron/yearly/user-report.js
+++ b/cron/yearly/user-report.js
@@ -202,6 +202,11 @@ const getCollectives = () => {
     where.slug = { [Op.in] : ['xdamman', 'digitalocean', 'fbopensource', 'piamancini', 'brusselstogether','wwcode'] };
   }
 
+  if (process.env.SLUGS) {
+    const slugs = process.env.SLUGS.split(',');
+    where.slug = { [Op.in] : slugs };
+  }
+
   return models.Collective.findAll({
     where: { ...where, type: { [Op.in]: ['ORGANIZATION', 'USER'] }}
   });

--- a/server/graphql/inputTypes.js
+++ b/server/graphql/inputTypes.js
@@ -290,7 +290,10 @@ export const ExpenseInputType = new GraphQLInputObjectType({
       description: { type: GraphQLString },
       category: { type: GraphQLString },
       status: { type: GraphQLString },
-      payoutMethod: { type: GraphQLString },
+      payoutMethod: {
+        type: GraphQLString,
+        description: "Can be paypal, donation, manual, other"
+      },
       privateMessage: { type: GraphQLString },
       attachment: { type: GraphQLString },
       user: { type: UserInputType },

--- a/server/graphql/mutations/expenses.js
+++ b/server/graphql/mutations/expenses.js
@@ -241,7 +241,7 @@ export async function payExpense(remoteUser, expenseId, paymentProcessFees) {
 
   const host = await expense.collective.getHostCollective();
 
-  // Expenses in kind can be maid for collectives without any
+  // Expenses in kind can be made for collectives without any
   // funds. That's why we skip earlier here.
   if (expense.payoutMethod === 'donation') {
     const transaction = await createTransactionFromPaidExpense(

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -289,7 +289,7 @@ export default function(Sequelize, DataTypes) {
       limit = (this.initialBalance > limit) ? limit : this.initialBalance;
     }
 
-    const result = await sumTransactions('netAmountInCollectiveCurrency', where, this.currency);
+    const result = await sumTransactions('netAmountInCollectiveCurrency', { where }, this.currency);
     const availableBalance = limit + result.totalInHostCurrency; // result.totalInHostCurrency is negative
     return { amount: availableBalance, currency: this.currency };
   };

--- a/templates/emails/host.report.hbs
+++ b/templates/emails/host.report.hbs
@@ -66,9 +66,6 @@ th {
 
 <div>
 <p>Hi {{recipient.firstName}}!</p>
-<p class="notice">Sorry, previous report sent yesterday was miscalculating the total amount received on your bank account in June. This numbers is the net amount received for all the collectives that you are hosting plus (and not minus) your host fees. <br /><br />
-  This has been corrected in this report. We also took the opportunity to make the summary table a bit more clear.<br /><br />
-  Sorry again for the inconvenience and don't hesitate to reply to this email if you have any questions or feedback to make this report better!</p>
 <p>Here are your {{#if month}}monthly{{else}}yearly{{/if}} stats:</p>
 <center>
 <table border=0 cellpadding=0 cellspacing=0 width=300 style="margin: 30px 0px">
@@ -84,8 +81,8 @@ th {
   </tr>
   <tr>
     <td align="center">
-      <span class="positive">(+{{{currency stats.totalAmountDonations.totalInHostCurrency currency=host.currency}}})</span><br />
-      <span class="negative">&nbsp;{{#if stats.totalAmountPaid.totalInHostCurrency}}({{{currency stats.totalAmountPaid.totalInHostCurrency currency=host.currency}}}){{/if}}&nbsp;</span>
+      <span class="positive">(+{{{currency stats.totalNetAmountReceived.totalInHostCurrency currency=host.currency}}})</span><br />
+      <span class="negative">&nbsp;{{#if stats.totalAmountSpent.totalInHostCurrency}}({{{currency stats.totalAmountSpent.totalInHostCurrency currency=host.currency}}}){{/if}}&nbsp;</span>
     </td>
     <td></td>
     <td align="center">
@@ -129,7 +126,7 @@ th {
     <td>Total donations (before fees)</td><td></td><td align="right">{{{currency stats.totalAmountDonations.totalInHostCurrency currency=host.currency}}}</td>
   </tr>
   <tr class="indent1">
-    <td>Payment processor fees (Stripe, PayPal)</td>
+    <td>Payment processor fees (Stripe)</td>
     <td></td>
     <td align="right">
       {{{currency stats.paymentProcessorFees.totalInHostCurrency currency=host.currency}}}
@@ -174,6 +171,22 @@ th {
   </tr>
   <tr>
     <td>Expenses paid</td><td></td><td align="right">{{{currency stats.totalAmountPaidExpenses.totalInHostCurrency currency=host.currency}}}</td>
+  </tr>
+  <tr class="indent1">
+    <td>Payment processor fees (PayPal)</td>
+    <td></td>
+    <td align="right">
+      {{{currency stats.paymentProcessorFees.totalInHostCurrency currency=host.currency}}}
+    </td>
+  </tr>
+  <tr>
+    <td colspan=2></td><td height=10 class="line"><hr /></td>
+  </tr>
+  <tr>
+    <td>Total amount spent</td><td></td><td align="right">{{{currency stats.totalAmountSpent.totalInHostCurrency currency=host.currency}}}</td>
+  </tr>
+  <tr>
+    <td colspan=3 class="muted">Total amount that left your {{host.name}} bank account</td>
   </tr>
 </table>
 

--- a/templates/emails/host.report.text.hbs
+++ b/templates/emails/host.report.text.hbs
@@ -1,12 +1,8 @@
 Hi {{recipient.firstName}}!
 
-Sorry, previous report sent yesterday was miscalculating the total amount received on your bank account in June. This numbers is the net amount received for all the collectives that you are hosting plus (and not minus) your host fees.
-This has been corrected in this report. We also took the opportunity to make the summary table a bit more clear.
-Sorry again for the inconvenience and don't hesitate to reply to this email if you have any questions or feedback to make this report better!
-
 Here is your {{#if month}}monthly{{else}}yearly{{/if}} report.
 
-Balance as of {{{moment reportDate}}}: {{{currency stats.balance.totalInHostCurrency currency=host.currency}}} (+{{{currency stats.totalAmountDonations.totalInHostCurrency currency=host.currency}}}{{#if stats.totalAmountPaid.totalInHostCurrency}}, {{{currency stats.totalAmountPaid.totalInHostCurrency currency=host.currency}}}{{/if}})
+Balance as of {{{moment reportDate}}}: {{{currency stats.balance.totalInHostCurrency currency=host.currency}}} (+{{{currency stats.totalNetAmountReceived.totalInHostCurrency currency=host.currency}}}{{#if stats.totalAmountSpent.totalInHostCurrency}}, {{{currency stats.totalAmountSpent.totalInHostCurrency currency=host.currency}}}{{/if}})
 
 {{{number stats.totalCollectives}}} {{{pluralize "collective" n=stats.totalCollectives}}} ({{{number stats.totalActiveCollectives}}} active)
 {{{number stats.backers.total}}} backers (+{{{number stats.backers.new}}}{{#if stats.backers.lost}}, -{{{number stats.backers.lost}}}{{/if}}) 
@@ -17,8 +13,8 @@ Details for the month:
 Transactions:                          {{{number stats.numberTransactions}}} ({{{number stats.numberDonations}}} {{{pluralize "donation" n=stats.numberDonations}}}, {{{number stats.numberPaidExpenses}}} {{{pluralize "expense" n=stats.numberPaidExpenses}}} paid)
 
 Donations received (before fees):      {{{currency stats.totalAmountDonations.totalInHostCurrency currency=host.currency}}}
-  Payment processors (Stripe, PayPal):  {{{currency stats.paymentProcessorFees.totalInHostCurrency currency=host.currency}}}
-  Platform fees (Open Collective):      {{{currency stats.platformFees.totalInHostCurrency 
+  Payment processor fees (Stripe):     {{{currency stats.paymentProcessorFees.totalInHostCurrency currency=host.currency}}}
+  Platform fees (Open Collective):     {{{currency stats.platformFees.totalInHostCurrency 
 currency=host.currency}}}
 ----------------------------------------------
 Total amount received:                 {{{currency stats.totalNetAmountReceived.totalInHostCurrency currency=host.currency}}}
@@ -31,6 +27,11 @@ Net amount:                            {{{currency stats.totalNetAmountReceivedF
 (Net amount received for your {{{number stats.totalCollectives}}} {{{pluralize "collective" n=stats.totalCollectives}}})
 
 Expenses paid:                         {{{currency stats.totalAmountPaidExpenses.totalInHostCurrency currency=host.currency}}}
+  Payment processor fees (PayPal):     {{{currency stats.payoutProcessorFeesPaypal.totalInHostCurrency currency=host.currency}}}
+  Payment processor fees (host):       {{{currency stats.payoutProcessorFeesManual.totalInHostCurrency currency=host.currency}}}
+----------------------------------------------
+Total amount spent:                    {{{currency stats.totalAmountSpent.totalInHostCurrency currency=host.currency}}}
+(Total amount that left your {{host.name}} bank account)
 
 
 🗒   {{transactions.length}} transactions

--- a/test/graphql.collective.test.js
+++ b/test/graphql.collective.test.js
@@ -261,7 +261,7 @@ describe('graphql.collective.test.js', () => {
     const { veganizerbxl } = await store.newCollectiveInHost(
       'veganizerbxl', 'EUR', hostCollective, null, { isActive: true });
 
-    // And given a hepler to create data for expenses
+    // And given a helper to create data for expenses
     const d = (amount, description, cid) => ({
       amount, description, currency: 'EUR',
       payoutMethod: 'manual', collective: { id: cid }

--- a/test/lib.host.test.js
+++ b/test/lib.host.test.js
@@ -93,20 +93,20 @@ describe('libhost', () => {
   });
 
   it('get the total amount of funds held by the host', async () => {
-    const res = await libhost.sumTransactionsByCurrency("netAmountInCollectiveCurrency", where);
+    const res = await libhost.sumTransactionsByCurrency("netAmountInCollectiveCurrency", { where });
     const usd = res.find(a => a.currency === 'USD');
     expect(usd.amount).to.equal(315000);
     expect(res.length).to.equal(2);
   });
 
   it('get the total amount of funds held by the host in host currency', async () => {
-    const res = await libhost.sumTransactions("netAmountInCollectiveCurrency", where);
+    const res = await libhost.sumTransactions("netAmountInCollectiveCurrency", { where });
     expect(res.byCurrency).to.have.length(2);
     expect(res.totalInHostCurrency).to.equal(720000);
   });
 
   it('get the total net amount of host fees', async () => {
-    const res = await libhost.sumTransactions("hostFeeInHostCurrency", where);
+    const res = await libhost.sumTransactions("hostFeeInHostCurrency", { where });
     expect(res.byCurrency).to.have.length(2);
     expect(res.totalInHostCurrency).to.equal(-80000);
     const cad = res.byCurrency.find(a => a.currency === 'CAD');


### PR DESCRIPTION
Splitting the fees for CREDIT and DEBIT transactions.

Before we reporting all payment processing fees together.
Problem was that the payment processing fees on expenses don't impact the net amount that the host receives from the transactions. Only the payment processing fees on CREDIT transactions do. This is fixed with this update.

![](https://d.pr/free/i/S56ndp+)