### PR TITLE
Handle edge cases in collective slug generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2937,6 +2937,11 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bulk-replace": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/bulk-replace/-/bulk-replace-0.0.1.tgz",
+      "integrity": "sha1-8JVoKolqvUs9ngjeQJzCIuIT+d0="
+    },
     "busboy": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
@@ -7879,6 +7884,14 @@
         "platform": "1.3.3"
       }
     },
+    "hepburn": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hepburn/-/hepburn-1.1.1.tgz",
+      "integrity": "sha512-Ok3ZmMJN3ek4WFAL4f5t8k+BmrDRlS5qGjI4um+3cHH0SrYVzJgUTYwIfGvU8s/eWqOEY+gsINwjJSoaBG3A9g==",
+      "requires": {
+        "bulk-replace": "0.0.1"
+      }
+    },
     "hide-powered-by": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.0.0.tgz",
@@ -9259,6 +9272,11 @@
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "optional": true
     },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -9414,6 +9432,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
+    },
+    "limax": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/limax/-/limax-1.7.0.tgz",
+      "integrity": "sha512-ibcGylOXT5vry2JKfKwLWx2tZudRYWm4SzG9AE/cc5zqwW+3nQy/uPLUvfAUChRdmqxVrK6SNepmO7ZY8RoKfA==",
+      "requires": {
+        "hepburn": "^1.1.0",
+        "pinyin": "^2.8.3",
+        "speakingurl": "^14.0.1"
+      }
     },
     "linkify-it": {
       "version": "2.0.3",
@@ -10939,6 +10967,15 @@
       "integrity": "sha1-zdCgkgOBkBq/w2nrV6biSx7W3co=",
       "requires": {
         "unidecode": "^0.1.3"
+      }
+    },
+    "nodejieba": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/nodejieba/-/nodejieba-2.2.6.tgz",
+      "integrity": "sha1-F81BZwW3sBwGLmzZ1xebMEU+tKM=",
+      "optional": true,
+      "requires": {
+        "nan": "~2.10.0"
       }
     },
     "nodemailer": {
@@ -13830,6 +13867,26 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pinyin": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/pinyin/-/pinyin-2.8.3.tgz",
+      "integrity": "sha1-MBzLQ1jM/oAlI8S9ZAphK+5NfEs=",
+      "requires": {
+        "commander": "~1.1.1",
+        "nodejieba": "^2.2.1",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+          "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
+          "requires": {
+            "keypress": "0.1.x"
+          }
+        }
+      }
+    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -16238,6 +16295,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+    },
+    "speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="
     },
     "split": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "juice": "2.0.0",
     "knox": "github:automattic/knox#278337d7673341658efcc81e631c3f63fa53d374",
     "knox-mpu-alt": "0.2.2",
+    "limax": "^1.7.0",
     "lodash": "3.10.1",
     "lru-cache": "4.1.1",
     "merge-options": "^1.0.1",

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -1,5 +1,5 @@
 import debugLib from 'debug';
-import slugify from 'slug';
+import slugify from 'limax';
 import { get, omit } from 'lodash';
 
 import models from '../../../models';

--- a/server/lib/collectivelib.js
+++ b/server/lib/collectivelib.js
@@ -1,0 +1,29 @@
+/**
+ * Check if given `slug` could conflict with existing routes or
+ * if it's a reserved keyword.
+ *
+ * The list is mostly based on frontend `src/server/pages.js` file and
+ * `src/pages/static` content.
+ *
+ * @param {String} slug
+ */
+export function isBlacklistedCollectiveSlug(slug) {
+  return [
+    'about',
+    'chapters',
+    'create',
+    'discover',
+    'faq',
+    'hosts',
+    'learn-more',
+    'opensource',
+    'privacypolicy',
+    'redeem',
+    'redeemed',
+    'search',
+    'signin',
+    'subscriptions',
+    'tos',
+    'widgets',
+  ].includes(slug);
+}

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -16,7 +16,7 @@ import {
   getDomain,
   formatCurrency,
 } from '../lib/utils';
-import slugify from 'slug';
+import slugify from 'limax';
 import activities from '../constants/activities';
 import Promise from 'bluebird';
 import userlib from '../lib/userlib';
@@ -2080,12 +2080,7 @@ export default function(Sequelize, DataTypes) {
 
     suggestions = suggestions
       .filter(slug => (slug ? true : false)) // filter out any nulls
-      .map(slug => slugify(slug.trim()).toLowerCase(/\./g, '')) // lowercase them all
-      // remove any '+' signs
-      .map(
-        slug =>
-          slug.indexOf('+') !== -1 ? slug.substr(0, slug.indexOf('+')) : slug,
-      );
+      .map(slug => slugify(slug)); // Will also trim, lowercase and remove + signs
 
     // fetch any matching slugs or slugs for the top choice in the list above
     return Sequelize.query(

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -27,6 +27,7 @@ import debugLib from 'debug';
 import fetch from 'isomorphic-fetch';
 import crypto from 'crypto';
 import moment from 'moment';
+import { isBlacklistedCollectiveSlug } from '../lib/collectivelib';
 const ics = require('ics'); // eslint-disable-line import/no-commonjs
 
 const debug = debugLib('collective');
@@ -2070,7 +2071,7 @@ export default function(Sequelize, DataTypes) {
     */
     const slugSuggestionHelper = (slugToCheck, slugList, count) => {
       const slug = count > 0 ? `${slugToCheck}${count}` : slugToCheck;
-      if (slugList.indexOf(slug) === -1) {
+      if (slugList.indexOf(slug) === -1 && !isBlacklistedCollectiveSlug(slug)) {
         return slug;
       } else {
         return slugSuggestionHelper(`${slugToCheck}`, slugList, count + 1);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -4,7 +4,7 @@
 import bcrypt from 'bcrypt';
 import config from 'config';
 import Promise from 'bluebird';
-import slugify from 'slug';
+import slugify from 'limax';
 
 import * as auth from '../lib/auth';
 import errors from '../lib/errors';

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -4,6 +4,7 @@
 import bcrypt from 'bcrypt';
 import config from 'config';
 import Promise from 'bluebird';
+import slugify from 'slug';
 
 import * as auth from '../lib/auth';
 import errors from '../lib/errors';
@@ -585,9 +586,19 @@ export default (Sequelize, DataTypes) => {
         if (name && userData.lastName) {
           name += ` ${userData.lastName}`;
         }
+
+        // If user doesn't provide a name, set it to "anonymous". If we cannot
+        // slugify it (for example firstName="------") then fallback on "user".
+        let collectiveName = userData.name || name;
+        if (!collectiveName || collectiveName.trim().length === 0) {
+          collectiveName = 'anonymous';
+        } else if (slugify(collectiveName).length === 0) {
+          collectiveName = 'user';
+        }
+
         const userCollective = {
           type: 'USER',
-          name: userData.name || name || 'anonymous',
+          name: collectiveName,
           image: userData.image,
           mission: userData.mission,
           description: userData.description,

--- a/test/collective.model.test.js
+++ b/test/collective.model.test.js
@@ -187,7 +187,7 @@ describe('Collective model', () => {
       })
       .then(() => Collective.create({ name: 'hélène & les g.arçons' }))
       .then(collective => {
-        expect(collective.slug).to.equal('helene-and-les-garcons');
+        expect(collective.slug).to.equal('helene-and-les-g-arcons');
       });
   });
 

--- a/test/collective.model.test.js
+++ b/test/collective.model.test.js
@@ -191,6 +191,17 @@ describe('Collective model', () => {
       });
   });
 
+  it('does not create collective with a blacklisted slug', () => {
+    return Collective.create({ name: 'learn more' }).then(collective => {
+      // `https://host/learn-more` is a protected page.
+      expect(collective.slug).to.not.equal('learn-more');
+      // However we'd like to keep the base slug: if an collective with the
+      // name "Learn More" is created, we expect to have an URL like
+      // `https://host/learn-more1`
+      expect(collective.slug.startsWith('learn-more')).to.equal(true);
+    });
+  });
+
   describe('events', () => {
     it('generates the ICS for an EVENT collective', async () => {
       const d = new Date();

--- a/test/user.model.test.js
+++ b/test/user.model.test.js
@@ -102,6 +102,18 @@ describe('user.models.test.js', () => {
         expect(user.collective.slug.startsWith('user')).to.equal(true);
       });
     });
+
+    it('knows how to deal with special characters', () => {
+      return User.createUserWithCollective({
+        email: randEmail('user@domain.com'),
+        firstName: '很棒的用户',
+        lastName: 'awesome',
+      }).then(user => {
+        expect(user.collective.slug).to.equal(
+          'hen3-bang4-de-yong4-hu4-awesome',
+        );
+      });
+    });
   });
 
   /**

--- a/test/user.model.test.js
+++ b/test/user.model.test.js
@@ -3,6 +3,7 @@ import config from 'config';
 import url from 'url';
 import { expect } from 'chai';
 import * as utils from '../test/utils';
+import { randEmail } from './features/support/stores';
 
 import models from '../server/models';
 import * as auth from '../server/lib/auth';
@@ -80,6 +81,25 @@ describe('user.models.test.js', () => {
         expect(user).to.have.property('createdAt');
         expect(user).to.have.property('password_hash');
         expect(user).to.have.property('updatedAt');
+      });
+    });
+  });
+
+  describe('#createUserWithCollective', () => {
+    it('uses "anonymous" slug if name is not provided', () => {
+      const userParams = { email: 'frank@zappa.com' };
+      return User.createUserWithCollective(userParams).then(user => {
+        expect(user.collective.slug.startsWith('anonymous')).to.equal(true);
+      });
+    });
+
+    it('uses "user" slug if name is not sluggifyable', () => {
+      return User.createUserWithCollective({
+        email: randEmail('user@domain.com'),
+        firstName: '...',
+        lastName: '?????',
+      }).then(user => {
+        expect(user.collective.slug.startsWith('user')).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/1359
Fix https://github.com/opencollective/opencollective/issues/1360

This PR implements three changes:

1. A blacklist of slugs for collective to avoid conflicting routes (see https://github.com/opencollective/opencollective/issues/1359)
2. If username cannot be slugified (ex: firstName = `"..."`) then collective is created with `user` slug.
3. Use [limax](https://github.com/lovell/limax) to generate slugs. This library handle Chinese characters and is actively maintained.