### PR TITLE
fix(weekly report): fix total amount of donations with stripe

### DIFF
--- a/cron/weekly/platform-report.js
+++ b/cron/weekly/platform-report.js
@@ -205,13 +205,23 @@ export default function run() {
     stripeDonationAmount: Transaction.aggregate(
       'amount',
       'SUM',
-      merge({}, lastWeekDonations, groupAndOrderBy('Transaction')),
+      merge(
+        {},
+        lastWeekDonations,
+        groupAndOrderBy('Transaction'),
+        service('stripe'),
+      ),
     ),
 
     priorStripeDonationAmount: Transaction.aggregate(
       'amount',
       'SUM',
-      merge({}, weekBeforeDonations, groupAndOrderBy('Transaction')),
+      merge(
+        {},
+        weekBeforeDonations,
+        groupAndOrderBy('Transaction'),
+        service('stripe'),
+      ),
     ),
 
     manualDonationAmount: Transaction.aggregate(


### PR DESCRIPTION
The total amount donated using Stripe was off because it was taking into accounts all transactions irrespective of the payment method used.