### PR TITLE
Fixing virtual card bugs

### DIFF
--- a/server/graphql/v1/mutations/paymentMethods.js
+++ b/server/graphql/v1/mutations/paymentMethods.js
@@ -67,25 +67,26 @@ export async function claimPaymentMethod(args, remoteUser) {
   });
   const {
     initialBalance,
+    monthlyLimitPerMember,
     currency,
     name,
     expiryDate,
    } = paymentMethod;
-
+  const amount = initialBalance || monthlyLimitPerMember;
   const emitter = await models.Collective.findById(paymentMethod.sourcePaymentMethod.CollectiveId);
   const userCollective = await user.getCollective();
   const userName = userCollective.name && userCollective.name.match(/anonymous/i) ? '' : userCollective.name;
 
   const qs = queryString.stringify({
     name: userName,
-    amount: initialBalance,
+    amount: amount,
     currency,
     emitterSlug: emitter.slug,
     emitterName: emitter.name,
   });
   emailLib.send('user.card.claimed', user.email, {
     loginLink: user.generateLoginLink(`/redeemed?${qs}`),
-    initialBalance,
+    initialBalance: amount,
     name,
     currency,
     expiryDate,

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -395,6 +395,10 @@ export default function(Sequelize, DataTypes) {
     if (user) {
       await user.populateRoles();
     }
+    // virtualcard monthlyLimitPerMember are calculated differently so the getBalance already returns the right result
+    if (this.type === 'virtualcard') {
+      return getBalance(this);
+    }
 
     const balance = await getBalance(this);
 


### PR DESCRIPTION
- [x] Email 0 -> It's considering only the `amount` field and not the `monthlyLimitPerMember`. Also images broken.
![0email](https://user-images.githubusercontent.com/8717041/46639027-d4deb000-cb31-11e8-8ca9-b7a869eaabeb.png)

- [x] Redeem Page not working properly because of the same problem as above(`amount` only, and not counting the `monthlyLimitPerMember` case.
![redeem0](https://user-images.githubusercontent.com/8717041/46639125-461e6300-cb32-11e8-8a7e-994d56e93ec1.png)

- [x] After a virtual card balance reaches $0, it should not be shown in the payment method options anymore. To fix this I've created the `hasBalanceAboveZero ` that would filter the $0 payment methods from the options. this way it won't affect other existing places the same query is being used and it also sometimes makes sense to return *ALL* payment methods(not in the options to pay with one that has $0 balance...)

references https://github.com/opencollective/opencollective/issues/1346