### PR TITLE
Enable Organizations/Hosts to have multiple prepaid card Payment method

### DIFF
--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -320,6 +320,7 @@ const mutations = {
       CollectiveId: { type: new GraphQLNonNull(GraphQLInt) },
       HostCollectiveId: { type: new GraphQLNonNull(GraphQLInt) },
       description: { type: GraphQLString },
+      PaymentMethodId: { type: GraphQLInt },
     },
     resolve: async (_, args, req) => addFundsToOrg(args, req.remoteUser),
   }

--- a/test/collective.model.test.js
+++ b/test/collective.model.test.js
@@ -178,7 +178,7 @@ describe('Collective model', () => {
         expect(e.message).to.contain(`This collective already has a host`);
       }
     });
-    
+
     it("fails to change host if there is a pending balance", async () => {
       try {
         await collective.changeHost();

--- a/test/graphql.addFunds.test.js
+++ b/test/graphql.addFunds.test.js
@@ -7,10 +7,17 @@ import models from '../server/models';
 import * as utils from './utils';
 import * as store from './features/support/stores';
 
+// const addFundsToOrgQuery = `
+//   mutation addFundsToOrg($totalAmount: Int!, $CollectiveId: Int!, $HostCollectiveId: Int!, $description: String) {
+//     addFundsToOrg(totalAmount: $totalAmount, CollectiveId: $CollectiveId, HostCollectiveId: $HostCollectiveId, description: $description) {
+//       id
+//     }
+//   }
+// `;
 
 const addFundsToOrgQuery = `
-  mutation addFundsToOrg($totalAmount: Int!, $CollectiveId: Int!, $HostCollectiveId: Int!, $description: String) {
-    addFundsToOrg(totalAmount: $totalAmount, CollectiveId: $CollectiveId, HostCollectiveId: $HostCollectiveId, description: $description) {
+  mutation addFundsToOrg($totalAmount: Int!, $CollectiveId: Int!, $HostCollectiveId: Int!, $description: String, $PaymentMethodId: Int) {
+    addFundsToOrg(totalAmount: $totalAmount, CollectiveId: $CollectiveId, HostCollectiveId: $HostCollectiveId, description: $description, PaymentMethodId: $PaymentMethodId) {
       id
     }
   }
@@ -53,7 +60,51 @@ describe('graphql.addFunds', () => {
     expect(dbResult[0].initialBalance).to.equal(2000);
   }); /* End of "should create a new payment method" */
 
-  it('should not create more than one payment method per host/organization', async () => {
+  it('should create only one payment method and add funds to it when there is a payment method id defined on the query parameters', async () => {
+    const args = {
+      totalAmount: 2000,
+      CollectiveId: collective.id,
+      HostCollectiveId: hostCollective.id,
+      description: 'test funds',
+    };
+
+    // When the funds are added
+    const gqlResult = await utils.graphqlQuery(addFundsToOrgQuery, args, user);
+
+    // Then it should be a successful call
+    gqlResult.errors && console.error(gqlResult.errors[0]);
+    expect(gqlResult.errors).to.be.empty;
+
+    // And then there should be a new payment method created in the
+    // database
+    let dbResult = await models.PaymentMethod.findAll({
+      where: { customerId: collective.slug }
+    });
+
+    expect(dbResult.length).to.equal(1);
+    expect(dbResult[0].name).to.equal('test funds');
+    expect(dbResult[0].initialBalance).to.equal(2000);
+
+    // Then create a second query to add more funds and specify
+    // the payment method the funds should go to
+    args.PaymentMethodId = dbResult[0].id;
+    // When the funds are added twice
+    const gqlResult0 = await utils.graphqlQuery(addFundsToOrgQuery, args, user);
+    gqlResult0.errors && console.error(gqlResult0.errors[0]);
+
+    // And then there should be a new payment method created in the
+    // database
+    dbResult = await models.PaymentMethod.findAll({
+      where: { customerId: collective.slug }
+    });
+
+    expect(dbResult.length).to.equal(1);
+    expect(dbResult[0].name).to.equal('test funds');
+    expect(dbResult[0].initialBalance).to.equal(4000);
+
+  }); /* End of "should create only one payment method and add funds to it when there is a payment method id defined on the query parameters" */
+
+  it('should create more than one payment method when there is no PaymentMethodId defined in query parameters', async () => {
     const args = {
       totalAmount: 2000,
       CollectiveId: collective.id,
@@ -65,20 +116,27 @@ describe('graphql.addFunds', () => {
     const gqlResult0 = await utils.graphqlQuery(addFundsToOrgQuery, args, user);
     gqlResult0.errors && console.error(gqlResult0.errors[0]);
     expect(gqlResult0.errors).to.be.empty;
+
+    // changing some properties on the second query parameters
+    args.totalAmount = 3000;
+    args.description = 'second test on adding funds';
+
+    // executing second query
     const gqlResult1 = await utils.graphqlQuery(addFundsToOrgQuery, args, user);
     gqlResult1.errors && console.error(gqlResult1.errors[0]);
     expect(gqlResult1.errors).to.be.empty;
 
-    // And then there should be a new payment method created in the
+    // And then there should be 2 payment methods created in the
     // database
     const dbResult = await models.PaymentMethod.findAll({
       where: { customerId: collective.slug }
     });
-
-    expect(dbResult.length).to.equal(1);
+    expect(dbResult.length).to.equal(2);
     expect(dbResult[0].name).to.equal('test funds');
-    expect(dbResult[0].initialBalance).to.equal(4000);
+    expect(dbResult[0].initialBalance).to.equal(2000);
+    expect(dbResult[1].name).to.equal('second test on adding funds');
+    expect(dbResult[1].initialBalance).to.equal(3000);
 
-  }); /* End of "should not create more than one payment method per host/organization" */
+  }); /* End of "should create more than one payment method when there is no PaymentMethodId defined in query parameters" */
 
 }); /* End of "graphql.addFunds" */

--- a/test/graphql.addFunds.test.js
+++ b/test/graphql.addFunds.test.js
@@ -7,14 +7,6 @@ import models from '../server/models';
 import * as utils from './utils';
 import * as store from './features/support/stores';
 
-// const addFundsToOrgQuery = `
-//   mutation addFundsToOrg($totalAmount: Int!, $CollectiveId: Int!, $HostCollectiveId: Int!, $description: String) {
-//     addFundsToOrg(totalAmount: $totalAmount, CollectiveId: $CollectiveId, HostCollectiveId: $HostCollectiveId, description: $description) {
-//       id
-//     }
-//   }
-// `;
-
 const addFundsToOrgQuery = `
   mutation addFundsToOrg($totalAmount: Int!, $CollectiveId: Int!, $HostCollectiveId: Int!, $description: String, $PaymentMethodId: Int) {
     addFundsToOrg(totalAmount: $totalAmount, CollectiveId: $CollectiveId, HostCollectiveId: $HostCollectiveId, description: $description, PaymentMethodId: $PaymentMethodId) {

--- a/test/paymentMethods.collective.to.collective.test.js
+++ b/test/paymentMethods.collective.to.collective.test.js
@@ -35,8 +35,8 @@ const createOrderQuery = `
 
 
 describe("paymentMethods.collective.to.collective.test.js", () => {
-  let sandbox, user1, user2, transactions,  collective1, collective2, 
-    collective3, collective4, collective5, collective6, host1, host2, host3, host4, 
+  let sandbox, user1, user2, transactions,  collective1, collective2,
+    collective3, collective4, collective5, collective6, host1, host2, host3, host4,
     organization, stripePaymentMethod, openCollectivePaymentMethod;
 
   before(async () => {
@@ -413,7 +413,7 @@ describe("paymentMethods.collective.to.collective.test.js", () => {
         CollectiveId: collective6.HostCollectiveId,
         monthlyLimitPerMember: 10000
       });
-      
+
       // finding opencollective payment method for collective1
       openCollectivePaymentMethod = await models.PaymentMethod.findOne({ where: {type: 'collective', CollectiveId: collective5.id}});
 
@@ -427,7 +427,7 @@ describe("paymentMethods.collective.to.collective.test.js", () => {
 
       // Executing queries
       const res = await utils.graphqlQuery(createOrderQuery, { order }, user1);
-      
+
       // Then there should be no errors
       res.errors && console.error(res.errors);
       expect(res.errors).to.not.exist;


### PR DESCRIPTION
Today, we are always adding funds(or if it's the first time create a prepaid card to then add those funds) to one prepaid card. It makes sense to have multiple prepaid cards and this PR enables it.

Closes opencollective/opencollective#1252