### PR TITLE
Create virtual property "monthlySpending" on Collective

### DIFF
--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -880,12 +880,7 @@ const serializeCollectivesResult = JSON.stringify;
 
 const unserializeCollectivesResult = string => {
   const result = JSON.parse(string);
-  result.collectives = result.collectives.map(collective => {
-    return {
-      ...models.Collective.build({ ...collective }),
-      monthlySpending: collective.monthlySpending,
-    };
-  });
+  result.collectives = result.collectives.map(collective => models.Collective.build(collective));
   return result;
 };
 

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -880,7 +880,12 @@ const serializeCollectivesResult = JSON.stringify;
 
 const unserializeCollectivesResult = string => {
   const result = JSON.parse(string);
-  result.collectives = result.collectives.map(collective => models.Collective.build(collective));
+  result.collectives = result.collectives.map(collective => {
+    return {
+      ...models.Collective.build({ ...collective }),
+      monthlySpending: collective.monthlySpending,
+    };
+  });
   return result;
 };
 

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -307,6 +307,10 @@ export default function(Sequelize, DataTypes) {
         type: DataTypes.BOOLEAN,
         defaultValue: false,
       },
+
+      monthlySpending: {
+        type: new DataTypes.VIRTUAL(DataTypes.INTEGER),
+      },
     },
     {
       paranoid: true,


### PR DESCRIPTION
The property `monthlySpending` was correctly saved on the cache but it was being ignored by the Collective Object because it's not present in the Collective model. To fix this, we could just create a simple sequelize property of type `VIRTUAL` which means it's a property that's not present in the db.

fixes #1528