### PR TITLE
fix(getTotalAmountRaised): Only include paid transactions in total

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1642,6 +1642,7 @@ export default function(Sequelize, DataTypes) {
       ],
       where: {
         ReferralCollectiveId: this.id,
+        status: 'PAID',
       },
       group: ['currency'],
     })


### PR DESCRIPTION
@piamancini this fixes the invalid total raised amount for TripleByte.

This will fix bad "Total amount raised" values. Problem origin wasn't gift cards as initially suspected, but the fact that we were counting failed transactions in amount calculation.
