### PR TITLE
Remove duplicated transactions when using includeVirtualCards=true on Graphql allTransactions query

### DIFF
--- a/server/controllers/collectives.js
+++ b/server/controllers/collectives.js
@@ -703,18 +703,17 @@ export const getTransactions = (req, res, next) => {
 /**
  * Get array of all transactions of a collective given its slug
  */
-export const getCollectiveTransactions = (req, res) => {
-  const args = req.query;
-  args.collectiveSlug = get(req, 'params.collectiveSlug');
-  return utils.graphqlQuery(allTransactionsQuery, req.query)
-  .then(response => {
+export const getCollectiveTransactions = async (req, res) => {
+  try {
+    const args = req.query;
+    args.collectiveSlug = get(req, 'params.collectiveSlug');
+    const response = await utils.graphqlQuery(allTransactionsQuery, req.query);
     if (response.errors) {
       throw new Error(response.errors[0]);
     }
     const result = get(response, 'data.allTransactions', []);
     res.send({ result });
-  })
-  .catch(error => {
+  } catch (error) {
     res.status(400).send({ error: error.toString() });
-  });
+  }
 };


### PR DESCRIPTION
Today we are filtering the transactions only through the Payment method ids, then we have the same transaction twice(When `PaymentMethod.CollectiveId` matches `Transaction.CollectiveId` and `Transaction.FromCollective`). We need to consider only When `PaymentMethod.CollectiveId` matches `Transaction.CollectiveId`.

fixes https://github.com/opencollective/opencollective/issues/1314