### PR TITLE
Remove duplicate tiers created for Collectives of open source flow

### DIFF
--- a/server/controllers/collectives.js
+++ b/server/controllers/collectives.js
@@ -283,23 +283,6 @@ export const createFromGithub = (req, res, next) => {
   const githubUser = payload.user;
   let createdCollective;
 
-  collectiveData.tiers = [
-    {
-      type: 'TIER',
-      name: 'backer',
-      slug: 'backers',
-      amount: 500,
-      interval: 'month',
-    },
-    {
-      type: 'TIER',
-      name: 'sponsor',
-      slug: 'sponsors',
-      amount: 10000,
-      interval: 'month',
-    },
-  ];
-
   // Find the creator's Connected Account
   ConnectedAccount.findOne({
     where: { id: connectedAccountId },
@@ -365,15 +348,6 @@ export const createFromGithub = (req, res, next) => {
         },
       }),
     )
-    .then(() => {
-      if (collectiveData.tiers) {
-        return models.Tier.createMany(collectiveData.tiers, {
-          CollectiveId: createdCollective.id,
-          currency: collectiveData.currency,
-        });
-      }
-      return null;
-    })
     .then(() => createdCollective.update({ isActive: true }))
     .then(() => {
       const data = {


### PR DESCRIPTION
When creating a Collective from github, we are generating the tiers twice:

- Two tiers in the top level method [createFromGithub](https://github.com/opencollective/opencollective-api/blob/master/server/controllers/collectives.js#L274)
- and other two similar tiers on the method [addHost](https://github.com/opencollective/opencollective-api/blob/master/server/models/Collective.js#L1197) that's called by createFromGithub.

This causes the generation of duplicated tiers.

fixes https://github.com/opencollective/opencollective/issues/1534