### PR TITLE
Disable access logs by default

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -18,6 +18,9 @@
       "secret": "JWT_SECRET"
     }
   },
+  "logs": {
+    "accessLogs": "ACCESS_LOGS"
+  },
   "stripe": {
     "secret": "STRIPE_SECRET",
     "key": "STRIPE_KEY",

--- a/config/default.json
+++ b/config/default.json
@@ -14,6 +14,9 @@
       "logging": false
     }
   },
+  "logs": {
+    "accessLogs": false
+  },
   "host": {
     "api": "http://localhost:3060",
     "webapp": "http://localhost:3000/app",

--- a/server/lib/express.js
+++ b/server/lib/express.js
@@ -11,6 +11,7 @@ import session from 'express-session';
 import helmet from 'helmet';
 import debug from 'debug';
 import cloudflareIps from 'cloudflare-ip/ips.json';
+import { get } from 'lodash';
 import { Strategy as GitHubStrategy } from 'passport-github';
 import { Strategy as TwitterStrategy } from 'passport-twitter';
 import { Strategy as MeetupStrategy } from 'passport-meetup-oauth2';
@@ -51,8 +52,8 @@ export default function(app) {
     });
   }
 
-  // Log requests if it's not the test environment
-  if (!['test', 'circleci'].includes(process.env.NODE_ENV)) {
+  // Log requests if enabled (default false)
+  if (get(config, 'logs.accessLogs')) {
     app.use(morgan('combined'));
   }
 


### PR DESCRIPTION
They don't provide much value (in our API context) and are taking a lot of space.