### PR TITLE
Add status field to Orders

### DIFF
--- a/migrations/20180727173834-add-status-to-order.js
+++ b/migrations/20180727173834-add-status-to-order.js
@@ -1,0 +1,134 @@
+'use strict';
+import status from '../server/constants/order_status';
+import models, { sequelize } from '../server/models';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    const { Op } = Sequelize;
+
+    return queryInterface.addColumn('Orders', 'status', {
+      type: Sequelize.STRING,
+      defaultValue: status.PENDING,
+      allowNull: false,
+    })
+    .then(() => queryInterface.addColumn('OrderHistories', 'status', {
+      type: Sequelize.STRING,
+      defaultValue: status.PENDING,
+      allowNull: false,
+    }))
+    .then(() => sequelize.sync())
+    .then(() => queryInterface.sequelize.transaction((transaction) => {
+      const updatePaidOrders = models.Transaction.findAll({
+        where: {
+          OrderId: {
+            [Op.not]: null,
+          },
+        },
+      })
+      .then((transactions) => {
+        const orders = transactions.map((t) => t.OrderId);
+        console.log(`Updating ${orders.length} orders to PAID`);
+        const paidUpdate = models.Order.update(
+          { status: status.PAID },
+          {
+            where: {
+              id: {
+                [Op.in]: orders,
+              },
+              SubscriptionId: null,
+            },
+            transaction,
+          },
+        );
+        const errorUpdate = models.Order.update(
+          { status: status.ERROR },
+          {
+            where: {
+              id: {
+                [Op.notIn]: orders,
+              },
+              SubscriptionId: null,
+            },
+            transaction,
+          },
+        );
+        return Promise.all([paidUpdate, errorUpdate]);
+      });
+      const updateActiveOrders = models.Subscription.findAll({
+        include: [{
+          model: models.Order,
+          required: true,
+        }],
+        where: {
+          deactivatedAt: null,
+        },
+      })
+      .then((subscriptions) => {
+        const orders = subscriptions.map((sub) => sub.Order.id);
+        console.log(`Updating ${orders.length} orders to ACTIVE`);
+        return models.Order.update(
+          { status: status.ACTIVE },
+          {
+            where: {
+              id: {
+                [Op.in]: orders,
+              },
+            },
+            transaction,
+          },
+        );
+      });
+      const updateCancelledSubscriptionOrders = models.Subscription.findAll({
+        include: [{
+          model: models.Order,
+          required: true,
+        }],
+        where: {
+          deactivatedAt: {
+            [Op.not]: null,
+          },
+        },
+      })
+      .then((subscriptions) => {
+        const orders = subscriptions.map((sub) => sub.Order.id );
+        console.log(`Updating ${orders.length} orders to CANCELLED`);
+        return models.Order.update(
+          { status: status.CANCELLED },
+          {
+            where: {
+              id: {
+                [Op.in]: orders,
+              },
+            },
+            transaction,
+          },
+        );
+      });
+      const updateCancelledOrders = models.Order.update(
+        { status: status.CANCELLED },
+        {
+          paranoid: false,
+          where: {
+            deletedAt: {
+              [Op.not]: null,
+            },
+          },
+          transaction,
+        },
+      );
+
+      console.log('Running updates to orders');
+      return Promise.all([
+        updatePaidOrders,
+        updateActiveOrders,
+        updateCancelledSubscriptionOrders,
+        updateCancelledOrders,
+      ]);
+    }));
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Orders', 'status')
+      .then(() => queryInterface.removeColumn('OrderHistories', 'status'));
+  }
+};

--- a/server/constants/order_status.js
+++ b/server/constants/order_status.js
@@ -1,0 +1,19 @@
+/*
+ * Constants for the order status
+ *
+ * pending -> paid (one-time)
+ * pending -> active (subscription)
+ * pending -> active -> cancelled (subscription)
+ * pending -> cancelled
+ * pending -> rejected
+*/
+
+export default {
+  PENDING: 'PENDING',
+  PAID: 'PAID',
+  ACTIVE: 'ACTIVE',
+  CANCELLED: 'CANCELLED',
+  REJECTED: 'REJECTED',
+  ERROR: 'ERROR',
+};
+

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -7,6 +7,7 @@ import { Op } from 'sequelize';
 import models from '../models';
 import emailLib from './email';
 import { types } from '../constants/collectives';
+import status from '../constants/order_status';
 import paymentProviders from '../paymentProviders';
 import * as libsubscription from './subscriptions';
 import * as libtransactions from './transactions';
@@ -232,6 +233,7 @@ export const executeOrder = (user, order, options) => {
     })
     .then(() => {
       return processOrder(order, options)
+        .tap(() => order.update({ status: order.SubscriptionId ? status.ACTIVE : status.PAID }))
         .tap(async () => {
           if (!order.matchingFund) return null;
           const matchingFundCollective = await models.Collective.findById(order.matchingFund.CollectiveId);

--- a/server/lib/subscriptions.js
+++ b/server/lib/subscriptions.js
@@ -8,6 +8,7 @@ import models from '../models';
 import emailLib from './email';
 import * as paymentsLib from './payments';
 import { getRecommendedCollectives } from './data';
+import status from '../constants/order_status';
 
 /** Maximum number of attempts before an order gets cancelled. */
 export const MAX_RETRIES = 3;
@@ -100,6 +101,7 @@ export async function processOrderWithSubscription(options, order) {
       console.log(`Error notifying order #${order.id} ${error}`);
     } finally {
       await order.Subscription.save();
+      await order.save();
     }
   }
 
@@ -193,6 +195,7 @@ export function getChargeRetryCount(status, order) {
 export function cancelSubscription(order) {
   order.Subscription.isActive = false;
   order.Subscription.deactivatedAt = new Date;
+  order.status = status.CANCELLED;
 }
 
 /** Group processed orders by their state

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -6,6 +6,8 @@ import Temporal from 'sequelize-temporal';
 import debugLib from 'debug';
 const debug = debugLib('order');
 
+import status from '../constants/order_status';
+
 export default function(Sequelize, DataTypes) {
 
   const { models } = Sequelize;
@@ -115,6 +117,18 @@ export default function(Sequelize, DataTypes) {
     },
 
     processedAt: DataTypes.DATE,
+
+    status: {
+      type: DataTypes.STRING,
+      defaultValue: status.PENDING,
+      allowNull: false,
+      validate: {
+        isIn: {
+          args: [Object.keys(status)],
+          msg: `Must be in ${Object.keys(status)}`,
+        },
+      },
+    },
 
     createdAt: {
       type: DataTypes.DATE,

--- a/test/lib.payments.test.js
+++ b/test/lib.payments.test.js
@@ -6,6 +6,7 @@ import models from '../server/models';
 import * as utils from '../test/utils';
 import * as payments from '../server/lib/payments';
 import roles from '../server/constants/roles';
+import status from '../server/constants/order_status';
 import * as stripe from '../server/paymentProviders/stripe/gateway';
 import Promise from 'bluebird';
 
@@ -168,6 +169,7 @@ describe('lib.payments.test.js', () => {
                 expect(order).to.have.property('CollectiveId', collective.id);
                 expect(order).to.have.property('currency', CURRENCY);
                 expect(order).to.have.property('totalAmount', AMOUNT);
+                expect(order).to.have.property('status', status.PAID);
               }));
 
             it('successfully adds the user as a backer', () => models.Member.findOne({
@@ -248,6 +250,7 @@ describe('lib.payments.test.js', () => {
               expect(res.rows[1]).to.have.property('currency', CURRENCY);
               expect(res.rows[1]).to.have.property('totalAmount', AMOUNT2);
               expect(res.rows[1]).to.have.property('SubscriptionId');
+              expect(res.rows[1]).to.have.property('status', status.ACTIVE);
             }));
 
           it('creates a Subscription model', () => models.Subscription

--- a/test/lib.subscriptions.test.js
+++ b/test/lib.subscriptions.test.js
@@ -7,6 +7,7 @@ import * as utils from './utils';
 import models from '../server/models';
 import emailLib from '../server/lib/email';
 import * as paymentsLib from '../server/lib/payments';
+import status from '../server/constants/order_status';
 
 // What's being tested
 import {
@@ -488,6 +489,7 @@ describe('LibSubscription', () => {
         // And the subscription should be marked as deactivated
         expect(order.Subscription.isActive).to.be.false;
         expect(order.Subscription.deactivatedAt.getTime()).to.be.at.most((new Date).getTime());
+        expect(order.status).to.eql(status.CANCELLED);
       });
     });
   });


### PR DESCRIPTION
To facilitate creating pledges for collectives (see opencollective/opencollective#1168), this PR adds a `status` field to Orders:

- PENDING (default)
- PAID (one-time completed orders)
- ACTIVE (subscriptions)
- CANCELLED
- REJECTED
- ERROR

The migration also includes code to update existing Orders.