### PR TITLE
Allow tags in CollectiveAttributesInputType

### DIFF
--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -162,6 +162,7 @@ export const CollectiveAttributesInputType = new GraphQLInputObjectType({
     maxAmount: { type: GraphQLInt },
     currency: { type: GraphQLString },
     settings: { type: GraphQLJSON },
+    tags: { type: new GraphQLList(GraphQLString) },
   }),
 });
 


### PR DESCRIPTION
The API updates for https://github.com/opencollective/opencollective-frontend/pull/1009

This allows collectives to be created through the GraphQL API with tags. 