### PR TITLE
updateOrder: initial implementation

### DIFF
--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -211,6 +211,7 @@ export const OrderInputType = new GraphQLInputObjectType({
   name: 'OrderInputType',
   description: 'Input type for OrderType',
   fields: () => ({
+    id: { type: GraphQLInt },
     quantity: { type: GraphQLInt },
     totalAmount: { type: GraphQLInt },
     hostFeePercent: { type: GraphQLInt },

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -11,6 +11,7 @@ import {
   updateSubscription,
   refundTransaction,
   addFundsToOrg,
+  updateOrder,
 } from './mutations/orders';
 import { createMember, removeMember } from './mutations/members';
 import { editTiers } from './mutations/tiers';
@@ -223,6 +224,17 @@ const mutations = {
     },
     resolve(_, args, req) {
       return createOrder(args.order, req.loaders, req.remoteUser);
+    },
+  },
+  updateOrder: {
+    type: OrderType,
+    args: {
+      order: {
+        type: new GraphQLNonNull(OrderInputType),
+      },
+    },
+    resolve(_, args, req) {
+      return updateOrder(req.remoteUser, args.order);
     },
   },
   createUpdate: {

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -39,6 +39,7 @@ import {
   UpdateType,
   MemberType,
   OrderByType,
+  OrderType,
   PaginatedExpensesType,
   PaymentMethodType,
 } from './types';
@@ -1194,6 +1195,19 @@ const queries = {
       }
       const transactions = await models.Transaction.findAll(query);
       return transactions;
+    },
+  },
+
+  Order: {
+    type: OrderType,
+    args: {
+      id: {
+        type: new GraphQLNonNull(GraphQLInt),
+      },
+    },
+    resolve: async (_, args) => {
+      const order = await models.Order.findById(args.id);
+      return order;
     },
   },
 };

--- a/templates/emails/pledge.complete.hbs
+++ b/templates/emails/pledge.complete.hbs
@@ -17,7 +17,7 @@ Subject: {{ collective.name }} has been claimed! Time to complete your pledge.
   <p>The {{collective.name}} collective has been claimed thanks to your pledge to give {{{currency order.totalAmount currency=order.currency}}}.</p>
 {{/if}}
 
-<p>You can now complete your pledge using the following link: <a href="https://opencollective.com/pledges/{{order.id}}/complete">Complete My Pledge</a>
+<p>You can now complete your pledge using the following link: <a href="https://opencollective.com/pledges/{{order.id}}">Complete My Pledge</a>
 
 <p>Warmly,</p>
 

--- a/test/graphql.updateOrder.test.js
+++ b/test/graphql.updateOrder.test.js
@@ -1,0 +1,232 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { pick } from 'lodash';
+
+import * as utils from '../test/utils';
+import models from '../server/models';
+
+const ordersData = utils.data('orders');
+
+const order = {
+  quantity: 1,
+  interval: null,
+  collective: {
+    id: null,
+  },
+};
+
+const updateOrderQuery = `
+  mutation updateOrder($order: OrderInputType!) {
+    updateOrder(order: $order) {
+      id
+      status
+      createdByUser {
+        id
+      }
+      paymentMethod {
+        id
+      }
+      totalAmount
+      fromCollective {
+        id
+        slug
+        name
+        website
+      }
+      collective {
+        id
+        slug
+        currency
+      }
+      subscription {
+        id
+        amount
+        interval
+        isActive
+        stripeSubscriptionId
+      }
+    }
+  }
+`;
+
+describe('updateOrder', () => {
+  let sandbox, user, user2, collective, paymentMethod, existingOrder;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  after(() => sandbox.restore());
+
+  beforeEach(async () => {
+    await utils.resetTestDB();
+    user = await models.User.createUserWithCollective(utils.data('user1'));
+    user2 = await models.User.createUserWithCollective(utils.data('user2'));
+    collective = await models.Collective.create(utils.data('collective1'));
+    paymentMethod = await models.PaymentMethod.create({
+      ...utils.data('paymentMethod2'),
+      CreatedByUserId: user2.id,
+    });
+
+    await user.collective.update({ currency: 'EUR' });
+    await user2.collective.update({ currency: 'EUR' });
+    await collective.addHost(user.collective, user);
+
+    await models.ConnectedAccount.create({
+      service: 'stripe',
+      token: 'sktest_123',
+      CollectiveId: user.CollectiveId,
+    });
+
+    existingOrder = await models.Order.create({
+      ...ordersData[0],
+      currency: 'EUR',
+      CreatedByUserId: user2.id,
+      FromCollectiveId: user2.CollectiveId,
+      CollectiveId: collective.id,
+      totalAmount: ordersData[0].amount,
+    });
+
+    utils.stubStripeCreate(sandbox, {
+      charge: { currency: 'eur', status: 'succeeded' },
+    });
+  });
+
+  afterEach(() => {
+    utils.clearbitStubAfterEach(sandbox);
+  });
+
+  it('fails if if no authorization provided', async () => {
+    const res = await utils.graphqlQuery(updateOrderQuery, {
+      order,
+    });
+
+    expect(res.errors).to.exist;
+    expect(res.errors[0].message).to.equal(
+      'You need to be logged in to update an order',
+    );
+  });
+
+  it('fails if no order exists yet', async () => {
+    const res = await utils.graphqlQuery(
+      updateOrderQuery,
+      {
+        order,
+      },
+      user2,
+    );
+
+    expect(res.errors).to.exist;
+    expect(res.errors[0].message).to.equal('Existing order not found');
+  });
+
+  it('fails if no paymentMethod is included', async () => {
+    order.id = existingOrder.id;
+    order.totalAmount = existingOrder.totalAmount;
+
+    const res = await utils.graphqlQuery(
+      updateOrderQuery,
+      {
+        order,
+      },
+      user2,
+    );
+
+    expect(res.errors).to.exist;
+    expect(res.errors[0].message).to.equal(
+      'This order requires a payment method',
+    );
+  });
+
+  it('updates an order as logged in user', async () => {
+    order.id = existingOrder.id;
+    order.totalAmount = existingOrder.totalAmount;
+    order.paymentMethod = pick(paymentMethod, [
+      'id',
+      'uuid',
+      'service',
+      'token',
+      'name',
+    ]);
+
+    utils.stubStripeBalance(
+      sandbox,
+      order.totalAmount,
+      'eur',
+      Math.round(order.totalAmount * 0.05),
+      4500,
+    ); // This is the payment processor fee.
+
+    // When the query is executed
+    const res = await utils.graphqlQuery(updateOrderQuery, { order }, user2);
+
+    // Then there should be no errors
+    expect(res.errors).to.not.exist;
+    expect(res.data.updateOrder.status).to.equal('PAID');
+    expect(res.data.updateOrder.subscription).to.not.exist;
+
+    // And then the creator of the order should be user
+    const orderForCollective = res.data.updateOrder.collective;
+    const transaction = await models.Transaction.findOne({
+      where: {
+        CollectiveId: orderForCollective.id,
+        amount: existingOrder.totalAmount,
+      },
+    });
+    expect(transaction.FromCollectiveId).to.equal(user2.CollectiveId);
+    expect(transaction.CollectiveId).to.equal(orderForCollective.id);
+    expect(transaction.currency).to.equal(orderForCollective.currency);
+    expect(transaction.hostFeeInHostCurrency).to.equal(
+      -(0.1 * order.totalAmount),
+    );
+    expect(transaction.platformFeeInHostCurrency).to.equal(
+      -(0.05 * order.totalAmount),
+    );
+    expect(transaction.data.charge.currency).to.equal(
+      orderForCollective.currency.toLowerCase(),
+    );
+    expect(transaction.data.charge.status).to.equal('succeeded');
+    expect(
+      transaction.data.balanceTransaction.net +
+        transaction.hostFeeInHostCurrency,
+    ).to.equal(transaction.netAmountInCollectiveCurrency);
+    // make sure the payment has been recorded in the connected
+    // Stripe Account of the host
+    expect(transaction.data.charge.currency).to.equal('eur');
+  });
+
+  it('updates an order with a new Subscription', async () => {
+    order.id = existingOrder.id;
+    order.interval = 'month';
+    order.totalAmount = existingOrder.totalAmount;
+    order.paymentMethod = pick(paymentMethod, [
+      'id',
+      'uuid',
+      'service',
+      'token',
+      'name',
+    ]);
+
+    utils.stubStripeBalance(
+      sandbox,
+      order.totalAmount,
+      'eur',
+      Math.round(order.totalAmount * 0.05),
+      4500,
+    ); // This is the payment processor fee.
+
+    // When the query is executed
+    const res = await utils.graphqlQuery(updateOrderQuery, { order }, user2);
+
+    // Then there should be no errors
+    expect(res.errors).to.not.exist;
+    expect(res.data.updateOrder.subscription).to.exist;
+    expect(res.data.updateOrder.status).to.equal('ACTIVE');
+
+    const { subscription } = res.data.updateOrder;
+
+    expect(subscription.interval).to.equal('month');
+    expect(subscription.isActive).to.be.true;
+    expect(subscription.amount).to.equal(order.totalAmount);
+  });
+});


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/1168

Includes:

- fix for the pledge.complete email template to use correct frontend route
- adds an `Order` query to the GraphQL API
- adds an `updateOrder` mutation to update existing orders, w/ initial test coverage