### PR TITLE
Allow prepaid as SourcePaymentMethod for VirtualCards

### DIFF
--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -436,6 +436,21 @@ export default function(Sequelize, DataTypes) {
   };
 
   /**
+   * Returns the sum of the children PaymenMethod values (aka the virtual cards which
+   * have `sourcePaymentMethod` set to this PM).
+   */
+  PaymentMethod.prototype.getChildrenPMTotalSum = async function() {
+    return models.PaymentMethod.findAll({
+      attributes: ['initialBalance', 'monthlyLimitPerMember'],
+      where: { SourcePaymentMethodId: this.id },
+    }).then(children => {
+      return children.reduce((total, pm) => {
+        return total + (pm.initialBalance || pm.monthlyLimitPerMember);
+      }, 0);
+    });
+  };
+
+  /**
    * Check if virtual card is claimed.
    * Always return true for other payment methods.
    */

--- a/server/paymentProviders/opencollective/prepaid.js
+++ b/server/paymentProviders/opencollective/prepaid.js
@@ -74,6 +74,12 @@ async function processOrder(order) {
   if (hostCollective.id !== data.HostCollectiveId)
     throw new Error('Prepaid method can only be used in collectives from the same host');
 
+  // Checking if balance is ok or will still be after completing the order
+  const balance = await getBalance(order.paymentMethod);
+  if (balance.amount - order.totalAmount < 0) {
+    throw new Error("This payment method doesn't have enough funds to complete this order");
+  }
+
   // Use the above payment method to donate to Collective
   const hostFeeInHostCurrency = libpayments.calcFee(order.totalAmount, order.collective.hostFeePercent);
   const platformFeeInHostCurrency = libpayments.calcFee(order.totalAmount, OC_FEE_PERCENT);

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -270,6 +270,11 @@ function getCreateParams(args, collective, sourcePaymentMethod, remoteUser) {
     throw new Error(`Currency ${args.currency} not supported. We only support USD and EUR at the moment.`);
   }
 
+  // Ensure sourcePaymentMethod type is supported
+  if (!['creditcard', 'prepaid'].includes(sourcePaymentMethod.type)) {
+    throw new Error('Only prepaid and creditcard can be used as gift cards source payment methods');
+  }
+
   // Ensure amount or monthlyLimitPerMember are valid
   if (!args.amount && !args.monthlyLimitPerMember) {
     throw Error('you need to define either the amount or the monthlyLimitPerMember of the payment method.');

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -287,6 +287,18 @@ async function checkSourcePaymentMethodBalance(paymentMethod, amount, virtualCar
     const currentBalanceDetails = `Current balance is ${formatCurrency(balance.amount, balance.currency)}`;
     throw new Error(`There is not enough funds on this PaymentMethod. ${currentBalanceDetails}`);
   }
+
+  // Total virtual cards sum cannot be more than the initial balance
+  const existingTotal = await paymentMethod.getChildrenPMTotalSum();
+  if (existingTotal + totalAmountInPaymentMethodCurrency > paymentMethod.initialBalance) {
+    const initialBalanceStr = formatCurrency(paymentMethod.initialBalance, paymentMethod.currency);
+    const alreadyCreatedAmountStr = formatCurrency(existingTotal, balance.currency);
+    const currentBalanceDetails = `Initial balance is ${initialBalanceStr}`;
+    const alreadyCreatedDetails = `you have already created ${alreadyCreatedAmountStr} worth of gift cards`;
+    throw new Error(
+      `There is not enough funds on this PaymentMethod for new gift cards. ${currentBalanceDetails} and ${alreadyCreatedDetails}.`,
+    );
+  }
 }
 
 /** Get currency from args, or returns default currency. Throws if currency is invalid */


### PR DESCRIPTION
- Allow prepaid as SourcePaymentMethod for VirtualCards

- Include transactions made with prepaid used as SourcePaymentMethod in prepaid balance calculation

- Check SourcePaymentMethod balance on virtualcard creation
> Cannot create 10 x $50 gift cards ($500) if prepaid has $100 amount

- Check already created virtualcards amounts

![selection_902](https://user-images.githubusercontent.com/1556356/50223233-e4347200-039a-11e9-914a-94d281ce8834.png)

- Check balance when making an order with prepaid to ensure there are sufficient funds

---

Resolve https://github.com/opencollective/opencollective/issues/1544