### PR TITLE
when updating order, order should be mark as CANCELLED if the update generates a new Order

### DIFF
--- a/migrations/20181203104500-updateNotCancelledOrders.js
+++ b/migrations/20181203104500-updateNotCancelledOrders.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+module.exports = {
+  up: (queryInterface, sequelize) => {
+    //set Status cancelled on all orders that are active but have subscription inactive
+    return queryInterface.sequelize.query(`
+      UPDATE "Orders" set status='CANCELLED' where id in (
+      SELECT o.id FROM "Orders" o
+      LEFT JOIN "Subscriptions" s ON o."SubscriptionId"=s.id
+      WHERE (o.status='ACTIVE' or o.status='PENDING') AND s."isActive"=false);
+    `);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return Promise.resolve(); // No way to revert this
+  },
+};

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -574,6 +574,7 @@ export async function updateSubscription(remoteUser, args) {
       totalAmount: amount,
       SubscriptionId: newSubscription.id,
       updatedAt: new Date(),
+      status: status.PENDING,
     });
 
     order = await models.Order.create(newOrderDataValues);

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -558,8 +558,9 @@ export async function updateSubscription(remoteUser, args) {
     if (amount < 100 || amount % 100 !== 0) {
       throw new Error('Invalid amount');
     }
-
-    order.Subscription.deactivate();
+    await order.Subscription.deactivate();
+    order.status = status.CANCELLED;
+    await order.save();
 
     const newSubscriptionDataValues = Object.assign(omit(order.Subscription.dataValues, ['id', 'deactivatedAt']), {
       amount: amount,
@@ -569,8 +570,7 @@ export async function updateSubscription(remoteUser, args) {
     });
 
     const newSubscription = await models.Subscription.create(newSubscriptionDataValues);
-
-    const newOrderDataValues = Object.assign(omit(order.dataValues, ['id']), {
+    const newOrderDataValues = Object.assign(omit(order.dataValues, ['id', 'status']), {
       totalAmount: amount,
       SubscriptionId: newSubscription.id,
       updatedAt: new Date(),


### PR DESCRIPTION
In some cases when we are updating an Order, for example if the `amount` changes, a new order is generated. For the **original** order, its subscription is marked `isActive` as *false* but the Order remains `PENDING` or `ACTIVE`.

We should mark the **original** order as CANCELLED. 

fixes https://github.com/opencollective/opencollective/issues/1504