### PR TITLE
Fix getBalance of virtual cards to sum transactions of different currencies properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opencollective-api",
-  "version": "2.0.232",
+  "version": "2.0.233",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencollective-api",
-  "version": "2.0.232",
+  "version": "2.0.233",
   "description": "Open Collective API",
   "author": "@philmod @arnaudbenard @xdamman @asood123",
   "main": "server/index.js",

--- a/server/middleware/security/auth.js
+++ b/server/middleware/security/auth.js
@@ -36,6 +36,7 @@ export async function checkClientApp(req, res, next) {
         req.loggedInAccount = await models.Collective.findById(collectiveId);
         req.remoteUser = await models.User.findById(collectiveId);
       }
+      next();
     } else {
       debug('auth')(`Invalid Client App (apiKey: ${apiKey}).`);
       next(new Unauthorized(`Invalid Api Key: ${apiKey}.`));

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -3,7 +3,6 @@ import uuidv4 from 'uuid/v4';
 import { get } from 'lodash';
 import models, { Op, sequelize } from '../../models';
 import * as libpayments from '../../lib/payments';
-import * as libtransactions from '../../lib/transactions';
 import * as currency from '../../lib/currency';
 import { formatCurrency } from '../../lib/utils';
 
@@ -44,7 +43,6 @@ async function getBalance(paymentMethod) {
     query = { ...query, createdAt: { [Op.between]: [firstDay, lastDay] } };
   }
   /* Result will be negative (We're looking for DEBIT transactions) */
-  // const spent = await libtransactions.sum(query);
   const allTransactions = await models.Transaction.findAll({
     attributes: ['netAmountInCollectiveCurrency', 'currency'],
     where: query,

--- a/server/routes.js
+++ b/server/routes.js
@@ -133,6 +133,7 @@ export default app => {
    */
   const server = new ApolloServer({
     schema: graphqlSchemaV2,
+    introspection: true,
     // Align with behavior from express-graphql
     context: ({ req }) => {
       return req;

--- a/test/paymentMethods.opencollective.virtualcard.nock.js
+++ b/test/paymentMethods.opencollective.virtualcard.nock.js
@@ -1,0 +1,52 @@
+import nock from 'nock';
+
+export default function() {
+  nock('http://data.fixer.io', { encodedQueryParams: true })
+    .get('/latest')
+    .times(2)
+    .query({ access_key: /.*/i, base: 'EUR', symbols: 'USD' })
+    .reply(200, {
+      success: true,
+      timestamp: 1532557927,
+      historical: true,
+      base: 'EUR',
+      date: '2018-07-25',
+      rates: { USD: 1.173428 },
+    });
+  nock('http://data.fixer.io', { encodedQueryParams: true })
+    .get('/latest')
+    .times(2)
+    .query({ access_key: /.*/i, base: 'EUR', symbols: 'USD' })
+    .reply(200, {
+      success: true,
+      timestamp: 1532557927,
+      historical: true,
+      base: 'EUR',
+      date: '2018-07-25',
+      rates: { USD: 1.173428 },
+    });
+  nock('http://data.fixer.io', { encodedQueryParams: true })
+    .get('/latest')
+    .times(2)
+    .query({ access_key: /.*/i, base: 'EUR', symbols: 'USD' })
+    .reply(200, {
+      success: true,
+      timestamp: 1532557927,
+      historical: true,
+      base: 'EUR',
+      date: '2018-07-25',
+      rates: { USD: 1.173428 },
+    });
+  nock('http://data.fixer.io', { encodedQueryParams: true })
+    .get('/latest')
+    .times(2)
+    .query({ access_key: /.*/i, base: 'EUR', symbols: 'USD' })
+    .reply(200, {
+      success: true,
+      timestamp: 1532557927,
+      historical: true,
+      base: 'EUR',
+      date: '2018-07-25',
+      rates: { USD: 1.173428 },
+    });
+}


### PR DESCRIPTION
Today the virtual cards `getBalance` method is wrong because it's summing up only transactions of the same currency of the payment method. It must instead sum all transactions converting the transactions with a different currency to the currency of the payment method so we can be sure that the contributor has not reached the limit.

references https://github.com/opencollective/opencollective/issues/1346