### PR TITLE
Virtual cards

### DIFF
--- a/migrations/20180909184500-adding-payment-method-virtual-card-columns.js
+++ b/migrations/20180909184500-adding-payment-method-virtual-card-columns.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.addColumn('PaymentMethods', 'claimUrl', {
+        type: Sequelize.STRING,
+        description: "Url Used to claim the Payment method"
+      })
+      .then(() => queryInterface.addColumn('PaymentMethods', 'SourcePaymentMethodId', {
+        type: Sequelize.INTEGER,
+        references: { model: 'PaymentMethods', key: 'id' },
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+        allowNull: true,
+        description: "References the PaymentMethod used to actually pay"
+      }));
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.removeColumn('PaymentMethods', 'claimUrl')
+      .then(() => queryInterface.removeColumn('PaymentMethods', 'SourcePaymentMethodId'));
+  }
+};

--- a/migrations/20180909184500-adding-payment-method-virtual-card-columns.js
+++ b/migrations/20180909184500-adding-payment-method-virtual-card-columns.js
@@ -4,22 +4,17 @@ const Promise = require('bluebird');
 
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    return queryInterface.addColumn('PaymentMethods', 'claimUrl', {
-        type: Sequelize.STRING,
-        description: "Url Used to claim the Payment method"
-      })
-      .then(() => queryInterface.addColumn('PaymentMethods', 'SourcePaymentMethodId', {
+    return queryInterface.addColumn('PaymentMethods', 'SourcePaymentMethodId', {
         type: Sequelize.INTEGER,
         references: { model: 'PaymentMethods', key: 'id' },
         onDelete: 'SET NULL',
         onUpdate: 'CASCADE',
         allowNull: true,
         description: "References the PaymentMethod used to actually pay"
-      }));
+      });
   },
 
   down: function (queryInterface, Sequelize) {
-    return queryInterface.removeColumn('PaymentMethods', 'claimUrl')
-      .then(() => queryInterface.removeColumn('PaymentMethods', 'SourcePaymentMethodId'));
+    return queryInterface.removeColumn('PaymentMethods', 'SourcePaymentMethodId');
   }
 };

--- a/server/controllers/paymentMethods.js
+++ b/server/controllers/paymentMethods.js
@@ -1,3 +1,5 @@
+import config from 'config';
+import moment from 'moment';
 import models, { Op } from '../models';
 import { extend, get, pick, pluck } from 'lodash';
 import * as utils from '../graphql/utils';
@@ -15,6 +17,7 @@ const createPaymentMethodQuery = `
       SourcePaymentMethodId
       initialBalance
       expiryDate
+      currency
     }
   }
 `;
@@ -45,10 +48,11 @@ async function createVirtualCardThroughGraphQL(args, user) {
     id: paymentMethod.id,
     name: paymentMethod.name,
     CollectiveId: paymentMethod.collective.id,
-    SourcePaymentMethodId: paymentMethod.SourcePaymentMethodId,
     balance: paymentMethod.initialBalance,
-    code: paymentMethod.uuid.slice(-8),
-    expiryDate: paymentMethod.expiryDate,
+    currency: paymentMethod.currency,
+    code: paymentMethod.uuid.substring(0,8),
+    expiryDate: moment(paymentMethod.expiryDate).format(),
+    redeemUrl: `${config.host.website}/redeem?code=${paymentMethod.uuid.substring(0,8)}`
   };
 }
 

--- a/server/controllers/paymentMethods.js
+++ b/server/controllers/paymentMethods.js
@@ -6,8 +6,8 @@ import * as utils from '../graphql/utils';
 const { PaymentMethod } = models;
 
 const createPaymentMethodQuery = `
-  mutation createPaymentMethod($amount: Int!, $CollectiveId: Int!, $PaymentMethodId: Int, $description: String, $expiryDate: String, $type: String!) {
-    createPaymentMethod(amount: $amount, CollectiveId: $CollectiveId, PaymentMethodId: $PaymentMethodId, description: $description, expiryDate: $expiryDate, type: $type) {
+  mutation createPaymentMethod($amount: Int!, $CollectiveId: Int!, $PaymentMethodId: Int, $description: String, $expiryDate: String, $type: String!, $currency: String!) {
+    createPaymentMethod(amount: $amount, CollectiveId: $CollectiveId, PaymentMethodId: $PaymentMethodId, description: $description, expiryDate: $expiryDate, type: $type, currency: $currency) {
       id
       name
       uuid
@@ -63,7 +63,7 @@ async function createVirtualCardThroughGraphQL(args, user) {
  */
 export function createVirtualCard(req, res) {
 
-  const args = pick(req.body, ['description','CollectiveId','PaymentMethodId','amount','expiryDate']);
+  const args = pick(req.body, ['description','CollectiveId','PaymentMethodId','amount', 'currency','expiryDate']);
   args.type = args.type || 'virtualcard';
 
   return createVirtualCardThroughGraphQL(args, req.remoteUser)

--- a/server/controllers/paymentMethods.js
+++ b/server/controllers/paymentMethods.js
@@ -1,21 +1,82 @@
-import _ from 'lodash';
 import models, { Op } from '../models';
-
+import _, { get } from 'lodash';
+import * as utils from '../../test/utils';
 const { PaymentMethod } = models;
 
+const createVirtualCardQuery = `
+  mutation createVirtualPaymentMethod($totalAmount: Int!, $CollectiveId: Int!, $PaymentMethodId: Int, $description: String, $expiryDate: String) {
+    createVirtualPaymentMethod(totalAmount: $totalAmount, CollectiveId: $CollectiveId, PaymentMethodId: $PaymentMethodId, description: $description, expiryDate: $expiryDate) {
+      id
+      name
+      uuid
+      collective {
+        id
+      }
+      SourcePaymentMethodId
+      initialBalance
+      expiryDate
+    }
+  }
+`;
 /**
  * Get the paymentMethods of the user.
  *
  * We use the method to know if the user need to confirm her/his paypal
  * account
  */
-export default function getPaymentMethods(req, res, next) {
+export function getPaymentMethods(req, res, next) {
   const { filter } = req.query;
-  const query = _.extend({}, filter, { CollectiveId: req.user.CollectiveId, confirmedAt: {[Op.ne]: null} });
+  const query = _.extend({}, filter, { CollectiveId: req.user.CollectiveId, confirmedAt: { [Op.ne]: null } });
 
   return PaymentMethod.findAll({ where: query })
   .then((response) => {
     res.send(_.pluck(response, 'info'));
+  })
+  .catch(next);
+}
+
+async function createVirtualCardThroughGraphQL(args, user) {
+  const gqlResult = await utils.graphqlQuery(createVirtualCardQuery, args, user);
+  if (!get(gqlResult, 'data.createVirtualPaymentMethod')) {
+    throw Error('Graphql Query did not return a result');
+  }
+  const paymentMethod = gqlResult.data.createVirtualPaymentMethod;
+  return {
+    id: paymentMethod.id,
+    name: paymentMethod.name,
+    CollectiveId: paymentMethod.collective.id,
+    SourcePaymentMethodId: paymentMethod.SourcePaymentMethodId,
+    balance: paymentMethod.initialBalance,
+    code: paymentMethod.uuid.slice(-8),
+    expiryDate: paymentMethod.expiryDate,
+  };
+}
+
+/**
+ * Creates a virtual card given (at least) an amount and a
+ * CollectiveId(if the logged in user is and admin of the collective).
+ */
+export function createVirtualCard(req, res, next) {
+  if (!get(req, 'remoteUser')) {
+    return res.status(401).send('User not logged in');
+  }
+  if (!get(req, 'body.CollectiveId')) {
+    return res.status(400).send('Request Payload does not contain "CollectiveId" field');
+  }
+  if (!get(req, 'body.totalAmount')) {
+    return res.status(400).send('Request Payload does not contain "totalAmount" field');
+  }
+  const args = {
+    description: req.body.description,
+    CollectiveId: req.body.CollectiveId,
+    PaymentMethodId: req.body.PaymentMethodId,
+    totalAmount: req.body.totalAmount,
+    expiryDate: req.body.expiryDate,
+  };
+
+  return createVirtualCardThroughGraphQL(args, req.remoteUser)
+  .then(response => {
+    res.send(response);
   })
   .catch(next);
 }

--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -4,7 +4,7 @@ import { createMember, removeMember } from './mutations/members';
 import { editTiers } from './mutations/tiers';
 import { editConnectedAccount } from './mutations/connectedAccounts';
 import { createExpense, editExpense, updateExpenseStatus, payExpense, deleteExpense } from './mutations/expenses';
-import { createVirtualPaymentMethod, claimVirtualCard } from './mutations/paymentMethods';
+import { createPaymentMethod, claimVirtualCard } from './mutations/paymentMethods';
 import * as updateMutations from './mutations/updates';
 import * as commentMutations from './mutations/comments';
 import * as applicationMutations from './mutations/applications';
@@ -366,24 +366,25 @@ const mutations = {
       return applicationMutations.deleteApplication(_, args, req);
     }
   },
-  createVirtualPaymentMethod: {
+  createPaymentMethod: {
     type: PaymentMethodType,
     args: {
-      totalAmount: { type: new GraphQLNonNull(GraphQLInt) },
+      type: { type: new GraphQLNonNull(GraphQLString) },
+      amount: { type: new GraphQLNonNull(GraphQLInt) },
       CollectiveId: { type: new GraphQLNonNull(GraphQLInt) },
       PaymentMethodId: { type: GraphQLInt },
       description: { type: GraphQLString },
       expiryDate: { type: GraphQLString },
     },
-    resolve: async (_, args, req) => createVirtualPaymentMethod(args, req.remoteUser),
+    resolve: async (_, args, req) => createPaymentMethod(args, req.remoteUser),
   },
   claimVirtualCard: {
     type: PaymentMethodType,
     args: {
       code: { type: new GraphQLNonNull(GraphQLString) },
-      email: { type: new GraphQLNonNull(GraphQLString) },
+      email: { type: GraphQLString },
     },
-    resolve: async (_, args, req) => claimVirtualCard(args, req),
+    resolve: async (_, args, req) => claimVirtualCard(args, req.remoteUser),
   }
 };
 

--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -383,7 +383,7 @@ const mutations = {
       code: { type: new GraphQLNonNull(GraphQLString) },
       email: { type: new GraphQLNonNull(GraphQLString) },
     },
-    resolve: async (_, args, req) => claimVirtualCard(args),
+    resolve: async (_, args, req) => claimVirtualCard(args, req),
   }
 };
 

--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -371,6 +371,7 @@ const mutations = {
     args: {
       type: { type: new GraphQLNonNull(GraphQLString) },
       amount: { type: new GraphQLNonNull(GraphQLInt) },
+      currency: { type: new GraphQLNonNull(GraphQLString) },
       CollectiveId: { type: new GraphQLNonNull(GraphQLInt) },
       PaymentMethodId: { type: GraphQLInt },
       description: { type: GraphQLString },

--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -4,6 +4,7 @@ import { createMember, removeMember } from './mutations/members';
 import { editTiers } from './mutations/tiers';
 import { editConnectedAccount } from './mutations/connectedAccounts';
 import { createExpense, editExpense, updateExpenseStatus, payExpense, deleteExpense } from './mutations/expenses';
+import { createVirtualPaymentMethod, claimVirtualCard } from './mutations/paymentMethods';
 import * as updateMutations from './mutations/updates';
 import * as commentMutations from './mutations/comments';
 import * as applicationMutations from './mutations/applications';
@@ -14,7 +15,7 @@ import {
   GraphQLNonNull,
   GraphQLList,
   GraphQLString,
-  GraphQLInt
+  GraphQLInt,
 } from 'graphql';
 
 import {
@@ -365,6 +366,25 @@ const mutations = {
       return applicationMutations.deleteApplication(_, args, req);
     }
   },
+  createVirtualPaymentMethod: {
+    type: PaymentMethodType,
+    args: {
+      totalAmount: { type: new GraphQLNonNull(GraphQLInt) },
+      CollectiveId: { type: new GraphQLNonNull(GraphQLInt) },
+      PaymentMethodId: { type: GraphQLInt },
+      description: { type: GraphQLString },
+      expiryDate: { type: GraphQLString },
+    },
+    resolve: async (_, args, req) => createVirtualPaymentMethod(args, req.remoteUser),
+  },
+  claimVirtualCard: {
+    type: PaymentMethodType,
+    args: {
+      code: { type: new GraphQLNonNull(GraphQLString) },
+      email: { type: new GraphQLNonNull(GraphQLString) },
+    },
+    resolve: async (_, args, req) => claimVirtualCard(args),
+  }
 };
 
 export default mutations;

--- a/server/graphql/mutations/collectives.js
+++ b/server/graphql/mutations/collectives.js
@@ -8,18 +8,18 @@ import activities from '../../constants/activities';
 
 export async function createCollective(_, args, req) {
   if (!req.remoteUser) {
-    throw new errors.Unauthorized({ message: "You need to be logged in to create a collective"});
+    throw new errors.Unauthorized({ message: 'You need to be logged in to create a collective' });
   }
 
   if (!args.collective.name) {
-    throw new errors.ValidationFailed({ message: "collective.name required" });
+    throw new errors.ValidationFailed({ message: 'collective.name required' });
   }
 
   let hostCollective, parentCollective, collective;
 
   const collectiveData = {
     ...args.collective,
-    CreatedByUserId: req.remoteUser.id
+    CreatedByUserId: req.remoteUser.id,
   };
 
   const location = args.collective.location;
@@ -51,7 +51,7 @@ export async function createCollective(_, args, req) {
           args.collective.HostCollectiveId = 9806; // Open Collective UK Host
         }
       }
-      collectiveData.tags.push("Tech meetups");
+      collectiveData.tags.push('Tech meetups');
     }
   }
 
@@ -80,7 +80,7 @@ export async function createCollective(_, args, req) {
     if (collectiveData.type === 'EVENT' || req.remoteUser.hasRole([roles.ADMIN, roles.HOST], hostCollective.id)) {
       collectiveData.isActive = true;
     } else if (!get(hostCollective, 'settings.apply')) {
-      throw new errors.Unauthorized({ message: `This host does not accept applications for new collectives` });
+      throw new errors.Unauthorized({ message: 'This host does not accept applications for new collectives' });
     }
   }
 
@@ -91,7 +91,7 @@ export async function createCollective(_, args, req) {
     collectiveData.slug = `${slug}-${parentCollective.id}${collectiveData.type.substr(0,2)}`.toLowerCase();
     const canCreateEvent = req.remoteUser.hasRole(['ADMIN', 'HOST', 'BACKER'], parentCollective.id);
     if (!canCreateEvent) {
-      throw new errors.Unauthorized({ message: `You must be logged in as a member of the ${parentCollective.slug} collective to create an event`});
+      throw new errors.Unauthorized({ message: `You must be logged in as a member of the ${parentCollective.slug} collective to create an event` });
     }
   }
 
@@ -100,7 +100,7 @@ export async function createCollective(_, args, req) {
   } catch (e) {
     let msg;
     switch (e.name) {
-      case "SequelizeUniqueConstraintError":
+      case 'SequelizeUniqueConstraintError':
         msg = `The slug ${e.fields.slug.replace(/\-[0-9]+ev$/, '')} is already taken. Please use another name for your ${collectiveData.type.toLowerCase()}.`;
         break;
       default:
@@ -113,7 +113,7 @@ export async function createCollective(_, args, req) {
   const promises = [
     collective.editTiers(collectiveData.tiers),
     collective.addUserWithRole(req.remoteUser, roles.ADMIN, { CreatedByUserId: req.remoteUser.id }),
-    collective.editPaymentMethods(args.collective.paymentMethods, { CreatedByUserId: req.remoteUser.id })
+    collective.editPaymentMethods(args.collective.paymentMethods, { CreatedByUserId: req.remoteUser.id }),
   ];
 
   if (collectiveData.HostCollectiveId) {
@@ -136,20 +136,20 @@ export async function createCollective(_, args, req) {
       host: get(hostCollective, 'info'),
       user: {
         email: req.remoteUser.email,
-        collective: remoteUserCollective.info
-      }
-    }
+        collective: remoteUserCollective.info,
+      },
+    },
   });
   return collective;
 }
 
 export function editCollective(_, args, req) {
   if (!req.remoteUser) {
-    throw new errors.Unauthorized({ message: "You need to be logged in to edit a collective" });
+    throw new errors.Unauthorized({ message: 'You need to be logged in to edit a collective' });
   }
 
   if (!args.collective.id) {
-    return Promise.reject(new errors.ValidationFailed({ message: "collective.id required" }));
+    return Promise.reject(new errors.ValidationFailed({ message: 'collective.id required' }));
   }
 
   const location = args.collective.location || {};
@@ -158,7 +158,7 @@ export function editCollective(_, args, req) {
     ...args.collective,
     locationName: location.name,
     address: location.address,
-    LastEditedByUserId: req.remoteUser.id
+    LastEditedByUserId: req.remoteUser.id,
   };
 
   updatedCollectiveData.type = updatedCollectiveData.type || 'COLLECTIVE';
@@ -166,7 +166,7 @@ export function editCollective(_, args, req) {
   if (location.lat) {
     updatedCollectiveData.geoLocationLatLong = {
       type: 'Point',
-      coordinates: [ location.lat, location.long ]
+      coordinates: [ location.lat, location.long ],
     };
   }
 
@@ -177,7 +177,7 @@ export function editCollective(_, args, req) {
       .then(c => {
         if (!c) throw new Error(`Collective with id ${args.collective.id} not found`);
         collective = c;
-      })
+      }),
     ];
 
   if (args.collective.ParentCollectiveId) {
@@ -199,9 +199,9 @@ export function editCollective(_, args, req) {
       updatedCollectiveData.slug = `${slug}-${parentCollective.id}${collective.type.substr(0,2)}`.toLowerCase();
     }
     if (updatedCollectiveData.type === 'EVENT') {
-      return (req.remoteUser.id === collective.CreatedByUserId) || req.remoteUser.hasRole(['ADMIN', 'HOST', 'BACKER'], parentCollective.id)
+      return (req.remoteUser.id === collective.CreatedByUserId) || req.remoteUser.hasRole(['ADMIN', 'HOST', 'BACKER'], parentCollective.id);
     } else {
-      return (req.remoteUser.id === collective.CreatedByUserId) || req.remoteUser.hasRole(['ADMIN', 'HOST'], updatedCollectiveData.id)
+      return (req.remoteUser.id === collective.CreatedByUserId) || req.remoteUser.hasRole(['ADMIN', 'HOST'], updatedCollectiveData.id);
     }
   })
   .then(canEditCollective => {
@@ -237,7 +237,7 @@ export function editCollective(_, args, req) {
 
 export async function approveCollective(remoteUser, CollectiveId) {
   if (!remoteUser) {
-    throw new errors.Unauthorized({ message: "You need to be logged in to approve a collective" });
+    throw new errors.Unauthorized({ message: 'You need to be logged in to approve a collective' });
   }
 
   const collective = await models.Collective.findById(CollectiveId);
@@ -248,7 +248,7 @@ export async function approveCollective(remoteUser, CollectiveId) {
   const hostCollective = await collective.getHostCollective();
 
   if (!remoteUser.isAdmin(hostCollective.id)) {
-    throw new errors.Unauthorized({ message: "You need to be logged in as an admin of the host of this collective to approve it", data: { HostCollectiveId: hostCollective.id } });
+    throw new errors.Unauthorized({ message: 'You need to be logged in as an admin of the host of this collective to approve it', data: { HostCollectiveId: hostCollective.id } });
   }
 
   models.Activity.create({
@@ -259,24 +259,24 @@ export async function approveCollective(remoteUser, CollectiveId) {
       collective: collective.info,
       host: hostCollective.info,
       user: {
-        email: remoteUser.email
-      }
-    }
-  })
+        email: remoteUser.email,
+      },
+    },
+  });
 
   return collective.update({ isActive: true });
 }
 
 export function deleteCollective(_, args, req) {
   if (!req.remoteUser) {
-    throw new errors.Unauthorized({ message: "You need to be logged in to delete a collective" });
+    throw new errors.Unauthorized({ message: 'You need to be logged in to delete a collective' });
   }
 
   return models.Collective.findById(args.id)
     .then(collective => {
       if (!collective) throw new errors.NotFound({ message: `Collective with id ${args.id} not found` });
       if (!req.remoteUser.isAdmin(collective.id) && !req.remoteUser.isAdmin(collective.ParentCollectiveId)) {
-        throw new errors.Unauthorized({ message: "You need to be logged in as a core contributor or as a host to delete this collective" });
+        throw new errors.Unauthorized({ message: 'You need to be logged in as a core contributor or as a host to delete this collective' });
       }
 
       return collective.destroy();

--- a/server/graphql/mutations/comments.js
+++ b/server/graphql/mutations/comments.js
@@ -10,15 +10,15 @@ function require(args, path) {
 
 export async function createComment(_, args, req) {
   if (!args.comment.markdown && !args.comment.html) {
-    throw new errors.ValidationFailed({ message: `comment.markdown or comment.html required` });
+    throw new errors.ValidationFailed({ message: 'comment.markdown or comment.html required' });
   }
-  mustBeLoggedInTo(req.remoteUser, "create a comment");
+  mustBeLoggedInTo(req.remoteUser, 'create a comment');
   const {
     comment: {
       CollectiveId,
       ExpenseId,
-      UpdateId
-    }
+      UpdateId,
+    },
   } = args;
 
   const commentData = {
@@ -26,7 +26,7 @@ export async function createComment(_, args, req) {
     ExpenseId,
     UpdateId,
     CreatedByUserId: req.remoteUser.id,
-    FromCollectiveId: req.remoteUser.CollectiveId
+    FromCollectiveId: req.remoteUser.CollectiveId,
   };
 
   if (args.comment.markdown) {

--- a/server/graphql/mutations/connectedAccounts.js
+++ b/server/graphql/mutations/connectedAccounts.js
@@ -5,7 +5,7 @@ import { pick } from 'lodash';
 
 const ediableAttributes = ['settings'];
 
-/**connectedAccount
+/** connectedAccount
  * Only the author or an admin of the collective can edit a connectedAccount
  */
 function canEditConnectedAccount(remoteUser, connectedAccount) {
@@ -15,13 +15,13 @@ function canEditConnectedAccount(remoteUser, connectedAccount) {
 
 export async function editConnectedAccount(remoteUser, connectedAccountData) {
   if (!remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to edit a connected account");
+    throw new errors.Unauthorized('You need to be logged in to edit a connected account');
   }
 
   const connectedAccount = await models.ConnectedAccount.findById(connectedAccountData.id);
 
   if (!connectedAccount) {
-    throw new errors.Unauthorized("Connected account not found");
+    throw new errors.Unauthorized('Connected account not found');
   }
 
   if (!canEditConnectedAccount(remoteUser, connectedAccount)) {
@@ -34,13 +34,13 @@ export async function editConnectedAccount(remoteUser, connectedAccountData) {
 
 export async function deleteConnectedAccount(remoteUser, connectedAccountId) {
   if (!remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to delete a connected account");
+    throw new errors.Unauthorized('You need to be logged in to delete a connected account');
   }
 
   const connectedAccount = await models.ConnectedAccount.findById(connectedAccountId);
 
   if (!connectedAccount) {
-    throw new errors.Unauthorized("Connected account not found");
+    throw new errors.Unauthorized('Connected account not found');
   }
 
   if (!canEditConnectedAccount(remoteUser, connectedAccount)) {

--- a/server/graphql/mutations/expenses.js
+++ b/server/graphql/mutations/expenses.js
@@ -9,7 +9,7 @@ import { formatCurrency } from '../../lib/utils';
 import paypalAdaptive from '../../paymentProviders/paypal/adaptiveGateway';
 import {
   createFromPaidExpense as createTransactionFromPaidExpense,
-  createTransactionFromInKindDonation
+  createTransactionFromInKindDonation,
 } from '../../lib/transactions';
 
 /**
@@ -38,17 +38,17 @@ function canEditExpense(remoteUser, expense) {
 
 export async function updateExpenseStatus(remoteUser, expenseId, status) {
   if (!remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to update the status of an expense");
+    throw new errors.Unauthorized('You need to be logged in to update the status of an expense');
   }
 
   if (Object.keys(statuses).indexOf(status) === -1) {
-    throw new errors.ValidationFailed("Invalid status, status must be one of ", Object.keys(statuses).join(', '));
+    throw new errors.ValidationFailed('Invalid status, status must be one of ', Object.keys(statuses).join(', '));
   }
 
   const expense = await models.Expense.findById(expenseId, { include: [ { model: models.Collective, as: 'collective' } ] });
 
   if (!expense) {
-    throw new errors.Unauthorized("Expense not found");
+    throw new errors.Unauthorized('Expense not found');
   }
 
   if (!canUpdateExpenseStatus(remoteUser, expense)) {
@@ -67,7 +67,7 @@ export async function updateExpenseStatus(remoteUser, expenseId, status) {
       break;
     case statuses.PAID:
       if (expense.status !== statuses.APPROVED) {
-        throw new errors.Unauthorized("The expense must be approved before you can set it to paid");
+        throw new errors.Unauthorized('The expense must be approved before you can set it to paid');
       }
       break;
   }
@@ -77,10 +77,10 @@ export async function updateExpenseStatus(remoteUser, expenseId, status) {
 
 export async function createExpense(remoteUser, expenseData) {
   if (!remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to create an expense");
+    throw new errors.Unauthorized('You need to be logged in to create an expense');
   }
   if (!get(expenseData, 'collective.id')) {
-    throw new errors.Unauthorized("Missing expense.collective.id");
+    throw new errors.Unauthorized('Missing expense.collective.id');
   }
 
   // Update remoteUser's paypal email if it has changed
@@ -97,7 +97,7 @@ export async function createExpense(remoteUser, expenseData) {
   }
 
   if (!collective) {
-    throw new errors.ValidationFailed("Collective not found");
+    throw new errors.ValidationFailed('Collective not found');
   }
 
   if (expenseData.currency && expenseData.currency !== collective.currency) {
@@ -109,12 +109,12 @@ export async function createExpense(remoteUser, expenseData) {
     status: statuses.PENDING,
     CollectiveId: collective.id,
     lastEditedById: expenseData.UserId,
-    incurredAt: expenseData.incurredAt || new Date
+    incurredAt: expenseData.incurredAt || new Date,
   });
 
   collective.addUserWithRole(remoteUser, roles.CONTRIBUTOR).catch(e => {
     if (e.name === 'SequelizeUniqueConstraintError') {
-      console.log("User ", remoteUser.id, "is already a contributor");
+      console.log('User ', remoteUser.id, 'is already a contributor');
     } else {
       console.error(e);
     }
@@ -128,13 +128,13 @@ export async function createExpense(remoteUser, expenseData) {
 
 export async function editExpense(remoteUser, expenseData) {
   if (!remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to edit an expense");
+    throw new errors.Unauthorized('You need to be logged in to edit an expense');
   }
 
   const expense = await models.Expense.findById(expenseData.id, { include: [ { model: models.Collective, as: 'collective' } ] });
 
   if (!expense) {
-    throw new errors.Unauthorized("Expense not found");
+    throw new errors.Unauthorized('Expense not found');
   }
 
   if (!canEditExpense(remoteUser, expense)) {
@@ -164,13 +164,13 @@ export async function editExpense(remoteUser, expenseData) {
 
 export async function deleteExpense(remoteUser, expenseId) {
   if (!remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to delete an expense");
+    throw new errors.Unauthorized('You need to be logged in to delete an expense');
   }
 
   const expense = await models.Expense.findById(expenseId, { include: [ { model: models.Collective, as: 'collective' } ] });
 
   if (!expense) {
-    throw new errors.Unauthorized("Expense not found");
+    throw new errors.Unauthorized('Expense not found');
   }
 
   if (!canEditExpense(remoteUser, expense)) {
@@ -190,14 +190,14 @@ async function payExpenseUpdate(expense) {
 
 export async function payExpense(remoteUser, expenseId, paymentProcessorFee) {
   if (!remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to pay an expense");
+    throw new errors.Unauthorized('You need to be logged in to pay an expense');
   }
   const expense = await models.Expense.findById(expenseId, { include: [ { model: models.Collective, as: 'collective' } ] });
   if (!expense) {
-    throw new errors.Unauthorized("Expense not found");
+    throw new errors.Unauthorized('Expense not found');
   }
   if (expense.status === statuses.PAID) {
-    throw new errors.Unauthorized("Expense has already been paid");
+    throw new errors.Unauthorized('Expense has already been paid');
   }
   if (expense.status !== statuses.APPROVED) {
     throw new errors.Unauthorized(`Expense needs to be approved. Current status of the expense: ${expense.status}.`);
@@ -246,9 +246,9 @@ export async function payExpense(remoteUser, expenseId, paymentProcessorFee) {
       expense.setPaid(remoteUser.id);
     } catch (err) {
       if (err.message.indexOf('The total amount of all payments exceeds the maximum total amount for all payments') !==-1) {
-        return new errors.BadRequest(`Not enough funds in your existing Paypal preapproval. Please refill your PayPal payment balance.`);
+        return new errors.BadRequest('Not enough funds in your existing Paypal preapproval. Please refill your PayPal payment balance.');
       } else {
-        return new errors.BadRequest(err.message)
+        return new errors.BadRequest(err.message);
       }
     }
   }

--- a/server/graphql/mutations/members.js
+++ b/server/graphql/mutations/members.js
@@ -6,10 +6,10 @@ export function createMember(_, args, req) {
   let collective;
 
   const checkPermission = () => {
-    if (!req.remoteUser) throw new errors.Unauthorized("You need to be logged in to create a member");
+    if (!req.remoteUser) throw new errors.Unauthorized('You need to be logged in to create a member');
     if (req.remoteUser.isAdmin(collective.id)) return true;
     throw new errors.Unauthorized(`You need to be logged in as a core contributor or as a host of the ${collective.slug} collective`);
-  }
+  };
 
   return req.loaders.collective.findById.load(args.collective.id)
   .then(c => {
@@ -29,8 +29,8 @@ export function createMember(_, args, req) {
       return req.loaders.collective.findById.load(args.member.id).then(memberCollective => {
         return {
           id: memberCollective.CreatedByUserId,
-          CollectiveId: memberCollective.id
-        }
+          CollectiveId: memberCollective.id,
+        };
       });
     }
   })
@@ -40,7 +40,7 @@ export function createMember(_, args, req) {
     CreatedByUserId: user.id,
     MemberCollectiveId: user.CollectiveId,
     CollectiveId: collective.id,
-    role: args.role.toUpperCase() || roles.FOLLOWER
+    role: args.role.toUpperCase() || roles.FOLLOWER,
   }));
 }
 
@@ -48,26 +48,26 @@ export function removeMember(_, args, req) {
   let membership;
 
   const checkPermission = () => {
-    if (!req.remoteUser) throw new errors.Unauthorized("You need to be logged in to remove a member");
+    if (!req.remoteUser) throw new errors.Unauthorized('You need to be logged in to remove a member');
     if (req.remoteUser.id === membership.CreatedByUserId) return true;
     if (req.remoteUser.isAdmin(membership.CollectiveId)) return true;
 
     throw new errors.Unauthorized(`You need to be logged in as this user or as a core contributor or as a host of the collective id ${membership.CollectiveId}`);
-  }
+  };
 
   return models.Member.findOne({
       where: {
         MemberCollectiveId: args.member.id,
         CollectiveId: args.collective.id,
-        role: args.role
-      }
+        role: args.role,
+      },
     })
     .then(m => {
-      if (!m) throw new errors.NotFound("Member not found");
+      if (!m) throw new errors.NotFound('Member not found');
       membership = m;
     })
     .then(checkPermission)
     .then(() => {
       return membership.destroy();
-    })
+    });
 }

--- a/server/graphql/mutations/orders.js
+++ b/server/graphql/mutations/orders.js
@@ -1,10 +1,8 @@
 import { pick, omit, get } from 'lodash';
 import moment from 'moment';
 import uuidv4 from 'uuid/v4';
-
 import debug from 'debug';
 import Promise from 'bluebird';
-
 import models from '../../models';
 import { capitalize, pluralize } from '../../lib/utils';
 import * as libPayments from '../../lib/payments';
@@ -13,23 +11,24 @@ import roles from '../../constants/roles';
 import status from '../../constants/order_status';
 import * as errors from '../errors';
 import activities from '../../constants/activities';
-import { getNextChargeAndPeriodStartDates, getChargeRetryCount} from '../../lib/subscriptions';
+import { getNextChargeAndPeriodStartDates, getChargeRetryCount } from '../../lib/subscriptions';
 
 const debugOrder = debug('order');
 
-export async function createOrder(order, loaders, remoteUser) {
-  try {
-    if (order.paymentMethod && order.paymentMethod.service === 'stripe' && order.paymentMethod.uuid && !remoteUser) {
-      throw new Error("You need to be logged in to be able to use a payment method on file");
-    }
+export function createOrder(order, loaders, remoteUser) {
+  let tier, collective, fromCollective, paymentRequired, interval, orderCreated, user;
 
-    if (!order.collective || (!order.collective.id && !order.collective.website)) {
-      throw new Error("No collective id or website provided");
-    }
+  if (order.paymentMethod && order.paymentMethod.service === 'stripe' && order.paymentMethod.uuid && !remoteUser) {
+    throw new Error('You need to be logged in to be able to use a payment method on file');
+  }
 
-    if (order.platformFeePercent && !remoteUser.isRoot()) {
-      throw new Error(`Only a root can change the platformFeePercent`);
-    }
+  if (!order.collective || !order.collective.id) {
+    throw new Error('No collective id provided');
+  }
+
+  if (order.platformFeePercent && !remoteUser.isRoot()) {
+    throw new Error('Only a root can change the platformFeePercent');
+  }
 
     // Check the existence of the recipient Collective
     let collective;
@@ -38,31 +37,45 @@ export async function createOrder(order, loaders, remoteUser) {
     } else if (order.collective.website) {
       collective = (await models.Collective.findOrCreate({ where: {website: order.collective.website}, defaults: order.collective }))[0];
     }
-
-    if (!collective) {
-      throw new Error(`No collective found: ${order.collective.id || order.collective.website}`);
+    if (!collective.isActive) {
+      throw new Error('This collective is not active');
     }
 
     if (order.fromCollective && order.fromCollective.id === collective.id) {
-      throw new Error('Orders cannot be created for a collective by that same collective.');
+      throw new Error('Well tried. But no you can\'t order yourself something ;-)');
     }
 
     if (order.hostFeePercent) {
-      const HostCollectiveId = await collective.getHostCollectiveId();
-
-      if (!remoteUser.isAdmin(HostCollectiveId)) {
-        throw new Error(`Only an admin of the host can change the hostFeePercent`);
-      }
+      return collective.getHostCollectiveId().then(HostCollectiveId => {
+        if (!remoteUser.isAdmin(HostCollectiveId)) {
+          throw new Error('Only an admin of the host can change the hostFeePercent');
+        }
+      });
     }
+  })
+  // Check the existence of the tier
+  .then(() => {
+    if (!order.tier) return;
+    return models.Tier.findById(order.tier.id)
+      .then(tier => {
+        if (!tier) throw new Error(`No tier found with tier id: ${order.tier.id} for collective slug ${collective.slug}`);
+        return tier;
+      });
+  })
+  .then(t => {
+    tier = t; // we may not have a tier
+    paymentRequired = order.totalAmount > 0 || tier && tier.amount > 0;
 
     order.collective = collective;
 
     let tier;
     if (order.tier) {
       tier = await models.Tier.findById(order.tier.id);
-
-      if (!tier) {
-        throw new Error(`No tier found with tier id: ${order.tier.id} for collective slug ${order.collective.slug}`);
+  // make sure that we have a payment method attached if this order requires a payment (totalAmount > 0)
+  .then(() => {
+    if (paymentRequired) {
+      if (!order.paymentMethod || !(order.paymentMethod.uuid || order.paymentMethod.token)) {
+        throw new Error('This order requires a payment method');
       }
     }
 
@@ -73,6 +86,10 @@ export async function createOrder(order, loaders, remoteUser) {
     ) {
       throw new Error('This order requires a payment method');
     }
+    return tier.checkAvailableQuantity(order.quantity)
+    .then(enoughQuantityAvailable => enoughQuantityAvailable ?
+      Promise.resolve() : Promise.reject(new Error(`No more tickets left for ${tier.name}`)));
+    })
 
     if (tier && tier.maxQuantityPerUser > 0 && order.quantity > tier.maxQuantityPerUser) {
       throw new Error(`You can buy up to ${tier.maxQuantityPerUser} ${pluralize('ticket', tier.maxQuantityPerUser)} per person`);
@@ -102,42 +119,110 @@ export async function createOrder(order, loaders, remoteUser) {
       fromCollective = await loaders.collective.findById.load(user.CollectiveId);
     }
 
-    // If a `fromCollective` is provided, we check its existence and if the user can create an order on its behalf
-    if (order.fromCollective && order.fromCollective.id) {
-      if (!remoteUser) {
-        throw new Error('You need to be logged in to create an order for an existing open collective');
+      // If a `fromCollective` is provided, we check its existence and if the user can create an order on its behalf
+      if (order.fromCollective.id) {
+        if (!remoteUser) throw new Error('You need to be logged in to create an order for an existing open collective');
+        return loaders.collective.findById.load(order.fromCollective.id)
+        .then(c => {
+          if (!c) throw new Error(`From collective id ${order.fromCollective.id} not found`);
+          const possibleRoles = [roles.ADMIN, roles.HOST];
+          if (c.type === types.ORGANIZATION) {
+            possibleRoles.push(roles.MEMBER);
+          }
+          if (!remoteUser.hasRole(possibleRoles, order.fromCollective.id)) {
+            // We only allow to add funds on behalf of a collective if the user is an admin of that collective or an admin of the host of the collective that receives the money
+            return collective.getHostCollectiveId().then(HostCollectiveId => {
+              if (!remoteUser.isAdmin(HostCollectiveId)) {
+                throw new Error(`You don't have sufficient permissions to create an order on behalf of the ${c.name} ${c.type.toLowerCase()}`);
+              } else {
+                return c;
+              }
+            });
+          }
+          return c;
+        });
+      } else {
+        // Create new organization collective
+        return models.Collective.createOrganization(order.fromCollective, user, remoteUser);
       }
 
       fromCollective = await loaders.collective.findById.load(order.fromCollective.id);
       if (!fromCollective) {
         throw new Error(`From collective id ${order.fromCollective.id} not found`);
       }
-
-      const possibleRoles = [roles.ADMIN, roles.HOST];
-      if (fromCollective.type === types.ORGANIZATION) {
-        possibleRoles.push(roles.MEMBER);
+      const tierNameInfo = (tier && tier.name) ? ` (${tier.name})` : '';
+      let defaultDescription;
+      if (interval) {
+        defaultDescription = `${capitalize(interval)}ly donation to ${collective.name}${tierNameInfo}`;
+      } else {
+        defaultDescription = `Donation to ${collective.name}${tierNameInfo}`;
       }
 
-      if (!remoteUser.hasRole(possibleRoles, order.fromCollective.id)) {
-        // We only allow to add funds on behalf of a collective if the user is an admin of that collective or an admin of the host of the collective that receives the money
-        const HostId = await collective.getHostCollectiveId();
-        if (!remoteUser.isAdmin(HostId)) {
-          throw new Error(`You don't have sufficient permissions to create an order on behalf of the ${fromCollective.name} ${fromCollective.type.toLowerCase()}`);
-        }
+      const orderData = {
+        CreatedByUserId: remoteUser ? remoteUser.id : user.id,
+        FromCollectiveId: fromCollective.id,
+        CollectiveId: collective.id,
+        TierId: tier && tier.id,
+        quantity,
+        totalAmount,
+        currency,
+        interval,
+        description: order.description || defaultDescription,
+        publicMessage: order.publicMessage,
+        privateMessage: order.privateMessage,
+        processedAt: paymentRequired ? null : new Date,
+        MatchingPaymentMethodId: order.MatchingPaymentMethodId,
+      };
+
+      if (order.referral && get(order, 'referral.id') !== orderData.FromCollectiveId) {
+        orderData.ReferralCollectiveId = order.referral.id;
       }
     }
+      return models.Order.create(orderData);
+    })
 
-    if (!fromCollective) {
-      fromCollective = await models.Collective.createOrganization(order.fromCollective, user, remoteUser);
-    }
-
-    let matchingFund;
-    if (order.matchingFund) {
-      matchingFund = await models.PaymentMethod.getMatchingFund(order.matchingFund, { ForCollectiveId: collective.id });
-      const canBeUsedForOrder = await matchingFund.canBeUsedForOrder(order, user);
-
-      if (!canBeUsedForOrder) {
-        matchingFund = null;
+    // process payment, if needed
+    .then(oi => {
+      orderCreated = oi;
+      orderCreated.interval = interval;
+      orderCreated.matchingFund = order.matchingFund;
+      if (order.paymentMethod && order.paymentMethod.save) {
+        order.paymentMethod.CollectiveId = orderCreated.FromCollectiveId;
+      }
+      if (paymentRequired) {
+        return orderCreated
+          .setPaymentMethod(order.paymentMethod)
+          .then(() => libPayments.executeOrder(remoteUser || user, orderCreated, pick(order, ['hostFeePercent', 'platformFeePercent']))); // also adds the user as a BACKER of collective
+      } else if (collective.type === types.EVENT) {
+        // Free ticket, add user as an ATTENDEE
+        const UserId = remoteUser ? remoteUser.id : user.id;
+        return collective.addUserWithRole(user, roles.ATTENDEE)
+          .then(() => models.Activity.create({
+            type: activities.TICKET_CONFIRMED,
+            data: {
+              EventCollectiveId: collective.id,
+              UserId,
+              recipient: { name: fromCollective.name },
+              order: orderCreated.info,
+              tier: tier && tier.info,
+            },
+          }));
+      }
+    })
+    // make sure we return the latest version of the Order Instance
+    .then(() => models.Order.findById(orderCreated.id))
+    .then(order => {
+      // If there was a referral for this order, we add it as a FUNDRAISER role
+      if (order.ReferralCollectiveId && order.ReferralCollectiveId !== user.CollectiveId) {
+        collective.addUserWithRole({ id: user.id, CollectiveId: order.ReferralCollectiveId }, roles.FUNDRAISER);
+      }
+      return order;
+    })
+    .catch(e => {
+      debugOrder('createOrder mutation error: ', e);
+      if (orderCreated && !orderCreated.processedAt) {
+        // TODO: Order should be updated with data JSON field to store the error to review later
+        orderCreated.update({ status: status.ERROR });
       }
     }
 
@@ -241,39 +326,39 @@ export async function createOrder(order, loaders, remoteUser) {
 export function cancelSubscription(remoteUser, orderId) {
 
   if (!remoteUser) {
-    throw new errors.Unauthorized({ message: "You need to be logged in to cancel a subscription" });
+    throw new errors.Unauthorized({ message: 'You need to be logged in to cancel a subscription' });
   }
 
   let order = null;
   const query = {
     where: {
-      id: orderId
+      id: orderId,
     },
     include: [
-      { model: models.Subscription},
-      { model: models.Collective, as: 'collective'},
-      { model: models.Collective, as: 'fromCollective'}
-    ]
+      { model: models.Subscription },
+      { model: models.Collective, as: 'collective' },
+      { model: models.Collective, as: 'fromCollective' },
+    ],
   };
   return models.Order.findOne(query)
   .tap(o => order = o)
   .tap(order => {
     if (!order) {
-      throw new Error("Subscription not found")
+      throw new Error('Subscription not found');
     }
-    return Promise.resolve()
+    return Promise.resolve();
   })
   .tap(order => {
     if (!remoteUser.isAdmin(order.FromCollectiveId)) {
       throw new errors.Unauthorized({
-        message: "You don't have permission to cancel this subscription"
-      })
+        message: "You don't have permission to cancel this subscription",
+      });
     }
     return Promise.resolve();
   })
   .tap(order => {
     if (!order.Subscription.isActive) {
-      throw new Error("Subscription already canceled")
+      throw new Error('Subscription already canceled');
     }
     return Promise.resolve();
   })
@@ -291,15 +376,15 @@ export function cancelSubscription(remoteUser, orderId) {
           subscription: order.Subscription,
           collective: order.collective.minimal,
           user: remoteUser.minimal,
-          fromCollective: order.fromCollective.minimal
-        }
+          fromCollective: order.fromCollective.minimal,
+        },
       }))
-  .then(() => models.Order.findOne(query)) // need to fetch it second time to get updated data.
+  .then(() => models.Order.findOne(query)); // need to fetch it second time to get updated data.
 }
 
 export async function updateSubscription(remoteUser, args) {
   if (!remoteUser) {
-    throw new errors.Unauthorized({ message: "You need to be logged in to update a subscription"});
+    throw new errors.Unauthorized({ message: 'You need to be logged in to update a subscription' });
   }
 
   const { id, paymentMethod, amount } = args;
@@ -309,20 +394,20 @@ export async function updateSubscription(remoteUser, args) {
       id,
     },
     include: [
-      { model: models.Subscription},
-      { model: models.PaymentMethod, as: 'paymentMethod'}
-    ]
+      { model: models.Subscription },
+      { model: models.PaymentMethod, as: 'paymentMethod' },
+    ],
   };
 
   let order = await models.Order.findOne(query);
 
   if (!order) {
-    throw new Error("Subscription not found")
+    throw new Error('Subscription not found');
   }
   if (!remoteUser.isAdmin(order.FromCollectiveId)) {
     throw new errors.Unauthorized({
-      message: "You don't have permission to update this subscription"
-    })
+      message: "You don't have permission to update this subscription",
+    });
   }
   if (!order.Subscription.isActive) {
     throw new Error('Subscription must be active to be updated');
@@ -336,7 +421,7 @@ export async function updateSubscription(remoteUser, args) {
 
       // means it's an existing paymentMethod
       if (paymentMethod.uuid && paymentMethod.uuid.length === 36) {
-        newPm = await models.PaymentMethod.findOne({ where: { uuid: paymentMethod.uuid }});
+        newPm = await models.PaymentMethod.findOne({ where: { uuid: paymentMethod.uuid } });
         if (!newPm){
           throw new Error('Payment method not found with this uuid', paymentMethod.uuid);
         }
@@ -354,7 +439,7 @@ export async function updateSubscription(remoteUser, args) {
         await order.Subscription.update({ nextChargeDate: updatedDates.nextChargeDate, chargeRetryCount });
       }
 
-      order = await order.update({ PaymentMethodId: newPm.id});
+      order = await order.update({ PaymentMethodId: newPm.id });
   }
 
   if (amount !== undefined) {
@@ -408,7 +493,7 @@ export async function refundTransaction(_, args, req) {
   //   b. Host Collective receiving the donation -- Not implemented yet
   //   c. Site Admin
   if (!req.remoteUser.isRoot()) {
-    throw new errors.Unauthorized({ message: "Not a site admin" });
+    throw new errors.Unauthorized({ message: 'Not a site admin' });
   }
 
   // 2. Refund via payment method
@@ -444,7 +529,7 @@ export async function addFundsToOrg(args, remoteUser) {
     hostCollective,
   ] = await Promise.all([
     models.Collective.findById(args.CollectiveId),
-    models.Collective.findById(args.HostCollectiveId)
+    models.Collective.findById(args.HostCollectiveId),
   ]);
   // creates a new Payment method
   const paymentMethod = await models.PaymentMethod.create({
@@ -463,5 +548,4 @@ export async function addFundsToOrg(args, remoteUser) {
     updatedAt: new Date,
   });
   return paymentMethod;
-
 }

--- a/server/graphql/mutations/paymentMethods.js
+++ b/server/graphql/mutations/paymentMethods.js
@@ -1,0 +1,34 @@
+import virtualcard from '../../paymentProviders/opencollective/virtualcard';
+
+/** Create the Virtual Card Payment Method through an organization
+ *
+ * @param {Object} args contains the parameters to create the new
+ *  payment method.
+ * @param {String} [args.description] The description of the new payment
+ *  method.
+ * @param {Number} args.CollectiveId The ID of the organization creating the virtual card.
+ * @param {Number} [args.PaymentMethodId] The ID of the Source Payment method the
+ *                 organization wants to use
+ * @param {Number} args.totalAmount The total amount that will be
+ *  credited to the newly created payment method.
+ * @param {Date} [args.expiryDate] The expiry date of the payment method
+ * @returns {models.PaymentMethod} return the virtual card payment method.
+ */
+export async function createVirtualPaymentMethod(args, remoteUser) {
+  if (!remoteUser.isAdmin(args.CollectiveId)) {
+    throw new Error('Only an admin of a Collective can create Virtual cards on its behalf.');
+  }
+  const paymentMethod = await virtualcard.create(args);
+  return paymentMethod;
+}
+
+/** Claim the Virtual Card Payment Method By an (existing or not) user
+ * @param {Object} args contains the parameters
+ * @param {String} args.code The 8 last digits of the UUID
+ * @param {email} args.email The email of the user claiming the virtual card
+ * @returns {models.PaymentMethod} return the virtual card payment method.
+ */
+export async function claimVirtualCard(args) {
+  const paymentMethod = await virtualcard.claim(args);
+  return paymentMethod;
+}

--- a/server/graphql/mutations/paymentMethods.js
+++ b/server/graphql/mutations/paymentMethods.js
@@ -1,5 +1,21 @@
 import virtualcard from '../../paymentProviders/opencollective/virtualcard';
 
+
+/** Create a Payment Method through a collective(organization or user)
+ *
+ * @param {Object} args contains the parameters to create the new
+ *  payment method.
+* @param {Object} args contains the parameters to create the new
+ *  payment method.
+*/
+export async function createPaymentMethod(args, remoteUser) {
+  // We only support the creation of virtual cards payment methods at the moment
+  if (!args || !args.type || args.type != 'virtualcard') {
+    throw Error('Creation of Payment Method not allowed.');
+  }
+  return createVirtualPaymentMethod(args, remoteUser);
+}
+
 /** Create the Virtual Card Payment Method through an organization
  *
  * @param {Object} args contains the parameters to create the new
@@ -14,7 +30,7 @@ import virtualcard from '../../paymentProviders/opencollective/virtualcard';
  * @param {Date} [args.expiryDate] The expiry date of the payment method
  * @returns {models.PaymentMethod} return the virtual card payment method.
  */
-export async function createVirtualPaymentMethod(args, remoteUser) {
+async function createVirtualPaymentMethod(args, remoteUser) {
   if (!remoteUser.isAdmin(args.CollectiveId)) {
     throw new Error('Only an admin of a Collective can create Virtual cards on its behalf.');
   }

--- a/server/graphql/mutations/paymentMethods.js
+++ b/server/graphql/mutations/paymentMethods.js
@@ -31,8 +31,11 @@ export async function createPaymentMethod(args, remoteUser) {
  * @returns {models.PaymentMethod} return the virtual card payment method.
  */
 async function createVirtualPaymentMethod(args, remoteUser) {
+  if (!remoteUser) {
+    throw new Error('You need to be logged in to create this payment method.');
+  }
   if (!remoteUser.isAdmin(args.CollectiveId)) {
-    throw new Error('Only an admin of a Collective can create Virtual cards on its behalf.');
+    throw new Error('You must be an admin of this Collective.');
   }
   const paymentMethod = await virtualcard.create(args);
   return paymentMethod;
@@ -44,7 +47,7 @@ async function createVirtualPaymentMethod(args, remoteUser) {
  * @param {email} args.email The email of the user claiming the virtual card
  * @returns {models.PaymentMethod} return the virtual card payment method.
  */
-export async function claimVirtualCard(args) {
-  const paymentMethod = await virtualcard.claim(args);
+export async function claimVirtualCard(args, remoteUser) {
+  const paymentMethod = await virtualcard.claim(args, remoteUser);
   return paymentMethod;
 }

--- a/server/graphql/mutations/paymentMethods.js
+++ b/server/graphql/mutations/paymentMethods.js
@@ -25,8 +25,9 @@ export async function createPaymentMethod(args, remoteUser) {
  * @param {Number} args.CollectiveId The ID of the organization creating the virtual card.
  * @param {Number} [args.PaymentMethodId] The ID of the Source Payment method the
  *                 organization wants to use
- * @param {Number} args.totalAmount The total amount that will be
+ * @param {Number} args.amount The total amount that will be
  *  credited to the newly created payment method.
+ * @param {String} args.currency The currency of the virtual card
  * @param {Date} [args.expiryDate] The expiry date of the payment method
  * @returns {models.PaymentMethod} return the virtual card payment method.
  */
@@ -36,6 +37,11 @@ async function createVirtualPaymentMethod(args, remoteUser) {
   }
   if (!remoteUser.isAdmin(args.CollectiveId)) {
     throw new Error('You must be an admin of this Collective.');
+  }
+  // making sure it's a string, trim and uppercase it.
+  args.currency = args.currency.toString().toUpperCase();
+  if (!['USD', 'EUR'].includes(args.currency)) {
+    throw new Error(`Currency ${args.currency} not supported. We only support USD and EUR at the moment.`);
   }
   const paymentMethod = await virtualcard.create(args);
   return paymentMethod;

--- a/server/graphql/mutations/tiers.js
+++ b/server/graphql/mutations/tiers.js
@@ -3,7 +3,7 @@ import errors from '../../lib/errors';
 export function editTiers(_, args, req) {
   let collective;
   if (!req.remoteUser) {
-    throw new errors.Unauthorized("You need to be logged in to edit tiers");
+    throw new errors.Unauthorized('You need to be logged in to edit tiers');
   }
 
   return req.loaders.collective.findById.load(args.id)
@@ -15,5 +15,5 @@ export function editTiers(_, args, req) {
   .then(canEdit => {
     if (!canEdit) throw new errors.Unauthorized(`You need to be logged in as a core contributor or as a host of the ${collective.name} collective`);
   })
-  .then(() => collective.editTiers(args.tiers))
+  .then(() => collective.editTiers(args.tiers));
 }

--- a/server/graphql/mutations/updates.js
+++ b/server/graphql/mutations/updates.js
@@ -10,7 +10,7 @@ function require(args, path) {
 
 export async function createUpdate(_, args, req) {
   const CollectiveId = get(args, 'update.collective.id');
-  mustHaveRole(req.remoteUser, 'ADMIN', CollectiveId, "create an update");
+  mustHaveRole(req.remoteUser, 'ADMIN', CollectiveId, 'create an update');
   require(args, 'update.title');
 
   const markdown = args.update.markdown
@@ -24,7 +24,7 @@ export async function createUpdate(_, args, req) {
     CollectiveId,
     TierId: get(args, 'update.tier.id'),
     CreatedByUserId: req.remoteUser.id,
-    FromCollectiveId: req.remoteUser.CollectiveId
+    FromCollectiveId: req.remoteUser.CollectiveId,
   });
 
   return update;

--- a/server/graphql/types.js
+++ b/server/graphql/types.js
@@ -1215,6 +1215,12 @@ export const PaymentMethodType = new GraphQLObjectType({
           return paymentMethod.service;
         }
       },
+      SourcePaymentMethodId: {
+        type: GraphQLInt,
+        resolve(paymentMethod) {
+          return paymentMethod.SourcePaymentMethodId;
+        }
+      },
       type: {
         type: GraphQLString,
         resolve(paymentMethod) {

--- a/server/graphql/utils.js
+++ b/server/graphql/utils.js
@@ -1,0 +1,40 @@
+import debug from 'debug';
+import { graphql } from 'graphql';
+import { loaders } from './loaders';
+import schema from './schema';
+
+
+export const makeRequest = (remoteUser, query) => {
+  return {
+    remoteUser,
+    body: { query },
+    loaders: loaders({ remoteUser })
+  }
+}
+
+export const graphqlQuery = async (query, variables, remoteUser) => {
+
+  const prepare = () => {
+    if (remoteUser) {
+      remoteUser.rolesByCollectiveId = null; // force refetching the roles
+      return remoteUser.populateRoles();
+    } else {
+      return Promise.resolve();
+    }
+  }
+
+  if (process.env.DEBUG && process.env.DEBUG.match(/graphql/)) {
+    debug('graphql')("query", query);
+    debug('graphql')("variables", variables);
+    debug('graphql')("context", remoteUser);
+  }
+
+  return prepare()
+    .then(() => graphql(
+      schema,
+      query,
+      null, // rootValue
+      makeRequest(remoteUser, query), // context
+      variables
+    ));
+}

--- a/server/middleware/security/auth.js
+++ b/server/middleware/security/auth.js
@@ -66,7 +66,6 @@ export function authorizeClientApp(req, res, next) {
   }
 
   const apiKey = req.get('Api-Key') || req.query.apiKey || req.query.api_key || req.body.api_key;
-
   if (req.clientApp) {
     debug('auth')(`Valid Client App`);
     next();

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1345,11 +1345,13 @@ export default function(Sequelize, DataTypes) {
       where: {
         ...where,
         CollectiveId: this.id,
-      },
-      order: [['confirmedAt', 'DESC'], ['createdAt', 'DESC']]
+      }
     };
     if (mustBeConfirmed) {
       query.where.confirmedAt = { [Op.ne]: null };
+      query.order = [['confirmedAt', 'DESC']];
+    } else {
+      query.order = [['createdAt', 'DESC']];
     }
     return models.PaymentMethod.findOne(query)
     .tap(paymentMethod => {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1340,15 +1340,18 @@ export default function(Sequelize, DataTypes) {
   };
 
   // Returns the last payment method that has been confirmed attached to this collective
-  Collective.prototype.getPaymentMethod = async function(where) {
-    return models.PaymentMethod.findOne({
+  Collective.prototype.getPaymentMethod = async function(where, mustBeConfirmed = true) {
+    const query = {
       where: {
         ...where,
         CollectiveId: this.id,
-        confirmedAt: { [Op.ne]: null }
       },
-      order: [['confirmedAt', 'DESC']]
-    })
+      order: [['confirmedAt', 'DESC'], ['createdAt', 'DESC']]
+    };
+    if (mustBeConfirmed) {
+      query.where.confirmedAt = { [Op.ne]: null };
+    }
+    return models.PaymentMethod.findOne(query)
     .tap(paymentMethod => {
       if (!paymentMethod) {
         throw new Error(`No payment method found`);

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -132,10 +132,6 @@ export default function(Sequelize, DataTypes) {
       description: "if not null, this payment method can only be used for collectives listed by their id"
     },
 
-    claimUrl: {
-      type: DataTypes.STRING,
-    },
-
     SourcePaymentMethodId: {
       type: DataTypes.INTEGER,
       references: {

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -130,7 +130,21 @@ export default function(Sequelize, DataTypes) {
     limitedToCollectiveIds: {
       type: DataTypes.ARRAY(DataTypes.INTEGER),
       description: "if not null, this payment method can only be used for collectives listed by their id"
-    }
+    },
+
+    claimUrl: {
+      type: DataTypes.STRING,
+    },
+
+    SourcePaymentMethodId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'PaymentMethods',
+        key: 'id'
+      },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE'
+    },
 
   }, {
     paranoid: true,

--- a/server/paymentProviders/opencollective/index.js
+++ b/server/paymentProviders/opencollective/index.js
@@ -3,12 +3,14 @@
 import collective from './collective';
 import prepaid from './prepaid';
 import giftcard from './giftcard';
+import virtualcard from './virtualcard';
 
 /** Process orders from Open Collective payment method types */
 async function processOrder(order) {
   switch (order.paymentMethod.type) {
   case 'prepaid': return prepaid.processOrder(order);
   case 'giftcard': return giftcard.processOrder(order);
+  case 'virtualcard': return virtualcard.processOrder(order);
   case 'collective':        // Fall through
   default: return collective.processOrder(order);
   }
@@ -23,6 +25,7 @@ export default {
     collective,
     giftcard,
     prepaid,
+    virtualcard,
   },
   processOrder,
 };

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import uuidv4 from 'uuid/v4';
-import Promise from 'bluebird';
 import { get } from 'lodash';
 import models, { Op, sequelize } from '../../models';
 import * as libpayments from '../../lib/payments';

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -1,7 +1,10 @@
-import models from '../../models';
+import moment from 'moment';
+import uuidv4 from 'uuid/v4';
+import Promise from 'bluebird';
+import { get } from 'lodash';
+import models, { Op, sequelize } from '../../models';
 import * as libpayments from '../../lib/payments';
 import * as libtransactions from '../../lib/transactions';
-import { get } from 'lodash';
 
 /**
  * Virtual Card Payment method - This payment Method works basically as an alias
@@ -16,8 +19,8 @@ import { get } from 'lodash';
  * @return {Object} with amount & currency from the payment method.
  */
 async function getBalance(paymentMethod) {
-  if (!libpayments.isProvider('opencollective.virtual', paymentMethod)) {
-    throw new Error(`Expected opencollective.virtual but got ${paymentMethod.service}.${paymentMethod.type}`);
+  if (!libpayments.isProvider('opencollective.virtualcard', paymentMethod)) {
+    throw new Error(`Expected opencollective.virtualcard but got ${paymentMethod.service}.${paymentMethod.type}`);
   }
   /* Result will be negative (We're looking for DEBIT transactions) */
   const spent = await libtransactions.sum({
@@ -37,33 +40,142 @@ async function getBalance(paymentMethod) {
  * @return {models.Transaction} the double entry generated transactions.
  */
 async function processOrder(order) {
-  const user = order.createdByUser;
-  const { paymentMethod: { data } } = order;
-
+  const paymentMethod = await models.PaymentMethod.findById(order.paymentMethod.id);
   // check if payment Method has expired
-  if (!paymentMethod.expiryDate || paymentMethod.expiryDate < new Date())
+  if (!paymentMethod.expiryDate || moment(paymentMethod.expiryDate) < moment()) {
     throw new Error('Payment method has already expired');
-  // Making sure the SourcePaymentMethodId is Set(requirement for virtual cards)
-  if (!get(paymentMethod, 'SourcePaymentMethodId'))
-    throw new Error('Virtual Card payment method must have a value a "SourcePaymentMethodId" defined');
+  }
 
-  // finding Source Payment method and processing order
+  // Checking if balance is ok or will still be after completing the order
+  const balance = await getBalance(paymentMethod);
+  if (!balance || balance.amount <= 0) {
+    throw new Error('Virtual card has no balance to complete this order');
+  }
+  if ( (balance.amount - order.totalAmount) < 0 ) {
+    throw new Error(`Order amount exceeds balance(${balance.amount} ${paymentMethod.currency})`);
+  }
+
+  // Making sure the SourcePaymentMethodId is Set(requirement for virtual cards)
+  if (!get(paymentMethod, 'SourcePaymentMethodId')) {
+    throw new Error('Virtual Card payment method must have a value a "SourcePaymentMethodId" defined');
+  }
+  // finding Source Payment method and update order payment method properties
   const sourcePaymentMethod = await models.PaymentMethod.findById(paymentMethod.SourcePaymentMethodId);
-  const transactions = await sourcePaymentMethod.processOrder(order);
+  order.PaymentMethodId = sourcePaymentMethod.id;
+  order.paymentMethod = sourcePaymentMethod;
+  // finding the payment provider lib to execute the order
+  const sourcePaymentMethodProvider = libpayments.findPaymentMethodProvider(sourcePaymentMethod);
+
+  // gets the Credit transaction generated
+  const creditTransaction = await sourcePaymentMethodProvider.processOrder(order);
+  // gets the Debit transaction generated through the TransactionGroup field.
+  const debitTransaction = await models.Transaction.findOne({
+    where: {
+      type: 'DEBIT',
+      TransactionGroup: creditTransaction.TransactionGroup,
+    },
+  });
   // Updating already created transactions to use the Virtual Payment Method id instead
-  const updatedPaymentMethodTransactions = await Promise.map(fileNames, function(fileName) {
-      await transaction.update({ PaymentMethodId: order.paymentMethod.id });  
+  const updatedPaymentMethodTransactions =
+    await Promise.map([creditTransaction, debitTransaction], async (transaction) => {
+      await transaction.update({ PaymentMethodId: paymentMethod.id });
       return transaction;
   });
-  return updatedPaymentMethodTransactions;
+  return updatedPaymentMethodTransactions[0];
+}
+
+/** Create Virtual payment method through an organization
+ *
+ * @param {Object} args contains the parameters to create the new
+ *  payment method.
+ * @param {String} [args.description] The description of the new payment
+ *  method.
+ * @param {Number} args.CollectiveId The ID of the organization creating the virtual card.
+ * @param {Number} [args.PaymentMethodId] The ID of the Source Payment method the
+ *                 organization wants to use
+ * @param {Number} args.totalAmount The total amount that will be
+ *  credited to the newly created payment method.
+ * @param {Date} [args.expiryDate] The expiry date of the payment method
+ * @returns {models.PaymentMethod + code} return the virtual card payment method with
+            an extra property "code" that is basically the last 8 digits of the UUID
+ */
+async function create(args) {
+  const collective = await models.Collective.findById(args.CollectiveId);
+  const hostCollective = await models.Collective.findById(collective.HostCollectiveId);
+  const pmDescription = `${args.totalAmount} ${hostCollective.currency} Virtual card by ${collective.name}`;
+  let sourcePaymentMethodId = args.PaymentMethodId;
+  if (!args.PaymentMethodId) {
+    const sourcePaymentMethod = await models.PaymentMethod.findOne({
+      where: {
+        CollectiveId: collective.id,
+        service: 'stripe',
+        type: 'creditcard',
+      },
+    });
+    if (!sourcePaymentMethod) {
+      throw Error(`Collective id ${collective.id} needs to have a credit card to create virtual cards.`);
+    }
+    sourcePaymentMethodId = sourcePaymentMethod.id;
+  }
+  const expiryDate = args.expiryDate ? moment(args.expiryDate).format() : moment().add(3, 'months').format();
+  // creates a new Virtual card Payment method
+  const paymentMethod = await models.PaymentMethod.create({
+    name: args.description || pmDescription,
+    initialBalance: args.totalAmount,
+    currency: hostCollective.currency,
+    CollectiveId: args.CollectiveId,
+    expiryDate: expiryDate,
+    uuid: uuidv4(),
+    service: 'opencollective',
+    type: 'virtualcard',
+    SourcePaymentMethodId: sourcePaymentMethodId,
+    createdAt: new Date,
+    updatedAt: new Date,
+  });
+  // adding code to payment method
+  paymentMethod.code = paymentMethod.uuid.slice(-8);
+  return paymentMethod;
+}
+
+/** Claim the Virtual Card Payment Method By an (existing or not) user
+ * @param {Object} args contains the parameters
+ * @param {String} args.code The 8 last digits of the UUID
+ * @param {email} args.email The email of the user claiming the virtual card
+ * @returns {models.PaymentMethod} return the virtual card payment method.
+ */
+export async function claim(args) {
+  // validate code
+  const virtualCardPaymentMethod = await models.PaymentMethod.findOne({
+    where: sequelize.and(
+        sequelize.where(sequelize.cast(sequelize.col('uuid'), 'text'), { [Op.like]: `%${args.code}` }),
+        { service: 'opencollective' },
+        { type: 'virtualcard' },
+      ),
+  });
+  if (!virtualCardPaymentMethod) {
+    throw Error(`Code "${args.code}" invalid: No virtual card Found`);
+  }
+  const sourcePaymentMethod = await models.PaymentMethod.findById(virtualCardPaymentMethod.SourcePaymentMethodId);
+  // if the virtual card PM Collective Id is different than the Source PM Collective Id
+  // it means this virtual card was already claimend
+  if (!sourcePaymentMethod || sourcePaymentMethod.CollectiveId !== virtualCardPaymentMethod.CollectiveId) {
+    throw Error('Virtual card not available to be claimed.');
+  }
+  // find or creating a user with its collective
+  const user = await models.User.findOrCreateByEmail(args.email);
+  // updating virtual card with collective Id of the user
+  await virtualCardPaymentMethod.update({ CollectiveId: user.CollectiveId });
+  return virtualCardPaymentMethod;
 }
 
 /* Expected API of a Payment Method Type */
 export default {
   features: {
     recurring: true,
-    waitToCharge: false
+    waitToCharge: false,
   },
   getBalance,
   processOrder,
+  create,
+  claim,
 };

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -1,0 +1,69 @@
+import models from '../../models';
+import * as libpayments from '../../lib/payments';
+import * as libtransactions from '../../lib/transactions';
+import { get } from 'lodash';
+
+/**
+ * Virtual Card Payment method - This payment Method works basically as an alias
+ * to other Payment method(field "SourcePaymentMethodId") that will create transactions
+ * and then the payment methods of those transactions will be replaced by
+ * the virtual card payment method that first processed the order.
+*/
+
+/** Get the balance of a virtual card card
+ * @param {models.PaymentMethod} paymentMethod is the instance of the
+ *  virtual card payment method.
+ * @return {Object} with amount & currency from the payment method.
+ */
+async function getBalance(paymentMethod) {
+  if (!libpayments.isProvider('opencollective.virtual', paymentMethod)) {
+    throw new Error(`Expected opencollective.virtual but got ${paymentMethod.service}.${paymentMethod.type}`);
+  }
+  /* Result will be negative (We're looking for DEBIT transactions) */
+  const spent = await libtransactions.sum({
+    PaymentMethodId: paymentMethod.id,
+    currency: paymentMethod.currency,
+    type: 'DEBIT',
+  });
+  return {
+    amount: paymentMethod.initialBalance + spent,
+    currency: paymentMethod.currency,
+  };
+}
+
+/** Process a virtual card order
+ *
+ * @param {models.Order} order The order instance to be processed.
+ * @return {models.Transaction} the double entry generated transactions.
+ */
+async function processOrder(order) {
+  const user = order.createdByUser;
+  const { paymentMethod: { data } } = order;
+
+  // check if payment Method has expired
+  if (!paymentMethod.expiryDate || paymentMethod.expiryDate < new Date())
+    throw new Error('Payment method has already expired');
+  // Making sure the SourcePaymentMethodId is Set(requirement for virtual cards)
+  if (!get(paymentMethod, 'SourcePaymentMethodId'))
+    throw new Error('Virtual Card payment method must have a value a "SourcePaymentMethodId" defined');
+
+  // finding Source Payment method and processing order
+  const sourcePaymentMethod = await models.PaymentMethod.findById(paymentMethod.SourcePaymentMethodId);
+  const transactions = await sourcePaymentMethod.processOrder(order);
+  // Updating already created transactions to use the Virtual Payment Method id instead
+  const updatedPaymentMethodTransactions = await Promise.map(fileNames, function(fileName) {
+      await transaction.update({ PaymentMethodId: order.paymentMethod.id });  
+      return transaction;
+  });
+  return updatedPaymentMethodTransactions;
+}
+
+/* Expected API of a Payment Method Type */
+export default {
+  features: {
+    recurring: true,
+    waitToCharge: false
+  },
+  getBalance,
+  processOrder,
+};

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -143,7 +143,7 @@ async function create(args) {
  * @param {email} args.email The email of the user claiming the virtual card
  * @returns {models.PaymentMethod} return the virtual card payment method.
  */
-export async function claim(args) {
+async function claim(args) {
   // validate code
   const virtualCardPaymentMethod = await models.PaymentMethod.findOne({
     where: sequelize.and(

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -89,6 +89,7 @@ async function processOrder(order) {
  *                 organization wants to use
  * @param {Number} args.amount The total amount that will be
  *  credited to the newly created payment method.
+ * @param {String} args.currency The currency of the card to be created.
  * @param {Date} [args.expiryDate] The expiry date of the payment method
  * @returns {models.PaymentMethod + code} return the virtual card payment method with
             an extra property "code" that is basically the last 8 digits of the UUID
@@ -108,17 +109,13 @@ async function create(args) {
     SourcePaymentMethodId = sourcePaymentMethod.id;
   }
   const expiryDate = args.expiryDate ? moment(args.expiryDate).format() : moment().add(3, 'months').format();
-  // validating and formatting currency of payment method(or collective if PM has no currency defined)
-  let formattedCurrency = get(collective, 'currency') ? formatCurrency(args.amount, collective.currency) : args.amount;
-  if (get(sourcePaymentMethod, 'currency')) {
-    formattedCurrency = formatCurrency(args.amount, sourcePaymentMethod.currency);
-  }
-  const pmDescription = `${formattedCurrency} card from ${collective.name}`;
+  
+  const pmDescription = `${formatCurrency(args.amount, args.currency)} card from ${collective.name}`;
   // creates a new Virtual card Payment method
   const paymentMethod = await models.PaymentMethod.create({
     name: args.description || pmDescription,
     initialBalance: args.amount,
-    currency: sourcePaymentMethod.currency ? sourcePaymentMethod.currency : collective.currency,
+    currency: args.currency,
     CollectiveId: args.CollectiveId,
     expiryDate: expiryDate,
     uuid: uuidv4(),

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -109,10 +109,11 @@ async function create(args) {
   }
   const expiryDate = args.expiryDate ? moment(args.expiryDate).format() : moment().add(3, 'months').format();
   // validating and formatting currency of payment method(or collective if PM has no currency defined)
-  const formattedCurrency = get(sourcePaymentMethod, 'currency') ? formatCurrency(args.amount, sourcePaymentMethod.currency) :
-    (get(collective, 'currency') ? formatCurrency(args.amount, collective.currency) : args.amount);
-
-  const pmDescription = `${formattedCurrency} ${sourcePaymentMethod.currency} card from ${collective.name}`;
+  let formattedCurrency = get(collective, 'currency') ? formatCurrency(args.amount, collective.currency) : args.amount;
+  if (get(sourcePaymentMethod, 'currency')) {
+    formattedCurrency = formatCurrency(args.amount, sourcePaymentMethod.currency);
+  }
+  const pmDescription = `${formattedCurrency} card from ${collective.name}`;
   // creates a new Virtual card Payment method
   const paymentMethod = await models.PaymentMethod.create({
     name: args.description || pmDescription,

--- a/server/routes.js
+++ b/server/routes.js
@@ -11,7 +11,7 @@ import getHomePage from './controllers/homepage';
 import uploadImage from './controllers/images';
 import * as mw from './controllers/middlewares';
 import * as notifications from './controllers/notifications';
-import {getPaymentMethods, createVirtualCard} from './controllers/paymentMethods';
+import {getPaymentMethods, createPaymentMethod} from './controllers/paymentMethods';
 import * as test from './controllers/test';
 import * as users from './controllers/users';
 import * as applications from './controllers/applications';
@@ -158,7 +158,7 @@ export default (app) => {
   *
   *  Let's assume for now a paymentMethod is linked to a user.
   */
-  app.post('/payment-methods/virtual-cards', createVirtualCard); // Creates a payment method.
+  app.post('/payment-methods', createPaymentMethod); // Creates a payment method.
 
   /**
    * Collectives.

--- a/server/routes.js
+++ b/server/routes.js
@@ -158,7 +158,7 @@ export default (app) => {
   *
   *  Let's assume for now a paymentMethod is linked to a user.
   */
-  app.post('/payment-methods', createPaymentMethod); // Creates a payment method.
+  app.post('/v1/payment-methods', createPaymentMethod); // Creates a payment method.
 
   /**
    * Collectives.

--- a/server/routes.js
+++ b/server/routes.js
@@ -11,7 +11,7 @@ import getHomePage from './controllers/homepage';
 import uploadImage from './controllers/images';
 import * as mw from './controllers/middlewares';
 import * as notifications from './controllers/notifications';
-import getPaymentMethods from './controllers/paymentMethods';
+import {getPaymentMethods, createVirtualCard} from './controllers/paymentMethods';
 import * as test from './controllers/test';
 import * as users from './controllers/users';
 import * as applications from './controllers/applications';
@@ -152,6 +152,13 @@ export default (app) => {
   app.post('/users/:userid/payment-methods', NotImplemented); // Create a user's paymentMethod.
   app.put('/users/:userid/payment-methods/:paymentMethodid', NotImplemented); // Update a user's paymentMethod.
   app.delete('/users/:userid/payment-methods/:paymentMethodid', NotImplemented); // Delete a user's paymentMethod.
+
+  /**
+  * Credit paymentMethod.
+  *
+  *  Let's assume for now a paymentMethod is linked to a user.
+  */
+  app.post('/payment-methods/virtual-cards', createVirtualCard); // Creates a payment method.
 
   /**
    * Collectives.

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -1,0 +1,564 @@
+// Test tools
+import app from '../server/index';
+import sinon from 'sinon';
+import moment from 'moment';
+import request from 'supertest-as-promised';
+import { expect } from 'chai';
+import * as utils from './utils';
+import models from '../server/models';
+import virtualcard from '../server/paymentProviders/opencollective/virtualcard';
+import * as store from './features/support/stores';
+
+const ORDER_TOTAL_AMOUNT = 5000;
+const STRIPE_FEE_STUBBED_VALUE = 300;
+
+const createVirtualCardQuery = `
+  mutation createVirtualPaymentMethod($totalAmount: Int!, $CollectiveId: Int!, $PaymentMethodId: Int, $description: String, $expiryDate: String) {
+    createVirtualPaymentMethod(totalAmount: $totalAmount, CollectiveId: $CollectiveId, PaymentMethodId: $PaymentMethodId, description: $description, expiryDate: $expiryDate) {
+      id
+    }
+  }
+`;
+const claimVirtualCardQuery = `
+  mutation claimVirtualCard($email: String!, $code: String!) {
+    claimVirtualCard(email: $email, code: $code) {
+      id
+    }
+  }
+`;
+const createOrderQuery = `
+  mutation createOrder($order: OrderInputType!) {
+    createOrder(order: $order) {
+      id
+      fromCollective {
+        id
+        slug
+      }
+      collective {
+        id
+        slug
+      }
+      subscription {
+        id
+        amount
+        interval
+        isActive
+        stripeSubscriptionId
+      }
+      totalAmount
+      currency
+      description
+    }
+  }
+`;
+
+describe('opencollective.virtualcard', () => {
+
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    // And given that the endpoint for creating customers on Stripe
+    // is patched
+    utils.stubStripeCreate(sandbox, { charge: { currency: 'usd', status: 'succeeded' } });
+    // And given the stripe stuff that depends on values in the
+    // order struct is patch. It's here and not on each test because
+    // the `totalAmount' field doesn't change throught the tests.
+    utils.stubStripeBalance(sandbox, ORDER_TOTAL_AMOUNT, 'usd',
+                            0,
+                            STRIPE_FEE_STUBBED_VALUE); // This is the payment processor fee.
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('paymentProviders.opencollective.virtualcard', () => {
+
+    describe('#create', async () => {
+      let host1, collective1, user1;
+
+      before(() => utils.resetTestDB());
+      before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => host1 = c));
+      before('create collective1(currency USD, hostCurrency:USD)', () => models.Collective.create({ name: 'collective1', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective1 = c));
+      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => user1 = u));
+      before('user1 to become Admin of collective1', () => models.Member.create({
+        CreatedByUserId: user1.id,
+        MemberCollectiveId: user1.CollectiveId,
+        CollectiveId: collective1.id,
+        role: 'ADMIN',
+      }));
+      before('create a payment method', () => models.PaymentMethod.create({
+        name: '4242',
+        service: 'stripe',
+        type: 'creditcard',
+        token: 'tok_123456781234567812345678',
+        CollectiveId: collective1.id,
+        monthlyLimitPerMember: 10000,
+      }));
+
+      it('should create a U$100 virtual card payment method', async () => {
+        const args = {
+          description: 'virtual card test',
+          CollectiveId: collective1.id,
+          totalAmount: 10000,
+        };
+        const paymentMethod = await virtualcard.create(args);
+        expect(paymentMethod).to.exist;
+        expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);
+        expect(paymentMethod.initialBalance).to.be.equal(args.totalAmount);
+        expect(paymentMethod.service).to.be.equal('opencollective');
+        expect(paymentMethod.type).to.be.equal('virtualcard');
+        expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD'))
+              .to.be.equal(moment().add(3, 'months').format('YYYY-MM-DD'));
+      });
+
+    }); /** End Of "#create" */
+
+    describe('#claim', async () => {
+      let host1, collective1, paymentMethod1, virtualCardPaymentMethod;
+
+      before(() => utils.resetTestDB());
+      before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => host1 = c));
+      before('create collective1(currency USD, hostCurrency:USD)', () => models.Collective.create({ name: 'collective1', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective1 = c));
+
+      before('create a credit card payment method', () => models.PaymentMethod.create({
+        name: '4242',
+        service: 'stripe',
+        type: 'creditcard',
+        token: 'tok_123456781234567812345678',
+        CollectiveId: collective1.id,
+        monthlyLimitPerMember: 10000,
+      }).then(pm => paymentMethod1 = pm));
+
+      before('create a virtual card payment method', () => virtualcard.create({
+        description: 'virtual card test',
+        CollectiveId: collective1.id,
+        totalAmount: 10000,
+      }).then(pm => virtualCardPaymentMethod = pm));
+
+      it('new User should claim a virtual card', async () => {
+        // setting correct code to claim virtual card by new User
+        const virtualCardCode = virtualCardPaymentMethod.uuid.slice(-8);
+        const args = {
+          email: 'new@user.com',
+          code: virtualCardCode,
+        };
+        // claim virtual
+        const paymentMethod = await virtualcard.claim(args);
+        // payment method should exist
+        expect(paymentMethod).to.exist;
+        // then paymentMethod SourcePaymentMethodId should be paymentMethod1.id(the PM of the organization collective1)
+        expect(paymentMethod.SourcePaymentMethodId).to.be.equal(paymentMethod1.id);
+        // and collective id of "original" virtual card should be different than the one returned
+        expect(virtualCardPaymentMethod.CollectiveId).not.to.be.equal(paymentMethod.CollectiveId);
+        // then find collective of created user
+        const userCollective = await models.Collective.findById(paymentMethod.CollectiveId);
+        // then find the user
+        const user = await models.User.findOne({
+          where: {
+            CollectiveId: userCollective.id,
+          },
+        });
+        // then check if the user email matches the email on the argument used on the claim
+        expect(user.email).to.be.equal(args.email);
+        // then check if both have the same uuid
+        expect(paymentMethod.uuid).not.to.be.equal(virtualCardPaymentMethod.id);
+        // and check if both have the same expiry
+        expect(moment(paymentMethod.expiryDate).format()).to.be
+          .equal(moment(virtualCardPaymentMethod.expiryDate).format());
+      });
+
+    }); /** End Of "#claim" */
+
+    describe('#processOrder', async () => {
+      let host1, collective1, collective2, paymentMethod1, virtualCardPaymentMethod, user, userCollective;
+
+      before(() => utils.resetTestDB());
+      before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => {
+        host1 = c;
+        // Create stripe connected account to host
+        return store.stripeConnectedAccount(host1.id);
+      }));
+
+      before('create collective1', () => models.Collective.create({ name: 'collective1', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective1 = c));
+      before('create collective2', () => models.Collective.create({ name: 'collective2', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective2 = c));
+      before('create a credit card payment method', () => models.PaymentMethod.create({
+        name: '4242',
+        service: 'stripe',
+        type: 'creditcard',
+        token: 'tok_123456781234567812345678',
+        CollectiveId: collective1.id,
+        monthlyLimitPerMember: 10000,
+      }).then(pm => paymentMethod1 = pm));
+
+      before('create a virtual card payment method', () => virtualcard.create({
+        description: 'virtual card test',
+        CollectiveId: collective1.id,
+        totalAmount: 10000,
+      }).then(pm => virtualCardPaymentMethod = pm));
+
+      before('new user claims a virtual card', () => virtualcard.claim({
+        email: 'new@user.com',
+        code: virtualCardPaymentMethod.uuid.slice(-8),
+      }).then(async (pm) => {
+        virtualCardPaymentMethod = await models.PaymentMethod.findById(pm.id);
+        userCollective = await models.Collective.findById(virtualCardPaymentMethod.CollectiveId);
+        user = await models.User.findOne({
+          where: {
+            CollectiveId: userCollective.id,
+          },
+        });
+      }));
+
+      it('Order should NOT be executed because its amount exceeds the balance of the virtual card', async () => {
+        expect(virtualCardPaymentMethod.SourcePaymentMethodId).to.be.equal(paymentMethod1.id);
+        const order = await models.Order.create({
+          CreatedByUserId: user.id,
+          FromCollectiveId: userCollective.id,
+          CollectiveId: collective2.id,
+          PaymentMethodId: virtualCardPaymentMethod.id,
+          totalAmount: 10000000,
+          currency: 'USD',
+        });
+        order.fromCollective = userCollective;
+        order.collective = collective2;
+        order.createdByUser = user;
+        order.paymentMethod = virtualCardPaymentMethod;
+
+        try {
+          await virtualcard.processOrder(order);
+          throw Error('Process should not be executed...');
+        } catch (error) {
+          expect(error).to.exist;
+          expect(error.toString()).to.contain('Order amount exceeds balance');
+        }
+      });
+
+      it('Process order of a virtual card', async () => {
+        const order = await models.Order.create({
+          CreatedByUserId: user.id,
+          FromCollectiveId: userCollective.id,
+          CollectiveId: collective2.id,
+          PaymentMethodId: virtualCardPaymentMethod.id,
+          totalAmount: ORDER_TOTAL_AMOUNT,
+          currency: 'USD',
+        });
+        order.fromCollective = userCollective;
+        order.collective = collective2;
+        order.createdByUser = user;
+        order.paymentMethod = virtualCardPaymentMethod;
+
+        // checking if transaction generated(CREDIT) matches the correct payment method
+        // amount, currency and collectives...
+        const creditTransaction = await virtualcard.processOrder(order);
+        expect(creditTransaction.type).to.be.equal('CREDIT');
+        expect(creditTransaction.PaymentMethodId).to.be.equal(virtualCardPaymentMethod.id);
+        expect(creditTransaction.FromCollectiveId).to.be.equal(userCollective.id);
+        expect(creditTransaction.CollectiveId).to.be.equal(collective2.id);
+        expect(creditTransaction.amount).to.be.equal(ORDER_TOTAL_AMOUNT);
+        expect(creditTransaction.amountInHostCurrency).to.be.equal(ORDER_TOTAL_AMOUNT);
+        expect(creditTransaction.currency).to.be.equal('USD');
+        expect(creditTransaction.hostCurrency).to.be.equal('USD');
+        // checking balance of virtual card(should be initial balance - order amount)
+        const virtualCardCurrentBalance = await virtualcard.getBalance(virtualCardPaymentMethod);
+        expect(virtualCardCurrentBalance.amount).to.be.equal(virtualCardPaymentMethod.initialBalance - ORDER_TOTAL_AMOUNT);
+      });
+    }); /** End Of "#processOrder" */
+  }); /** End Of "paymentProviders.opencollective.virtualcard" */
+
+  describe('graphql.mutations.paymentMethods.virtualcard', () => {
+
+    describe('#create', async () => {
+      let host1, collective1, user1;
+
+      before(() => utils.resetTestDB());
+      before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => host1 = c));
+      before('create collective1(currency USD, hostCurrency:USD)', () => models.Collective.create({ name: 'collective1', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective1 = c));
+      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => user1 = u));
+      before('user1 to become Admin of collective1', () => models.Member.create({
+        CreatedByUserId: user1.id,
+        MemberCollectiveId: user1.CollectiveId,
+        CollectiveId: collective1.id,
+        role: 'ADMIN',
+      }));
+
+      before('create a payment method', () => models.PaymentMethod.create({
+        name: '4242',
+        service: 'stripe',
+        type: 'creditcard',
+        token: 'tok_123456781234567812345678',
+        CollectiveId: collective1.id,
+        monthlyLimitPerMember: 10000,
+      }));
+
+      it('should create a U$100 virtual card payment method', async () => {
+        const args = {
+          description: 'virtual card test',
+          CollectiveId: collective1.id,
+          totalAmount: 10000,
+        };
+        // call graphql mutation
+        const gqlResult = await utils.graphqlQuery(createVirtualCardQuery, args, user1);
+
+        gqlResult.errors && console.error(gqlResult.errors[0]);
+        expect(gqlResult.errors).to.be.empty;
+
+        const paymentMethod = await models.PaymentMethod.findById(gqlResult.data.createVirtualPaymentMethod.id);
+        expect(paymentMethod).to.exist;
+        expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);
+        expect(paymentMethod.initialBalance).to.be.equal(args.totalAmount);
+        expect(paymentMethod.service).to.be.equal('opencollective');
+        expect(paymentMethod.type).to.be.equal('virtualcard');
+        expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD'))
+              .to.be.equal(moment().add(3, 'months').format('YYYY-MM-DD'));
+      });
+
+    }); /** End Of "#create" */
+
+    describe('#claim', async () => {
+      let host1, collective1, paymentMethod1, virtualCardPaymentMethod;
+
+      before(() => utils.resetTestDB());
+      before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => host1 = c));
+      before('create collective1(currency USD, hostCurrency:USD)', () => models.Collective.create({ name: 'collective1', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective1 = c));
+
+      before('create a credit card payment method', () => models.PaymentMethod.create({
+        name: '4242',
+        service: 'stripe',
+        type: 'creditcard',
+        token: 'tok_123456781234567812345678',
+        CollectiveId: collective1.id,
+        monthlyLimitPerMember: 10000,
+      }).then(pm => paymentMethod1 = pm));
+
+      before('create a virtual card payment method', () => virtualcard.create({
+        description: 'virtual card test',
+        CollectiveId: collective1.id,
+        totalAmount: 10000,
+      }).then(pm => virtualCardPaymentMethod = pm));
+
+      it('new User should claim a virtual card', async () => {
+        // setting correct code to claim virtual card by new User
+        const virtualCardCode = virtualCardPaymentMethod.uuid.slice(-8);
+        const args = {
+          email: 'new@user.com',
+          code: virtualCardCode,
+        };
+        // claim virtual card
+        // call graphql mutation
+        const gqlResult = await utils.graphqlQuery(claimVirtualCardQuery, args);
+
+        gqlResult.errors && console.error(gqlResult.errors[0]);
+        expect(gqlResult.errors).to.be.empty;
+
+        const paymentMethod = await models.PaymentMethod.findById(gqlResult.data.claimVirtualCard.id);
+        // payment method should exist
+        expect(paymentMethod).to.exist;
+        // then paymentMethod SourcePaymentMethodId should be paymentMethod1.id(the PM of the organization collective1)
+        expect(paymentMethod.SourcePaymentMethodId).to.be.equal(paymentMethod1.id);
+        // and collective id of "original" virtual card should be different than the one returned
+        expect(virtualCardPaymentMethod.CollectiveId).not.to.be.equal(paymentMethod.CollectiveId);
+        // then find collective of created user
+        const userCollective = await models.Collective.findById(paymentMethod.CollectiveId);
+        // then find the user
+        const user = await models.User.findOne({
+          where: {
+            CollectiveId: userCollective.id,
+          },
+        });
+        // then check if the user email matches the email on the argument used on the claim
+        expect(user.email).to.be.equal(args.email);
+        // then check if both have the same uuid
+        expect(paymentMethod.uuid).not.to.be.equal(virtualCardPaymentMethod.id);
+        // and check if both have the same expiry
+        expect(moment(paymentMethod.expiryDate).format()).to.be
+          .equal(moment(virtualCardPaymentMethod.expiryDate).format());
+      });
+
+    }); /** End Of "#claim" */
+
+    describe('#processOrder', async () => {
+      let host1, collective1, collective2, virtualCardPaymentMethod, user1, userVirtualCard, userVirtualCardCollective;
+
+      before(() => utils.resetTestDB());
+      before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => {
+        host1 = c;
+        // Create stripe connected account to host
+        return store.stripeConnectedAccount(host1.id);
+      }));
+      before('create collective1', () => models.Collective.create({ name: 'collective1', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective1 = c));
+      before('create collective2', () => models.Collective.create({ name: 'collective2', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective2 = c));
+      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => user1 = u));
+      before('user1 to become Admin of collective1', () => models.Member.create({
+        CreatedByUserId: user1.id,
+        MemberCollectiveId: user1.CollectiveId,
+        CollectiveId: collective1.id,
+        role: 'ADMIN',
+      }));
+      before('create a credit card payment method', () => models.PaymentMethod.create({
+        name: '4242',
+        service: 'stripe',
+        type: 'creditcard',
+        token: 'tok_123456781234567812345678',
+        CollectiveId: collective1.id,
+        monthlyLimitPerMember: 10000,
+      }));
+
+      before('create a virtual card payment method', () => virtualcard.create({
+        description: 'virtual card test',
+        CollectiveId: collective1.id,
+        totalAmount: 10000,
+      }).then(pm => virtualCardPaymentMethod = pm));
+
+      before('new user claims a virtual card', () => virtualcard.claim({
+        email: 'new@user.com',
+        code: virtualCardPaymentMethod.uuid.slice(-8),
+      }).then(async (pm) => {
+        virtualCardPaymentMethod = await models.PaymentMethod.findById(pm.id);
+        userVirtualCardCollective = await models.Collective.findById(virtualCardPaymentMethod.CollectiveId);
+        userVirtualCard = await models.User.findOne({
+          where: {
+            CollectiveId: userVirtualCardCollective.id,
+          },
+        });
+      }));
+
+      it('Order should NOT be executed because its amount exceeds the balance of the virtual card', async () => {
+        // Setting up order
+        const order = {
+          fromCollective: { id: userVirtualCard.CollectiveId },
+          collective: { id: collective2.id },
+          paymentMethod: { uuid: virtualCardPaymentMethod.uuid },
+          totalAmount: 1000000,
+        };
+        // Executing queries
+        const gqlResult = await utils.graphqlQuery(createOrderQuery, { order }, userVirtualCard);
+        expect(gqlResult.errors).to.not.be.empty;
+        expect(gqlResult.errors[0]).to.exist;
+        expect(gqlResult.errors[0].toString()).to.contain('You don\'t have enough funds available');
+
+      }); /** End Of "Order should NOT be executed because its amount exceeds the balance of the virtual card" */
+
+      it('Process order of a virtual card', async () => {
+        // Setting up order
+        const order = {
+          fromCollective: { id: userVirtualCard.CollectiveId },
+          collective: { id: collective2.id },
+          paymentMethod: { uuid: virtualCardPaymentMethod.uuid },
+          totalAmount: ORDER_TOTAL_AMOUNT,
+        };
+        // Executing queries
+        const gqlResult = await utils.graphqlQuery(createOrderQuery, { order }, userVirtualCard);
+
+        gqlResult.errors && console.error(gqlResult.errors[0]);
+        expect(gqlResult.errors).to.be.empty;
+        const transactions = await models.Transaction.findAll({
+          where: {
+            OrderId: gqlResult.data.createOrder.id,
+          },
+          order: [
+            ['id', 'DESC'],
+          ],
+          limit: 2,
+        });
+        // checking if transaction generated(CREDIT) matches the correct payment method
+        // amount, currency and collectives...
+        const creditTransaction = transactions[0];
+        expect(creditTransaction.type).to.be.equal('CREDIT');
+        expect(creditTransaction.PaymentMethodId).to.be.equal(virtualCardPaymentMethod.id);
+        expect(creditTransaction.FromCollectiveId).to.be.equal(userVirtualCard.CollectiveId);
+        expect(creditTransaction.CollectiveId).to.be.equal(collective2.id);
+        expect(creditTransaction.amount).to.be.equal(ORDER_TOTAL_AMOUNT);
+        expect(creditTransaction.amountInHostCurrency).to.be.equal(ORDER_TOTAL_AMOUNT);
+        expect(creditTransaction.currency).to.be.equal('USD');
+        expect(creditTransaction.hostCurrency).to.be.equal('USD');
+        // checking balance of virtual card(should be initial balance - order amount)
+        const virtualCardCurrentBalance = await virtualcard.getBalance(virtualCardPaymentMethod);
+        expect(virtualCardCurrentBalance.amount).to.be.equal(virtualCardPaymentMethod.initialBalance - ORDER_TOTAL_AMOUNT);
+      }); /** End Of "Process order of a virtual card" */
+
+      it('should fail when multiple orders exceed the balance of the virtual card', async () => {
+        // Setting up order
+        const order = {
+          fromCollective: { id: userVirtualCard.CollectiveId },
+          collective: { id: collective2.id },
+          paymentMethod: { uuid: virtualCardPaymentMethod.uuid },
+          totalAmount: ORDER_TOTAL_AMOUNT,
+        };
+        // Executing queries that overstep virtual card balance
+        await utils.graphqlQuery(createOrderQuery, { order }, userVirtualCard);
+        await utils.graphqlQuery(createOrderQuery, { order }, userVirtualCard);
+        const gqlResult = await utils.graphqlQuery(createOrderQuery, { order }, userVirtualCard);
+
+        expect(gqlResult.errors).to.not.be.empty;
+        expect(gqlResult.errors[0]).to.exist;
+        expect(gqlResult.errors[0].toString()).to.contain('You don\'t have enough funds available');
+      }); /** End Of "should fail when multiple orders exceed the balance of the virtual card" */
+
+    }); /** End Of "#processOrder" */
+
+  }); /** End Of "graphql.mutations.paymentMethods.virtualcard" */
+
+  describe('routes.paymentMethods.virtualcard', () => {
+
+    describe('POST /payment-methods/virtual-cards to Create a virtual card', async () => {
+      let host1, collective1, user1;
+
+      before(() => utils.resetTestDB());
+      before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => host1 = c));
+      before('create collective1(currency USD, hostCurrency:USD)', () => models.Collective.create({ name: 'collective1', currency: 'USD', HostCollectiveId: host1.id, isActive: true }).then(c => collective1 = c));
+      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => user1 = u));
+      before('user1 to become Admin of collective1', () => models.Member.create({
+        CreatedByUserId: user1.id,
+        MemberCollectiveId: user1.CollectiveId,
+        CollectiveId: collective1.id,
+        role: 'ADMIN',
+      }));
+
+      before('create a payment method', () => models.PaymentMethod.create({
+        name: '4242',
+        service: 'stripe',
+        type: 'creditcard',
+        token: 'tok_123456781234567812345678',
+        CollectiveId: collective1.id,
+        monthlyLimitPerMember: 10000,
+      }));
+
+      it('should Get 401 because there is no user authenticated', () => {
+        const args = {
+          description: 'virtual card test',
+          CollectiveId: collective1.id,
+          totalAmount: 10000,
+        };
+        return request(app)
+        .post('/payment-methods/virtual-cards')
+        .send(args)
+        .expect(401);
+      });
+
+      it('should create a U$100 virtual card payment method', () => {
+        const args = {
+          description: 'virtual card test',
+          CollectiveId: collective1.id,
+          totalAmount: 10000,
+        };
+        return request(app)
+        .post('/payment-methods/virtual-cards')
+        .set('Authorization', `Bearer ${user1.jwt()}`)
+        // .set('Client-Id', `Bearer ${user1.jwt()}`)
+        .send(args)
+        .expect(200)
+        .toPromise()
+        .then(res => {
+          expect(res.body).to.exist;
+          const paymentMethod = res.body;
+          expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);
+          expect(paymentMethod.balance).to.be.equal(args.totalAmount);
+        });
+      });
+
+    }); /** End Of "#create" */
+
+  }); /** End Of "routes.paymentMethods.virtualcard" */
+
+});
+

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -521,7 +521,7 @@ describe('opencollective.virtualcard', () => {
       let host1, collective1, user1, appKeyData;
 
       before(() => utils.resetTestDB());
-      before('create Host 1(USD)', () => models.Application.create({}).then(key => appKeyData = key));
+      before('generating API KEY)', () => models.Application.create({}).then(key => appKeyData = key));
       before('create Host 1(USD)', () => models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true }).then(c => host1 = c));
       before('create collective1(currency USD, No Host)', () => models.Collective.create({ name: 'collective1', currency: 'USD', isActive: true }).then(c => collective1 = c));
       before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => user1 = u));
@@ -588,6 +588,7 @@ describe('opencollective.virtualcard', () => {
         .expect(200)
         .toPromise()
         .then(res => {
+          console.log(`res: ${res}`);
           expect(res.body).to.exist;
           const paymentMethod = res.body;
           expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -530,7 +530,7 @@ describe('opencollective.virtualcard', () => {
           amount: 10000,
         };
         return request(app)
-        .post('/payment-methods')
+        .post('/v1/payment-methods')
         .send(args)
         .expect(400);
       });
@@ -541,7 +541,7 @@ describe('opencollective.virtualcard', () => {
           amount: 10000,
         };
         return request(app)
-        .post('/payment-methods')
+        .post('/v1/payment-methods')
         .set('Authorization', `Bearer ${user1.jwt()}`)
         .set('Client-Id', appKeyData.clientId)
         .send(args)

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -9,8 +9,6 @@ import models from '../server/models';
 import virtualcard from '../server/paymentProviders/opencollective/virtualcard';
 import * as store from './features/support/stores';
 
-const application = utils.data('application');
-
 const ORDER_TOTAL_AMOUNT = 5000;
 const STRIPE_FEE_STUBBED_VALUE = 300;
 
@@ -532,18 +530,18 @@ describe('opencollective.virtualcard', () => {
           amount: 10000,
         };
         return request(app)
-        .post(`/payment-methods`)
+        .post('/payment-methods')
         .send(args)
         .expect(400);
       });
 
-      it.only('should create a U$100 virtual card payment method', () => {
+      it('should create a U$100 virtual card payment method', () => {
         const args = {
           CollectiveId: collective1.id,
           amount: 10000,
         };
         return request(app)
-        .post(`/payment-methods`)
+        .post('/payment-methods')
         .set('Authorization', `Bearer ${user1.jwt()}`)
         .set('Client-Id', appKeyData.clientId)
         .send(args)

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -9,6 +9,8 @@ import models from '../server/models';
 import virtualcard from '../server/paymentProviders/opencollective/virtualcard';
 import * as store from './features/support/stores';
 
+const application = utils.data('application');
+
 const ORDER_TOTAL_AMOUNT = 5000;
 const STRIPE_FEE_STUBBED_VALUE = 300;
 
@@ -530,7 +532,7 @@ describe('opencollective.virtualcard', () => {
           totalAmount: 10000,
         };
         return request(app)
-        .post('/payment-methods/virtual-cards')
+        .post(`/payment-methods/virtual-cards?api_key=${application.api_key}`)
         .send(args)
         .expect(401);
       });
@@ -542,7 +544,7 @@ describe('opencollective.virtualcard', () => {
           totalAmount: 10000,
         };
         return request(app)
-        .post('/payment-methods/virtual-cards')
+        .post(`/payment-methods/virtual-cards?api_key=${application.api_key}`)
         .set('Authorization', `Bearer ${user1.jwt()}`)
         // .set('Client-Id', `Bearer ${user1.jwt()}`)
         .send(args)


### PR DESCRIPTION
Adding a new type of payment methods: virtual cards.

It's important to be consistent as much as possible throughout our code base and API.
To that goal, here is a first proposal for the create a new virtual card api endpoint:

```sh
curl "https://api.opencollective.com/v1/payment-methods" \
  -H "Content-Type: application/json"\
  -H "Authorization: Bearer ${token}" \
  -H "Client-Id: ${clientId}"

```

POST Parameters:

- `CollectiveId`: id of the User or Organization
- `type`: "virtualcard" (This is optional as it defaults to `virtualcard`)
- `amount`: amount in cents

Example:

Create a $100 virtual card for CollectiveId 13223:

```sh
curl "https://api.opencollective.com/v1/payment-methods" \
  -H "Content-Type: application/json"\
  -H "Authorization: Bearer ${token}" \
  -H "Client-Id: ${clientId}"\
  --data '{"amount": 10000, "CollectiveId": "XXXXXX"}'
```

This returns a JSON:

```json
{
  "id": 912838,
  "CollectiveId": 327865,
  "code": "c7194e16fb07",
  "balance": 10000,
  "expiryDate": "2014-09-08T08:02:17-05:00",
  "currency": "USD",
  "redeemUrl": "https://opencollective.com/redeem?code=c7194e16fb07"
}
```

fixes opencollective/opencollective#1272
fixes opencollective/opencollective#1293