### PR TITLE
Claim Collective

### DIFF
--- a/scripts/compile-email.js
+++ b/scripts/compile-email.js
@@ -258,6 +258,23 @@ data['user.monthlyreport'] = {
   ],
 };
 
+data['pledge.complete'] = {
+  collective: {
+    name: 'Johnny Five',
+    slug: 'johnny-five',
+  },
+  fromCollective: {
+    name: 'Jane Doe',
+    slug: 'jane-doe',
+  },
+  interval: 'month',
+  order: {
+    currency: 'USD',
+    id: '123456',
+    totalAmount: 1000,
+  },
+};
+
 const defaultData = {
   config: {
     host: {

--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -34,6 +34,7 @@ export const createOrUpdate = (req, res, next, accessToken, data, emails) => {
       const image = `https://images.githubusercontent.com/${
         data.profile.username
       }`;
+
       // TODO should simplify using findOrCreate but need to upgrade Sequelize to have this fix:
       // https://github.com/sequelize/sequelize/issues/4631
       if (req.remoteUser) {
@@ -91,12 +92,13 @@ export const createOrUpdate = (req, res, next, accessToken, data, emails) => {
             caId,
             data.profile.username,
           );
-          res.redirect(
-            redirect ||
-              `${
-                config.host.website
-              }/github/apply/${token}?utm_source=${utm_source}`,
-          );
+          const newLocation = redirect ?
+            `${redirect}?token=${token}` : 
+            `${
+              config.host.website
+            }/github/apply/${token}?utm_source=${utm_source}`;
+
+          res.redirect(newLocation);
         })
         .catch(next);
     }

--- a/server/graphql/CollectiveInterface.js
+++ b/server/graphql/CollectiveInterface.js
@@ -22,6 +22,7 @@ import {
   PaymentMethodType,
   ConnectedAccountType,
   ExpenseType,
+  OrderStatusType,
 } from './types';
 
 import {
@@ -585,7 +586,12 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
           slug: { type: GraphQLString },
         },
       },
-      orders: { type: new GraphQLList(OrderType) },
+      orders: {
+        type: new GraphQLList(OrderType),
+        args: {
+          status: { type: OrderStatusType },
+        },
+      },
       ordersFromCollective: {
         type: new GraphQLList(OrderType),
         args: {
@@ -1012,10 +1018,18 @@ const CollectiveFields = () => {
     },
     orders: {
       type: new GraphQLList(OrderType),
-      resolve(collective) {
+      args: {
+        status: { type: OrderStatusType },
+      },
+      resolve(collective, args = {}) {
         return collective.getIncomingOrders({
-          where: { processedAt: { [Op.ne]: null } },
-          order: [['createdAt', 'DESC']],
+          where: {
+            [Op.or]: [
+              { processedAt: { [Op.ne]: null } },
+              args,
+            ],
+          },
+          order: [ ['createdAt', 'DESC'] ]
         });
       },
     },

--- a/server/graphql/mutations.js
+++ b/server/graphql/mutations.js
@@ -1,4 +1,5 @@
 import {
+  claimCollective,
   createCollective,
   editCollective,
   deleteCollective,
@@ -97,6 +98,15 @@ const mutations = {
     resolve(_, args, req) {
       return deleteCollective(_, args, req);
     },
+  },
+  claimCollective: {
+    type: CollectiveInterfaceType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+    resolve(...args) {
+      return claimCollective(...args);
+    }
   },
   approveCollective: {
     type: CollectiveInterfaceType,

--- a/server/lib/emailTemplates.js
+++ b/server/lib/emailTemplates.js
@@ -50,6 +50,7 @@ const templateNames = [
   'organization.newmember',
   'payment.failed',
   'payment.failed.text',
+  'pledge.complete',
   'processing',
   'report.platform',
   'subscription.canceled',

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -31,7 +31,7 @@ const ics = require('ics'); // eslint-disable-line import/no-commonjs
 
 const debug = debugLib('collective');
 
-const defaultTiers = (HostCollectiveId, currency) => {
+export const defaultTiers = (HostCollectiveId, currency) => {
   const tiers = [];
 
   if (HostCollectiveId === 858) {
@@ -1138,7 +1138,7 @@ export default function(Sequelize, DataTypes) {
   Collective.prototype.addUserWithRole = function(
     user,
     role,
-    defaultAttributes,
+    defaultAttributes = {},
   ) {
     if (role === roles.HOST) {
       return console.error(

--- a/templates/emails/pledge.complete.hbs
+++ b/templates/emails/pledge.complete.hbs
@@ -1,0 +1,36 @@
+Subject: {{ collective.name }} has been claimed! Time to complete your pledge.
+
+{{> header }}
+
+{{> toplogo }}
+
+{{#if fromCollective.name}}
+  <p>Dear {{fromCollective.name}},</p>
+{{else}}
+  <p>Hello!</p>
+{{/if}}
+
+
+{{#if interval}}
+  <p>The {{collective.name}} collective has been claimed thanks to your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.</p>
+{{else}}
+  <p>The {{collective.name}} collective has been claimed thanks to your pledge to give {{{currency order.totalAmount currency=order.currency}}}.</p>
+{{/if}}
+
+<p>You can now complete your pledge using the following link: <a href="https://opencollective.com/pledges/{{order.id}}/complete">Complete My Pledge</a>
+
+<p>Warmly,</p>
+
+<p>
+  – The {{collective.name}} open collective
+</p>
+
+{{> footer}}
+
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+  OpenCollective, Inc.<br />
+  EIN: 47-3896707<br />
+  340 S LEMON AVE #3717<br />
+  Walnut CA 91789<br />
+  USA
+</p>


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/1168

Pairs with https://github.com/opencollective/opencollective-frontend/pull/873

Includes:

- add `status` arg to orders list in the CollectiveInterface for GraphQL
- new `claimCollective` mutation
- `pledge.complete` test data for local email

Email preview:

<img width="593" alt="screen shot 2018-09-25 at 4 42 37 pm" src="https://user-images.githubusercontent.com/3051193/46367981-072d7080-c64d-11e8-9a09-aa8ac61878d7.png">
