### PR TITLE
Add ability to filter collective PaymentMethods with a list of types

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -648,6 +648,10 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
           service: { type: GraphQLString },
           limit: { type: GraphQLInt },
           hasBalanceAboveZero: { type: GraphQLBoolean },
+          types: {
+            type: new GraphQLList(GraphQLString),
+            description: 'Filter on given types (creditcard, virtualcard...)',
+          },
         },
       },
       connectedAccounts: { type: new GraphQLList(ConnectedAccountType) },
@@ -1180,6 +1184,7 @@ const CollectiveFields = () => {
         service: { type: GraphQLString },
         limit: { type: GraphQLInt },
         hasBalanceAboveZero: { type: GraphQLBoolean },
+        types: { type: new GraphQLList(GraphQLString) },
       },
       async resolve(collective, args, req) {
         if (!req.remoteUser || !req.remoteUser.isAdmin(collective.id))
@@ -1190,6 +1195,11 @@ const CollectiveFields = () => {
         if (args.service) {
           paymentMethods = paymentMethods.filter(
             pm => pm.service === args.service,
+          );
+        }
+        if (args.types) {
+          paymentMethods = paymentMethods.filter(pm =>
+            args.types.includes(pm.type),
           );
         }
         if (args.hasBalanceAboveZero) {


### PR DESCRIPTION
Current GraphQL query doesn't allow to get only the creditcards **and** the virtualcards. This new parameter will solve the issue, allowing to display both payment methods on the frontend.