### PR TITLE
feature(api v1): fetch transaction by id or uuid

### DIFF
--- a/server/controllers/collectives.js
+++ b/server/controllers/collectives.js
@@ -1,7 +1,7 @@
 /**
  * Dependencies.
  */
-import { get, pick, omit } from 'lodash';
+import { pick, omit } from 'lodash';
 import async from 'async';
 import {
   defaultHostCollective,
@@ -19,52 +19,8 @@ import errors from '../lib/errors';
 import debugLib from 'debug';
 import config from 'config';
 import prependHttp from 'prepend-http';
-import * as utils from '../graphql/v1/utils';
 
 const { Activity, Notification, Collective, ConnectedAccount, User } = models;
-
-const allTransactionsQuery = `
-  query allTransactions($collectiveSlug: String!, $limit: Int, $offset: Int, $type: String, $includeVirtualCards: Boolean ) {
-    allTransactions(collectiveSlug: $collectiveSlug, limit: $limit, offset: $offset, type: $type, includeVirtualCards: $includeVirtualCards) {
-      id
-      uuid
-      type
-      amount
-      currency
-      hostCurrency
-      hostCurrencyFxRate
-      hostFeeInHostCurrency
-      platformFeeInHostCurrency
-      paymentProcessorFeeInHostCurrency
-      netAmountInCollectiveCurrency
-      createdAt
-      updatedAt
-      host {
-        id
-        slug
-      }
-      createdByUser {
-        id
-        email
-      }
-      fromCollective {
-        id
-        slug
-        name
-        image
-      }
-      collective {
-        id
-        slug
-        name
-        image
-      }
-      paymentMethod {
-        id
-      }
-    }
-  }
-`;
 
 const _addUserToCollective = (collective, user, options) => {
   const checkIfCollectiveHasHost = () => {
@@ -702,22 +658,4 @@ export const getTransactions = (req, res, next) => {
       );
     })
     .catch(next);
-};
-
-/**
- * Get array of all transactions of a collective given its slug
- */
-export const getCollectiveTransactions = async (req, res) => {
-  try {
-    const args = req.query;
-    args.collectiveSlug = get(req, 'params.collectiveSlug');
-    const response = await utils.graphqlQuery(allTransactionsQuery, req.query);
-    if (response.errors) {
-      throw new Error(response.errors[0]);
-    }
-    const result = get(response, 'data.allTransactions', []);
-    res.send({ result });
-  } catch (error) {
-    res.status(400).send({ error: error.toString() });
-  }
 };

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -638,11 +638,14 @@ const queries = {
     type: TransactionInterfaceType,
     args: {
       id: {
-        type: new GraphQLNonNull(GraphQLInt),
+        type: GraphQLInt,
+      },
+      uuid: {
+        type: GraphQLString,
       },
     },
     resolve(_, args) {
-      return models.Transaction.findOne({ where: { id: args.id } });
+      return models.Transaction.findOne({ where: { ...args } });
     },
   },
 

--- a/server/graphql/v1/restapi.js
+++ b/server/graphql/v1/restapi.js
@@ -1,5 +1,5 @@
 import * as utils from './utils';
-import { get } from 'lodash';
+import { get, pick } from 'lodash';
 
 const allTransactionsQuery = `
 query allTransactions($collectiveSlug: String!, $limit: Int, $offset: Int, $type: String, $includeVirtualCards: Boolean ) {
@@ -46,8 +46,8 @@ query allTransactions($collectiveSlug: String!, $limit: Int, $offset: Int, $type
 `;
 
 const getTransactionQuery = `
-  query Transaction($uuid: String) {
-    Transaction(uuid: $uuid) {
+  query Transaction($id: Int, $uuid: String) {
+    Transaction(id: $id, uuid: $uuid) {
       id
       uuid
       type
@@ -121,9 +121,10 @@ export const getLatestTransactions = async (req, res) => {
  */
 export const getTransaction = async (req, res) => {
   try {
-    const response = await utils.graphqlQuery(getTransactionQuery, {
-      uuid: req.params.uuid,
-    });
+    const response = await utils.graphqlQuery(
+      getTransactionQuery,
+      pick(req.params, ['id', 'uuid']),
+    );
     if (response.errors) {
       throw new Error(response.errors[0]);
     }

--- a/server/graphql/v1/restapi.js
+++ b/server/graphql/v1/restapi.js
@@ -1,0 +1,135 @@
+import * as utils from './utils';
+import { get } from 'lodash';
+
+const allTransactionsQuery = `
+query allTransactions($collectiveSlug: String!, $limit: Int, $offset: Int, $type: String, $includeVirtualCards: Boolean ) {
+  allTransactions(collectiveSlug: $collectiveSlug, limit: $limit, offset: $offset, type: $type, includeVirtualCards: $includeVirtualCards) {
+    id
+    uuid
+    type
+    amount
+    currency
+    hostCurrency
+    hostCurrencyFxRate
+    hostFeeInHostCurrency
+    platformFeeInHostCurrency
+    paymentProcessorFeeInHostCurrency
+    netAmountInCollectiveCurrency
+    createdAt
+    host {
+      id
+      slug
+    }
+    createdByUser {
+      id
+      email
+    }
+    fromCollective {
+      id
+      slug
+      name
+      image
+    }
+    collective {
+      id
+      slug
+      name
+      image
+    }
+    paymentMethod {
+      id
+      service
+      name
+    }
+  }
+}
+`;
+
+const getTransactionQuery = `
+  query Transaction($uuid: String) {
+    Transaction(uuid: $uuid) {
+      id
+      uuid
+      type
+      createdAt
+      description
+      amount      
+      currency
+      hostCurrency
+      hostCurrencyFxRate
+      netAmountInCollectiveCurrency
+      hostFeeInHostCurrency
+      platformFeeInHostCurrency
+      paymentProcessorFeeInHostCurrency
+      paymentMethod {
+        id
+        service
+        name
+      }
+      fromCollective {
+        id
+        slug
+        name
+        image
+      }
+      collective {
+        id
+        slug
+        name
+        image
+      }
+      host {
+        id
+        slug
+        name
+        image
+      }
+      ... on Order {
+        order {
+          id
+          status
+          subscription {
+            id
+            interval
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Get array of all transactions of a collective given its slug
+ */
+export const getLatestTransactions = async (req, res) => {
+  try {
+    const args = req.query;
+    args.collectiveSlug = get(req, 'params.collectiveSlug');
+    const response = await utils.graphqlQuery(allTransactionsQuery, req.query);
+    if (response.errors) {
+      throw new Error(response.errors[0]);
+    }
+    const result = get(response, 'data.allTransactions', []);
+    res.send({ result });
+  } catch (error) {
+    res.status(400).send({ error: error.toString() });
+  }
+};
+
+/**
+ * Get one transaction of a collective given its uuid
+ */
+export const getTransaction = async (req, res) => {
+  try {
+    const response = await utils.graphqlQuery(getTransactionQuery, {
+      uuid: req.params.uuid,
+    });
+    if (response.errors) {
+      throw new Error(response.errors[0]);
+    }
+    const result = get(response, 'data.Transaction');
+    res.send({ result });
+  } catch (error) {
+    res.status(400).send({ error: error.toString() });
+  }
+};

--- a/server/middleware/params.js
+++ b/server/middleware/params.js
@@ -9,7 +9,7 @@ const { User, Collective, Transaction, Expense } = models;
  * Parse id or uuid and returns the where condition to get the element
  * @POST: { uuid: String } or { id: Int }
  */
-const parseId = param => {
+const parseIdOrUUID = param => {
   if (isUUID(param)) {
     return Promise.resolve({ uuid: param });
   }
@@ -41,7 +41,8 @@ export function uuid(req, res, next, uuid) {
   ) {
     req.params.uuid = uuid;
   } else {
-    req.params.uuid = null;
+    const id = parseInt(uuid);
+    if (!_.isNaN(id)) req.params.id = id;
   }
   next();
 }
@@ -95,7 +96,7 @@ export function transactionuuid(req, res, next, transactionuuid) {
  * Transactionid for a paranoid (deleted) ressource
  */
 export function paranoidtransactionid(req, res, next, id) {
-  parseId(id)
+  parseIdOrUUID(id)
     .then(where => {
       return Transaction.findOne({
         where,
@@ -125,7 +126,7 @@ export function expenseid(req, res, next, expenseid) {
     queryInCollective = { CollectiveId: req.params.collectiveid };
     NotFoundInCollective = `in collective ${req.params.collectiveid}`;
   }
-  parseId(expenseid)
+  parseIdOrUUID(expenseid)
     .then(where =>
       Expense.findOne({
         where: Object.assign({}, where, queryInCollective),

--- a/server/middleware/params.js
+++ b/server/middleware/params.js
@@ -33,6 +33,19 @@ function getByKeyValue(model, key, value) {
   });
 }
 
+export function uuid(req, res, next, uuid) {
+  if (
+    uuid.match(
+      /^[A-F\d]{8}-[A-F\d]{4}-4[A-F\d]{3}-[89AB][A-F\d]{3}-[A-F\d]{12}$/i,
+    )
+  ) {
+    req.params.uuid = uuid;
+  } else {
+    req.params.uuid = null;
+  }
+  next();
+}
+
 /**
  * userid
  */

--- a/server/routes.js
+++ b/server/routes.js
@@ -114,6 +114,7 @@ export default app => {
   /**
    * Parameters.
    */
+  app.param('uuid', params.uuid);
   app.param('userid', params.userid);
   app.param('collectiveid', params.collectiveid);
   app.param('transactionuuid', params.transactionuuid);

--- a/server/routes.js
+++ b/server/routes.js
@@ -11,7 +11,10 @@ import getHomePage from './controllers/homepage';
 import uploadImage from './controllers/images';
 import * as mw from './controllers/middlewares';
 import * as notifications from './controllers/notifications';
-import { getPaymentMethods, createPaymentMethod } from './controllers/paymentMethods';
+import {
+  getPaymentMethods,
+  createPaymentMethod,
+} from './controllers/paymentMethods';
 import * as test from './controllers/test';
 import * as users from './controllers/users';
 import * as applications from './controllers/applications';
@@ -224,10 +227,10 @@ export default app => {
   app.delete('/users/:userid/payment-methods/:paymentMethodid', NotImplemented); // Delete a user's paymentMethod.
 
   /**
-  * Create a payment method.
-  *
-  *  Let's assume for now a paymentMethod is linked to a user.
-  */
+   * Create a payment method.
+   *
+   *  Let's assume for now a paymentMethod is linked to a user.
+   */
   app.post('/v1/payment-methods', createPaymentMethod);
 
   /**

--- a/server/routes.js
+++ b/server/routes.js
@@ -6,6 +6,7 @@ import * as connectedAccounts from './controllers/connectedAccounts';
 import getDiscoverPage from './controllers/discover';
 import * as transactions from './controllers/transactions';
 import * as collectives from './controllers/collectives';
+import * as RestApi from './graphql/v1/restapi';
 import getHomePage from './controllers/homepage';
 import uploadImage from './controllers/images';
 import * as mw from './controllers/middlewares';
@@ -229,12 +230,6 @@ export default app => {
   */
   app.post('/v1/payment-methods', createPaymentMethod);
 
- /**
-  * Get transactions of a collective given its slug.
-  *
-  */
- app.get('/v1/collectives/:collectiveSlug/transactions', collectives.getCollectiveTransactions);
-
   /**
    * Collectives.
    */
@@ -294,6 +289,16 @@ export default app => {
   /**
    * Transactions (financial).
    */
+
+  // Get transactions of a collective given its slug.
+  app.get(
+    '/v1/collectives/:collectiveSlug/transactions',
+    RestApi.getLatestTransactions,
+  );
+  app.get(
+    '/v1/collectives/:collectiveSlug/transactions/:uuid',
+    RestApi.getTransaction,
+  );
   app.get('/transactions/:transactionuuid', transactions.getOne); // Get the transaction details
   app.get(
     '/groups/:collectiveid/transactions',

--- a/server/routes.js
+++ b/server/routes.js
@@ -299,7 +299,7 @@ export default app => {
     RestApi.getLatestTransactions,
   );
   app.get(
-    '/v1/collectives/:collectiveSlug/transactions/:uuid',
+    '/v1/collectives/:collectiveSlug/transactions/:IdOrUUID',
     RestApi.getTransaction,
   );
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -302,7 +302,11 @@ export default app => {
     '/v1/collectives/:collectiveSlug/transactions/:uuid',
     RestApi.getTransaction,
   );
+
+  // xdamman: Is this route still being used anywhere? If not, we should deprecate this
   app.get('/transactions/:transactionuuid', transactions.getOne); // Get the transaction details
+
+  // xdamman: Is this route still being used anywhere? If not, we should deprecate this
   app.get(
     '/groups/:collectiveid/transactions',
     mw.paginate(),

--- a/test/api.v1.test.js
+++ b/test/api.v1.test.js
@@ -1,0 +1,101 @@
+/**
+ * Note: to update the snapshots run:
+ * TZ=UTC CHAI_JEST_SNAPSHOT_UPDATE_ALL=true mocha test/api.v1.test.js
+ */
+
+import app from '../server/index';
+import { expect } from 'chai';
+import { omit } from 'lodash';
+import request from 'supertest';
+import * as utils from '../test/utils';
+import models from '../server/models';
+import roles from '../server/constants/roles';
+const application = utils.data('application');
+const publicCollectiveData = utils.data('collective1');
+const transactionsData = utils.data('transactions1.transactions');
+
+describe('api.v1.test.js', () => {
+  let collective, user, host;
+
+  before(() => utils.resetTestDB());
+
+  // Create users
+  before('create user', () =>
+    models.User.createUserWithCollective(utils.data('user1')).tap(
+      u => (user = u),
+    ),
+  );
+  before('create host', () =>
+    models.User.createUserWithCollective(utils.data('host1')).tap(
+      u => (host = u),
+    ),
+  );
+
+  // Create collectives
+  before('create collective', () =>
+    models.Collective.create(publicCollectiveData).tap(g => (collective = g)),
+  );
+
+  // Add users to collectives
+  before('add host to collective', () => collective.addHost(host.collective));
+  before('add user to collective as a member', () =>
+    collective.addUserWithRole(user, roles.ADMIN),
+  );
+
+  let transaction, defaultAttributes;
+
+  before(() => {
+    defaultAttributes = {
+      CreatedByUserId: user.id,
+      FromCollectiveId: user.CollectiveId,
+      HostCollectiveId: host.CollectiveId,
+    };
+  });
+
+  before('create multiple transactions for collective', () => {
+    models.Transaction.createMany(transactionsData, {
+      CollectiveId: collective.id,
+      ...defaultAttributes,
+    }).then(transactions => {
+      transaction = transactions[0];
+    });
+  });
+
+  /**
+   * Get collective's transactions.
+   */
+  describe('#get', () => {
+    it('get the latest transactions', done => {
+      request(app)
+        .get(
+          `/v1/collectives/${collective.slug}/transactions?api_key=${
+            application.api_key
+          }`,
+        )
+        .expect(200)
+        .end((e, res) => {
+          expect(e).to.not.exist;
+          const transactions = res.body.result;
+          expect(transactions.length).to.equal(9);
+          expect(omit(transactions[0], ['id', 'createdAt'])).to.matchSnapshot();
+          done();
+        });
+    });
+
+    it('get one transaction details by uuid', done => {
+      request(app)
+        .get(
+          `/v1/collectives/${collective.slug}/transactions/${
+            transaction.uuid
+          }?api_key=${application.api_key}`,
+        )
+        .expect(200)
+        .end((e, res) => {
+          expect(e).to.not.exist;
+          const transaction = omit(res.body.result, ['id', 'createdAt']);
+          expect(transaction).to.matchSnapshot();
+          done();
+        });
+    });
+  });
+});

--- a/test/api.v1.test.js.snap
+++ b/test/api.v1.test.js.snap
@@ -1,0 +1,143 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`api.test.js #get get one transaction details by uuid 1`] = `
+Object {
+  "amount": -20000,
+  "collective": Object {
+    "id": 3,
+    "image": null,
+    "name": "Scouts d'Arlon",
+    "slug": "scouts",
+  },
+  "currency": "USD",
+  "description": "Homepage design",
+  "fromCollective": Object {
+    "id": 1,
+    "image": null,
+    "name": "Phil Mod",
+    "slug": "philmod",
+  },
+  "host": Object {
+    "id": 2,
+    "image": null,
+    "name": "WWCode",
+    "slug": "wwcode",
+  },
+  "hostCurrency": "USD",
+  "hostCurrencyFxRate": null,
+  "hostFeeInHostCurrency": null,
+  "netAmountInCollectiveCurrency": null,
+  "paymentMethod": null,
+  "paymentProcessorFeeInHostCurrency": null,
+  "platformFeeInHostCurrency": null,
+  "type": "DEBIT",
+  "uuid": null,
+}
+`;
+
+exports[`api.test.js #get get the latest transactions 1`] = `
+Object {
+  "amount": 5000,
+  "collective": Object {
+    "id": 3,
+    "image": null,
+    "name": "Scouts d'Arlon",
+    "slug": "scouts",
+  },
+  "createdByUser": Object {
+    "email": null,
+    "id": 1,
+  },
+  "currency": "USD",
+  "fromCollective": Object {
+    "id": 1,
+    "image": null,
+    "name": "Phil Mod",
+    "slug": "philmod",
+  },
+  "host": Object {
+    "id": 2,
+    "slug": "wwcode",
+  },
+  "hostCurrency": null,
+  "hostCurrencyFxRate": null,
+  "hostFeeInHostCurrency": null,
+  "netAmountInCollectiveCurrency": 4500,
+  "paymentMethod": null,
+  "paymentProcessorFeeInHostCurrency": null,
+  "platformFeeInHostCurrency": null,
+  "type": "CREDIT",
+  "uuid": null,
+}
+`;
+
+exports[`api.v1.test.js #get get one transaction details by uuid 1`] = `
+Object {
+  "amount": -20000,
+  "collective": Object {
+    "id": 3,
+    "image": null,
+    "name": "Scouts d'Arlon",
+    "slug": "scouts",
+  },
+  "currency": "USD",
+  "description": "Homepage design",
+  "fromCollective": Object {
+    "id": 1,
+    "image": null,
+    "name": "Phil Mod",
+    "slug": "philmod",
+  },
+  "host": Object {
+    "id": 2,
+    "image": null,
+    "name": "WWCode",
+    "slug": "wwcode",
+  },
+  "hostCurrency": "USD",
+  "hostCurrencyFxRate": null,
+  "hostFeeInHostCurrency": null,
+  "netAmountInCollectiveCurrency": null,
+  "paymentMethod": null,
+  "paymentProcessorFeeInHostCurrency": null,
+  "platformFeeInHostCurrency": null,
+  "type": "DEBIT",
+  "uuid": null,
+}
+`;
+
+exports[`api.v1.test.js #get get the latest transactions 1`] = `
+Object {
+  "amount": 5000,
+  "collective": Object {
+    "id": 3,
+    "image": null,
+    "name": "Scouts d'Arlon",
+    "slug": "scouts",
+  },
+  "createdByUser": Object {
+    "email": null,
+    "id": 1,
+  },
+  "currency": "USD",
+  "fromCollective": Object {
+    "id": 1,
+    "image": null,
+    "name": "Phil Mod",
+    "slug": "philmod",
+  },
+  "host": Object {
+    "id": 2,
+    "slug": "wwcode",
+  },
+  "hostCurrency": null,
+  "hostCurrencyFxRate": null,
+  "hostFeeInHostCurrency": null,
+  "netAmountInCollectiveCurrency": 4500,
+  "paymentMethod": null,
+  "paymentProcessorFeeInHostCurrency": null,
+  "platformFeeInHostCurrency": null,
+  "type": "CREDIT",
+  "uuid": null,
+}
+`;

--- a/test/graphql.transaction.test.js
+++ b/test/graphql.transaction.test.js
@@ -5,6 +5,7 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import models from '../server/models';
 
 import * as utils from './utils';
 import * as store from './features/support/stores';
@@ -104,9 +105,9 @@ describe('graphql.transaction.test.js', () => {
   });
 
   describe('return transactions', () => {
-    it('returns one transaction ', async () => {
+    it('returns one transaction by id', async () => {
       const query = `
-        query Transaction($id: Int!) {
+        query Transaction($id: Int) {
           Transaction(id: $id) {
             id
             type
@@ -136,6 +137,44 @@ describe('graphql.transaction.test.js', () => {
         }
       `;
       const result = await utils.graphqlQuery(query, { id: 2 });
+      expect(result).to.matchSnapshot();
+    });
+
+    it('returns one transaction by uuid', async () => {
+      const query = `
+        query Transaction($uuid: String) {
+          Transaction(uuid: $uuid) {
+            id
+            type
+            createdByUser {
+              id
+              firstName
+              email
+            },
+            host {
+              id
+              slug
+            },
+            ... on Expense {
+              attachment
+            }
+            ... on Order {
+              paymentMethod {
+                id
+                name
+              },
+              subscription {
+                id
+                interval
+              }
+            }
+          }
+        }
+      `;
+      const transaction = await models.Transaction.findOne();
+      const result = await utils.graphqlQuery(query, {
+        uuid: transaction.uuid,
+      });
       expect(result).to.matchSnapshot();
     });
 

--- a/test/graphql.transaction.test.js.snap
+++ b/test/graphql.transaction.test.js.snap
@@ -1172,6 +1172,52 @@ Object {
 }
 `;
 
+exports[`graphql.transaction.test.js return transactions returns one transaction by id 1`] = `
+Object {
+  "data": Object {
+    "Transaction": Object {
+      "createdByUser": Object {
+        "email": null,
+        "firstName": null,
+        "id": 2,
+      },
+      "host": Object {
+        "id": 2,
+        "slug": "wwcode",
+      },
+      "id": 2,
+      "paymentMethod": Object {
+        "id": 3,
+        "name": null,
+      },
+      "subscription": null,
+      "type": "CREDIT",
+    },
+  },
+}
+`;
+
+exports[`graphql.transaction.test.js return transactions returns one transaction by uuid 1`] = `
+Object {
+  "data": Object {
+    "Transaction": Object {
+      "attachment": null,
+      "createdByUser": Object {
+        "email": null,
+        "firstName": null,
+        "id": 2,
+      },
+      "host": Object {
+        "id": 2,
+        "slug": "wwcode",
+      },
+      "id": 1,
+      "type": "DEBIT",
+    },
+  },
+}
+`;
+
 exports[`graphql.transaction.test.js return transactions with dateFrom 1`] = `
 Object {
   "data": Object {

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,7 +5,7 @@ import nock from 'nock';
 import Promise from 'bluebird';
 import Stripe from 'stripe';
 import { graphql } from 'graphql';
-import { isArray, values } from 'lodash';
+import { isArray, values, get, cloneDeep } from 'lodash';
 
 /* Test data */
 import jsonData from './mocks/data';
@@ -31,9 +31,9 @@ jsonData.application = {
   api_key: config.keys.opencollective.api_key,
 };
 
-export const data = item => {
-  const copy = Object.assign({}, jsonData[item]); // to avoid changing these data
-  return isArray(jsonData[item]) ? values(copy) : copy;
+export const data = path => {
+  const copy = cloneDeep(get(jsonData, path)); // to avoid changing these data
+  return isArray(get(jsonData, path)) ? values(copy) : copy;
 };
 
 export const clearbitStubBeforeEach = sandbox => {


### PR DESCRIPTION
This adds a new route for the rest api v1 to get details about a given transaction
`https://api.opencollective.com/v1/collectives/:collectiveSlug/transactions/:uuid`

This matches the existing route that has been exposed for Tripebyte to get their latest transactions:
https://api.opencollective.com/v1/collectives/triplebyte/transactions?includeVirtualCards=true

Those calls require an API KEY or ClientId that can be obtained via the "applications" menu (in your logged in user menu). More info: https://medium.com/open-collective/open-collective-graphql-api-preview-3b42ed1d55ff

Needed for https://github.com/opencollective/opencollective/issues/1402