### PR TITLE
Remove not null restriction from the field CreateByUserId on the Comments table

### DIFF
--- a/migrations/20180726232100-change-comments-createByUserId.js
+++ b/migrations/20180726232100-change-comments-createByUserId.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, sequelize) => {
+    
+    return queryInterface.changeColumn('Comments', 'CreatedByUserId', {
+      type: sequelize.INTEGER,
+      allowNull: true
+    });
+  },
+
+  down: (queryInterface, sequelize) => {
+    return Promise.resolve(); 
+  }
+};


### PR DESCRIPTION
Simple migration script meant to remove the `Not Null` restriction of the field `CreateByUserId`. This restriction is limiting the [W9 Bot Feature](https://github.com/opencollective/opencollective-api/pull/1383) at the moment.