### PR TITLE
More permissive checkOrdersLimit in dev

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -29,6 +29,15 @@
     "webapp": "http://localhost:3000/app",
     "website": "http://localhost:3000"
   },
+  "limits": {
+    "ordersPerHour": {
+      "perAccount": 10,
+      "perAccountForCollective": 2,
+      "perEmail": 10,
+      "perEmailForCollective": 2,
+      "perIp": 5
+    }
+  },
   "email": {
     "from": "Open Collective <info@opencollective.com>"
   },

--- a/config/development.json
+++ b/config/development.json
@@ -10,6 +10,15 @@
       "benchmark": true
     }
   },
+  "limits": {
+    "ordersPerHour": {
+      "perAccount": 100,
+      "perAccountForCollective": 20,
+      "perEmail": 100,
+      "perEmailForCollective": 20,
+      "perIp": 50
+    }
+  },
   "maintenancedb": {
     "database": "postgres",
     "username": "postgres",


### PR DESCRIPTION
During development I got stuck a few times by this limit. As the message is (voluntarily) unclear, a typical open source developer will have to search for the root cause of this error. My fix here is a quick one, a better approach would be:
1. To log a different message in dev that inform the developer on what can be done to overthrow the limitation
2. To use an ENV variable to configure the orders limit per hour, set to `MAX_ORDERS_PER_HOUR=10000` in dev

My favorite approach being 2.

@znarf do you have an opinion about this?