### PR TITLE
Pledges: bug fixes

### DIFF
--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -199,7 +199,7 @@ export const fetchAllRepositories = (req, res, next) => {
   const payload = req.jwtPayload;
   ConnectedAccount.findOne({ where: { id: payload.connectedAccountId } })
     .then(ca => {
-      return Promise.map([1, 2, 3, 4, 5], page =>
+      return Promise.map([1, 2, 3, 4, 5, 6, 7, 8, 9], page =>
         request({
           uri: 'https://api.github.com/user/repos',
           qs: {

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -251,7 +251,7 @@ export async function createOrder(order, loaders, remoteUser) {
       description: order.description || defaultDescription,
       publicMessage: order.publicMessage,
       privateMessage: order.privateMessage,
-      processedAt: paymentRequired ? null : new Date(),
+      processedAt: (paymentRequired || !collective.isActive) ? null : new Date(),
       MatchingPaymentMethodId: order.MatchingPaymentMethodId,
     };
 


### PR DESCRIPTION
When going through the final testing for the pledges workflow, I found two places that needed some quick fixes. 

- added more pages to be fetched from github when getting all of a user's repositories (there is still no way to get a total count automatically)
- added logic to prevent setting `processedAt` for pending orders (a.k.a pledges)