### PR TITLE
CollectiveInterface: correct status query for orders

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1024,13 +1024,16 @@ const CollectiveFields = () => {
         status: { type: OrderStatusType },
       },
       resolve(collective, args = {}) {
+        const where = {};
+
+        if (args.status) {
+          where.status = args.status;
+        } else {
+          where.processedAt = { [Op.ne]: null };
+        }
+
         return collective.getIncomingOrders({
-          where: {
-            [Op.or]: [
-              { processedAt: { [Op.ne]: null } },
-              args,
-            ],
-          },
+          where,
           order: [ ['createdAt', 'DESC'] ]
         });
       },


### PR DESCRIPTION
While working on https://github.com/opencollective/opencollective-frontend/pull/946, I discovered the `status` argument for collective orders was including too much due to the OR operation with `processedAt != null`. This fixes that issue by being exclusive about the status query. 