### PR TITLE
Order PaymentMethods by type in GraphQL API

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -35,7 +35,7 @@ import { ApplicationType } from './Application';
 import { types } from '../../constants/collectives';
 import models, { Op } from '../../models';
 import roles from '../../constants/roles';
-import { get } from 'lodash';
+import { get, sortBy } from 'lodash';
 
 export const TypeOfCollectiveType = new GraphQLEnumType({
   name: 'TypeOfCollective',
@@ -70,6 +70,16 @@ export const CollectiveOrderFieldType = new GraphQLEnumType({
     },
     updatedAt: {
       description: 'Order collectives by updated time.',
+    },
+  },
+});
+
+export const PaymentMethodOrderFieldType = new GraphQLEnumType({
+  name: 'PaymenMethodOrderField',
+  description: 'Properties by which PaymenMethods can be ordered',
+  values: {
+    type: {
+      description: 'Order payment methods by type (creditcard, virtualcard...)',
     },
   },
 });
@@ -657,6 +667,11 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
             type: new GraphQLList(GraphQLString),
             description: 'Filter on given types (creditcard, virtualcard...)',
           },
+          orderBy: {
+            type: PaymentMethodOrderFieldType,
+            description:
+              'Order entries based on given column. Set to null for no ordering.',
+          },
         },
       },
       connectedAccounts: { type: new GraphQLList(ConnectedAccountType) },
@@ -1191,6 +1206,10 @@ const CollectiveFields = () => {
         hasBalanceAboveZero: { type: GraphQLBoolean },
         isConfirmed: { type: GraphQLBoolean, defaultValue: true },
         types: { type: new GraphQLList(GraphQLString) },
+        orderBy: {
+          type: PaymentMethodOrderFieldType,
+          defaultValue: 'type',
+        },
       },
       async resolve(collective, args, req) {
         if (!req.remoteUser || !req.remoteUser.isAdmin(collective.id))
@@ -1228,6 +1247,10 @@ const CollectiveFields = () => {
         if (args.limit) {
           paymentMethods = paymentMethods.slice(0, args.limit);
         }
+        if (args.orderBy) {
+          paymentMethods = sortBy(paymentMethods, args.orderBy);
+        }
+
         return paymentMethods;
       },
     },


### PR DESCRIPTION
I've made this change in the GraphQL API so all payment methods will be sorted by default. 

## Before

![Edit payment methods (before)](https://user-images.githubusercontent.com/1556356/48906921-4cf50100-ee66-11e8-9be4-ef6c2bea41aa.png)

## After

![Edit payment methods](https://user-images.githubusercontent.com/1556356/48906893-377fd700-ee66-11e8-9768-4ae225053b3d.png)

![Edit subscriptions](https://user-images.githubusercontent.com/1556356/48906881-2df66f00-ee66-11e8-85b3-6f4db5c645c8.png)
