### PR TITLE
Add @babel/node to package dependency for cron jobs

### DIFF
--- a/cron/10mn/milestones.js
+++ b/cron/10mn/milestones.js
@@ -188,7 +188,7 @@ const compileTweet = async (collective, template, twitterAccount) => {
     );
   }
 
-  let tweet = await twitter.compileTweet(
+  let tweet = twitter.compileTweet(
     template,
     replacements,
     get(twitterAccount, `settings.${template}.tweet`),

--- a/cron/monthly/collective-tweet.js
+++ b/cron/monthly/collective-tweet.js
@@ -207,7 +207,7 @@ const sendTweet = async (twitterAccount, data) => {
 
   const template =
     stats.totalReceived === 0 ? 'monthlyStatsNoNewDonation' : 'monthlyStats';
-  const tweet = await twitter.compileTweet(template, replacements);
+  const tweet = twitter.compileTweet(template, replacements);
 
   // We thread the tweet with the previos monthly stats
   const in_reply_to_status_id = get(

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "npm": "6.1.0"
   },
   "dependencies": {
+    "@babel/node": "7.0.0",
     "algoliasearch": "3.24.9",
     "apollo-errors": "1.9.0",
     "apollo-server-express": "2.0.5",
@@ -101,7 +102,6 @@
   "devDependencies": {
     "@babel/cli": "7.1.5",
     "@babel/core": "7.1.5",
-    "@babel/node": "7.0.0",
     "@babel/plugin-proposal-class-properties": "7.1.0",
     "@babel/plugin-transform-async-to-generator": "7.1.0",
     "@babel/polyfill": "7.0.0",


### PR DESCRIPTION
Fixes opencollective/opencollective#1449

Also fixes an issue around the expected value returned by `compileTweet` in our `twitter` utility. 