### PR TITLE
Allow for manual donations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2303,7 +2303,7 @@
     },
     "@types/debug": {
       "version": "0.0.29",
-      "resolved": "http://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
       "integrity": "sha1-oeUUrfvZLwOiJLpU1pMRHb8fN1Q="
     },
     "@types/events": {
@@ -5027,7 +5027,7 @@
     },
     "csv-stringify": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
         "lodash.get": "^4.0.0"
@@ -5516,7 +5516,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -5774,7 +5774,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -6520,7 +6520,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
@@ -6692,7 +6692,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "jsonwebtoken": {
@@ -7035,7 +7035,7 @@
     },
     "follow-redirects": {
       "version": "0.0.7",
-      "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
       "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
       "requires": {
         "debug": "^2.2.0",
@@ -8131,12 +8131,12 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "lodash": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz",
           "integrity": "sha1-msQ4RMWV4o0wEIt7pYNwM5WSLfw="
         }
       }
@@ -8198,7 +8198,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz",
           "integrity": "sha1-k9UcZygopEFqEq9XIguoqHN+L7s="
         }
       }
@@ -8337,7 +8337,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -8393,7 +8393,7 @@
     },
     "graphql-config": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/graphql-config/-/graphql-config-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-2.0.1.tgz",
       "integrity": "sha512-eb4FzlODifHE/Q+91QptAmkGw39wL5ToinJ2556UUsGt2drPc4tzifL+HSnHSaxiIbH8EUhc/Fa6+neinF04qA==",
       "dev": true,
       "requires": {
@@ -8422,7 +8422,7 @@
     },
     "graphql-import": {
       "version": "0.4.5",
-      "resolved": "http://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz",
       "integrity": "sha512-G/+I08Qp6/QGTb9qapknCm3yPHV0ZL7wbaalWFpxsfR8ZhZoTBe//LsbsCKlbALQpcMegchpJhpTSKiJjhaVqQ==",
       "dev": true,
       "requires": {
@@ -9414,7 +9414,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -10047,7 +10047,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "inflected": {
@@ -11089,6 +11089,15 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -11531,7 +11540,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -11907,12 +11916,6 @@
         }
       }
     },
-    "nodesecurity-npm-utils": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-6.0.0.tgz",
-      "integrity": "sha512-NLRle1woNaT2orR6fue2jNqkhxDTktgJj3sZxvR/8kp21pvOY7Gwlx5wvo0H8ZVPqdgd2nE2ADB9wDu5Cl8zNg==",
-      "dev": true
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -11932,7 +11935,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -11992,24 +11995,6 @@
         "yargs": "^9.0.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -12025,6 +12010,71 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "cli-table": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+          "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+          "requires": {
+            "colors": "1.0.3"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+            }
           }
         },
         "cliui": {
@@ -12051,11 +12101,59 @@
             }
           }
         },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-          "dev": true
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "requires": {
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+              "integrity": "sha1-vY+ehqjrIh//oHvRS+/VXfFCgV4=",
+              "dev": true,
+              "requires": {
+                "extend": "~3.0.0",
+                "semver": "~5.0.1"
+              },
+              "dependencies": {
+                "semver": {
+                  "version": "5.0.3",
+                  "resolved": "http://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                  "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+                  "dev": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "dev": true,
+              "requires": {
+                "ms": "0.7.1"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            }
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -12064,6 +12162,42 @@
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
+          }
+        },
+        "joi": {
+          "version": "6.10.1",
+          "resolved": "http://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+          "requires": {
+            "hoek": "2.x.x",
+            "isemail": "1.x.x",
+            "moment": "2.x.x",
+            "topo": "1.x.x"
+          },
+          "dependencies": {
+            "hoek": {
+              "version": "2.16.3",
+              "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+            },
+            "isemail": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+              "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+            },
+            "moment": {
+              "version": "2.12.0",
+              "resolved": "http://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
+              "integrity": "sha1-3CVg0Zg41sBzGxpq+gRnUmTTYNY="
+            },
+            "topo": {
+              "version": "1.1.0",
+              "resolved": "http://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+              "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+              "requires": {
+                "hoek": "2.x.x"
+              }
+            }
           }
         },
         "load-json-file": {
@@ -12078,6 +12212,12 @@
             "strip-bom": "^3.0.0"
           }
         },
+        "nodesecurity-npm-utils": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz",
+          "integrity": "sha1-Baow3jDKjIRcQEjpT9eOXgi1Xtk=",
+          "dev": true
+        },
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
@@ -12087,18 +12227,12 @@
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
             "mem": "^1.1.0"
-          },
-          "dependencies": {
-            "mem": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-              "dev": true,
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            }
           }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
         },
         "path-type": {
           "version": "2.0.0",
@@ -12114,6 +12248,39 @@
           "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
+        },
+        "rc": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+          "requires": {
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~1.0.4"
+          },
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
+            },
+            "ini": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+            }
+          }
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -12136,19 +12303,59 @@
             "read-pkg": "^2.0.0"
           }
         },
+        "semver": {
+          "version": "5.1.0",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "dev": true
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
+        "subcommand": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
+          "integrity": "sha1-mz/Rp1PjxEHwBBDLRBMdhlX1LDI=",
           "requires": {
-            "has-flag": "^3.0.0"
+            "cliclopts": "^1.1.0",
+            "debug": "^2.1.3",
+            "minimist": "^1.2.0",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "cliclopts": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
+              "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8="
+            },
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "requires": {
+                "ms": "0.7.1"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+            }
           }
         },
         "which-module": {
@@ -12165,6 +12372,23 @@
           "requires": {
             "boom": "5.x.x",
             "hoek": "4.x.x"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "2.10.1",
+              "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+              "dev": true,
+              "requires": {
+                "hoek": "2.x.x"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+              "dev": true
+            }
           }
         },
         "yargs": {
@@ -13537,7 +13761,7 @@
         },
         "dotenv": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
           "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk="
         },
         "is-fullwidth-code-point": {
@@ -13642,7 +13866,7 @@
         },
         "yargs": {
           "version": "4.8.1",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "requires": {
             "cliui": "^3.2.0",
@@ -13811,7 +14035,7 @@
       "dependencies": {
         "lodash": {
           "version": "4.5.0",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz",
           "integrity": "sha1-IoSqBvWxNq29lUuQNRG2L8OdH1k="
         }
       }
@@ -14042,7 +14266,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -14656,7 +14880,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -15467,12 +15691,12 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "lodash": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz",
           "integrity": "sha1-msQ4RMWV4o0wEIt7pYNwM5WSLfw="
         }
       }
@@ -15511,14 +15735,14 @@
         },
         "uuid": {
           "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },
     "seneca-mem-store": {
       "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/seneca-mem-store/-/seneca-mem-store-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/seneca-mem-store/-/seneca-mem-store-0.5.0.tgz",
       "integrity": "sha1-LDgxkSMw+uMWI06prmiXNuB0Vzg=",
       "requires": {
         "lodash": "3.10.1"
@@ -15542,7 +15766,7 @@
       "dependencies": {
         "lodash": {
           "version": "4.5.0",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz",
           "integrity": "sha1-IoSqBvWxNq29lUuQNRG2L8OdH1k="
         }
       }
@@ -15564,7 +15788,7 @@
         },
         "pg": {
           "version": "5.1.0",
-          "resolved": "http://registry.npmjs.org/pg/-/pg-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-5.1.0.tgz",
           "integrity": "sha1-BzubNnY62KVHjbuF7/70XnObqdg=",
           "requires": {
             "buffer-writer": "1.0.1",
@@ -15594,7 +15818,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "lodash": {
@@ -15615,7 +15839,7 @@
       "dependencies": {
         "lodash": {
           "version": "4.5.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.1.tgz",
           "integrity": "sha1-gOigdMpfOJOmscELKmNkktcQwxY="
         }
       }
@@ -15661,7 +15885,7 @@
       "dependencies": {
         "lodash": {
           "version": "4.5.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.1.tgz",
           "integrity": "sha1-gOigdMpfOJOmscELKmNkktcQwxY="
         },
         "lru-cache": {
@@ -15681,7 +15905,7 @@
     },
     "seneca-web": {
       "version": "0.7.1",
-      "resolved": "http://registry.npmjs.org/seneca-web/-/seneca-web-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/seneca-web/-/seneca-web-0.7.1.tgz",
       "integrity": "sha1-9pT4CtK7Rhj8a4VmcKG9zfTewH0=",
       "requires": {
         "async": "1.5.2",
@@ -15700,7 +15924,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "connect": {
@@ -15716,7 +15940,7 @@
         },
         "debug": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "requires": {
             "ms": "0.7.1"
@@ -15724,7 +15948,7 @@
         },
         "finalhandler": {
           "version": "0.4.1",
-          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
           "requires": {
             "debug": "~2.2.0",
@@ -15743,14 +15967,14 @@
           "dependencies": {
             "lodash": {
               "version": "2.4.2",
-              "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
             }
           }
         },
         "http-errors": {
           "version": "1.3.1",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "requires": {
             "inherits": "~2.0.1",
@@ -15764,7 +15988,7 @@
         },
         "lodash": {
           "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz",
           "integrity": "sha1-Fx/c+7ww1onFRM0YwFKfVt5sGqk="
         },
         "mime": {
@@ -15789,7 +16013,7 @@
           "dependencies": {
             "lodash": {
               "version": "2.4.2",
-              "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
             }
           }
@@ -15988,7 +16212,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -16837,7 +17061,7 @@
     },
     "stampit": {
       "version": "2.1.2",
-      "resolved": "http://registry.npmjs.org/stampit/-/stampit-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/stampit/-/stampit-2.1.2.tgz",
       "integrity": "sha1-3odBo+HwaBXonI7Rx1MpW7ooNWo=",
       "requires": {
         "lodash": "^3.9.1",
@@ -16999,7 +17223,7 @@
     },
     "stripe": {
       "version": "4.8.0",
-      "resolved": "http://registry.npmjs.org/stripe/-/stripe-4.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-4.8.0.tgz",
       "integrity": "sha1-fb46EUSHelncmLMJNVlG/RKgskY=",
       "requires": {
         "bluebird": "^2.10.2",
@@ -17009,7 +17233,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "qs": {
@@ -17511,7 +17735,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -18167,7 +18391,7 @@
     },
     "use-plugin": {
       "version": "0.3.1",
-      "resolved": "http://registry.npmjs.org/use-plugin/-/use-plugin-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/use-plugin/-/use-plugin-0.3.1.tgz",
       "integrity": "sha1-XZafuZq1XOTxr5BsmXgjKnWJIa8=",
       "requires": {
         "eraro": "~0.4.1",
@@ -18178,7 +18402,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -18888,7 +19112,7 @@
     },
     "winston": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
       "integrity": "sha1-LIU92Hq1UqjoSF1yy7+aIobwKbc=",
       "requires": {
         "async": "~1.0.0",
@@ -18902,7 +19126,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         },
         "colors": {
@@ -19146,7 +19370,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -46,7 +46,10 @@ export const PaymentMethodInputType = new GraphQLInputObjectType({
     uuid: { type: GraphQLString }, // used to fetch an existing payment method
     token: { type: GraphQLString },
     service: { type: GraphQLString },
-    type: { type: GraphQLString, description: 'creditcard or bitcoin' },
+    type: {
+      type: GraphQLString,
+      description: 'creditcard, bitcoin, prepaid, manual',
+    },
     customerId: { type: GraphQLString },
     data: { type: GraphQLJSON },
     name: { type: GraphQLString },

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -344,6 +344,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
         reqIp,
         recaptchaResponse: recaptchaResponse,
       },
+      status: status.PENDING, // default status, will get updated after the order is processed
     };
 
     if (

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -389,7 +389,8 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
       });
       await orderCreated.update({ SubscriptionId: subscription.id });
     } else if (collective.type === types.EVENT) {
-      // Free ticket, add user as an ATTENDEE
+      // Free ticket, mark as processed and add user as an ATTENDEE
+      await orderCreated.update({ processedAt: new Date() });
       const UserId = remoteUser ? remoteUser.id : user.id;
       await collective.addUserWithRole(user, roles.ATTENDEE);
       await models.Activity.create({

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -173,7 +173,11 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     if (
       paymentRequired &&
       (!order.paymentMethod ||
-        !(order.paymentMethod.uuid || order.paymentMethod.token))
+        !(
+          order.paymentMethod.uuid ||
+          order.paymentMethod.token ||
+          order.paymentMethod.type === 'manual'
+        ))
     ) {
       throw new Error('This order requires a payment method');
     }
@@ -453,7 +457,11 @@ export async function updateOrder(remoteUser, order) {
   if (
     paymentRequired &&
     (!order.paymentMethod ||
-      !(order.paymentMethod.uuid || order.paymentMethod.token))
+      !(
+        order.paymentMethod.uuid ||
+        order.paymentMethod.token ||
+        order.paymentMethod.type === 'manual'
+      ))
   ) {
     throw new Error('This order requires a payment method');
   }

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -949,13 +949,20 @@ export const TierType = new GraphQLObjectType({
         type: new GraphQLList(OrderType),
         args: {
           isActive: { type: GraphQLBoolean },
+          isProcessed: {
+            type: GraphQLBoolean,
+            description:
+              'only return orders that have been processed (fulfilled)',
+          },
           limit: { type: GraphQLInt },
         },
         resolve(tier, args) {
           const query = {
-            where: { processedAt: { [Op.ne]: null } },
             limit: args.limit,
           };
+          if (args.isProcessed) {
+            query.where = { processedAt: { [Op.ne]: null } };
+          }
           if (args.isActive) {
             query.include = [
               { model: models.Subscription, where: { isActive: true } },

--- a/server/lib/currency.js
+++ b/server/lib/currency.js
@@ -59,7 +59,10 @@ export function getFxRate(fromCurrency, toCurrency, date = 'latest') {
       .catch(e => {
         console.error('Unable to fetch fxrate', e.message);
         // for testing in airplane mode
-        if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+        if (
+          !process.env.NODE_ENV ||
+          ['test', 'development'].includes(process.env.NODE_ENV)
+        ) {
           console.log(
             '>>> development environment -> returning 1.1 instead of throwing the error',
             e,

--- a/server/lib/emailTemplates.js
+++ b/server/lib/emailTemplates.js
@@ -51,7 +51,7 @@ const templateNames = [
   'payment.failed',
   'payment.failed.text',
   'pledge.complete',
-  'processing',
+  'order.processing',
   'report.platform',
   'subscription.canceled',
   'ticket.confirmed',

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -70,8 +70,14 @@ export function findPaymentMethodProvider(paymentMethod) {
  *  the `PaymentMethods` table.
  */
 export async function processOrder(order, options) {
-  const paymentMethod = findPaymentMethodProvider(order.paymentMethod);
-  return await paymentMethod.processOrder(order, options);
+  const paymentMethodProvider = findPaymentMethodProvider(order.paymentMethod);
+  if (get(paymentMethodProvider, 'features.waitToCharge')) {
+    return sendOrderProcessingEmail(order, options);
+  } else {
+    return await paymentMethodProvider.processOrder(order, options);
+  }
+}
+
 export async function updateOrderStatus(order, transaction) {
   if (transaction) {
     order.update({

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -82,7 +82,7 @@ export async function updateOrderStatus(order, transaction) {
   if (transaction) {
     order.update({
       status: status.PAID,
-      processedAt: new Date,
+      processedAt: new Date(),
     });
   }
 }
@@ -228,10 +228,88 @@ export async function associateTransactionRefundId(transaction, refund, data) {
   return find([tr1, tr2, tr3, tr4], { id: transaction.id });
 }
 
+export const sendEmailNotifications = (order, transaction) => {
+  // for gift cards and manual payment methods
+  if (!transaction) {
+    sendOrderProcessingEmail(order);
+    if (isProvider('opencollective.giftcard', order.paymentMethod)) {
+      sendSupportEmailForManualIntervention(order); // async
+    }
+  } else {
+    order.transaction = transaction;
+    sendOrderConfirmedEmail(order); // async
+  }
+};
 
 export const addBackerToCollective = async (user, collective, TierId) => {
-  return await collective.findOrAddUserWithRole(user, roles.BACKER, { CreatedByUserId: user.id, TierId });
-}
+  return await collective.findOrAddUserWithRole(user, roles.BACKER, {
+    CreatedByUserId: user.id,
+    TierId,
+  });
+};
+
+export const processMatchingFund = async (order, options) => {
+  const matchingFundCollective = await models.Collective.findById(
+    order.matchingFund.CollectiveId,
+  );
+  // if there is a matching fund, we execute the order
+  // also adds the owner of the matching fund as a BACKER of collective
+  const matchingOrder = {
+    ...pick(order, ['id', 'collective', 'tier', 'currency']),
+    totalAmount: order.totalAmount * order.matchingFund.matching,
+    paymentMethod: order.matchingFund,
+    FromCollectiveId: order.matchingFund.CollectiveId,
+    fromCollective: matchingFundCollective,
+    description: `Matching ${order.matchingFund.matching}x ${
+      order.fromCollective.name
+    }'s donation`,
+    createdByUser: await matchingFundCollective.getUser(),
+  };
+
+  // processOrder expects an update function to update `order.processedAt`
+  matchingOrder.update = () => {};
+
+  return paymentProviders[order.paymentMethod.service].types[
+    order.paymentMethod.type || 'default'
+  ]
+    .processOrder(matchingOrder, options) // eslint-disable-line import/namespace
+    .then(transaction => {
+      sendOrderConfirmedEmail({ ...order, transaction }); // async
+      return null;
+    });
+};
+
+export const createSubscription = async order => {
+  const subscription = await models.Subscription.create({
+    amount: order.totalAmount,
+    interval: order.interval,
+    currency: order.currency,
+  });
+  // The order instance doesn't have the Subscription field
+  // here because it was just created and no models were
+  // included so we're doing that manually here. Not the
+  // cutest but works.
+  order.Subscription = subscription;
+  const updatedDates = libsubscription.getNextChargeAndPeriodStartDates(
+    'new',
+    order,
+  );
+  order.Subscription.nextChargeDate = updatedDates.nextChargeDate;
+  order.Subscription.nextPeriodStart =
+    updatedDates.nextPeriodStart || order.Subscription.nextPeriodStart;
+
+  // Both subscriptions and one time donations are charged
+  // immediatelly and there won't be a better time to update
+  // this field after this. Please notice that it will change
+  // when the issue #729 is tackled.
+  // https://github.com/opencollective/opencollective/issues/729
+  order.Subscription.chargeNumber = 1;
+  order.Subscription.activate();
+  order.update({
+    status: status.ACTIVE,
+    SubscriptionId: order.Subscription.id,
+  });
+};
 
 /**
  * Execute an order as user using paymentMethod
@@ -239,7 +317,12 @@ export const addBackerToCollective = async (user, collective, TierId) => {
  * @param {Object} order { tier, description, totalAmount, currency, interval (null|month|year), paymentMethod }
  * @param {Object} options { hostFeePercent, platformFeePercent} (only for add funds and if remoteUser is admin of host or root)
  */
-export const executeOrder = (user, order, options) => {
+export const executeOrder = async (user, order, options) => {
+  if (!(user instanceof models.User)) {
+    return Promise.reject(
+      new Error('user should be an instance of the User model'),
+    );
+  }
   if (!(order instanceof models.Order)) {
     return Promise.reject(
       new Error('order should be an instance of the Order model'),
@@ -270,109 +353,22 @@ export const executeOrder = (user, order, options) => {
     return Promise.reject(error);
   }
 
-  return order
-    .populate()
-    .then(() => {
-      if (payment.interval) {
-        // @lincoln: shouldn't this section be executed after we successfully charge the user for the first payment? (ie. after `processOrder`)
-        return order
-          .getSubscription({ rejectOnEmpty: true })
-          .catch(() => models.Subscription.create(payment))
-          .then(subscription => {
-            // The order instance doesn't have the Subscription field
-            // here because it was just created and no models were
-            // included so we're doing that manually here. Not the
-            // cutest but works.
-            order.Subscription = subscription;
-            const updatedDates = libsubscription.getNextChargeAndPeriodStartDates(
-              'new',
-              order,
-            );
-            order.Subscription.nextChargeDate = updatedDates.nextChargeDate;
-            order.Subscription.nextPeriodStart =
-              updatedDates.nextPeriodStart ||
-              order.Subscription.nextPeriodStart;
+  await order.populate();
 
-            // Both subscriptions and one time donations are charged
-            // immediatelly and there won't be a better time to update
-            // this field after this. Please notice that it will change
-            // when the issue #729 is tackled.
-            // https://github.com/opencollective/opencollective/issues/729
-            order.Subscription.chargeNumber = 1;
-            return subscription.save();
-          })
-          .then(subscription => {
-            return order.update({ SubscriptionId: subscription.id });
-          });
-      }
-      return null;
-    })
-    .then(() => {
-      return processOrder(order, options)
-        .tap(() =>
-          order.update({
-            status: order.SubscriptionId ? status.ACTIVE : status.PAID,
-          }),
-        )
-        .tap(async () => {
-          if (!order.matchingFund) return null;
-          const matchingFundCollective = await models.Collective.findById(
-            order.matchingFund.CollectiveId,
-          );
-          // if there is a matching fund, we execute the order
-          // also adds the owner of the matching fund as a BACKER of collective
-          const matchingOrder = {
-            ...pick(order, ['id', 'collective', 'tier', 'currency']),
-            totalAmount: order.totalAmount * order.matchingFund.matching,
-            paymentMethod: order.matchingFund,
-            FromCollectiveId: order.matchingFund.CollectiveId,
-            fromCollective: matchingFundCollective,
-            description: `Matching ${order.matchingFund.matching}x ${
-              order.fromCollective.name
-            }'s donation`,
-            createdByUser: await matchingFundCollective.getUser(),
-          };
+  const transaction = await processOrder(order, options);
+  order.matchingFund && processMatchingFund(order, options);
+  transaction && updateOrderStatus(order, transaction);
+  addBackerToCollective(
+    { id: user.id, CollectiveId: order.FromCollectiveId },
+    order.collective,
+    get(order, 'tier.id'),
+  );
+  sendEmailNotifications(order, transaction);
 
-          // processOrder expects an update function to update `order.processedAt`
-          matchingOrder.update = () => {};
-
-          return paymentProviders[order.paymentMethod.service].types[
-            order.paymentMethod.type || 'default'
-          ]
-            .processOrder(matchingOrder, options) // eslint-disable-line import/namespace
-            .then(transaction => {
-              sendOrderConfirmedEmail({ ...order, transaction }); // async
-              return null;
-            });
-        });
-    })
-    .then(transaction => {
-      // for gift cards
-      if (
-        !transaction &&
-        isProvider('opencollective.giftcard', order.paymentMethod)
-      ) {
-        sendOrderProcessingEmail(order).then(() =>
-          sendSupportEmailForManualIntervention(order),
-        ); // async
-      } else if (
-        !transaction &&
-        order.paymentMethod.service === 'stripe' &&
-        order.paymentMethod.type === 'bitcoin'
-      ) {
-        sendOrderProcessingEmail(order); // async
-      } else {
-        order.transaction = transaction;
-        sendOrderConfirmedEmail(order); // async
-      }
-      return transaction;
-    })
-    .tap(async transaction => {
-      // Credit card charges are synchronous. If the transaction is
-      // created here it means that the payment went through so it's
-      // safe to enable subscriptions after this.
-      if (payment.interval && transaction) await order.Subscription.activate();
-    });
+  // Credit card charges are synchronous. If the transaction is
+  // created here it means that the payment went through so it's
+  // safe to create subscription after this.
+  order.interval && transaction && (await createSubscription(order));
 };
 
 const validatePayment = payment => {
@@ -448,17 +444,16 @@ const sendOrderConfirmedEmail = async order => {
         matching: order.matchingFund.matching,
         amount: order.matchingFund.matching * order.totalAmount,
       };
-    }
-
-    // sending the order confirmed email to the matching fund owner or to the donor
-    if (
-      get(order, 'transaction.FromCollectiveId') ===
-      get(order, 'matchingFund.CollectiveId')
-    ) {
-      const recipients = await matchingFundCollective.getEmails();
-      return emailLib.send('donationmatched', recipients, data, emailOptions);
-    } else {
-      return emailLib.send('thankyou', user.email, data, emailOptions);
+      // sending the order confirmed email to the matching fund owner or to the donor
+      if (
+        get(order, 'transaction.FromCollectiveId') ===
+        get(order, 'matchingFund.CollectiveId')
+      ) {
+        const recipients = await matchingFundCollective.getEmails();
+        return emailLib.send('donationmatched', recipients, data, emailOptions);
+      } else {
+        return emailLib.send('thankyou', user.email, data, emailOptions);
+      }
     }
   }
 };
@@ -479,14 +474,19 @@ const sendOrderProcessingEmail = order => {
   const user = order.createdByUser;
 
   return emailLib.send(
-      'order.processing',
-      user.email,
-      { order: order.info,
-        user: user.info,
-        collective: collective.info,
-        fromCollective: fromCollective.minimal,
-        subscriptionsLink: user.generateLoginLink(`/${fromCollective.slug}/subscriptions`)
-      }, {
-        from: `${collective.name} <hello@${collective.slug}.opencollective.com>`
-      });
+    'order.processing',
+    user.email,
+    {
+      order: order.info,
+      user: user.info,
+      collective: collective.info,
+      fromCollective: fromCollective.minimal,
+      subscriptionsLink: user.generateLoginLink(
+        `/${fromCollective.slug}/subscriptions`,
+      ),
+    },
+    {
+      from: `${collective.name} <hello@${collective.slug}.opencollective.com>`,
+    },
+  );
 };

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -8,6 +8,7 @@ import models from '../models';
 import emailLib from './email';
 import { types } from '../constants/collectives';
 import status from '../constants/order_status';
+import roles from '../constants/roles';
 import activities from '../constants/activities';
 import paymentProviders from '../paymentProviders';
 import * as libsubscription from './subscriptions';
@@ -71,6 +72,13 @@ export function findPaymentMethodProvider(paymentMethod) {
 export async function processOrder(order, options) {
   const paymentMethod = findPaymentMethodProvider(order.paymentMethod);
   return await paymentMethod.processOrder(order, options);
+export async function updateOrderStatus(order, transaction) {
+  if (transaction) {
+    order.update({
+      status: status.PAID,
+      processedAt: new Date,
+    });
+  }
 }
 
 /** Refund a transaction
@@ -212,6 +220,11 @@ export async function associateTransactionRefundId(transaction, refund, data) {
   // graphql mutation needs it to return to the user. However we have
   // to return the updated instances, not the ones we received.
   return find([tr1, tr2, tr3, tr4], { id: transaction.id });
+}
+
+
+export const addBackerToCollective = async (user, collective, TierId) => {
+  return await collective.findOrAddUserWithRole(user, roles.BACKER, { CreatedByUserId: user.id, TierId });
 }
 
 /**

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -80,7 +80,7 @@ export async function processOrder(order, options) {
 
 export async function updateOrderStatus(order, transaction) {
   if (transaction) {
-    order.update({
+    await order.update({
       status: status.PAID,
       processedAt: new Date(),
     });
@@ -305,7 +305,7 @@ export const createSubscription = async order => {
   // https://github.com/opencollective/opencollective/issues/729
   order.Subscription.chargeNumber = 1;
   order.Subscription.activate();
-  order.update({
+  await order.update({
     status: status.ACTIVE,
     SubscriptionId: order.Subscription.id,
   });
@@ -356,9 +356,9 @@ export const executeOrder = async (user, order, options) => {
   await order.populate();
 
   const transaction = await processOrder(order, options);
-  order.matchingFund && processMatchingFund(order, options);
-  transaction && updateOrderStatus(order, transaction);
-  addBackerToCollective(
+  order.matchingFund && (await processMatchingFund(order, options));
+  transaction && (await updateOrderStatus(order, transaction));
+  await addBackerToCollective(
     { id: user.id, CollectiveId: order.FromCollectiveId },
     order.collective,
     get(order, 'tier.id'),
@@ -454,6 +454,8 @@ const sendOrderConfirmedEmail = async order => {
       } else {
         return emailLib.send('thankyou', user.email, data, emailOptions);
       }
+    } else {
+      return emailLib.send('thankyou', user.email, data, emailOptions);
     }
   }
 };

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -473,19 +473,14 @@ const sendOrderProcessingEmail = order => {
   const user = order.createdByUser;
 
   return emailLib.send(
-    'processing',
-    user.email,
-    {
-      order: order.info,
-      user: user.info,
-      collective: collective.info,
-      fromCollective: fromCollective.minimal,
-      subscriptionsLink: user.generateLoginLink(
-        `/${fromCollective.slug}/subscriptions`,
-      ),
-    },
-    {
-      from: `${collective.name} <hello@${collective.slug}.opencollective.com>`,
-    },
-  );
+      'order.processing',
+      user.email,
+      { order: order.info,
+        user: user.info,
+        collective: collective.info,
+        fromCollective: fromCollective.minimal,
+        subscriptionsLink: user.generateLoginLink(`/${fromCollective.slug}/subscriptions`)
+      }, {
+        from: `${collective.name} <hello@${collective.slug}.opencollective.com>`
+      });
 };

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -337,7 +337,7 @@ export default function(Sequelize, DataTypes) {
         this.type !== 'manual'
       ) {
         throw new Error(
-          `You don't have enough permissions to use this payment method (you need to be an admin of the collective that owns this payment method)`,
+          "You don't have enough permissions to use this payment method (you need to be an admin of the collective that owns this payment method)",
         );
       }
     }

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -253,33 +253,56 @@ export default function(Sequelize, DataTypes) {
     }
 
     if (this.limitedToTags) {
-      const collective = order.collective || await order.getCollective();
+      const collective = order.collective || (await order.getCollective());
       if (intersection(collective.tags, this.limitedToTags).length === 0) {
-        throw new Error(`This payment method can only be used for collectives in ${formatArrayToString(this.limitedToTags)}`);
+        throw new Error(
+          `This payment method can only be used for collectives in ${formatArrayToString(
+            this.limitedToTags,
+          )}`,
+        );
       }
     }
 
     // quick helper to get the name of a collective given its id to format better error messages
-    const fetchCollectiveName = (CollectiveId) => {
-      return CollectiveId && models.Collective.findOne({
-        attributes: ['name'],
-        where: { id: CollectiveId },
-      }).then(r => r && r.name);
+    const fetchCollectiveName = CollectiveId => {
+      return (
+        CollectiveId &&
+        models.Collective.findOne({
+          attributes: ['name'],
+          where: { id: CollectiveId },
+        }).then(r => r && r.name)
+      );
     };
 
     if (this.limitedToCollectiveIds) {
-      const collective = order.collective || await order.getCollective();
+      const collective = order.collective || (await order.getCollective());
       if (!this.limitedToCollectiveIds.includes(collective.HostCollectiveId)) {
-        const collectives = await Promise.map(this.limitedToCollectiveIds, fetchCollectiveName);
-        throw new Error(`This payment method can only be used for the following collectives ${formatArrayToString(collectives)}`);
+        const collectives = await Promise.map(
+          this.limitedToCollectiveIds,
+          fetchCollectiveName,
+        );
+        throw new Error(
+          `This payment method can only be used for the following collectives ${formatArrayToString(
+            collectives,
+          )}`,
+        );
       }
     }
 
     if (this.limitedToHostCollectiveIds) {
-      const collective = order.collective || await order.getCollective();
-      if (!this.limitedToHostCollectiveIds.includes(collective.HostCollectiveId)) {
-        const hostCollectives = await Promise.map(this.limitedToHostCollectiveIds, fetchCollectiveName);
-        throw new Error(`This payment method can only be used for collectives hosted by ${formatArrayToString(hostCollectives)}`);
+      const collective = order.collective || (await order.getCollective());
+      if (
+        !this.limitedToHostCollectiveIds.includes(collective.HostCollectiveId)
+      ) {
+        const hostCollectives = await Promise.map(
+          this.limitedToHostCollectiveIds,
+          fetchCollectiveName,
+        );
+        throw new Error(
+          `This payment method can only be used for collectives hosted by ${formatArrayToString(
+            hostCollectives,
+          )}`,
+        );
       }
     }
 
@@ -308,9 +331,13 @@ export default function(Sequelize, DataTypes) {
       }
 
       // If there is no monthly limit, the user needs to be an admin of the collective that owns the payment method
-      if (!this.monthlyLimitPerMember && !user.isAdmin(this.CollectiveId)) {
+      if (
+        !this.monthlyLimitPerMember &&
+        !user.isAdmin(this.CollectiveId) &&
+        this.type !== 'manual'
+      ) {
         throw new Error(
-          "You don't have enough permissions to use this payment method (you need to be an admin of the collective that owns this payment method)",
+          `You don't have enough permissions to use this payment method (you need to be an admin of the collective that owns this payment method)`,
         );
       }
     }

--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -4,7 +4,6 @@ import Promise from 'bluebird';
 import { getFxRate } from '../../lib/currency';
 import * as paymentsLib from '../../lib/payments';
 import { formatCurrency } from '../../lib/utils';
-import roles from '../../constants/roles';
 
 const paymentMethodProvider = {};
 
@@ -225,14 +224,6 @@ paymentMethodProvider.processOrder = async (order, options = {}) => {
   };
 
   const transactions = await models.Transaction.createFromPayload(payload);
-
-  const CollectiveId = order.fromCollective.id;
-  const CreatedByUserId = order.createdByUser.id;
-  await order.collective.findOrAddUserWithRole(
-    { id: CreatedByUserId, CollectiveId },
-    roles.BACKER,
-    { CreatedByUserId, TierId: order.TierId },
-  );
 
   return transactions;
 };

--- a/server/paymentProviders/opencollective/index.js
+++ b/server/paymentProviders/opencollective/index.js
@@ -4,6 +4,7 @@ import collective from './collective';
 import prepaid from './prepaid';
 import giftcard from './giftcard';
 import virtualcard from './virtualcard';
+import manual from './manual';
 
 /** Process orders from Open Collective payment method types */
 async function processOrder(order) {
@@ -14,6 +15,8 @@ async function processOrder(order) {
       return giftcard.processOrder(order);
     case 'virtualcard':
       return virtualcard.processOrder(order);
+    case 'manual':
+      return manual.processOrder(order);
     case 'collective': // Fall through
     default:
       return collective.processOrder(order);
@@ -28,6 +31,7 @@ export default {
     default: collective,
     collective,
     giftcard,
+    manual,
     prepaid,
     virtualcard,
   },

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -50,7 +50,6 @@ async function processOrder(order) {
   };
 
   const creditTransaction = await models.Transaction.createFromPayload(payload);
-  console.log(">> creditTransaction", creditTransaction.dataValues);
   return creditTransaction;
 }
 

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -1,0 +1,65 @@
+import { pick } from 'lodash';
+import models from '../../models';
+import { TransactionTypes } from '../../constants/transactions';
+
+/**
+ * Manual Payment method
+ * This payment method enables a host to manually receive donations (e.g. by wire directly to the host's bank account)
+ * The order's status will be set to PENDING and will have to be updated manually by the host
+ */
+
+/** Get the balance
+ * Since we don't have a way to check the balance of the donor, we return Infinity
+ * note: since GraphQL doesn't like Infinity, we use 10000000
+ */
+async function getBalance() {
+  return 10000000;
+}
+
+/** Process an order with a manual payment method
+ *
+ * @param {models.Order} order The order instance to be processed.
+ * @return {models.Transaction} the double entry generated transactions.
+ */
+async function processOrder(order) {
+  // gets the Credit transaction generated
+  const payload = pick(order, ['CreatedByUserId', 'FromCollectiveId', 'CollectiveId', 'PaymentMethodId']);
+  const host = await order.collective.getHostCollective();
+
+  if (host.currency !== order.currency) {
+    throw Error(`Cannot manually record a transaction in a different currency than the currency of the host ${host.currency}`);
+  }
+
+  const hostFeeInHostCurrency = -(Math.round(order.collective.hostFeePercent * order.totalAmount));
+  const platformFeeInHostCurrency = 0;
+  const paymentProcessorFeeInHostCurrency = 0;
+
+  payload.transaction = {
+    type: TransactionTypes.CREDIT,
+    OrderId: order.id,
+    amount: order.totalAmount,
+    currency: order.currency,
+    hostCurrency: host.currency,
+    hostCurrencyFxRate: 1,
+    netAmountInCollectiveCurrency: order.totalAmount - hostFeeInHostCurrency - platformFeeInHostCurrency,
+    amountInHostCurrency: order.totalAmount,
+    hostFeeInHostCurrency,
+    platformFeeInHostCurrency,
+    paymentProcessorFeeInHostCurrency,
+    description: order.description,
+  };
+
+  const creditTransaction = await models.Transaction.createFromPayload(payload);
+  console.log(">> creditTransaction", creditTransaction.dataValues);
+  return creditTransaction;
+}
+
+/* Expected API of a Payment Method Type */
+export default {
+  features: {
+    recurring: false,
+    waitToCharge: true, // don't process the order automatically. Wait for host to "mark it as paid"
+  },
+  getBalance,
+  processOrder,
+};

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -3,7 +3,6 @@ import config from 'config';
 
 import models from '../../models';
 import * as constants from '../../constants/transactions';
-import roles from '../../constants/roles';
 import * as stripeGateway from './gateway';
 import * as paymentsLib from '../../lib/payments';
 import { planId } from '../../lib/utils';
@@ -143,6 +142,7 @@ export default {
     };
 
     let hostStripeAccount, transactions;
+
     return (
       collective
         .getHostStripeAccount()
@@ -159,23 +159,11 @@ export default {
         .then(() => createChargeAndTransactions(hostStripeAccount))
         .tap(t => (transactions = t))
 
-        // add user to the collective
-        .tap(() =>
-          collective.findOrAddUserWithRole(
-            { id: user.id, CollectiveId: fromCollective.id },
-            roles.BACKER,
-            { CreatedByUserId: user.id, TierId: order.TierId },
-          ),
-        )
-
-        // Mark order row as processed
-        .tap(() => order.update({ processedAt: new Date() }))
-
         // Mark paymentMethod as confirmed
         .tap(() => paymentMethod.update({ confirmedAt: new Date() }))
 
-        .then(() => transactions)
-    ); // make sure we return the transactions created
+        .then(() => transactions) // make sure we return the transactions created
+    );
   },
 
   /** Refund a given transaction */

--- a/templates/emails/order.processing.hbs
+++ b/templates/emails/order.processing.hbs
@@ -16,18 +16,21 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 </p>
 
+<h2>Help us raise more money!</h2>
+<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate?referral={{fromCollective.id}}">https://opencollective.com/{{collective.slug}}/donate?referral={{fromCollective.id}}</a><br />
+The total amount that you will help us raise will be shown on your profile! <a href="https://opencollective.com/{{fromCollective.slug}}">https://opencollective.com/{{fromCollective.slug}}</a>
+</p>
+
 <p>Warmly,</p>
 
 <p>
-  – Team Open Collective
+  – The {{collective.name}} open collective
 </p>
+
+{{#if recommendedCollectives.length}}
+  {{> recommendedcollectives}}
+{{else if relatedCollectives.length}}
+  {{> relatedcollectives}}
+{{/if}}
 
 {{> footer}}
-
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-OpenCollective, Inc.<br />
-EIN: 47-3896707<br />
-340 S LEMON AVE #3717<br />
-Walnut CA 91789<br />
-USA
-</p>

--- a/templates/emails/thankyou.hbs
+++ b/templates/emails/thankyou.hbs
@@ -59,11 +59,3 @@ The total amount that you will help us raise will be shown on your profile! <a h
 {{/if}}
 
 {{> footer}}
-
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-OpenCollective, Inc.<br />
-EIN: 47-3896707<br />
-340 S LEMON AVE #3717<br />
-Walnut CA 91789<br />
-USA
-</p>

--- a/test/features/support/steps/users-and-collectives.js
+++ b/test/features/support/steps/users-and-collectives.js
@@ -125,7 +125,7 @@ async function handleDonation(
   }[paymentMethodName];
   if (!method) throw new Error(`Payment Method ${paymentMethod} doesn't exist`);
   return method({
-    user,
+    remoteUser: user,
     userCollective,
     collective,
     currency,

--- a/test/graphql.collective.test.js
+++ b/test/graphql.collective.test.js
@@ -54,7 +54,8 @@ describe('graphql.collective.test.js', () => {
       orgadm0,
     );
     await store.stripeOneTimeDonation({
-      userCollective: org0,
+      remoteUser: orgadm0,
+      fromCollective: org0,
       collective: apex,
       currency,
       amount: 20000,
@@ -64,7 +65,7 @@ describe('graphql.collective.test.js', () => {
     for (let i = 0; i < 10; i++) {
       const { user } = await store.newUser(`testuser${i}`);
       await store.stripeOneTimeDonation({
-        userCollective: user.collective,
+        remoteUser: user,
         collective: apex,
         currency,
         amount: 1000 * (i + 1),
@@ -416,7 +417,9 @@ describe('graphql.collective.test.js', () => {
     }
     `;
 
-    const result = await utils.graphqlQuery(query, { slug: 'brusselstogether' });
+    const result = await utils.graphqlQuery(query, {
+      slug: 'brusselstogether',
+    });
     result.errors && console.error(result.errors);
     expect(result.errors).to.not.exist;
 
@@ -475,31 +478,31 @@ describe('graphql.collective.test.js', () => {
     await store.stripeConnectedAccount(hostCollective.id);
     // And given some purchases from users to the collective
     await store.stripeOneTimeDonation({
-      userCollective: theuser0.collective,
+      remoteUser: theuser0,
       collective,
       currency,
       amount: 100,
     });
     await store.stripeOneTimeDonation({
-      userCollective: theuser0.collective,
+      remoteUser: theuser0,
       collective,
       currency,
       amount: 200,
     });
     await store.stripeOneTimeDonation({
-      userCollective: theuser0.collective,
+      remoteUser: theuser0,
       collective,
       currency,
       amount: 500,
     });
     await store.stripeOneTimeDonation({
-      userCollective: theuser1.collective,
+      remoteUser: theuser1,
       collective,
       currency,
       amount: 5000,
     });
     await store.stripeOneTimeDonation({
-      userCollective: theuser1.collective,
+      remoteUser: theuser1,
       collective,
       currency,
       amount: 5000,
@@ -515,19 +518,22 @@ describe('graphql.collective.test.js', () => {
     );
     // And given some donations from the above orgs
     await store.stripeOneTimeDonation({
-      userCollective: org0,
+      remoteUser: orgadm0,
+      fromCollective: org0,
       collective,
       currency,
       amount: 100000,
     });
     await store.stripeOneTimeDonation({
-      userCollective: org0,
+      remoteUser: orgadm0,
+      fromCollective: org0,
       collective,
       currency,
       amount: 200000,
     });
     await store.stripeOneTimeDonation({
-      userCollective: org1,
+      remoteUser: orgadm1,
+      fromCollective: org1,
       collective,
       currency,
       amount: 100000,
@@ -539,6 +545,7 @@ describe('graphql.collective.test.js', () => {
       Collective(slug: $slug) {
         members(type: $type, limit: 10, offset: 0) {
           id
+          role
           stats {
             totalDonations
           }
@@ -646,25 +653,25 @@ describe('graphql.collective.test.js', () => {
       await store.stripeConnectedAccount(hostCollective.id);
       // And given some purchases
       await store.stripeOneTimeDonation({
-        userCollective: user.collective,
+        remoteUser: user,
         collective,
         currency,
         amount: 100,
       });
       await store.stripeOneTimeDonation({
-        userCollective: user0.collective,
+        remoteUser: user0,
         collective,
         currency,
         amount: 100,
       });
       await store.stripeOneTimeDonation({
-        userCollective: user1.collective,
+        remoteUser: user1,
         collective,
         currency,
         amount: 500,
       });
       await store.stripeOneTimeDonation({
-        userCollective: xdamman.collective,
+        remoteUser: xdamman,
         collective,
         currency,
         amount: 2000,
@@ -687,13 +694,13 @@ describe('graphql.collective.test.js', () => {
         { isActive: true },
       );
       await store.stripeOneTimeDonation({
-        userCollective: xdamman.collective,
+        remoteUser: xdamman,
         collective: veganizerbxl,
         currency,
         amount: 1000,
       });
       await store.stripeOneTimeDonation({
-        userCollective: xdamman.collective,
+        remoteUser: xdamman,
         collective: another,
         currency,
         amount: 1000,
@@ -708,7 +715,7 @@ describe('graphql.collective.test.js', () => {
         { isActive: true },
       );
       await store.stripeOneTimeDonation({
-        userCollective: piamancini.collective,
+        remoteUser: piamancini,
         collective: opensource,
         currency,
         amount: 1000,

--- a/test/graphql.createOrder.test.js
+++ b/test/graphql.createOrder.test.js
@@ -77,7 +77,11 @@ const constants = Object.freeze({
 });
 
 describe('createOrder', () => {
-  let sandbox, tweetStatusSpy, fearlesscitiesbrussels, emailSendMessageSpy;
+  let sandbox,
+    tweetStatusSpy,
+    fearlesscitiesbrussels,
+    emailSendMessageSpy,
+    hostCollective;
 
   before(() => {
     nock('http://data.fixer.io')
@@ -113,7 +117,10 @@ describe('createOrder', () => {
     emailSendMessageSpy = sandbox.spy(emailLib, 'sendMessage');
 
     // Given a collective (with a host)
-    ({ fearlesscitiesbrussels } = await store.newCollectiveWithHost(
+    ({
+      fearlesscitiesbrussels,
+      hostCollective,
+    } = await store.newCollectiveWithHost(
       'fearlesscitiesbrussels',
       'EUR',
       'EUR',
@@ -192,6 +199,39 @@ describe('createOrder', () => {
     expect(res.errors).to.not.exist;
     expect(res.data.createOrder.status).to.equal('PENDING');
     expect(res.data.createOrder.subscription.interval).to.equal('month');
+  });
+
+  it('creates a pending order (pledge) if the collective is active and no payment method attached', async () => {
+    const collective = await models.Collective.create({
+      slug: 'test',
+      name: 'test',
+      isActive: true,
+    });
+    const thisOrder = cloneDeep(baseOrder);
+    delete thisOrder.paymentMethod;
+    const pm = await models.PaymentMethod.create({
+      service: 'opencollective',
+      type: 'manual',
+      CollectiveId: hostCollective.id,
+    });
+    thisOrder.paymentMethod = { uuid: pm.uuid };
+    thisOrder.collective.id = collective.id;
+    thisOrder.user = {
+      firstName: 'John',
+      lastName: 'Smith',
+      email: 'jsmith@email.com',
+      twitterHandle: 'johnsmith',
+    };
+
+    const res = await utils.graphqlQuery(createOrderQuery, {
+      order: thisOrder,
+    });
+    expect(res.errors).to.not.exist;
+    expect(res.data.createOrder.status).to.equal('PENDING');
+    const transactionsCount = await models.Transaction.count({
+      where: { OrderId: res.data.createOrder.id },
+    });
+    expect(transactionsCount).to.equal(0);
   });
 
   it('creates an order as new user and sends a tweet', async () => {
@@ -362,7 +402,6 @@ describe('createOrder', () => {
     const res = await utils.graphqlQuery(createOrderQuery, { order }, xdamman);
     // Then there should be no errors
     expect(res.errors).to.not.exist;
-    expect(res.data.createOrder.status).to.equal('PAID');
     // And then the creator of the order should be xdamman
     const collective = res.data.createOrder.collective;
     const transaction = await models.Transaction.findOne({
@@ -388,6 +427,8 @@ describe('createOrder', () => {
     // make sure the payment has been recorded in the connected
     // Stripe Account of the host
     expect(transaction.data.charge.currency).to.equal('eur');
+    const createdOrder = await models.Order.findById(res.data.createOrder.id);
+    expect(createdOrder.status).to.equal('PAID');
   });
 
   it('creates an order as logged in user using saved credit card', async () => {
@@ -487,9 +528,8 @@ describe('createOrder', () => {
     expect(res.errors).to.not.exist;
     // Then the created transaction should match the requested data
     const orderCreated = res.data.createOrder;
-    expect(orderCreated.status).to.equal('ACTIVE');
-    const collective = orderCreated.collective;
-    const subscription = orderCreated.subscription;
+    const { collective, subscription } = orderCreated;
+    console.log('>>> orderCreated', orderCreated);
 
     expect(subscription.interval).to.equal('month');
     expect(subscription.isActive).to.be.true;
@@ -507,6 +547,8 @@ describe('createOrder', () => {
     expect(transaction.FromCollectiveId).to.equal(xdamman.CollectiveId);
     expect(transaction.CollectiveId).to.equal(collective.id);
     expect(transaction.currency).to.equal(collective.currency);
+    const createdOrder = await models.Order.findById(res.data.createOrder.id);
+    expect(createdOrder.status).to.equal('ACTIVE');
   });
 
   it('creates an order as a new user for a new organization', async () => {

--- a/test/graphql.invoices.test.js
+++ b/test/graphql.invoices.test.js
@@ -17,12 +17,12 @@ import * as store from './features/support/stores';
  *
  * The payment method is always stripe for now.
  */
-async function donate(userCollective, currency, amount, createdAt, collective) {
+async function donate(user, currency, amount, createdAt, collective) {
   const timer = sinon.useFakeTimers(new Date(createdAt).getTime());
   try {
     await store.stripeConnectedAccount(collective.HostCollectiveId);
     await store.stripeOneTimeDonation({
-      userCollective,
+      remoteUser: user,
       collective,
       currency,
       amount,
@@ -39,7 +39,7 @@ describe('graphql.invoices.test.js', () => {
     // First reset the test database
     await utils.resetTestDB();
     // Given a user and its collective
-    const { userCollective, user } = await store.newUser('xdamman');
+    const { user } = await store.newUser('xdamman');
     xdamman = user;
     // And given the collective (with their host)
     const { collective } = await store.newCollectiveWithHost(
@@ -49,11 +49,11 @@ describe('graphql.invoices.test.js', () => {
       10,
     );
     // And given some donations to that collective
-    await donate(userCollective, 'EUR', 1000, '2017-09-03 00:00', collective);
-    await donate(userCollective, 'EUR', 1000, '2017-10-05 00:00', collective);
-    await donate(userCollective, 'EUR', 500, '2017-10-25 00:00', collective);
-    await donate(userCollective, 'EUR', 500, '2017-11-05 00:00', collective);
-    await donate(userCollective, 'EUR', 500, '2017-11-25 00:00', collective);
+    await donate(user, 'EUR', 1000, '2017-09-03 00:00', collective);
+    await donate(user, 'EUR', 1000, '2017-10-05 00:00', collective);
+    await donate(user, 'EUR', 500, '2017-10-25 00:00', collective);
+    await donate(user, 'EUR', 500, '2017-11-05 00:00', collective);
+    await donate(user, 'EUR', 500, '2017-11-25 00:00', collective);
   });
 
   describe('return transactions', () => {

--- a/test/graphql.matchingFund.test.js
+++ b/test/graphql.matchingFund.test.js
@@ -238,19 +238,19 @@ describe('graphql.matchingFund.test.js', () => {
 
     // check that email went out
     expect(emailSendSpy.callCount).to.equal(2);
-    expect(emailSendSpy.firstCall.args[0]).to.equal('thankyou');
-    expect(emailSendSpy.firstCall.args[1]).to.equal(user2.email);
-    expect(
-      emailSendSpy.firstCall.args[2].matchingFund.collective.slug,
-    ).to.equal(user1.collective.slug);
-    expect(emailSendSpy.secondCall.args[0]).to.equal('donationmatched');
-    expect(emailSendSpy.secondCall.args[1][0]).to.equal(user1.email);
-    expect(emailSendSpy.secondCall.args[2].fromCollective.slug).to.equal(
+    expect(emailSendSpy.firstCall.args[0]).to.equal('donationmatched');
+    expect(emailSendSpy.firstCall.args[1][0]).to.equal(user1.email);
+    expect(emailSendSpy.firstCall.args[2].fromCollective.slug).to.equal(
       user2.collective.slug,
     );
-    expect(emailSendSpy.secondCall.args[2].transaction.uuid).to.equal(
+    expect(emailSendSpy.firstCall.args[2].transaction.uuid).to.equal(
       matchingTransaction.uuid,
     );
+    expect(emailSendSpy.secondCall.args[0]).to.equal('thankyou');
+    expect(emailSendSpy.secondCall.args[1]).to.equal(user2.email);
+    expect(
+      emailSendSpy.secondCall.args[2].matchingFund.collective.slug,
+    ).to.equal(user1.collective.slug);
   });
 
   it('fails if not enough funds available in matching fund', async () => {

--- a/test/graphql.query.test.js
+++ b/test/graphql.query.test.js
@@ -306,7 +306,7 @@ describe('Query Tests', () => {
           `;
           const req = utils.makeRequest(null);
           const result = await graphql(schema, query, null, req);
-          expect(result).to.deep.equal({
+          const expectedResult = {
             data: {
               allEvents: [
                 {
@@ -360,6 +360,15 @@ describe('Query Tests', () => {
                             'I have been working on open source for over a decade',
                           createdByUser: { id: 3, firstName: 'Xavier' },
                         },
+                        {
+                          id: 3,
+                          description:
+                            'I have been working on open source for over a decade',
+                          createdByUser: {
+                            id: 1,
+                            firstName: 'Phil',
+                          },
+                        },
                       ],
                     },
                     {
@@ -380,7 +389,8 @@ describe('Query Tests', () => {
                 },
               ],
             },
-          });
+          };
+          expect(result).to.deep.equal(expectedResult);
         });
       });
     });

--- a/test/graphql.transaction.test.js
+++ b/test/graphql.transaction.test.js
@@ -37,18 +37,16 @@ describe('graphql.transaction.test.js', () => {
     // in sequence, not in parallel since stripeOneTimeDonation can't
     // patch the same object more than once at a time.
     for (let i = 0; i < userNames.length; i++) {
-      const { user, userCollective } = await store.newUser(userNames[i]);
+      const { user } = await store.newUser(userNames[i]);
       await store.stripeOneTimeDonation({
-        user,
-        userCollective,
+        remoteUser: user,
         collective,
         currency: 'USD',
         amount: 1000 * (i + 1),
         createdAt: new Date(2018, i, i, 0, 0, i),
       });
       await store.stripeOneTimeDonation({
-        user,
-        userCollective,
+        remoteUser: user,
         collective,
         currency: 'USD',
         amount: 1000 * (i + 1),

--- a/test/lib.host.test.js
+++ b/test/lib.host.test.js
@@ -12,7 +12,7 @@ async function donation(collective, user, amount, currency, createdAt) {
   return store.stripeOneTimeDonation({
     amount,
     currency,
-    userCollective: user.collective,
+    remoteUser: user,
     collective,
     createdAt,
   });

--- a/test/lib.payments.test.js
+++ b/test/lib.payments.test.js
@@ -243,18 +243,16 @@ describe('lib.payments.test.js', () => {
                 expect(member).to.exist;
               }));
 
-            it('successfully sends out an email to donor1', done => {
-              setTimeout(() => {
-                expect(emailSendSpy.lastCall.args[0]).to.equal('thankyou');
-                expect(emailSendSpy.lastCall.args[1]).to.equal(user.email);
-                expect(
-                  emailSendSpy.lastCall.args[2].relatedCollectives,
-                ).to.have.length(1);
-                expect(
-                  emailSendSpy.lastCall.args[2].relatedCollectives[0],
-                ).to.have.property('settings');
-                done();
-              }, 150);
+            it('successfully sends out an email to donor1', async () => {
+              await utils.waitForCondition(() => emailSendSpy.callCount > 0);
+              expect(emailSendSpy.lastCall.args[0]).to.equal('thankyou');
+              expect(emailSendSpy.lastCall.args[1]).to.equal(user.email);
+              expect(
+                emailSendSpy.lastCall.args[2].relatedCollectives,
+              ).to.have.length(1);
+              expect(
+                emailSendSpy.lastCall.args[2].relatedCollectives[0],
+              ).to.have.property('settings');
             });
           });
 

--- a/test/lib.transactions.test.js
+++ b/test/lib.transactions.test.js
@@ -21,35 +21,35 @@ describe('lib.transactions.test.js', () => {
       currency,
       10,
     );
-    const { userCollective } = await store.newUser('a new user');
+    const { user } = await store.newUser('a new user');
     // And given some transactions
     await store.stripeConnectedAccount(collective.HostCollectiveId);
     await store.stripeOneTimeDonation({
-      userCollective,
+      remoteUser: user,
       collective,
       currency,
       amount: 100,
     });
     await store.stripeOneTimeDonation({
-      userCollective,
+      remoteUser: user,
       collective,
       currency,
       amount: 200,
     });
     await store.stripeOneTimeDonation({
-      userCollective,
+      remoteUser: user,
       collective,
       currency,
       amount: 300,
     });
     await store.stripeOneTimeDonation({
-      userCollective,
+      remoteUser: user,
       collective,
       currency,
       amount: 400,
     });
     await store.stripeOneTimeDonation({
-      userCollective,
+      remoteUser: user,
       collective,
       currency,
       amount: 500,

--- a/test/members.routes.test.js
+++ b/test/members.routes.test.js
@@ -160,15 +160,13 @@ describe('members.routes.test.js', () => {
         .end((e, res) => {
           expect(e).to.not.exist;
           expect(res.body).to.have.property('success', true);
-          users[1]
-            .getMemberships()
-            .then(memberships => {
-              expect(memberships[0].CollectiveId).to.equal(collective.id);
-              expect(memberships[0].role).to.equal(roles.ADMIN);
-              expect(memberships[1].role).to.equal(roles.BACKER);
-              done();
-            })
-            .catch(done);
+          users[1].getMemberships().then(memberships => {
+            expect(memberships[0].CollectiveId).to.equal(collective.id);
+            const membershipsRoles = [memberships[0].role, memberships[1].role];
+            expect(membershipsRoles).to.include(roles.ADMIN);
+            expect(membershipsRoles).to.include(roles.BACKER);
+            done();
+          });
         });
     });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,6 +6,7 @@ import Promise from 'bluebird';
 import Stripe from 'stripe';
 import { graphql } from 'graphql';
 import { isArray, values, get, cloneDeep } from 'lodash';
+import { execSync } from 'child_process';
 
 /* Test data */
 import jsonData from './mocks/data';
@@ -170,6 +171,19 @@ export const readFee = (amount, feeStr) => {
     /* The `* 100` is for converting from cents */
     return parseFloat(feeStr) * 100;
   }
+};
+
+export const separator = length => {
+  const terminalCols =
+    process.platform === 'win32'
+      ? length || 40
+      : length || parseInt(execSync(`tput cols`).toString());
+
+  let separator = '';
+  for (let i = 0; i < terminalCols; i++) {
+    separator += '-';
+  }
+  console.log(`\n${separator}\n`);
 };
 
 /* ---- Stripe Helpers ---- */

--- a/test/utils.js
+++ b/test/utils.js
@@ -173,11 +173,20 @@ export const readFee = (amount, feeStr) => {
   }
 };
 
+export const getTerminalCols = () => {
+  let length = 40;
+  if (process.platform === 'win32') {
+    return length;
+  }
+  try {
+    length = parseInt(execSync('tput cols').toString());
+  } catch {
+    return length;
+  }
+};
+
 export const separator = length => {
-  const terminalCols =
-    process.platform === 'win32'
-      ? length || 40
-      : length || parseInt(execSync(`tput cols`).toString());
+  const terminalCols = length || getTerminalCols();
 
   let separator = '';
   for (let i = 0; i < terminalCols; i++) {


### PR DESCRIPTION
This PR enables orders to specify a "manual" payment method, in which case the order's status will be PENDING and will have to be manually confirmed as PAID.

Related issue: https://github.com/opencollective/opencollective/issues/1281

TODO:
- [x] New manual payment provider
- [x] Set default order status to PENDING
- [x] Email notification for pending orders

For another PR to avoid growing this PR even more:
- Add a mutation to mark a donation as PAID
