### PR TITLE
Pledges: create pending subscription for pledges with interval

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -280,6 +280,18 @@ export async function createOrder(order, loaders, remoteUser) {
         orderCreated,
         pick(order, ['hostFeePercent', 'platformFeePercent']),
       );
+    } else if (
+      !paymentRequired &&
+      order.interval &&
+      collective.type === types.COLLECTIVE
+    ) {
+      // create inactive subscription to hold the interval info
+      const subscription = await models.Subscription.create({
+        amount: order.totalAmount,
+        interval: order.interval,
+        currency: order.currency,
+      });
+      await orderCreated.update({ SubscriptionId: subscription.id });
     } else if (collective.type === types.EVENT) {
       // Free ticket, add user as an ATTENDEE
       const UserId = remoteUser ? remoteUser.id : user.id;

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -250,7 +250,9 @@ export const executeOrder = (user, order, options) => {
     .then(() => {
       if (payment.interval) {
         // @lincoln: shouldn't this section be executed after we successfully charge the user for the first payment? (ie. after `processOrder`)
-        return models.Subscription.create(payment)
+        return order
+          .getSubscription({ rejectOnEmpty: true })
+          .catch(() => models.Subscription.create(payment))
           .then(subscription => {
             // The order instance doesn't have the Subscription field
             // here because it was just created and no models were

--- a/test/graphql.createOrder.test.js
+++ b/test/graphql.createOrder.test.js
@@ -167,6 +167,33 @@ describe('createOrder', () => {
     expect(res.data.createOrder.status).to.equal('PENDING');
   });
 
+  it('creates a pending order (pledge) with inactive subscription if interval is included and collective is not active', async () => {
+    const collective = await models.Collective.create({
+      slug: 'test',
+      name: 'test',
+      isActive: false,
+      website: 'https://github.com/opencollective/frontend',
+    });
+    const thisOrder = cloneDeep(order);
+    thisOrder.collective.id = collective.id;
+    thisOrder.user = {
+      firstName: 'John',
+      lastName: 'Smith',
+      email: 'jsmith@email.com',
+      twitterHandle: 'johnsmith',
+      newsletterOptIn: true,
+    };
+    thisOrder.interval = 'month';
+
+    const res = await utils.graphqlQuery(createOrderQuery, {
+      order: thisOrder,
+    });
+
+    expect(res.errors).to.not.exist;
+    expect(res.data.createOrder.status).to.equal('PENDING');
+    expect(res.data.createOrder.subscription.interval).to.equal('month');
+  });
+
   it('creates an order as new user and sends a tweet', async () => {
     // And given a twitter connected account for the above
     // collective


### PR DESCRIPTION
This PR adds support for pledged subscriptions instead of just one-time donations. Due to this change, the payments lib now checks for an existing subscription before creating a new one when executing an Order. 