### PR TITLE
Add User To Host W9 Received forms List

### DIFF
--- a/test/w9.bot.test.js
+++ b/test/w9.bot.test.js
@@ -5,6 +5,7 @@
 /* Test libraries */
 import sinon from 'sinon';
 import { expect } from 'chai';
+import { get } from 'lodash';
 
 /* Test utilities */
 import * as utils from './utils';
@@ -15,6 +16,7 @@ import models from '../server/models';
 import emailLib from '../server/lib/email';
 import nock from 'nock';
 import initNock from './w9.bot.nock';
+import { W9_BOT_SLUG } from '../server/constants/collectives';
 
 /* Queries used throughout these tests */
 const createExpenseQuery = `
@@ -24,14 +26,18 @@ const createExpenseQuery = `
       status
       user { id name collective { id name slug } } } }`;
 
+const approveExpenseQuery = `
+  mutation approveExpense($id: Int!) {
+    approveExpense(id: $id) { id status } }`;
+
 // W9 Bot Collective based on the migration file
 // 20180725202700-createW9BotCollective.js
 const botCollectiveData = {
-  name: "W9 bot",
-  slug: "w9bot",
-  mission: "Help hosts by automating requesting users to submit their W9 or W8-BEN form when needed",
-  description: "Help hosts by automating requesting users to submit their W9 or W8-BEN form when needed",
-  longDescription: "Whenever someone files an expense to a host that has USD as its base currency, this bot will look at the sum of all past expenses of that user made during the year. If the sum exceeds $600, it will create a comment on the expense to ask to submit the W9, W8-BEN or W8-BEN-e form to the host",
+  name: 'W9 bot',
+  slug: 'w9bot',
+  mission: 'Help hosts by automating requesting users to submit their W9 or W8-BEN form when needed',
+  description: 'Help hosts by automating requesting users to submit their W9 or W8-BEN form when needed',
+  longDescription: 'Whenever someone files an expense to a host that has USD as its base currency, this bot will look at the sum of all past expenses of that user made during the year. If the sum exceeds $600, it will create a comment on the expense to ask to submit the W9, W8-BEN or W8-BEN-e form to the host',
   currency: 'USD',
   image: 'https://cldup.com/rdmBCmH20l.png',
   isActive: true,
@@ -80,7 +86,7 @@ describe('w9.bot.test.js', () => {
 
     afterEach(() => sandbox.restore());
 
-    it('creates a new expense greater than 600 USD but DO NOT create Comment because host is not USD based', async () => {
+    it('creates a new expense greater than W9 Bot threshold but DO NOT create Comment because host is not USD based', async () => {
       // Given a collective in USD with a host in EUR
       const { collective } = await store.newCollectiveWithHost('Test Collective', 'USD', 'EUR', 10);
       // And given an admin for the above collective
@@ -88,12 +94,20 @@ describe('w9.bot.test.js', () => {
       await collective.addUserWithRole(admin, 'ADMIN');
       // And given a user to file expenses
       const { user } = await store.newUser('someone cool');
+      // And given the W9 Bot THRESHOLD
+      const w9Bot = await models.Collective.findOne({
+        where: {
+          slug: W9_BOT_SLUG
+        }
+      });
+      const threshold = get(w9Bot, 'settings.W9.threshold');
+      expect(threshold).to.be.above(0);
       // When a new expense is created
       const data = {
-        amount: 70000, currency: 'USD', payoutMethod: 'paypal',
-        description: "Test expense for pizza",
+        amount: threshold + 100, currency: 'USD', payoutMethod: 'paypal',
+        description: 'Test expense for pizza',
         privateMessage: 'Private instructions to reimburse this expense',
-        attachment: "https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg",
+        attachment: 'https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg',
         incurredAt: new Date,
         collective: { id: collective.id }
       };
@@ -105,27 +119,27 @@ describe('w9.bot.test.js', () => {
 
       // And then the newly created expense should have the PENDING
       // status as its initial status
-      expect(result.data.createExpense.status).to.equal('PENDING');
+      expect(result.data.createExpense.status).to.be.equal('PENDING');
       // And then the expense's creator should be our user
-      expect(result.data.createExpense.user.id).to.equal(user.id);
+      expect(result.data.createExpense.user.id).to.be.equal(user.id);
 
       // And then the user should become a member of the project
       const membership = await models.Member.findOne({ where: { CollectiveId: collective.id, role: 'CONTRIBUTOR' } });
       expect(membership).to.exist;
-      expect(membership.MemberCollectiveId).to.equal(user.CollectiveId);
+      expect(membership.MemberCollectiveId).to.be.equal(user.CollectiveId);
 
       // And then an email should have been sent to the admin. This
       // call to the function `waitForCondition()` is required because
       // notifications are sent asynchronously.
       await utils.waitForCondition(() => emailSendMessageSpy.callCount > 0);
-      expect(emailSendMessageSpy.callCount).to.equal(1);
-      expect(emailSendMessageSpy.firstCall.args[0]).to.equal(admin.email);
-      expect(emailSendMessageSpy.firstCall.args[1]).to.equal("New expense on Test Collective: $700 for Test expense for pizza");
-      expect(emailSendMessageSpy.firstCall.args[2]).to.contain("/test-collective/expenses/1/approve");
+      expect(emailSendMessageSpy.callCount).to.be.equal(1);
+      expect(emailSendMessageSpy.firstCall.args[0]).to.be.equal(admin.email);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.be.equal(`New expense on Test Collective: $${(threshold + 100)/100} for Test expense for pizza`);
+      expect(emailSendMessageSpy.firstCall.args[2]).to.contain('/test-collective/expenses/1/approve');
 
-    }); /* End of "creates a new expense greater than 600 USD but DO NOT create Comment because host is not USD based" */
+    }); /* End of "creates a new expense greater than W9 Bot threshold but DO NOT create Comment because host is not USD based" */
 
-    it('creates a new expense greater than 600 USD but DO NOT create Comment because host has already received the user\'s W9', async () => {
+    it('creates a new expense greater than W9 Bot threshold but DO NOT create Comment because host has already received the user\'s W9', async () => {
       // Given a collective in USD with a host in EUR
       const { collective, hostCollective } = await store.newCollectiveWithHost('Test Collective', 'USD', 'EUR', 10);
       // And given an admin for the above collective
@@ -134,12 +148,21 @@ describe('w9.bot.test.js', () => {
       // And given a user to file expenses
       const { user } = await store.newUser('someone cool');
       hostCollective.update({ data: { W9: { receivedFromUserIds: [ user.id ] } } });
+
+      // And given the W9 Bot THRESHOLD
+      const w9Bot = await models.Collective.findOne({
+        where: {
+          slug: W9_BOT_SLUG
+        }
+      });
+      const threshold = get(w9Bot, 'settings.W9.threshold');
+      expect(threshold).to.be.above(0);
       // When a new expense is created
       const data = {
-        amount: 70000, currency: 'USD', payoutMethod: 'paypal',
-        description: "Test expense for pizza",
+        amount: threshold + 100, currency: 'USD', payoutMethod: 'paypal',
+        description: 'Test expense for pizza',
         privateMessage: 'Private instructions to reimburse this expense',
-        attachment: "https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg",
+        attachment: 'https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg',
         incurredAt: new Date,
         collective: { id: collective.id }
       };
@@ -151,27 +174,27 @@ describe('w9.bot.test.js', () => {
 
       // And then the newly created expense should have the PENDING
       // status as its initial status
-      expect(result.data.createExpense.status).to.equal('PENDING');
+      expect(result.data.createExpense.status).to.be.equal('PENDING');
       // And then the expense's creator should be our user
-      expect(result.data.createExpense.user.id).to.equal(user.id);
+      expect(result.data.createExpense.user.id).to.be.equal(user.id);
 
       // And then the user should become a member of the project
       const membership = await models.Member.findOne({ where: { CollectiveId: collective.id, role: 'CONTRIBUTOR' } });
       expect(membership).to.exist;
-      expect(membership.MemberCollectiveId).to.equal(user.CollectiveId);
+      expect(membership.MemberCollectiveId).to.be.equal(user.CollectiveId);
 
       // And then an email should have been sent to the admin. This
       // call to the function `waitForCondition()` is required because
       // notifications are sent asynchronously.
       await utils.waitForCondition(() => emailSendMessageSpy.callCount > 0);
-      expect(emailSendMessageSpy.callCount).to.equal(1);
-      expect(emailSendMessageSpy.firstCall.args[0]).to.equal(admin.email);
-      expect(emailSendMessageSpy.firstCall.args[1]).to.equal("New expense on Test Collective: $700 for Test expense for pizza");
-      expect(emailSendMessageSpy.firstCall.args[2]).to.contain("/test-collective/expenses/1/approve");
+      expect(emailSendMessageSpy.callCount).to.be.equal(1);
+      expect(emailSendMessageSpy.firstCall.args[0]).to.be.equal(admin.email);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.be.equal(`New expense on Test Collective: $${(threshold + 100)/100} for Test expense for pizza`);
+      expect(emailSendMessageSpy.firstCall.args[2]).to.contain('/test-collective/expenses/1/approve');
 
-    }); /* End of "creates a new expense greater than 600 USD but DO NOT create Comment because host is not USD based" */
+    }); /* End of "creates a new expense greater than W9 Bot threshold but DO NOT create Comment because host is not USD based" */
 
-    it('creates a new expense greater than 600 USD and create Comment expense forms email', async () => {
+    it('creates a new expense greater than W9 Bot threshold and create Comment expense forms email', async () => {
       // Given a collective in USD with a host in USD
       const { hostCollective, collective } = await store.newCollectiveWithHost('Test Collective', 'USD', 'USD', 10);
       // And given an admin for the above collective
@@ -179,12 +202,20 @@ describe('w9.bot.test.js', () => {
       await collective.addUserWithRole(admin, 'ADMIN');
       // And given a user to file expenses
       const { user } = await store.newUser('someone cool');
+      // And given the W9 Bot THRESHOLD
+      const w9Bot = await models.Collective.findOne({
+        where: {
+          slug: W9_BOT_SLUG
+        }
+      });
+      const threshold = get(w9Bot, 'settings.W9.threshold');
+      expect(threshold).to.be.above(0);
       // When a new expense is created
       const data = {
-        amount: 70000, currency: 'USD', payoutMethod: 'paypal',
-        description: "Test expense for pizza",
+        amount: threshold + 100, currency: 'USD', payoutMethod: 'paypal',
+        description: 'Test expense for pizza',
         privateMessage: 'Private instructions to reimburse this expense',
-        attachment: "https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg",
+        attachment: 'https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg',
         incurredAt: new Date,
         collective: { id: collective.id }
       };
@@ -196,41 +227,41 @@ describe('w9.bot.test.js', () => {
 
       // And then the newly created expense should have the PENDING
       // status as its initial status
-      expect(result.data.createExpense.status).to.equal('PENDING');
+      expect(result.data.createExpense.status).to.be.equal('PENDING');
       // And then the expense's creator should be our user
-      expect(result.data.createExpense.user.id).to.equal(user.id);
+      expect(result.data.createExpense.user.id).to.be.equal(user.id);
 
       // And then the user should become a member of the project
       const membership = await models.Member.findOne({ where: { CollectiveId: collective.id, role: 'CONTRIBUTOR' } });
       expect(membership).to.exist;
-      expect(membership.MemberCollectiveId).to.equal(user.CollectiveId);
+      expect(membership.MemberCollectiveId).to.be.equal(user.CollectiveId);
 
       // And then an email should have been sent to the admin. This
       // call to the function `waitForCondition()` is required because
       // notifications are sent asynchronously.
       await utils.waitForCondition(() => emailSendMessageSpy.callCount == 2);
 
-      expect(emailSendMessageSpy.callCount).to.equal(2);
-      expect(emailSendMessageSpy.firstCall.args[0]).to.equal(admin.email);
-      expect(emailSendMessageSpy.firstCall.args[1]).to.equal("New expense on Test Collective: $700 for Test expense for pizza");
-      expect(emailSendMessageSpy.firstCall.args[2]).to.contain("/test-collective/expenses/1/approve");
-      expect(emailSendMessageSpy.secondCall.args[0]).to.equal(user.email);
-      expect(emailSendMessageSpy.secondCall.args[1]).to.contain("New comment on your expense");
+      expect(emailSendMessageSpy.callCount).to.be.equal(2);
+      expect(emailSendMessageSpy.firstCall.args[0]).to.be.equal(admin.email);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.be.equal(`New expense on Test Collective: $${(threshold + 100)/100} for Test expense for pizza`);
+      expect(emailSendMessageSpy.firstCall.args[2]).to.contain('/test-collective/expenses/1/approve');
+      expect(emailSendMessageSpy.secondCall.args[0]).to.be.equal(user.email);
+      expect(emailSendMessageSpy.secondCall.args[1]).to.contain('New comment on your expense');
 
       // Checks that the compile html worked with a proper mailto containing the name of the collective/host and permalink to expense
-      expect(emailSendMessageSpy.secondCall.args[2]).to.contain("mailto:w9@opencollective.com?subject=W9%20for%20Test Collective%20(hosted%20by%20Test Collective)&body=Please%20find%20attached%20the%20[W9|W8-BEN|W8-BEN-E]%20form.%0D%0A%0D%0A-%20someone cool%0D%0A%0D%0A---%0D%0A");
-      expect(emailSendMessageSpy.secondCall.args[2]).to.contain("/test-collective/expenses/1%0D%0ATotal%20amount%20expensed%20this%20year%20so%20far:%20$700%0D%0A%0D%0A");
+      expect(emailSendMessageSpy.secondCall.args[2]).to.contain('mailto:w9@opencollective.com?subject=W9%20for%20Test Collective%20(hosted%20by%20Test Collective)&body=Please%20find%20attached%20the%20[W9|W8-BEN|W8-BEN-E]%20form.%0D%0A%0D%0A-%20someone cool%0D%0A%0D%0A---%0D%0A');
+      expect(emailSendMessageSpy.secondCall.args[2]).to.contain(`/test-collective/expenses/1%0D%0ATotal%20amount%20expensed%20this%20year%20so%20far:%20$${(threshold + 100)/100}%0D%0A%0D%0A`);
 
       // And then find Updated Host Collection to check if it includes the userId in its data.w9UserIds field
       const updatedHostCollective = await models.Collective.findById(hostCollective.id);
       expect(updatedHostCollective).to.exist;
       expect(updatedHostCollective.data).to.exist;
       expect(updatedHostCollective.data.W9.requestSentToUserIds).to.exist;
-      expect(updatedHostCollective.data.W9.requestSentToUserIds.length).to.equal(1);
-      expect(updatedHostCollective.data.W9.requestSentToUserIds[0]).to.equal(user.id);
-    }); /* End of "creates a new expense greater than 600 USD and create Comment expense forms email" */
+      expect(updatedHostCollective.data.W9.requestSentToUserIds.length).to.be.equal(1);
+      expect(updatedHostCollective.data.W9.requestSentToUserIds[0]).to.be.equal(user.id);
+    }); /* End of "creates a new expense greater than W9 Bot threshold and create Comment expense forms email" */
 
-    it('creates 2 new expenses that adds up more than 600 USD(each) and DO NOT create a new Bot Comment after the first one', async () => {
+    it('creates 2 new expenses that adds up more than W9 Bot threshold(each) and DO NOT create a new Bot Comment after the first one', async () => {
       // Given a collective in USD with a host in USD
       const { hostCollective, collective } = await store.newCollectiveWithHost('Test Collective', 'USD', 'USD', 10);
 
@@ -241,61 +272,70 @@ describe('w9.bot.test.js', () => {
       // And given a user to file expenses
       const { user } = await store.newUser('someone cool');
 
+      // And given the W9 Bot THRESHOLD
+      const w9Bot = await models.Collective.findOne({
+        where: {
+          slug: W9_BOT_SLUG
+        }
+      });
+      const threshold = get(w9Bot, 'settings.W9.threshold');
+      expect(threshold).to.be.above(0);
+
       // When the first expense is created
       const firstExpenseData = {
-        amount: 70000, currency: 'USD', payoutMethod: 'paypal',
-        description: "Test expense for pizza",
+        amount: threshold + 100, currency: 'USD', payoutMethod: 'paypal',
+        description: 'Test expense for pizza',
         privateMessage: 'Private instructions to reimburse this expense',
-        attachment: "https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg",
+        attachment: 'https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg',
         incurredAt: new Date,
         collective: { id: collective.id }
       };
       const firstExpense = await utils.graphqlQuery(createExpenseQuery, { expense: firstExpenseData }, user);
       firstExpense.errors && console.error(firstExpense.errors);
       expect(firstExpense.errors).to.not.exist;
-      expect(firstExpense.data.createExpense.status).to.equal('PENDING');
-      expect(firstExpense.data.createExpense.user.id).to.equal(user.id);
+      expect(firstExpense.data.createExpense.status).to.be.equal('PENDING');
+      expect(firstExpense.data.createExpense.user.id).to.be.equal(user.id);
 
       // First expense triggers 2 emails(admin warning email and new comment email)
       await utils.waitForCondition(() => emailSendMessageSpy.callCount == 2);
 
-      expect(emailSendMessageSpy.callCount).to.equal(2);
-      expect(emailSendMessageSpy.firstCall.args[0]).to.equal(admin.email);
-      expect(emailSendMessageSpy.firstCall.args[1]).to.contain("New expense on");
-      expect(emailSendMessageSpy.firstCall.args[2]).to.contain("/test-collective/expenses/1/approve");
-      expect(emailSendMessageSpy.secondCall.args[0]).to.equal(user.email);
-      expect(emailSendMessageSpy.secondCall.args[1]).to.contain("New comment on your expense");
+      expect(emailSendMessageSpy.callCount).to.be.equal(2);
+      expect(emailSendMessageSpy.firstCall.args[0]).to.be.equal(admin.email);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.contain('New expense on');
+      expect(emailSendMessageSpy.firstCall.args[2]).to.contain('/test-collective/expenses/1/approve');
+      expect(emailSendMessageSpy.secondCall.args[0]).to.be.equal(user.email);
+      expect(emailSendMessageSpy.secondCall.args[1]).to.contain('New comment on your expense');
 
       // And then find Updated Host Collection to check if it includes the userId in its data.W9.requestSentToUserIds field
       const updatedHostCollective = await models.Collective.findById(hostCollective.id);
       expect(updatedHostCollective).to.exist;
       expect(updatedHostCollective.data).to.exist;
       expect(updatedHostCollective.data.W9.requestSentToUserIds).to.exist;
-      expect(updatedHostCollective.data.W9.requestSentToUserIds.length).to.equal(1);
-      expect(updatedHostCollective.data.W9.requestSentToUserIds[0]).to.equal(user.id);
+      expect(updatedHostCollective.data.W9.requestSentToUserIds.length).to.be.equal(1);
+      expect(updatedHostCollective.data.W9.requestSentToUserIds[0]).to.be.equal(user.id);
 
       const numberOfComments = await models.Comment.count();
       // When second expense is created
       const secondExpenseData = {
-        amount: 70000, currency: 'USD', payoutMethod: 'paypal',
-        description: "Test expense for drink",
+        amount: threshold + 100, currency: 'USD', payoutMethod: 'paypal',
+        description: 'Test expense for drink',
         privateMessage: 'Private instructions to reimburse this expense',
-        attachment: "https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg",
+        attachment: 'https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg',
         incurredAt: new Date,
         collective: { id: collective.id }
       };
       const secondExpense = await utils.graphqlQuery(createExpenseQuery, { expense: secondExpenseData }, user);
       secondExpense.errors && console.error(secondExpense.errors);
       expect(secondExpense.errors).to.not.exist;
-      expect(secondExpense.data.createExpense.status).to.equal('PENDING');
-      expect(secondExpense.data.createExpense.user.id).to.equal(user.id);
+      expect(secondExpense.data.createExpense.status).to.be.equal('PENDING');
+      expect(secondExpense.data.createExpense.user.id).to.be.equal(user.id);
 
       // Second expense Does Not Generate Any new Comment
       const numberOfCommentsAfterAddExpense = await models.Comment.count();
-      expect(numberOfComments).to.equal(numberOfCommentsAfterAddExpense);
-    });/* End of "creates 2 new expenses that adds up more than 600 USD(each) and DO NOT create a new Bot Comment after the first one" */
+      expect(numberOfComments).to.be.equal(numberOfCommentsAfterAddExpense);
+    });/* End of "creates 2 new expenses that adds up more than W9 Bot threshold(each) and DO NOT create a new Bot Comment after the first one" */
 
-    it('creates 2 new expenses that adds up more than 600 USD and create Comment expense forms email', async () => {
+    it('creates 2 new expenses that adds up more than the W9 Bot Threshold and create Comment expense forms email', async () => {
       // Given a collective in EUR with a host in USD
       const { collective } = await store.newCollectiveWithHost('Test Collective', 'EUR', 'USD', 10);
 
@@ -306,52 +346,220 @@ describe('w9.bot.test.js', () => {
       // And given a user to file expenses
       const { user } = await store.newUser('someone cool');
 
+      // And given the W9 Bot THRESHOLD
+      const w9Bot = await models.Collective.findOne({
+        where: {
+          slug: W9_BOT_SLUG
+        }
+      });
+      const threshold = get(w9Bot, 'settings.W9.threshold');
+      expect(threshold).to.be.above(0);
+
       // When the first expense is created
       const firstExpenseData = {
-        amount: 30000, currency: 'EUR', payoutMethod: 'paypal',
-        description: "Test expense for pizza",
+        amount: threshold/2, currency: 'EUR', payoutMethod: 'paypal',
+        description: 'Test expense for pizza',
         privateMessage: 'Private instructions to reimburse this expense',
-        attachment: "https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg",
+        attachment: 'https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg',
         incurredAt: new Date,
         collective: { id: collective.id }
       };
       const firstExpense = await utils.graphqlQuery(createExpenseQuery, { expense: firstExpenseData }, user);
       firstExpense.errors && console.error(firstExpense.errors);
       expect(firstExpense.errors).to.not.exist;
-      expect(firstExpense.data.createExpense.status).to.equal('PENDING');
-      expect(firstExpense.data.createExpense.user.id).to.equal(user.id);
+      expect(firstExpense.data.createExpense.status).to.be.equal('PENDING');
+      expect(firstExpense.data.createExpense.user.id).to.be.equal(user.id);
 
       // First expense triggers only one email(admin warning)
       await utils.waitForCondition(() => emailSendMessageSpy.callCount > 0);
-      expect(emailSendMessageSpy.callCount).to.equal(1);
-      expect(emailSendMessageSpy.firstCall.args[0]).to.equal(admin.email);
-      expect(emailSendMessageSpy.firstCall.args[1]).to.contain("New expense on");
-      expect(emailSendMessageSpy.firstCall.args[2]).to.contain("/test-collective/expenses/1/approve");
+      expect(emailSendMessageSpy.callCount).to.be.equal(1);
+      expect(emailSendMessageSpy.firstCall.args[0]).to.be.equal(admin.email);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.contain('New expense on');
+      expect(emailSendMessageSpy.firstCall.args[2]).to.contain('/test-collective/expenses/1/approve');
 
       // When second expense is created
       const secondExpenseData = {
-        amount: 90000, currency: 'EUR', payoutMethod: 'paypal',
-        description: "Test expense for drink",
+        amount: threshold, currency: 'EUR', payoutMethod: 'paypal',
+        description: 'Test expense for drink',
         privateMessage: 'Private instructions to reimburse this expense',
-        attachment: "https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg",
+        attachment: 'https://opencollective-production.s3-us-west-1.amazonaws.com/imagejpg_969a1f70-9d47-11e5-80cb-dba89a9a10b0.jpg',
         incurredAt: new Date,
         collective: { id: collective.id }
       };
       const secondExpense = await utils.graphqlQuery(createExpenseQuery, { expense: secondExpenseData }, user);
       secondExpense.errors && console.error(secondExpense.errors);
       expect(secondExpense.errors).to.not.exist;
-      expect(secondExpense.data.createExpense.status).to.equal('PENDING');
-      expect(secondExpense.data.createExpense.user.id).to.equal(user.id);
+      expect(secondExpense.data.createExpense.status).to.be.equal('PENDING');
+      expect(secondExpense.data.createExpense.user.id).to.be.equal(user.id);
 
-      // Second expense triggers 2 emails(admin warning and new comment because it stepped over 600USD)
+      // Second expense triggers 2 emails(admin warning and new comment)
       await utils.waitForCondition(() => emailSendMessageSpy.callCount > 2);
-      expect(emailSendMessageSpy.secondCall.args[0]).to.equal(admin.email);
-      expect(emailSendMessageSpy.secondCall.args[1]).to.contain("New expense on");
-      expect(emailSendMessageSpy.secondCall.args[2]).to.contain("/test-collective/expenses/2/approve");
-      expect(emailSendMessageSpy.thirdCall.args[0]).to.equal(user.email);
-      expect(emailSendMessageSpy.thirdCall.args[1]).to.contain("New comment on your expense");
+      expect(emailSendMessageSpy.callCount).to.be.equal(3);
 
-    });/* End of "creates 2 new expenses that adds up more than 600 USD and create Comment expense forms email" */
+    });/* End of "creates 2 new expenses that adds up more than the W9 Bot Threshold and create Comment expense forms email" */
+
+    it('Host Data must NOT include user in W9 Received List if he didn\'t spend more than W9 Threshold after Expense is Approved', async () => {
+      // Given that we have a collective
+      const { hostCollective, hostAdmin, collective } = await store.newCollectiveWithHost('rollup', 'USD', 'USD', 10);
+      // And given a user that will file an expense
+      const { user } = await store.newUser('an internet user', { paypalEmail: 'testuser@paypal.com' });
+      // And given the above collective has one expense (created by
+      // the above user)
+      const data = {
+        currency: 'USD', payoutMethod: 'paypal',
+        privateMessage: 'Private instructions to reimburse this expense',
+        collective: { id: collective.id },
+      };
+      const expense = await store.createExpense(user, { amount: 1, description: 'Pizza', ...data });
+
+      // When the expense is approved by the admin of host
+      const result = await utils.graphqlQuery(approveExpenseQuery, { id: expense.id }, hostAdmin);
+      result.errors && console.error(result.errors);
+      // Then there should be no errors in the result
+      expect(result.errors).to.not.exist;
+      // And then the approved expense should be set as APPROVED
+      expect(result.data.approveExpense.status).to.be.equal('APPROVED');
+
+      // Approved expense triggers one email as well
+      await utils.waitForCondition(() => emailSendMessageSpy.callCount > 1);
+      expect(emailSendMessageSpy.callCount).to.be.equal(2);
+
+      // And then the host data has to be null
+      const updatedHost = await models.Collective.findById(hostCollective.id);
+      expect(updatedHost.data).to.be.null;
+    });/* End of "Host Data must NOT include user in W9 Received List if he didn\'t spend more than W9 Threshold after Expense is Approved" */
+
+    it('After User Expense is approved and User Expenses exceed W9 threshold, Host Data must include user in W9 Received List', async () => {
+      // Given that we have a collective
+      const {  hostAdmin, collective } = await store.newCollectiveWithHost('rollup', 'USD', 'USD', 10);
+      // And given a user that will file an expense
+      const { user } = await store.newUser('an internet user', { paypalEmail: 'testuser@paypal.com' });
+      // And given the W9 Bot information
+      const w9Bot = await models.Collective.findOne({
+        where: {
+          slug: W9_BOT_SLUG
+        }
+      });
+      // Get Bot Threshold
+      const threshold = get(w9Bot, 'settings.W9.threshold');
+      expect(threshold).to.be.above(0);
+
+      // Then creates the first expense that exceeds the threshold
+      const expenseData = {
+        currency: 'USD', payoutMethod: 'paypal',
+        privateMessage: 'First expense',
+        collective: { id: collective.id },
+      };
+      await store.createExpense(user, { amount: threshold + 100, description: "Pizza", ...expenseData });
+
+      // Created Expense triggers "New Comment" email
+      await utils.waitForCondition(() => emailSendMessageSpy.callCount > 0);
+      expect(emailSendMessageSpy.callCount).to.be.equal(1);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.contain('New comment');
+
+      // And then the host must have the user included in his W9.requestSentToUserIds List
+      const hostAfterCreatedExpense = await models.Collective.findById(collective.HostCollectiveId);
+      expect(hostAfterCreatedExpense.data).to.exist;
+      expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.exist;
+      expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.have.lengthOf(1);
+      expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')[0]).to.be.equal(user.id);
+
+      // And then another expense is created
+      const expense2 = await store.createExpense(user, { amount: 100, description: 'tet', ...expenseData });
+
+      // And When the expense is approved by the admin of host
+      const result = await utils.graphqlQuery(approveExpenseQuery, { id: expense2.id }, hostAdmin);
+      result.errors && console.error(result.errors);
+
+      // Then there should be no errors in the result
+      expect(result.errors).to.not.exist;
+      // And then the expense status should be set as APPROVED
+      expect(result.data.approveExpense.status).to.be.equal('APPROVED');
+
+      // Refetching host data again after expense is approved
+      const hostAfterApprovedExpense = await models.Collective.findById(collective.HostCollectiveId);
+      // Host.data.W9.receivedFromUserIds must include user
+      expect(hostAfterApprovedExpense.data).to.exist;
+      expect(get(hostAfterApprovedExpense, 'data.W9.receivedFromUserIds')).to.exist;
+      expect(get(hostAfterApprovedExpense, 'data.W9.receivedFromUserIds')).to.have.lengthOf(1);
+      expect(get(hostAfterApprovedExpense, 'data.W9.receivedFromUserIds')[0]).to.be.equal(user.id);
+    });/* End of "After User Expenses exceed W9 threshold, Host Data must include user in W9 Received List" */
+
+    it('User that\'s already in Host Data(W9 Received List) Must not be included again', async () => {
+      // Given that we have a collective
+      const {  hostAdmin, collective } = await store.newCollectiveWithHost('rollup', 'USD', 'USD', 10);
+      // And given a user that will file an expense
+      const { user } = await store.newUser('an internet user', { paypalEmail: 'testuser@paypal.com' });
+      // And given the W9 Bot information
+      const w9Bot = await models.Collective.findOne({
+        where: {
+          slug: W9_BOT_SLUG
+        }
+      });
+      // Get Bot Threshold
+      const threshold = get(w9Bot, 'settings.W9.threshold');
+      expect(threshold).to.be.above(0);
+
+      // Then creates the first expense that exceeds the threshold
+      const expenseData = {
+        currency: 'USD', payoutMethod: 'paypal',
+        privateMessage: 'First expense',
+        collective: { id: collective.id },
+      };
+      await store.createExpense(user, { amount: threshold + 100, description: "Pizza", ...expenseData });
+
+      // Created Expense triggers "New Comment" email
+      await utils.waitForCondition(() => emailSendMessageSpy.callCount > 0);
+      expect(emailSendMessageSpy.callCount).to.be.equal(1);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.contain('New comment');
+
+      // And then the host must have the user included in his W9.requestSentToUserIds List
+      const hostAfterCreatedExpense = await models.Collective.findById(collective.HostCollectiveId);
+      expect(hostAfterCreatedExpense.data).to.exist;
+      expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.exist;
+      expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.have.lengthOf(1);
+      expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')[0]).to.be.equal(user.id);
+
+      // And then another expense is created
+      const expense2 = await store.createExpense(user, { amount: 100, description: 'expense 2', ...expenseData });
+
+      // And When the expense is approved by the admin of host
+      const result = await utils.graphqlQuery(approveExpenseQuery, { id: expense2.id }, hostAdmin);
+      result.errors && console.error(result.errors);
+
+      // Then there should be no errors in the result
+      expect(result.errors).to.not.exist;
+      // And then the expense status should be set as APPROVED
+      expect(result.data.approveExpense.status).to.be.equal('APPROVED');
+
+      // Refetching host data again after expense is approved
+      const hostAfterApprovedExpense = await models.Collective.findById(collective.HostCollectiveId);
+      // Host.data.W9.receivedFromUserIds must include user
+      expect(hostAfterApprovedExpense.data).to.exist;
+      expect(get(hostAfterApprovedExpense, 'data.W9.receivedFromUserIds')).to.exist;
+      expect(get(hostAfterApprovedExpense, 'data.W9.receivedFromUserIds')).to.have.lengthOf(1);
+      expect(get(hostAfterApprovedExpense, 'data.W9.receivedFromUserIds')[0]).to.be.equal(user.id);
+
+      // And then another expense is created
+      const expense3 = await store.createExpense(user, { amount: 100, description: 'expense 3', ...expenseData });
+
+      // And When the expense is approved by the admin of host
+      const result2 = await utils.graphqlQuery(approveExpenseQuery, { id: expense3.id }, hostAdmin);
+      result.errors && console.error(result.errors);
+
+      // Then there should be no errors in the result
+      expect(result2.errors).to.not.exist;
+      // And then the expense status should be set as APPROVED
+      expect(result2.data.approveExpense.status).to.be.equal('APPROVED');
+
+      // Refetching host data again after expense is approved
+      const hostAfterThirdExpense = await models.Collective.findById(collective.HostCollectiveId);
+      // Host.data.W9.receivedFromUserIds must include user ONLY ONE time
+      expect(hostAfterThirdExpense.data).to.exist;
+      expect(get(hostAfterThirdExpense, 'data.W9.receivedFromUserIds')).to.exist;
+      expect(get(hostAfterThirdExpense, 'data.W9.receivedFromUserIds')).to.have.lengthOf(1);
+      expect(get(hostAfterThirdExpense, 'data.W9.receivedFromUserIds')[0]).to.be.equal(user.id);
+    });/* End of "User that\'s already in Host Data(W9 Received List) Must not be included again" */
 
   }); /* End of "#createCommentForExpenses" */
 }); /* End of "w9.bot.test.js" */


### PR DESCRIPTION
Today when we create an expense that exceeds the **W9 Bot Threshold**(600USD as of Today), we create a comment to warn the user that he needs to send the form to the Host and also add that user to the list of users that already received the request(`host.data.W9.requestSentToUserIds`). 

Through this PR we will consider that after the request is done, whenever the **Host** approves that expense(or any other after the warn) it means that the Host already received the form. So we add the user to the List of Users that already sent the form on the **Host** data(`host.data.W9.receivedFromUserIds`).

Extra: Refactored some Tests to look for the W9 Threshold in the database instead of hardcoding a 600USD value(today we have this value, but if we change it tomorrow we will change the database value).

Closes opencollective/opencollective#1200