### PR TITLE
Script to refund transactions and Transaction.data update

### DIFF
--- a/scripts/add_refund_transactions_from_collective.js
+++ b/scripts/add_refund_transactions_from_collective.js
@@ -5,8 +5,7 @@
  * from status 'ACTIVE' to status 'CANCELLED'
  *  1) Refund transactions
  *  2) Mark Orders as cancelled
- *  2) Get transactions ORders and Mark the order Subscriptions of orders as isActive False and deactivedAt now()
- * 
+ *  3) Get transactions ORders and Mark the order Subscriptions of orders as isActive False and deactivedAt now()
  */
 import Promise from 'bluebird';
 import debug from 'debug';
@@ -54,11 +53,13 @@ async function refundTransaction(transaction) {
     await order.save();
     debugRefund('updating subscription to be deactived');
     
-    // mark subscriptions with isActive as false and deactivedAt now.
-    const subscription = await models.Subscription.findById(order.SubscriptionId);
-    subscription.isActive = false;
-    subscription.deactivatedAt = new Date();
-    await subscription.save();
+    // if the order has a subscription, mark it with isActive as false and deactivedAt now.
+    if (order.SubscriptionId) {
+      const subscription = await models.Subscription.findById(order.SubscriptionId);
+      subscription.isActive = false;
+      subscription.deactivatedAt = new Date();
+      await subscription.save();
+    }
   }
   return models.Transaction.findById(transaction.id);
 }

--- a/scripts/add_refund_transactions_from_collective.js
+++ b/scripts/add_refund_transactions_from_collective.js
@@ -1,0 +1,102 @@
+/*
+ * Given an array of fromCollective Ids(field FromCollectiveId from Transactions model), 
+ * This script creates refund transactions. It first tries to create the refun 
+ * We also mark all those transactions Orders 
+ * from status 'ACTIVE' to status 'CANCELLED'
+ *  1) Refund transactions
+ *  2) Get transactions ORders and Mark the order Subscriptions of orders as isActive False and deactivedAt now()
+ * 
+ */
+import Promise from 'bluebird';
+import debug from 'debug';
+import models from '../server/models';
+import * as libPayments from '../server/lib/payments';
+
+// history: ,
+// count	collective	  FromCollectiveId	CollectiveId	email
+//                          23709 ------------------------------------------------------- OK
+// 191	  anonymous1309	    23461             13775	    rato07@yopmail.com_old ---------- 
+// 20	    anonymous1320	    23546             13775	    rato007@gmx.com_old ------------- 
+// 7	    anonymous1155	    21715             13775	    vitinholippi00973@gmail.com -----
+// DATABASE SCRIPTS
+// --------
+// ----  TOMORROW WITH PIA
+// -- getting all transactions from the FromCollectiveId 21715
+// select * from "Transactions" t 
+// left join "Orders" o on t."OrderId"=o.id 
+// left join "Subscriptions" s on o."SubscriptionId"=s.id 
+// where t."FromCollectiveId"=21715; -- and s."isActive"=true and t."TransactionGroup"='271eb993-9092-4f55-8014-ad0d7e58514a'
+// -- We have already refunded this transactions from FromCollectiveId 21715
+// select * from "Transactions" where id in (130697,130698);
+// -- and here are their refund transactions:
+// select * from "Transactions" where id in (134631, 134632);
+
+const fromCollectiveIds = process.env.FROM_COLLECTIVE_IDS || [21715];
+const debugRefund = debug('refundTransactions');
+
+async function refundTransaction(transaction) {
+  // find the kind of payment method type
+  const paymentMethod = libPayments.findPaymentMethodProvider(transaction.PaymentMethod);
+  // look for the Stripe Connected Account
+  const stripeAccounts = await models.ConnectedAccount.findAll({
+    where: { 
+      CollectiveId: transaction.HostCollectiveId,
+      service: 'stripe',
+    },
+  });
+  debugRefund(`stripeAccounts: ${JSON.stringify(stripeAccounts, null,2)}`);
+  // If it's credit card then we will refund
+  if (transaction.PaymentMethod && transaction.PaymentMethod.type === 'creditcard') {
+    debugRefund('refunding transaction...');
+    try {
+      // try to do both stripe and database refunds
+      const refundTransactions  = await paymentMethod.refundTransaction(transaction, {id: 18520});  
+      debugRefund(`Stripe refundTransactions: ${JSON.stringify(refundTransactions, null,2)}`);
+    } catch (error) {
+      // Error means stripe has already refunded
+      debugRefund(`STRIPE error meaning it was already refund...trying to refund only on our database:`);
+      try {
+        const refundTransactions  = await paymentMethod.refundTransactionOnlyInDatabase(transaction, {id: 18520});  
+        debugRefund(`Database ONLY refundTransactions: ${JSON.stringify(refundTransactions, null,2)}`);  
+      } catch (error) {
+        // throwing error on purpose to stop everything if something unexpected happens..
+        console.error(error);
+        throw error;  
+      }
+    }
+  }
+
+  const order = transaction.Order;
+  // We mark 
+  if (order && order.status === 'ACTIVE' && order.SubscriptionId) {
+    debugRefund('updating subscription to be deactived');
+    // subscription
+    const subscription = await models.Subscription.findById(order.SubscriptionId);
+    subscription.isActive = false;
+    subscription.deactivatedAt = new Date();
+    
+    await subscription.save();
+    const newSubscription = await models.Subscription.findById(order.SubscriptionId);
+    debugRefund(`UPDATED Subscripttion ${JSON.stringify(newSubscription, null,2)}`);
+    // mark isActive as false and deactivedAt now.
+  }
+  return models.Transaction.findById(transaction.id);
+}
+
+async function run() {
+  const transactions = await models.Transaction.findAll({
+    where: {
+      FromCollectiveId: fromCollectiveIds,
+      type: 'CREDIT',
+      RefundTransactionId: null
+    },
+    include: [models.Order, models.PaymentMethod],
+  });
+  // TO DO: instead of consider only the first of the above array, we'll consider all
+  // doing this because we are carefully and slowly running this script in PROD
+  const mapResult = await Promise.map([transactions[0]], refundTransaction);
+  debugRefund(`mapResult(tip: result transactions need to have RefundTransactionId set): ${JSON.stringify(mapResult, null,2)}`);
+  process.exit(0);
+}
+
+run();

--- a/scripts/add_refund_transactions_from_collective.js
+++ b/scripts/add_refund_transactions_from_collective.js
@@ -12,7 +12,7 @@ import debug from 'debug';
 import models from '../server/models';
 import * as libPayments from '../server/lib/payments';
 
-const fromCollectiveIds = process.env.FROM_COLLECTIVE_IDS || [21715];
+const fromCollectiveIds = process.env.FROM_COLLECTIVE_IDS || [23461];
 const debugRefund = debug('refundTransactions');
 
 async function refundTransaction(transaction) {
@@ -73,11 +73,17 @@ async function run() {
     },
     include: [models.Order, models.PaymentMethod],
   });
-  // TO DO: instead of consider only the first of the above array, we'll consider all
-  // doing this because we are carefully and slowly running this script in PROD
-  const mapResult = await Promise.map([transactions[0]], refundTransaction);
-  debugRefund(`mapResult(tip: result transactions need to have RefundTransactionId set): ${JSON.stringify(mapResult, null,2)}`);
-  process.exit(0);
+  try {
+    const mapResult = await Promise.map(transactions, refundTransaction);
+    debugRefund(`Script finished successfully,
+      mapResult(tip: result transactions need to have RefundTransactionId set):
+      ${JSON.stringify(mapResult, null,2)}`
+    );
+    process.exit(0);
+  } catch (error) {
+    debugRefund('Error executing script',error);
+    process.exit(1);
+  }
 }
 
 run();

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -182,7 +182,7 @@ export async function createRefundTransaction(
   return models.Transaction.createDoubleEntry(userLedgerRefund);
 }
 
-export async function associateTransactionRefundId(transaction, refund) {
+export async function associateTransactionRefundId(transaction, refund, data) {
   const [tr1, tr2, tr3, tr4] = await models.Transaction.findAll({
     order: ['id'],
     where: {
@@ -192,6 +192,12 @@ export async function associateTransactionRefundId(transaction, refund) {
       ],
     },
   });
+  // After refunding a transaction, in some cases the data may
+  // be update as well(stripe data changes after refunds)
+  if (data) {
+    tr1.data = data;
+    tr2.data = data;
+  }
 
   tr1.RefundTransactionId = tr4.id;
   await tr1.save(); // User Ledger

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -217,6 +217,47 @@ export default {
     );
   },
 
+  /** Refund a given transaction that was already refunded
+   * in stripe but not in our database
+   */
+  refundTransactionOnlyInDatabase: async (transaction, user) => {
+    /* What's going to be refunded */
+    const chargeId = _.result(transaction.data, 'charge.id');
+
+    /* From which stripe account it's going to be refunded */
+    const collective = await models.Collective.findById(
+      transaction.type === 'CREDIT'
+        ? transaction.CollectiveId
+        : transaction.FromCollectiveId,
+    );
+    const hostStripeAccount = await collective.getHostStripeAccount();
+
+    /* Refund both charge & application fee */
+    const refund = await stripeGateway.retrieveRefundFromChargeId(
+      hostStripeAccount,
+      chargeId,
+    );
+    const balance = await stripeGateway.retrieveBalanceTransaction(
+      hostStripeAccount,
+      refund.balance_transaction,
+    );
+    const fees = stripeGateway.extractFees(balance);
+
+    /* Create negative transactions for the received transaction */
+    const refundTransaction = await paymentsLib.createRefundTransaction(
+      transaction,
+      fees.stripeFee,
+      { refund, balance },
+      user,
+    );
+
+    /* Associate RefundTransactionId to all the transactions created */
+    return paymentsLib.associateTransactionRefundId(
+      transaction,
+      refundTransaction,
+    );
+  },
+
   webhook: (requestBody, event) => {
     const invoice = event.data.object;
     const invoiceLineItems = invoice.lines.data;

--- a/server/paymentProviders/stripe/gateway.js
+++ b/server/paymentProviders/stripe/gateway.js
@@ -209,6 +209,24 @@ export const retrieveBalanceTransaction = (stripeAccount, txn) => {
 };
 
 /**
+ * Given a charge id, retrieves the refund data if there is one.
+ */
+export const retrieveRefundFromChargeId = (stripeAccount, chargeId) => {
+  return retrieveCharge(stripeAccount, chargeId)
+  .then(charge => {
+    const refundId = _.get(charge, 'refunds.data[0].id');
+    if (!refundId) {
+      throw new Error(`charge with id ${chargeId} has no refunds.`);
+    }
+    return appStripe.refunds.retrieve(refundId, {
+      stripe_account: stripeAccount.username,
+    });
+  }).catch(err => {
+    throw err;
+  });
+};
+
+/**
  * Retreive an event (for webhook)
  */
 export const retrieveEvent = (stripeAccount, eventId) => {

--- a/test/graphql.refundTransaction.test.js
+++ b/test/graphql.refundTransaction.test.js
@@ -101,13 +101,14 @@ async function setupTestObjects() {
 }
 
 function initStripeNock({ amount, fee, fee_details, net }) {
+  const refund = {
+    id: 're_1Bvu79LzdXg9xKNSFNBqv7Jn',
+    amount: 5000,
+    balance_transaction: 'txn_1Bvu79LzdXg9xKNSWEVCLSUu',
+  };
   nock('https://api.stripe.com:443')
     .post('/v1/refunds')
-    .reply(200, {
-      id: 're_1Bvu79LzdXg9xKNSFNBqv7Jn',
-      amount: 5000,
-      balance_transaction: 'txn_1Bvu79LzdXg9xKNSWEVCLSUu',
-    });
+    .reply(200, refund);
   nock('https://api.stripe.com:443')
     .get('/v1/balance/history/txn_1Bvu79LzdXg9xKNSWEVCLSUu')
     .reply(200, {
@@ -116,6 +117,20 @@ function initStripeNock({ amount, fee, fee_details, net }) {
       fee,
       fee_details,
       net,
+    });
+  nock('https://api.stripe.com:443')
+    .get('/v1/charges/ch_1Bs9ECBYycQg1OMfGIYoPFvk')
+    .reply(200, {
+      id: 'ch_1Bs9ECBYycQg1OMfGIYoPFvk',
+      amount,
+      fee,
+      fee_details,
+      refunds: {
+        object: 'list',
+        data: [
+          refund,
+        ],
+      },
     });
 }
 


### PR DESCRIPTION
 Adding Script to refund transactions either from stripe or only in the opencollective database given an array of `FromCollectiveId`s, considering this Collective ids on the following query:
```
where: {
      FromCollectiveId: fromCollectiveIds,
      type: 'CREDIT',
      RefundTransactionId: null
    }
```
where `fromCollectiveIds` is the array. 

I'm also updating the `Transaction.data` payload field: 
- after a refund, because the charge information is updated on the "ordinary"(non-refund) transactions regarding stripe.
- the refund transactions payload data was inconsistent if compared with the "ordinary" transactions. Standardizing it as well..

Also other fixes:
fixes https://github.com/opencollective/opencollective/issues/1416
fixes https://github.com/opencollective/opencollective/issues/1417