### PR TITLE
Remove hosts from getSponsors raw query

### DIFF
--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -409,12 +409,13 @@ const getSponsors = async (where = {}, { orderDirection = 'ASC', limit = 0, offs
     with "sponsors" as (
       SELECT c.id, SUM(amount) as "amountSent"
       FROM "Transactions" t
-      INNER JOIN "Collectives" c ON t."FromCollectiveId" = c.id
+      LEFT JOIN "Collectives" c ON t."FromCollectiveId" = c.id
       WHERE
         t.type = 'CREDIT'
         AND c.id != 9805
         AND t."deletedAt" IS NULL
         AND c."isActive" IS TRUE
+        AND t."platformFeeInHostCurrency" < 0
         ${whereStatement}
         AND c."deletedAt" IS NULL
         GROUP BY c.id


### PR DESCRIPTION
In order to show a more accurate list of backers and sponsors, the query needs to check for a `platformFeeInHostCurrency` on the joined transaction as less than 0 to remove any hosts from the results. 