### PR TITLE
Add links for expenses in expenses workflow emails

### DIFF
--- a/templates/emails/collective.expense.approved.hbs
+++ b/templates/emails/collective.expense.approved.hbs
@@ -2,12 +2,12 @@ Subject: Your expense to {{collective.name}} for {{{currency expense.amount curr
 
 {{> header}}
 
-<p>Quick message to let you know that your expense for {{expense.description}} has been approved.</p>
+<p>Quick message to let you know that your expense for <a href="{{config.host.website}}/expenses/{{expense.id}}">{{expense.description}}</a> has been approved.</p>
 <p>Next step: the host of the <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}} collective</a> (<a href="{{config.host.website}}/{{host.slug}}">{{host.name}}</a>) will reimburse your expense shortly (may take a couple of days depending on the host)</p>
 
 <center>
   <h1>{{{currency expense.amount currency=expense.currency precision=2}}}</h1>
-  <div>{{expense.description}}</div>
+  <div><a href="{{config.host.website}}/expenses/{{expense.id}}">{{expense.description}}</a></div>
 </center>
 
 <br />

--- a/templates/emails/collective.expense.created.hbs
+++ b/templates/emails/collective.expense.created.hbs
@@ -4,7 +4,7 @@ Subject: New expense on {{collective.name}}: {{{currency expense.amount currency
 
 <center>
   <h1>{{{currency expense.amount currency=expense.currency precision=2}}}</h1>
-  <div>{{expense.description}}</div>
+  <div><a href="{{config.host.website}}/expenses/{{expense.id}}">{{expense.description}}</a></div>
   <div>Submitted by: {{fromCollective.name}}</div>
   <div>Paypal Email: {{user.paypalEmail}}</div>
   <p><font color="#999">{{expense.notes}}</font></p>

--- a/templates/emails/collective.expense.paid.hbs
+++ b/templates/emails/collective.expense.paid.hbs
@@ -11,7 +11,7 @@ Subject: {{#ifCond expense.currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond expen
 
 <center>
   <h3>Hi there!</h3>
-  <p>Just a quick note to let you know that your expense <b>{{expense.description}}</b> that you filed on {{{moment expense.createdAt}}} to the <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}} collective</a> has just been paid.</p>
+  <p>Just a quick note to let you know that your expense <b><a href="{{config.host.website}}/expenses/{{expense.id}}">{{expense.description}}</a></b> that you filed on {{{moment expense.createdAt}}} to the <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}} collective</a> has just been paid.</p>
   <h2>{{{currency expense.amount currency=expense.currency precision=2}}}</h2>
   <div>{{transaction.description}}</div>
   <table>


### PR DESCRIPTION

Add links to expenses in expenses workflow emails.

fixes https://github.com/opencollective/opencollective/issues/1521