### PR TITLE
Fix permissions for deleting and editing updates

### DIFF
--- a/test/graphql.updates.test.js
+++ b/test/graphql.updates.test.js
@@ -265,7 +265,7 @@ describe('graphql.updates.test', () => {
       );
     });
 
-    it('fails if not authenticated as author or admin of collective', async () => {
+    it('fails if not authenticated as admin of collective', async () => {
       const result = await utils.graphqlQuery(
         editUpdateQuery,
         { update: { id: update1.id } },
@@ -273,7 +273,7 @@ describe('graphql.updates.test', () => {
       );
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal(
-        'You must be the author or an admin of this collective to edit this update',
+        "You don't have sufficient permissions to edit this update",
       );
     });
 
@@ -339,7 +339,7 @@ describe('graphql.updates.test', () => {
       );
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal(
-        'You need to be logged in as a core contributor or as a host to delete this update',
+        "You don't have sufficient permissions to delete this update",
       );
       return models.Update.findById(update1.id).then(updateFound => {
         expect(updateFound).to.not.be.null;


### PR DESCRIPTION
Permission check on `deleteUpdate` was calling `remoteUser.isAdmin` with an update ID as param. However `isAdmin` takes a CollectiveID as parameter, not an update.id:
```es6
  User.prototype.isAdmin = function(CollectiveId) {
    const result =
      this.CollectiveId === Number(CollectiveId) ||
      this.hasRole([roles.HOST, roles.ADMIN], CollectiveId);
    debug('isAdmin of CollectiveId', CollectiveId, '?', result);
    return result;
  };
```

Test `deletes an update` was successful because the ID we were giving was matching an existing collective for which user had the authorization.