### PR TITLE
Trigger only one comment per user for each host

### DIFF
--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -204,8 +204,8 @@ async function w9bot(activity) {
 
   // Host has already received form from the current user so it won't trigger
   if (
-    get(host, 'data.W9.receivedFromUserIds') &&
-    host.data.W9.receivedFromUserIds.includes(activity.data.user.id)
+    get(host, 'data.W9.requestSentToUserIds') &&
+    host.data.W9.requestSentToUserIds.includes(activity.data.user.id)
   ) {
     return;
   }


### PR DESCRIPTION
Today we add a new comment to each expense of the contributor until one of those expenses are marked as paid. But sometimes the contributor sends the w9 form but those expenses are not marked as paid and then they get confused as they have already sent them. This PR is a simple change to add only one comment per user for each host( if the user contributes to collectives with different hosts, he will receive only ONE comment for each distinct host)

fixes https://github.com/opencollective/opencollective/issues/1333