### PR TITLE
fix(paymentMethod): Add index to Transaction table to speed up balance computation

### DIFF
--- a/migrations/201811210000-Transaction-addIndex.js
+++ b/migrations/201811210000-Transaction-addIndex.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: function(queryInterface) {
+    return queryInterface.addIndex(
+      'Transactions',
+      ['PaymentMethodId', 'type', 'deletedAt'],
+      {
+        indexName: 'PaymentMethodId',
+        indicesType: 'INDEX',
+      },
+    );
+  },
+
+  down: function(queryInterface) {
+    return queryInterface.removeIndex('Transactions', 'PaymentMethodId');
+  },
+};


### PR DESCRIPTION
Fetching my logged in user take 30s locally.
The reason being that for every single collective I'm an admin of, it fetches all payment methods and for each, it has to compute the balance, which takes 400+ms a piece.
https://github.com/opencollective/opencollective-api/blob/master/server/models/PaymentMethod.js#L442-L445

The reason being that fetching transaction by `PaymentMethodId` is doing a table scan.

This fixes it. 
