### PR TITLE
Move @babel/core into package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "npm": "6.1.0"
   },
   "dependencies": {
+    "@babel/core": "7.1.5",
     "@babel/node": "7.0.0",
     "algoliasearch": "3.24.9",
     "apollo-errors": "1.9.0",
@@ -101,7 +102,6 @@
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.5",
     "@babel/plugin-proposal-class-properties": "7.1.0",
     "@babel/plugin-transform-async-to-generator": "7.1.0",
     "@babel/polyfill": "7.0.0",


### PR DESCRIPTION
Fixes opencollective/opencollective#1449

`@babel/core` is a peer dependency of `@babel/node`. Need to have both available in production for our cron jobs. 