### PR TITLE
README local set-up instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,37 @@ $ docker-compose -f docker/docker-compose.yml up --build
 Then you'll be able to access the UI from http://localhost:13000 and
 the API from the address http://localhost:13060.
 
+### Local setup
+
+#### Requirements
+- A PostgreSQL installation (10.3, 9.6.8, 9.5.12, 9.4.17, 9.3.22 or newer)
+
+#### Steps
+
+Make sure you have python 2 as your active version. You can use `pyenv` to switch python versions.
+
+Copy `env.default` and rename it to `.env`
+ 
+Install the dependencies by running: 
+
+```
+npm install
+```
+
+If you're running into node-gyp issues related to Python 3 vs Python 2 you can run `npm rebuild` or run `npm install` again.
+
+Setup your database and restore the seed dump by running:
+
+```
+npm run db:setup && ./node_modules/.bin/babel-node ./scripts/db_restore.js opencollective_dvl
+```
+
+Start the API by running:
+
+```
+npm run dev
+```
+
 ### Once it's running
 
 This new environment is created with the `opencollective_dvl`

--- a/README.md
+++ b/README.md
@@ -67,13 +67,9 @@ Install the dependencies by running:
 npm install
 ```
 
-If you're running into node-gyp issues related to Python 3 vs Python 2 you can run `npm rebuild` or run `npm install` again.
-
-Setup your database and restore the seed dump by running:
-
-```
-npm run db:setup && ./node_modules/.bin/babel-node ./scripts/db_restore.js opencollective_dvl
-```
+Troubleshooting:
+- If you're running into node-gyp issues related to Python 3 vs Python 2 you can run `npm rebuild` or run `npm install` again.
+- The postinstall script should set-up your default environment and bootstrap the database along with some seed data. If it is failing you can try to run: `npm run db:setup && ./node_modules/.bin/babel-node ./scripts/db_restore.js opencollective_dvl`
 
 Start the API by running:
 

--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -48,8 +48,8 @@ if [ -z "$LOCALDBNAME" ]; then usage; fi;
 # where pg_stat_activity.datname = '$LOCALDBNAME'
 # EOF
 
-dropdb $LOCALDBNAME;
-createdb -O $LOCALDBUSER $LOCALDBNAME 2> /dev/null
+dropdb --if-exists $LOCALDBNAME;
+createdb $LOCALDBNAME 2> /dev/null
 
 # Add POSTGIS extension
 psql "${LOCALDBNAME}" -c "CREATE EXTENSION POSTGIS;" 1> /dev/null


### PR DESCRIPTION
I have updated the README to include local set-up instructions. 

I have also attempted to make db_restore work when running it for the first time. I'm not sure what the impact of this is but it solves 2 issues:
- script failing when the database has not been created before
- createdb trying to use a role which hasn't been created yet

`createdb $LOCALDBNAME 2> /dev/null` the pipe to /dev/null also makes this silently fail