### PR TITLE
GraphQL allCollectives: ignore collectives without a name

### DIFF
--- a/server/graphql/queries.js
+++ b/server/graphql/queries.js
@@ -636,6 +636,9 @@ const queries = {
       query.where.createdAt = {
         [Op.not]: null,
       };
+      query.where.name = {
+        [Op.ne]: '',
+      };
 
       const result = await models.Collective.findAndCountAll(query);
 


### PR DESCRIPTION
We tend to get test accounts created without a name. This constraint will eventually be rolled into a home page specific query to prevent test accounts from showing under the "Recently Created" row. 