### PR TITLE
Add monthly limit per member on virtual cards

### DIFF
--- a/server/controllers/paymentMethods.js
+++ b/server/controllers/paymentMethods.js
@@ -7,7 +7,8 @@ const { PaymentMethod } = models;
 
 const createPaymentMethodQuery = `
   mutation createPaymentMethod(
-    $amount: Int!,
+    $amount: Int,
+    $monthlyLimitPerMember: Int,
     $CollectiveId: Int!,
     $PaymentMethodId: Int,
     $description: String,
@@ -20,6 +21,7 @@ const createPaymentMethodQuery = `
     ) {
     createPaymentMethod(
       amount: $amount,
+      monthlyLimitPerMember: $monthlyLimitPerMember,
       CollectiveId: $CollectiveId,
       PaymentMethodId: $PaymentMethodId,
       description: $description,
@@ -38,6 +40,7 @@ const createPaymentMethodQuery = `
       }
       SourcePaymentMethodId
       initialBalance
+      monthlyLimitPerMember
       expiryDate
       currency
       limitedToTags
@@ -84,6 +87,7 @@ async function createVirtualCardThroughGraphQL(args, user) {
     name: paymentMethod.name,
     CollectiveId: paymentMethod.collective.id,
     balance: paymentMethod.initialBalance,
+    monthlyLimitPerMember: paymentMethod.monthlyLimitPerMember,
     currency: paymentMethod.currency,
     limitedToTags: paymentMethod.limitedToTags,
     limitedToCollectiveIds: paymentMethod.limitedToCollectiveIds,
@@ -106,6 +110,7 @@ export function createVirtualCard(req, res) {
     'CollectiveId',
     'PaymentMethodId',
     'amount',
+    'monthlyLimitPerMember',
     'currency',
     'expiryDate',
     'limitedToTags',

--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -384,8 +384,9 @@ const mutations = {
     type: PaymentMethodType,
     args: {
       type: { type: new GraphQLNonNull(GraphQLString) },
-      amount: { type: new GraphQLNonNull(GraphQLInt) },
       currency: { type: new GraphQLNonNull(GraphQLString) },
+      amount: { type: GraphQLInt },
+      monthlyLimitPerMember: { type: GraphQLInt },
       limitedToTags: {
         type: new GraphQLList(GraphQLString),
         description: 'Limit this payment method to make donations to collectives having those tags',
@@ -403,7 +404,13 @@ const mutations = {
       description: { type: GraphQLString },
       expiryDate: { type: GraphQLString },
     },
-    resolve: async (_, args, req) => createPaymentMethod(args, req.remoteUser),
+    resolve: async (_, args, req) => {
+      // either amount or monthlyLimitPerMember needs to be present
+      if (!args.amount && !args.monthlyLimitPerMember) {
+        throw Error('you need to define either the amount or the monthlyLimitPerMember of the payment method.');
+      }
+      return createPaymentMethod(args, req.remoteUser);
+    } ,
   },
   claimPaymentMethod: {
     type: PaymentMethodType,

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -156,8 +156,7 @@ async function create(args, remoteUser) {
   let description = `${formatCurrency(amount, args.currency)} card from ${collective.name}`;
   if (args.monthlyLimitPerMember) {
     monthlyLimitPerMember = args.monthlyLimitPerMember;
-    const monthsFromNowToExpiryDate = Math.round(moment(expiryDate).diff(moment(), 'months', true));
-    amount = Math.round(monthlyLimitPerMember * monthsFromNowToExpiryDate);
+    amount = null;
     description = `${formatCurrency(args. monthlyLimitPerMember, args.currency)} monthly card from ${collective.name}`;
   }
 

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -153,13 +153,14 @@ async function create(args, remoteUser) {
   // consider monthlyLimitPerMember times the months from now until the expiry date
   let monthlyLimitPerMember;
   let amount = args.amount;
+  let description = `${formatCurrency(amount, args.currency)} card from ${collective.name}`;
   if (args.monthlyLimitPerMember) {
     monthlyLimitPerMember = args.monthlyLimitPerMember;
     const monthsFromNowToExpiryDate = Math.round(moment(expiryDate).diff(moment(), 'months', true));
     amount = Math.round(monthlyLimitPerMember * monthsFromNowToExpiryDate);
+    description = `${formatCurrency(args. monthlyLimitPerMember, args.currency)} monthly card from ${collective.name}`;
   }
 
-  const description = `${formatCurrency(amount, args.currency)} card from ${collective.name}`;
   // creates a new Virtual card Payment method
   const paymentMethod = await models.PaymentMethod.create({
     CreatedByUserId: remoteUser && remoteUser.id,

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -183,10 +183,8 @@ describe('opencollective.virtualcard', () => {
             .format('YYYY-MM-DD'),
         );
         expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);
-        // paymentMethod.initialBalance should be equals 
-        // monthlyLimitPerMember times the months from now until the expiry date
-        const monthsFromNowToExpiryDate = Math.round(moment(paymentMethod.expiryDate).diff(moment(), 'months', true));
-        expect(paymentMethod.initialBalance).to.be.equal(Math.round(paymentMethod.monthlyLimitPerMember * monthsFromNowToExpiryDate));
+        // if there is a monthlyLimitPerMember balance must not exist
+        expect(paymentMethod.balance).to.not.exist;
         expect(paymentMethod.description).to.contain('monthly card from');
       }); /** End Of "should create a virtual card with monthly limit member of U$100 per month" */
 
@@ -206,10 +204,8 @@ describe('opencollective.virtualcard', () => {
         expect(paymentMethod.type).to.be.equal('virtualcard');
         expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(expiryDate);
         expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);
-        // paymentMethod.initialBalance should be equals 
-        // monthlyLimitPerMember times the months from now until the expiry date
-        const monthsFromNowToExpiryDate = Math.round(moment(paymentMethod.expiryDate).diff(moment(), 'months', true));
-        expect(paymentMethod.initialBalance).to.be.equal(Math.round(paymentMethod.monthlyLimitPerMember * monthsFromNowToExpiryDate));
+        // if there is a monthlyLimitPerMember balance must not exist
+        expect(paymentMethod.balance).to.not.exist;
       }); /** End Of "should create a virtual card with monthly limit member of U$100 per month defining an expiry date" */
 
     }); /** End Of "#create" */
@@ -966,10 +962,8 @@ describe('opencollective.virtualcard', () => {
                 .format('YYYY-MM-DD'),
             );
             expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);
-            // paymentMethod.initialBalance should be equals 
-            // monthlyLimitPerMember times the months from now until the expiry date
-            const monthsFromNowToExpiryDate = Math.round(moment(paymentMethod.expiryDate).diff(moment(), 'months', true));
-            expect(paymentMethod.balance).to.be.equal(Math.round(paymentMethod.monthlyLimitPerMember * monthsFromNowToExpiryDate));
+            // if there is a monthlyLimitPerMember balance must not exist
+            expect(paymentMethod.balance).to.not.exist;
           });
       }); /** End Of "should create a virtual card with monthly limit member of U$100 per month" */
     }); /** End Of "POST /payment-methods to Create a virtual card" */

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -142,12 +142,12 @@ describe('opencollective.virtualcard', () => {
             .add(3, 'months')
             .format('YYYY-MM-DD'),
         );
+        expect(paymentMethod.description).to.be.equal(args.description);
       }); /** End Of "should create a U$100 virtual card payment method" */
 
       it('should create a U$100 virtual card payment method defining an expiry date', async () => {
         const expiryDate = moment().add(6, 'months').format('YYYY-MM-DD');
         const args = {
-          description: 'virtual card test',
           CollectiveId: collective1.id,
           amount: 10000,
           currency: 'USD',
@@ -160,11 +160,12 @@ describe('opencollective.virtualcard', () => {
         expect(paymentMethod.service).to.be.equal('opencollective');
         expect(paymentMethod.type).to.be.equal('virtualcard');
         expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(expiryDate);
+        expect(paymentMethod.description).to.contain('card from');
+        expect(paymentMethod.description).to.not.contain('monthly card');
       }); /** End Of "should create a U$100 virtual card payment method defining an expiry date" */
 
       it('should create a virtual card with monthly limit member of U$100 per month', async () => {
         const args = {
-          description: 'virtual card test',
           CollectiveId: collective1.id,
           monthlyLimitPerMember: 10000,
           currency: 'USD',
@@ -186,6 +187,7 @@ describe('opencollective.virtualcard', () => {
         // monthlyLimitPerMember times the months from now until the expiry date
         const monthsFromNowToExpiryDate = Math.round(moment(paymentMethod.expiryDate).diff(moment(), 'months', true));
         expect(paymentMethod.initialBalance).to.be.equal(Math.round(paymentMethod.monthlyLimitPerMember * monthsFromNowToExpiryDate));
+        expect(paymentMethod.description).to.contain('monthly card from');
       }); /** End Of "should create a virtual card with monthly limit member of U$100 per month" */
 
       it('should create a virtual card with monthly limit member of U$100 per month defining an expiry date', async () => {

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -14,8 +14,8 @@ const ORDER_TOTAL_AMOUNT = 5000;
 const STRIPE_FEE_STUBBED_VALUE = 300;
 
 const createPaymentMethodQuery = `
-  mutation createPaymentMethod($amount: Int!, $CollectiveId: Int!, $PaymentMethodId: Int, $description: String, $expiryDate: String, $type: String!, $currency: String!, $limitedToTags: [String], $limitedToCollectiveIds: [Int], $limitedToHostCollectiveIds: [Int]) {
-    createPaymentMethod(amount: $amount, CollectiveId: $CollectiveId, PaymentMethodId: $PaymentMethodId, description: $description, expiryDate: $expiryDate, type:  $type, currency: $currency, limitedToTags: $limitedToTags, limitedToCollectiveIds: $limitedToCollectiveIds, limitedToHostCollectiveIds: $limitedToHostCollectiveIds) {
+  mutation createPaymentMethod($amount: Int, $monthlyLimitPerMember: Int, $CollectiveId: Int!, $PaymentMethodId: Int, $description: String, $expiryDate: String, $type: String!, $currency: String!, $limitedToTags: [String], $limitedToCollectiveIds: [Int], $limitedToHostCollectiveIds: [Int]) {
+    createPaymentMethod(amount: $amount, monthlyLimitPerMember: $monthlyLimitPerMember, CollectiveId: $CollectiveId, PaymentMethodId: $PaymentMethodId, description: $description, expiryDate: $expiryDate, type:  $type, currency: $currency, limitedToTags: $limitedToTags, limitedToCollectiveIds: $limitedToCollectiveIds, limitedToHostCollectiveIds: $limitedToHostCollectiveIds) {
       id
     }
   }
@@ -142,7 +142,74 @@ describe('opencollective.virtualcard', () => {
             .add(3, 'months')
             .format('YYYY-MM-DD'),
         );
-      });
+      }); /** End Of "should create a U$100 virtual card payment method" */
+
+      it('should create a U$100 virtual card payment method defining an expiry date', async () => {
+        const expiryDate = moment().add(6, 'months').format('YYYY-MM-DD');
+        const args = {
+          description: 'virtual card test',
+          CollectiveId: collective1.id,
+          amount: 10000,
+          currency: 'USD',
+          expiryDate: expiryDate,
+        };
+        const paymentMethod = await virtualcard.create(args);
+        expect(paymentMethod).to.exist;
+        expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);
+        expect(paymentMethod.initialBalance).to.be.equal(args.amount);
+        expect(paymentMethod.service).to.be.equal('opencollective');
+        expect(paymentMethod.type).to.be.equal('virtualcard');
+        expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(expiryDate);
+      }); /** End Of "should create a U$100 virtual card payment method defining an expiry date" */
+
+      it('should create a virtual card with monthly limit member of U$100 per month', async () => {
+        const args = {
+          description: 'virtual card test',
+          CollectiveId: collective1.id,
+          monthlyLimitPerMember: 10000,
+          currency: 'USD',
+        };
+        const paymentMethod = await virtualcard.create(args);
+        expect(paymentMethod).to.exist;
+        expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);
+        expect(paymentMethod.service).to.be.equal('opencollective');
+        expect(paymentMethod.type).to.be.equal('virtualcard');
+        expect(
+          moment(paymentMethod.expiryDate).format('YYYY-MM-DD'),
+        ).to.be.equal(
+          moment()
+            .add(3, 'months')
+            .format('YYYY-MM-DD'),
+        );
+        expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);
+        // paymentMethod.initialBalance should be equals 
+        // monthlyLimitPerMember times the months from now until the expiry date
+        const monthsFromNowToExpiryDate = Math.round(moment(paymentMethod.expiryDate).diff(moment(), 'months', true));
+        expect(paymentMethod.initialBalance).to.be.equal(Math.round(paymentMethod.monthlyLimitPerMember * monthsFromNowToExpiryDate));
+      }); /** End Of "should create a virtual card with monthly limit member of U$100 per month" */
+
+      it('should create a virtual card with monthly limit member of U$100 per month defining an expiry date', async () => {
+        const expiryDate = moment().add(6, 'months').format('YYYY-MM-DD');
+        const args = {
+          description: 'virtual card test',
+          CollectiveId: collective1.id,
+          monthlyLimitPerMember: 10000,
+          currency: 'USD',
+          expiryDate: expiryDate,
+        };
+        const paymentMethod = await virtualcard.create(args);
+        expect(paymentMethod).to.exist;
+        expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);
+        expect(paymentMethod.service).to.be.equal('opencollective');
+        expect(paymentMethod.type).to.be.equal('virtualcard');
+        expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(expiryDate);
+        expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);
+        // paymentMethod.initialBalance should be equals 
+        // monthlyLimitPerMember times the months from now until the expiry date
+        const monthsFromNowToExpiryDate = Math.round(moment(paymentMethod.expiryDate).diff(moment(), 'months', true));
+        expect(paymentMethod.initialBalance).to.be.equal(Math.round(paymentMethod.monthlyLimitPerMember * monthsFromNowToExpiryDate));
+      }); /** End Of "should create a virtual card with monthly limit member of U$100 per month defining an expiry date" */
+
     }); /** End Of "#create" */
 
     describe('#claim', async () => {
@@ -215,7 +282,7 @@ describe('opencollective.virtualcard', () => {
         expect(moment(paymentMethod.expiryDate).format()).to.be.equal(
           moment(virtualCardPaymentMethod.expiryDate).format(),
         );
-      });
+      }); /** End Of "new User should claim a virtual card" */
     }); /** End Of "#claim" */
 
     describe('#processOrder', async () => {
@@ -290,7 +357,7 @@ describe('opencollective.virtualcard', () => {
           expect(error).to.exist;
           expect(error.toString()).to.contain('Order amount exceeds balance');
         }
-      });
+      }); /** End Of "Order should NOT be executed because its amount exceeds the balance of the virtual card" */
 
       it('Process order of a virtual card', async () => {
         const order = await models.Order.create({
@@ -330,7 +397,7 @@ describe('opencollective.virtualcard', () => {
         expect(virtualCardCurrentBalance.amount).to.be.equal(
           virtualCardPaymentMethod.initialBalance - ORDER_TOTAL_AMOUNT,
         );
-      });
+      }); /** End Of "Process order of a virtual card" */
     }); /** End Of "#processOrder" */
   }); /** End Of "paymentProviders.opencollective.virtualcard" */
 
@@ -384,8 +451,24 @@ describe('opencollective.virtualcard', () => {
           user1,
         );
         expect(gqlResult.errors[0]).to.exist;
-        expect(gqlResult.errors[0].toString()).to.contain('not provided');
+        expect(gqlResult.errors[0].toString()).to.contain('"$currency" of required type "String!" was not provided.');
       }); /** End of "should fail creating a virtual card because there is no currency defined" */
+
+      it('should fail creating a virtual card because there is no amount or monthlyLimitPerMember defined', async () => {
+        const args = {
+          type: 'virtualcard',
+          currency: 'USD',
+          CollectiveId: collective1.id,
+        };
+        // call graphql mutation
+        const gqlResult = await utils.graphqlQuery(
+          createPaymentMethodQuery,
+          args,
+          user1,
+        );
+        expect(gqlResult.errors[0]).to.exist;
+        expect(gqlResult.errors[0].toString()).to.contain('you need to define either the amount or the monthlyLimitPerMember of the payment method.');
+      }); /** End of "should fail creating a virtual card because there is amount or monthlyLimitPerMember defined" */
 
       it('should create a U$100 virtual card payment method limited to open source', async () => {
         const args = {
@@ -812,7 +895,7 @@ describe('opencollective.virtualcard', () => {
           .post('/v1/payment-methods')
           .send(args)
           .expect(400);
-      });
+      }); /** End Of "should Get 400 because there is no user authenticated" */
 
       it('should fail creating a virtual card without a currency defined', () => {
         const args = {
@@ -825,7 +908,7 @@ describe('opencollective.virtualcard', () => {
           .set('Client-Id', appKeyData.clientId)
           .send(args)
           .expect(400);
-      });
+      }); /** End Of "should fail creating a virtual card without a currency defined" */
 
       it('should create a U$100 virtual card payment method', () => {
         const args = {
@@ -850,7 +933,43 @@ describe('opencollective.virtualcard', () => {
             expect(paymentMethod.limitedToHostCollectiveIds[0]).to.be.equal(args.limitedToHostCollectiveIds[0]);
             expect(paymentMethod.balance).to.be.equal(args.amount);
           });
-      });
-    }); /** End Of "#create" */
+      }); /** End Of "should create a U$100 virtual card payment method" */
+
+      it('should create a virtual card with monthly limit member of U$100 per month', () => {
+        const args = {
+          CollectiveId: collective1.id,
+          monthlyLimitPerMember: 10000,
+          currency: 'USD',
+          limitedToTags: ['open source', 'diversity in tech'],
+          limitedToHostCollectiveIds: [1],
+        };
+        return request(app)
+          .post('/v1/payment-methods')
+          .set('Authorization', `Bearer ${user1.jwt()}`)
+          .set('Client-Id', appKeyData.clientId)
+          .send(args)
+          .expect(200)
+          .toPromise()
+          .then(res => {
+            expect(res.body).to.exist;
+            const paymentMethod = res.body;
+            expect(paymentMethod.CollectiveId).to.be.equal(collective1.id);
+            expect(paymentMethod.limitedToTags[0]).to.be.equal(args.limitedToTags[0]);
+            expect(paymentMethod.limitedToHostCollectiveIds[0]).to.be.equal(args.limitedToHostCollectiveIds[0]);
+            expect(
+              moment(paymentMethod.expiryDate).format('YYYY-MM-DD'),
+            ).to.be.equal(
+              moment()
+                .add(3, 'months')
+                .format('YYYY-MM-DD'),
+            );
+            expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);
+            // paymentMethod.initialBalance should be equals 
+            // monthlyLimitPerMember times the months from now until the expiry date
+            const monthsFromNowToExpiryDate = Math.round(moment(paymentMethod.expiryDate).diff(moment(), 'months', true));
+            expect(paymentMethod.balance).to.be.equal(Math.round(paymentMethod.monthlyLimitPerMember * monthsFromNowToExpiryDate));
+          });
+      }); /** End Of "should create a virtual card with monthly limit member of U$100 per month" */
+    }); /** End Of "POST /payment-methods to Create a virtual card" */
   }); /** End Of "routes.paymentMethods.virtualcard" */
 });


### PR DESCRIPTION
This feature allows adding a `monthlyLimitPerMember` to a virtual card instead of defining only an `amount`. 

Example: 
  Organization OpenCollective creates a virtual card with a `monthlyLimitPerMember` of U$ 50 and an expiryDate of 6 months from now. It's going to generate a Payment Method service `opencollective` and type `virtualcard` and **initialBalance** of `U$ 300`( `monthlyLimitPerMember`, U$ 50, times the months that the virtual card will be valid, in this case **6**)

PS: If an `amount` **AND** a `monthlyLimitPerMember` are defined, the `amount` will be ignored and will be replaced by `monthlyLimitPerMember` with the field `expiryDate`(See example above).
 
fixes https://github.com/opencollective/opencollective/issues/1328