### PR TITLE
Filter Credit card of hosts when Collective is donating across hosts

### DIFF
--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -109,7 +109,7 @@ paymentMethodProvider.processOrder = async (order, options = {}) => {
       where: {
         CollectiveId: fromCollectiveHost.id,
         type: 'creditcard',
-        primary: true,
+        matching: null,
         archivedAt:  null ,
         deletedAt: null,
       },

--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -108,8 +108,14 @@ paymentMethodProvider.processOrder = async (order, options = {}) => {
     const fromCollectiveHostPaymentMethod = await models.PaymentMethod.findOne({
       where: {
         CollectiveId: fromCollectiveHost.id,
-        type: 'creditcard'
-      }
+        type: 'creditcard',
+        primary: true,
+        archivedAt:  null ,
+        deletedAt: null,
+      },
+      order: [
+        ['initialBalance', 'DESC'],
+      ],
     });
     if (!fromCollectiveHostPaymentMethod) {
       throw new Error(`Host ${fromCollectiveHost.name} needs to add a credit card to send money to a different host (${collectiveHost.name}).`);


### PR DESCRIPTION
When the collective is donating across hosts, it activates the Hosts credit card.
The query was neither filtering deleted or archived cards nor getting the `Primary` cards.

Improved the query to filter those and I'm also ordering by The card with the biggest balance on file( as the collective pays through it's `service opencollective type collective` Payment method, there is no easy way to define the "correct" credit card of the host to be used when the host has more than one credit card)