### PR TITLE
Use `mem`package to memoize async functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11209,6 +11209,14 @@
         "pify": "^3.0.0"
       }
     },
+    "map-age-cleaner": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
+      "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -11288,11 +11296,13 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^1.0.0",
+        "p-is-promise": "^1.1.0"
       }
     },
     "memory-fs": {
@@ -12295,6 +12305,17 @@
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
             "mem": "^1.1.0"
+          },
+          "dependencies": {
+            "mem": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+              "dev": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            }
           }
         },
         "path-type": {
@@ -13939,10 +13960,20 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "1.2.0",
@@ -16235,6 +16266,16 @@
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
             "mem": "^1.1.0"
+          },
+          "dependencies": {
+            "mem": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            }
           }
         },
         "path-type": {
@@ -16449,6 +16490,16 @@
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
             "mem": "^1.1.0"
+          },
+          "dependencies": {
+            "mem": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            }
           }
         },
         "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "limax": "^1.7.0",
     "lodash": "4.17.11",
     "lru-cache": "4.1.1",
+    "mem": "^4.0.0",
     "merge-options": "^1.0.1",
     "mime": "2.2.2",
     "moment": "2.19.3",

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -2,8 +2,8 @@ import models, { sequelize, Op } from '../models';
 import currencies from '../constants/currencies';
 import Promise from 'bluebird';
 import config from 'config';
-import { memoize, pick } from 'lodash';
-memoize.Cache = Map;
+import { pick } from 'lodash';
+import mem from 'mem';
 
 /*
 * Hacky way to do currency conversion
@@ -562,9 +562,8 @@ const getCollectivesOrderedByMonthlySpendingQuery = async ({
 
   return { total, collectives };
 };
-const getCollectivesOrderedByMonthlySpending = memoize(
+const getCollectivesOrderedByMonthlySpending = mem(
   getCollectivesOrderedByMonthlySpendingQuery,
-  JSON.stringify,
 );
 
 const getMembersOfCollectiveWithRole = CollectiveIds => {
@@ -901,10 +900,7 @@ const getCollectivesWithMinBackersQuery = async ({
 
   return { total, collectives };
 };
-const getCollectivesWithMinBackers = memoize(
-  getCollectivesWithMinBackersQuery,
-  JSON.stringify,
-);
+const getCollectivesWithMinBackers = mem(getCollectivesWithMinBackersQuery);
 
 const queries = {
   getPublicHostsByTotalCollectives,


### PR DESCRIPTION
Part of the upgrade to Babel 7 (#1509) required using the `@babel/plugin-transform-async-to-generator` to transpile async / await usage into using [bluebird coroutine](http://bluebirdjs.com/docs/api/promise.coroutine.html) calls as generators. This was necessary due to how `babel/polyfill` used to replace Promises with Bluebird promises and async / await with the `regenerator/runtime`, so any Promise returned by an `async` function could used the Bluebird API, i.e. `.tap` method.

In order to just use native async / await in Node, we need to fix those areas where we assume the Bluebird API is available. (TODO: Add Link to tracking issue for this work)

This PR fixes how the babel transforming affects memoized (using the [lodash memoize function](https://lodash.com/docs#memoize)) async functions. By using the [`mem` package](https://www.npmjs.com/package/mem), which is designed to handle `async` functions, we eliminate the error produced by the Bluebird API. 

This has been tested and confirmed working on staging. 