### PR TITLE
Ensure user is logged in when making a donation with an existing email

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -562,6 +562,16 @@ export default (Sequelize, DataTypes) => {
       return Promise.reject(new Error('Please provide a valid email address'));
     }
     debug('findOrCreateByEmail', email, 'other attributes: ', otherAttributes);
+    return User.findByEmailOrPaypalEmail(email).then(
+      user =>
+        user ||
+        models.User.createUserWithCollective(
+          Object.assign({}, { email }, otherAttributes),
+        ),
+    );
+  };
+
+  User.findByEmailOrPaypalEmail = email => {
     return User.findOne({
       where: {
         [Op.or]: {
@@ -569,13 +579,7 @@ export default (Sequelize, DataTypes) => {
           paypalEmail: email,
         },
       },
-    }).then(
-      user =>
-        user ||
-        models.User.createUserWithCollective(
-          Object.assign({}, { email }, otherAttributes),
-        ),
-    );
+    });
   };
 
   User.createUserWithCollective = userData => {


### PR DESCRIPTION
Some of the test were failing because an `user` field was added in global `order` object in another test.

To avoid this kind of errors in the future I've added an `Object.freeze` on it to make it immutable and added `const order = cloneDeep(baseOrder);` in tests to make local copies.