### PR TITLE
Unify the way collective transactions are loaded to include virtualcards

### DIFF
--- a/cron/monthly/collective-report.js
+++ b/cron/monthly/collective-report.js
@@ -170,9 +170,7 @@ const processCollective = collective => {
     collective.getCancelledOrders(startDate, endDate),
     collective.getUpdates('published', startDate, endDate),
     collective.getNextGoal(endDate),
-    collective.getTransactions({
-      where: { createdAt: { [Op.gte]: startDate, [Op.lt]: endDate } },
-    }),
+    collective.getTransactions({ startDate, endDate }),
   ];
 
   let emailData = {};

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1066,12 +1066,7 @@ const CollectiveFields = () => {
         offset: { type: GraphQLInt },
       },
       resolve(collective, args) {
-        const query = {};
-        if (args.type) query.where = { type: args.type };
-        if (args.limit) query.limit = args.limit;
-        if (args.offset) query.offset = args.offset;
-        query.order = [['id', 'DESC']];
-        return collective.getTransactions(query);
+        return collective.getTransactions({ ...args, order: [['id', 'DESC']] });
       },
     },
     expenses: {


### PR DESCRIPTION
:information_source: Should be merged and deployed at the same time as https://github.com/opencollective/opencollective-frontend/pull/1117

As of today collective-report, collective model and graphql api each have they own way of loading collective transactions. But now we have virtual cards, there's a little business logic we need to add to ensure we always load the proper transactions for collective.

When fetching collective transactions with the new function, we now include:
- Debit transactions made by this collective without using a virtual card
- Debit transactions made using a virtual card from this collective
- Credit transactions made to this collective