### PR TITLE
Update Sequelize findById -> findByPk

### DIFF
--- a/cron/hourly/event-reminder.js
+++ b/cron/hourly/event-reminder.js
@@ -79,7 +79,7 @@ function processEvent(event, template) {
       const user = await models.User.findOne({
         where: { CollectiveId: get(order, 'fromCollective.id') },
       });
-      const fromCollective = await models.Collective.findById(get(order, 'fromCollective.id'));
+      const fromCollective = await models.Collective.findByPk(get(order, 'fromCollective.id'));
       event.path = await event.getUrlPath();
       const recipient = user.email;
       const data = {

--- a/cron/monthly/user-report.js
+++ b/cron/monthly/user-report.js
@@ -107,7 +107,7 @@ const init = async () => {
 };
 
 const processBacker = async FromCollectiveId => {
-  const backerCollective = await models.Collective.findById(FromCollectiveId);
+  const backerCollective = await models.Collective.findByPk(FromCollectiveId);
   console.log('>>> Processing backer', backerCollective.slug);
   const query = {
     attributes: ['CollectiveId', 'HostCollectiveId'],
@@ -156,7 +156,7 @@ const processBacker = async FromCollectiveId => {
   if (get(backerCollective, 'settings.sendInvoiceByEmail')) {
     const distinctHostCollectiveIds = uniq(distinctTransactions.map(t => t.dataValues.HostCollectiveId));
     const hosts = await Promise.map(distinctHostCollectiveIds, HostCollectiveId =>
-      models.Collective.findById(HostCollectiveId, {
+      models.Collective.findByPk(HostCollectiveId, {
         attributes: ['id', 'slug'],
       }),
     );
@@ -301,7 +301,7 @@ const collectivesData = {};
 const processCollective = async CollectiveId => {
   if (collectivesData[CollectiveId]) return collectivesData[CollectiveId];
 
-  const collective = await models.Collective.findById(CollectiveId);
+  const collective = await models.Collective.findByPk(CollectiveId);
   const promises = [
     collective.getBackersStats(startDate, endDate),
     collective.getBalance(endDate),

--- a/scripts/add_refund_transactions_from_collective.js
+++ b/scripts/add_refund_transactions_from_collective.js
@@ -55,13 +55,13 @@ async function refundTransaction(transaction) {
 
     // if the order has a subscription, mark it with isActive as false and deactivedAt now.
     if (order.SubscriptionId) {
-      const subscription = await models.Subscription.findById(order.SubscriptionId);
+      const subscription = await models.Subscription.findByPk(order.SubscriptionId);
       subscription.isActive = false;
       subscription.deactivatedAt = new Date();
       await subscription.save();
     }
   }
-  return models.Transaction.findById(transaction.id);
+  return models.Transaction.findByPk(transaction.id);
 }
 
 async function run() {

--- a/scripts/add_users_to_w9_list_on_hosts.js
+++ b/scripts/add_users_to_w9_list_on_hosts.js
@@ -19,7 +19,7 @@ const done = err => {
 // look for a host data given an array of userIds that were supposed to be in
 // both data.W9.requestSentToUserIds and data.W9.receivedFromUserIds
 async function checkAndInsertUserIntoHostList(hostId, userIds) {
-  const host = await models.Collective.findById(hostId);
+  const host = await models.Collective.findByPk(hostId);
   const requestSentToUserIds = get(host, 'data.W9.requestSentToUserIds', []);
   const receivedFromUserIds = get(host, 'data.W9.receivedFromUserIds', []);
   for (let i = 0; i < userIds.length; i++) {
@@ -40,7 +40,7 @@ function run() {
     .query(
       `
   select host.id as "HostId", u.id as "UserId" from "Comments" c -- distinct(col."CreatedByUserId")
-    left join "Expenses" e on c."ExpenseId"=e.id 
+    left join "Expenses" e on c."ExpenseId"=e.id
     left join "Users" u on e."UserId"=u.id
     left join "Collectives" col on c."CollectiveId"=col.id
     left join "Collectives" host on col."HostCollectiveId"=host.id

--- a/server/controllers/applications.js
+++ b/server/controllers/applications.js
@@ -9,7 +9,7 @@ const { Application } = models;
 async function getApp(appId) {
   appId = parseInt(appId, 10);
   if (appId) {
-    const app = await Application.findById(appId);
+    const app = await Application.findByPk(appId);
     if (app) {
       return app;
     } else {
@@ -66,7 +66,7 @@ export const update = async (req, res, next) => {
     if (props) {
       await app.update(props);
     }
-    const updatedApp = await Application.findById(app.id);
+    const updatedApp = await Application.findByPk(app.id);
     res.send(updatedApp.info);
   } catch (e) {
     next(e);

--- a/server/controllers/collectives.js
+++ b/server/controllers/collectives.js
@@ -229,7 +229,7 @@ export const create = (req, res, next) => {
     })
     .tap(() => {
       // find Host
-      return models.Collective.findById(collectiveData.hostId || collectiveData.HostCollectiveId).then(h => {
+      return models.Collective.findByPk(collectiveData.hostId || collectiveData.HostCollectiveId).then(h => {
         if (!h) {
           throw new Error('Host not found: ', collectiveData.hostId);
         }
@@ -291,7 +291,7 @@ export const createFromGithub = (req, res, next) => {
     .then(ca => {
       debug('connected account found', ca && ca.username);
       creatorCollective = ca.collective;
-      return models.User.findById(creatorCollective.CreatedByUserId);
+      return models.User.findByPk(creatorCollective.CreatedByUserId);
     })
     .then(user => {
       creatorUser = user;
@@ -334,7 +334,7 @@ export const createFromGithub = (req, res, next) => {
     .tap(g => debug('createdCollective', g && g.dataValues))
     .tap(g => (createdCollective = g))
     .then(() => _addUserToCollective(createdCollective, creatorUser, options))
-    .then(() => models.Collective.findById(defaultHostCollective('opensource').CollectiveId))
+    .then(() => models.Collective.findByPk(defaultHostCollective('opensource').CollectiveId))
     .tap(hostCollective => createdCollective.addHost(hostCollective, creatorUser))
     .tap(host =>
       Activity.create({

--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -61,7 +61,7 @@ export const createOrUpdate = (req, res, next, accessToken, data, emails) => {
           attrs.clientId = profile.id;
           attrs.data = profile;
           attrs.CreatedByUserId = user.id;
-          return models.Collective.findById(user.CollectiveId);
+          return models.Collective.findByPk(user.CollectiveId);
         })
         .then(c => {
           userCollective = c;
@@ -111,7 +111,7 @@ export const createOrUpdate = (req, res, next, accessToken, data, emails) => {
       let collective;
       const profile = data.profile._json;
 
-      return models.Collective.findById(req.query.CollectiveId)
+      return models.Collective.findByPk(req.query.CollectiveId)
         .then(c => {
           collective = c;
           collective.image =
@@ -209,7 +209,7 @@ export const getOrgMemberships = async (req, res, next) => {
 
 function createConnectedAccountForCollective(CollectiveId, service) {
   const attrs = { service };
-  return models.Collective.findById(CollectiveId)
+  return models.Collective.findByPk(CollectiveId)
     .then(collective => (attrs.CollectiveId = collective.id))
     .then(() => ConnectedAccount.findOne({ where: attrs }))
     .then(ca => ca || ConnectedAccount.create(attrs));

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -182,7 +182,7 @@ export const show = (req, res, next) => {
 
   if (req.remoteUser && req.remoteUser.id === req.user.id) {
     Promise.all([
-      models.Collective.findById(req.user.CollectiveId),
+      models.Collective.findByPk(req.user.CollectiveId),
       models.ConnectedAccount.findOne({
         where: { service: 'stripe', CollectiveId: req.remoteUser.CollectiveId },
       }),

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -675,13 +675,13 @@ const CollectiveFields = () => {
     createdByUser: {
       type: UserType,
       resolve(collective) {
-        return models.User.findById(collective.CreatedByUserId);
+        return models.User.findByPk(collective.CreatedByUserId);
       },
     },
     parentCollective: {
       type: CollectiveInterfaceType,
       resolve(collective) {
-        return models.Collective.findById(collective.ParentCollectiveId);
+        return models.Collective.findByPk(collective.ParentCollectiveId);
       },
     },
     type: {

--- a/server/graphql/v1/TransactionInterface.js
+++ b/server/graphql/v1/TransactionInterface.js
@@ -161,15 +161,15 @@ const TransactionFields = () => {
         let HostCollectiveId = transaction.HostCollectiveId;
         // if the transaction is from the perspective of the fromCollective
         if (!HostCollectiveId) {
-          const fromCollective = await models.Collective.findById(FromCollectiveId);
+          const fromCollective = await models.Collective.findByPk(FromCollectiveId);
           HostCollectiveId = await fromCollective.getHostCollectiveId();
           // if fromCollective has no host, we try the collective
           if (!HostCollectiveId) {
-            const collective = await models.Collective.findById(CollectiveId);
+            const collective = await models.Collective.findByPk(CollectiveId);
             HostCollectiveId = await collective.getHostCollectiveId();
           }
         }
-        return models.Collective.findById(HostCollectiveId);
+        return models.Collective.findByPk(HostCollectiveId);
       },
     },
     createdByUser: {
@@ -192,7 +192,7 @@ const TransactionFields = () => {
           return transaction.getFromCollective();
         }
         if (get(transaction, 'fromCollective.id')) {
-          return models.Collective.findById(get(transaction, 'fromCollective.id'));
+          return models.Collective.findByPk(get(transaction, 'fromCollective.id'));
         }
         return null;
       },
@@ -206,7 +206,7 @@ const TransactionFields = () => {
           return transaction.getVirtualCardEmitterCollective();
         }
         if (transaction && transaction.UsingVirtualCardFromCollectiveId) {
-          return models.Collective.findById(transaction.UsingVirtualCardFromCollectiveId);
+          return models.Collective.findByPk(transaction.UsingVirtualCardFromCollectiveId);
         }
         return null;
       },
@@ -220,7 +220,7 @@ const TransactionFields = () => {
           return transaction.getCollective();
         }
         if (get(transaction, 'collective.id')) {
-          return models.Collective.findById(get(transaction, 'collective.id'));
+          return models.Collective.findByPk(get(transaction, 'collective.id'));
         }
         return null;
       },

--- a/server/graphql/v1/mutations/applications.js
+++ b/server/graphql/v1/mutations/applications.js
@@ -29,7 +29,7 @@ export async function createApplication(_, args, req) {
 }
 
 export async function updateApplication(_, args, req) {
-  const app = await Application.findById(args.id);
+  const app = await Application.findByPk(args.id);
   if (!app) {
     throw new errors.NotFound({
       message: `Application with id ${args.id} not found`,
@@ -46,7 +46,7 @@ export async function updateApplication(_, args, req) {
 }
 
 export async function deleteApplication(_, args, req) {
-  const app = await Application.findById(args.id);
+  const app = await Application.findByPk(args.id);
   if (!app) {
     throw new errors.NotFound({
       message: `Application with id ${args.id} not found`,

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -151,7 +151,7 @@ export async function createCollective(_, args, req) {
   if (collective.type !== types.COLLECTIVE) {
     return collective;
   }
-  const remoteUserCollective = await models.Collective.findById(req.remoteUser.CollectiveId);
+  const remoteUserCollective = await models.Collective.findByPk(req.remoteUser.CollectiveId);
   models.Activity.create({
     type: activities.COLLECTIVE_CREATED,
     UserId: req.remoteUser.id,
@@ -286,7 +286,7 @@ export async function approveCollective(remoteUser, CollectiveId) {
     });
   }
 
-  const collective = await models.Collective.findById(CollectiveId);
+  const collective = await models.Collective.findByPk(CollectiveId);
   if (!collective) {
     throw new errors.NotFound({
       message: `Collective with id ${CollectiveId} not found`,
@@ -325,7 +325,7 @@ export function deleteCollective(_, args, req) {
     });
   }
 
-  return models.Collective.findById(args.id).then(collective => {
+  return models.Collective.findByPk(args.id).then(collective => {
     if (!collective)
       throw new errors.NotFound({
         message: `Collective with id ${args.id} not found`,
@@ -347,7 +347,7 @@ export async function claimCollective(_, args, req) {
     });
   }
 
-  let collective = await models.Collective.findById(args.id);
+  let collective = await models.Collective.findByPk(args.id);
   if (!collective) {
     throw new errors.NotFound({
       message: `Collective with id ${args.id} not found`,
@@ -412,7 +412,7 @@ export async function claimCollective(_, args, req) {
   // add opensource collective as host
   // set collective as active
   // create default tiers
-  const host = await models.Collective.findById(defaultHostCollective('opensource').CollectiveId);
+  const host = await models.Collective.findByPk(defaultHostCollective('opensource').CollectiveId);
 
   collective = await collective.addHost(host, {
     ...req.remoteUser.minimal,

--- a/server/graphql/v1/mutations/comments.js
+++ b/server/graphql/v1/mutations/comments.js
@@ -41,7 +41,7 @@ export async function createComment(_, args, req) {
 }
 
 async function fetchComment(id) {
-  const comment = await models.Comment.findById(id);
+  const comment = await models.Comment.findByPk(id);
   if (!comment) throw new errors.NotFound({ message: `Comment with id ${id} not found` });
   return comment;
 }

--- a/server/graphql/v1/mutations/connectedAccounts.js
+++ b/server/graphql/v1/mutations/connectedAccounts.js
@@ -17,7 +17,7 @@ export async function editConnectedAccount(remoteUser, connectedAccountData) {
     throw new errors.Unauthorized('You need to be logged in to edit a connected account');
   }
 
-  const connectedAccount = await models.ConnectedAccount.findById(connectedAccountData.id);
+  const connectedAccount = await models.ConnectedAccount.findByPk(connectedAccountData.id);
 
   if (!connectedAccount) {
     throw new errors.Unauthorized('Connected account not found');
@@ -36,7 +36,7 @@ export async function deleteConnectedAccount(remoteUser, connectedAccountId) {
     throw new errors.Unauthorized('You need to be logged in to delete a connected account');
   }
 
-  const connectedAccount = await models.ConnectedAccount.findById(connectedAccountId);
+  const connectedAccount = await models.ConnectedAccount.findByPk(connectedAccountId);
 
   if (!connectedAccount) {
     throw new errors.Unauthorized('Connected account not found');

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -48,7 +48,7 @@ export async function updateExpenseStatus(remoteUser, expenseId, status) {
     throw new errors.ValidationFailed('Invalid status, status must be one of ', Object.keys(statuses).join(', '));
   }
 
-  const expense = await models.Expense.findById(expenseId, {
+  const expense = await models.Expense.findByPk(expenseId, {
     include: [{ model: models.Collective, as: 'collective' }],
   });
 
@@ -95,7 +95,7 @@ export async function createExpense(remoteUser, expenseData) {
   }
   expenseData.UserId = remoteUser.id;
 
-  const collective = await models.Collective.findById(expenseData.collective.id);
+  const collective = await models.Collective.findByPk(expenseData.collective.id);
 
   if (expenseData.currency && expenseData.currency !== collective.currency) {
     throw new errors.ValidationFailed(
@@ -144,7 +144,7 @@ export async function editExpense(remoteUser, expenseData) {
     throw new errors.Unauthorized('You need to be logged in to edit an expense');
   }
 
-  const expense = await models.Expense.findById(expenseData.id, {
+  const expense = await models.Expense.findByPk(expenseData.id, {
     include: [{ model: models.Collective, as: 'collective' }],
   });
 
@@ -187,7 +187,7 @@ export async function deleteExpense(remoteUser, expenseId) {
     throw new errors.Unauthorized('You need to be logged in to delete an expense');
   }
 
-  const expense = await models.Expense.findById(expenseId, {
+  const expense = await models.Expense.findByPk(expenseId, {
     include: [{ model: models.Collective, as: 'collective' }],
   });
 
@@ -269,7 +269,7 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
   if (!remoteUser) {
     throw new errors.Unauthorized('You need to be logged in to pay an expense');
   }
-  const expense = await models.Expense.findById(expenseId, {
+  const expense = await models.Expense.findByPk(expenseId, {
     include: [{ model: models.Collective, as: 'collective' }],
   });
   if (!expense) {
@@ -291,7 +291,7 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
   if (expense.payoutMethod === 'donation') {
     const transaction = await createTransactionFromPaidExpense(host, null, expense, null, expense.UserId);
     await createTransactionFromInKindDonation(transaction);
-    const user = await models.User.findById(expense.UserId);
+    const user = await models.User.findByPk(expense.UserId);
     await expense.collective.addUserWithRole(user, 'BACKER');
     return markExpenseAsPaid(expense);
   }

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -208,7 +208,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
     let tier;
     if (order.tier) {
-      tier = await models.Tier.findById(order.tier.id);
+      tier = await models.Tier.findByPk(order.tier.id);
 
       if (!tier) {
         throw new Error(`No tier found with tier id: ${order.tier.id} for collective slug ${order.collective.slug}`);
@@ -412,7 +412,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
       });
     }
 
-    order = await models.Order.findById(orderCreated.id);
+    order = await models.Order.findByPk(orderCreated.id);
 
     // If there was a referral for this order, we add it as a FUNDRAISER role
     if (order.ReferralCollectiveId && order.ReferralCollectiveId !== user.CollectiveId) {
@@ -640,7 +640,7 @@ export async function updateSubscription(remoteUser, args) {
 
 export async function refundTransaction(_, args, req) {
   // 0. Retrieve transaction from database
-  const transaction = await models.Transaction.findById(args.id, {
+  const transaction = await models.Transaction.findByPk(args.id, {
     include: [models.Order, models.PaymentMethod],
   });
   if (!transaction) {
@@ -682,8 +682,8 @@ export async function refundTransaction(_, args, req) {
 export async function addFundsToOrg(args, remoteUser) {
   if (!remoteUser.isRoot()) throw new Error('Only site admins can perform this operation');
   const [fromCollective, hostCollective] = await Promise.all([
-    models.Collective.findById(args.CollectiveId),
-    models.Collective.findById(args.HostCollectiveId),
+    models.Collective.findByPk(args.CollectiveId),
+    models.Collective.findByPk(args.HostCollectiveId),
   ]);
   // creates a new Payment method
   const paymentMethod = await models.PaymentMethod.create({
@@ -712,7 +712,7 @@ export async function markOrderAsPaid(remoteUser, id) {
   }
 
   // fetch the order
-  const order = await models.Order.findById(id);
+  const order = await models.Order.findByPk(id);
   if (!order) {
     throw new errors.NotFound({ message: 'Order not found' });
   }

--- a/server/graphql/v1/mutations/paymentMethods.js
+++ b/server/graphql/v1/mutations/paymentMethods.js
@@ -62,7 +62,7 @@ export async function claimPaymentMethod(args, remoteUser) {
   });
   const { initialBalance, monthlyLimitPerMember, currency, name, expiryDate } = paymentMethod;
   const amount = initialBalance || monthlyLimitPerMember;
-  const emitter = await models.Collective.findById(paymentMethod.sourcePaymentMethod.CollectiveId);
+  const emitter = await models.Collective.findByPk(paymentMethod.sourcePaymentMethod.CollectiveId);
 
   const qs = queryString.stringify({
     code: paymentMethod.uuid.substring(0, 8),

--- a/server/graphql/v1/mutations/updates.js
+++ b/server/graphql/v1/mutations/updates.js
@@ -29,7 +29,7 @@ export async function createUpdate(_, args, req) {
 }
 
 async function fetchUpdate(id) {
-  const update = await models.Update.findById(id);
+  const update = await models.Update.findByPk(id);
   if (!update) throw new errors.NotFound({ message: `Update with id ${id} not found` });
   return update;
 }

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -55,7 +55,7 @@ const queries = {
       if (args.slug) {
         collective = models.Collective.findBySlug(args.slug.toLowerCase());
       } else if (args.id) {
-        collective = models.Collective.findById(args.id);
+        collective = models.Collective.findByPk(args.id);
       } else {
         return new Error('Please provide a slug or an id');
       }
@@ -72,7 +72,7 @@ const queries = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args) {
-      return models.Tier.findById(args.id);
+      return models.Tier.findByPk(args.id);
     },
   },
 
@@ -100,7 +100,7 @@ const queries = {
   AuthenticatedUser: {
     type: CollectiveInterfaceType,
     resolve(_, args, req) {
-      return models.Collective.findById(req.remoteUser.CollectiveId);
+      return models.Collective.findByPk(req.remoteUser.CollectiveId);
     },
   },
 
@@ -137,7 +137,7 @@ const queries = {
         const HostCollectiveId = transaction.HostCollectiveId;
         hostsById[HostCollectiveId] =
           hostsById[HostCollectiveId] ||
-          (await models.Collective.findById(HostCollectiveId, {
+          (await models.Collective.findByPk(HostCollectiveId, {
             attributes: ['id', 'slug'],
           }));
         const createdAt = new Date(transaction.createdAt);
@@ -425,7 +425,7 @@ const queries = {
     },
     async resolve(_, args) {
       if (args.id) {
-        return models.Update.findById(args.id);
+        return models.Update.findByPk(args.id);
       }
       const CollectiveId = await fetchCollectiveId(args.collectiveSlug);
       return models.Update.findOne({
@@ -441,7 +441,7 @@ const queries = {
     },
     async resolve(_, args) {
       if (args.id) {
-        return models.Application.findById(args.id);
+        return models.Application.findByPk(args.id);
       } else {
         return new Error('Please provide an id.');
       }
@@ -699,7 +699,7 @@ const queries = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args) {
-      return models.Expense.findById(args.id);
+      return models.Expense.findByPk(args.id);
     },
   },
 
@@ -1120,7 +1120,7 @@ const queries = {
     },
     resolve(_, args) {
       if (args.id) {
-        return models.PaymentMethod.findById(args.id);
+        return models.PaymentMethod.findByPk(args.id);
       } else if (args.code) {
         return models.PaymentMethod.findOne({
           where: sequelize.and(
@@ -1254,7 +1254,7 @@ const queries = {
       },
     },
     resolve: async (_, args) => {
-      const order = await models.Order.findById(args.id);
+      const order = await models.Order.findByPk(args.id);
       return order;
     },
   },

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -528,7 +528,7 @@ export const ExpenseType = new GraphQLObjectType({
                 } -- has the user been deleted?`,
               );
             }
-            return models.Collective.findById(u.CollectiveId);
+            return models.Collective.findByPk(u.CollectiveId);
           });
         },
       },
@@ -796,13 +796,13 @@ export const CommentType = new GraphQLObjectType({
       expense: {
         type: ExpenseType,
         resolve(comment) {
-          return models.Expense.findById(comment.ExpenseId);
+          return models.Expense.findByPk(comment.ExpenseId);
         },
       },
       update: {
         type: UpdateType,
         resolve(comment) {
-          return models.Update.findById(comment.UpdateId);
+          return models.Update.findByPk(comment.UpdateId);
         },
       },
     };
@@ -1413,7 +1413,7 @@ export const PaymentMethodType = new GraphQLObjectType({
         async resolve(paymentMethod, args, req) {
           // TODO: could we have a getter for SourcePaymentMethod?
           if (paymentMethod.SourcePaymentMethodId) {
-            const sourcePaymentMethod = await models.PaymentMethod.findById(paymentMethod.SourcePaymentMethodId);
+            const sourcePaymentMethod = await models.PaymentMethod.findByPk(paymentMethod.SourcePaymentMethodId);
             if (sourcePaymentMethod) {
               return req.loaders.collective.findById.load(sourcePaymentMethod.CollectiveId);
             }

--- a/server/graphql/v2/query/AccountQuery.js
+++ b/server/graphql/v2/query/AccountQuery.js
@@ -27,7 +27,7 @@ const AccountQuery = {
       collective = await models.Collective.findBySlug(slug);
     } else if (args.id) {
       const id = idDecode(args.id, 'account');
-      collective = await models.Collective.findById(id);
+      collective = await models.Collective.findByPk(id);
     } else {
       return new Error('Please provide a slug or an id');
     }

--- a/server/graphql/v2/query/CollectiveQuery.js
+++ b/server/graphql/v2/query/CollectiveQuery.js
@@ -24,7 +24,7 @@ const CollectiveQuery = {
       collective = await models.Collective.findBySlug(slug);
     } else if (args.id) {
       const id = idDecode(args.id, 'account');
-      collective = await models.Collective.findById(id);
+      collective = await models.Collective.findByPk(id);
     } else {
       return new Error('Please provide a slug or an id');
     }

--- a/server/graphql/v2/query/IndividualQuery.js
+++ b/server/graphql/v2/query/IndividualQuery.js
@@ -24,7 +24,7 @@ const IndividualQuery = {
       collective = await models.Collective.findBySlug(slug);
     } else if (args.id) {
       const id = idDecode(args.id, 'account');
-      collective = await models.Collective.findById(id);
+      collective = await models.Collective.findByPk(id);
     } else {
       return new Error('Please provide a slug or an id');
     }

--- a/server/graphql/v2/query/TransactionQuery.js
+++ b/server/graphql/v2/query/TransactionQuery.js
@@ -20,7 +20,7 @@ const TransactionQuery = {
     let transaction;
     if (args.id) {
       const id = idDecode(args.id, 'transaction');
-      transaction = await models.Transaction.findById(id);
+      transaction = await models.Transaction.findByPk(id);
     } else {
       return new Error('Please provide an id');
     }

--- a/server/graphql/v2/query/index.js
+++ b/server/graphql/v2/query/index.js
@@ -16,7 +16,7 @@ const query = {
   loggedInAccount: {
     type: Account,
     resolve(_, args, req) {
-      return models.Collective.findById(req.remoteUser.CollectiveId);
+      return models.Collective.findByPk(req.remoteUser.CollectiveId);
     },
   },
 };

--- a/server/lib/ledger.js
+++ b/server/lib/ledger.js
@@ -200,9 +200,9 @@ export function parseLedgerTransactionToApiFormat(legacyId, transactions, legacy
  * @return {Object} returns an api transaction with nested models
  */
 export async function getTransactionWithNestedProperties(transaction) {
-  const fromCollective = await models.Collective.findById(transaction.FromCollectiveId);
+  const fromCollective = await models.Collective.findByPk(transaction.FromCollectiveId);
   const fromCollectiveHost = await fromCollective.getHostCollective();
-  const collective = await models.Collective.findById(transaction.CollectiveId);
+  const collective = await models.Collective.findByPk(transaction.CollectiveId);
   const collectiveHost = await collective.getHostCollective();
   transaction.fromCollectiveSlug = fromCollective.slug;
   transaction.FromCollectiveHostId = fromCollectiveHost && fromCollectiveHost.id;
@@ -220,49 +220,49 @@ export async function getTransactionWithNestedProperties(transaction) {
   });
   transaction.debitId = debitTransaction.id;
   if (transaction.HostCollectiveId) {
-    const hostCollective = await models.Collective.findById(transaction.HostCollectiveId);
+    const hostCollective = await models.Collective.findByPk(transaction.HostCollectiveId);
     transaction.hostCollectiveSlug = hostCollective.slug;
-    const paymentMethod = await models.PaymentMethod.findById(transaction.PaymentMethodId);
+    const paymentMethod = await models.PaymentMethod.findByPk(transaction.PaymentMethodId);
     transaction.paymentMethodService = paymentMethod.service;
     transaction.paymentMethodType = paymentMethod.type;
     if (paymentMethod.CollectiveId) {
       transaction.paymentMethodCollectiveId = paymentMethod.CollectiveId;
-      const pmCollective = await models.Collective.findById(paymentMethod.CollectiveId);
+      const pmCollective = await models.Collective.findByPk(paymentMethod.CollectiveId);
       transaction.paymentMethodCollectiveSlug = pmCollective.slug;
     }
   }
   if (transaction.OrderId) {
-    const order = await models.Order.findById(transaction.OrderId);
+    const order = await models.Order.findByPk(transaction.OrderId);
     if (order.FromCollectiveId) {
       transaction.orderFromCollectiveId = order.FromCollectiveId;
-      const orderFromCollective = await models.Collective.findById(order.FromCollectiveId);
+      const orderFromCollective = await models.Collective.findByPk(order.FromCollectiveId);
       transaction.orderFromCollectiveSlug = orderFromCollective.slug;
     }
     if (order.PaymentMethodId) {
-      const orderPaymentMethod = await models.PaymentMethod.findById(order.PaymentMethodId);
+      const orderPaymentMethod = await models.PaymentMethod.findByPk(order.PaymentMethodId);
       transaction.orderPaymentMethodService = orderPaymentMethod.service;
       transaction.orderPaymentMethodType = orderPaymentMethod.type;
       if (orderPaymentMethod.CollectiveId) {
         transaction.orderPaymentMethodCollectiveId = orderPaymentMethod.CollectiveId;
-        const orderPaymentMethodCollective = await models.Collective.findById(orderPaymentMethod.CollectiveId);
+        const orderPaymentMethodCollective = await models.Collective.findByPk(orderPaymentMethod.CollectiveId);
         transaction.orderPaymentMethodCollectiveSlug = orderPaymentMethodCollective.slug;
       }
     }
   }
   if (transaction.ExpenseId) {
-    const expense = await models.Expense.findById(transaction.ExpenseId);
+    const expense = await models.Expense.findByPk(transaction.ExpenseId);
     transaction.expensePayoutMethod = expense.payoutMethod;
     if (expense.UserId) {
       transaction.expenseUserId = expense.UserId;
-      const expenseUser = await models.User.findById(expense.UserId);
+      const expenseUser = await models.User.findByPk(expense.UserId);
       transaction.expenseUserPaypalEmail = expenseUser.paypalEmail;
       if (expenseUser.CollectiveId) {
-        const expenseUserCollective = await models.Collective.findById(expenseUser.CollectiveId);
+        const expenseUserCollective = await models.Collective.findByPk(expenseUser.CollectiveId);
         transaction.expenseUserCollectiveSlug = expenseUserCollective.slug;
       }
     }
     if (expense.CollectiveId) {
-      const expenseCollective = await models.Collective.findById(expense.CollectiveId);
+      const expenseCollective = await models.Collective.findByPk(expense.CollectiveId);
       transaction.expenseCollectiveId = expense.CollectiveId;
       transaction.expenseCollectiveSlug = expenseCollective.slug;
     }

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -126,11 +126,11 @@ async function notifySubscribers(users, activity, options = {}) {
 }
 
 async function notifyUserId(UserId, activity, options = {}) {
-  const user = await models.User.findById(UserId);
+  const user = await models.User.findByPk(UserId);
   debug('notifyUserId', UserId, user && user.email, activity.type);
 
   if (activity.type === activityType.TICKET_CONFIRMED) {
-    const event = await models.Collective.findById(activity.data.EventCollectiveId);
+    const event = await models.Collective.findByPk(activity.data.EventCollectiveId);
     const parentCollective = await event.getParentCollective();
     const ics = await event.getICS();
     options.attachments = [{ filename: `${event.slug}.ics`, content: ics }];
@@ -144,7 +144,7 @@ async function notifyUserId(UserId, activity, options = {}) {
 
 export async function notifyAdminsOfCollective(CollectiveId, activity, options = {}) {
   debug('notify admins of CollectiveId', CollectiveId);
-  const collective = await models.Collective.findById(CollectiveId);
+  const collective = await models.Collective.findByPk(CollectiveId);
   if (!collective) {
     throw new Error(
       `notifyAdminsOfCollective> can't notify ${activity.type}: no collective found with id ${CollectiveId}`,
@@ -161,7 +161,7 @@ export async function notifyAdminsOfCollective(CollectiveId, activity, options =
 
 async function w9bot(activity) {
   const HostCollectiveId = get(activity, 'data.host.id');
-  const host = await models.Collective.findById(HostCollectiveId);
+  const host = await models.Collective.findByPk(HostCollectiveId);
 
   if (!host) {
     throw new Error(`w9bot: Host id ${HostCollectiveId} not found`);
@@ -224,7 +224,7 @@ async function w9bot(activity) {
 
 async function notifyMembersOfCollective(CollectiveId, activity, options) {
   debug('notify members of CollectiveId', CollectiveId);
-  const collective = await models.Collective.findById(CollectiveId);
+  const collective = await models.Collective.findByPk(CollectiveId);
   const allUsers = await collective.getUsers();
   debug('Total users to notify:', allUsers.length);
   activity.CollectiveId = collective.id;
@@ -245,11 +245,11 @@ async function notifyByEmail(activity) {
 
     case activityType.COLLECTIVE_UPDATE_PUBLISHED:
       twitter.tweetActivity(activity);
-      activity.data.update = await models.Update.findById(activity.data.update.id, {
+      activity.data.update = await models.Update.findByPk(activity.data.update.id, {
         include: [{ model: models.Collective, as: 'fromCollective' }],
       });
       notifyMembersOfCollective(activity.data.update.CollectiveId, activity, {
-        from: `${activity.data.collective.name} 
+        from: `${activity.data.collective.name}
         <hello@${activity.data.collective.slug}.opencollective.com>`,
       });
       break;
@@ -270,14 +270,14 @@ async function notifyByEmail(activity) {
       break;
 
     case activityType.COLLECTIVE_COMMENT_CREATED:
-      activity.data.collective = await models.Collective.findById(activity.CollectiveId);
-      activity.data.fromCollective = await models.Collective.findById(activity.data.FromCollectiveId);
+      activity.data.collective = await models.Collective.findByPk(activity.CollectiveId);
+      activity.data.fromCollective = await models.Collective.findByPk(activity.data.FromCollectiveId);
       if (activity.data.ExpenseId) {
-        activity.data.expense = await models.Expense.findById(activity.data.ExpenseId);
+        activity.data.expense = await models.Expense.findByPk(activity.data.ExpenseId);
         activity.data.UserId = activity.data.expense.UserId;
         activity.data.path = `/${activity.data.collective.slug}/expenses/${activity.data.expense.id}`;
       } else {
-        activity.data.update = await models.Update.findById(activity.data.UpdateId);
+        activity.data.update = await models.Update.findByPk(activity.data.UpdateId);
         activity.data.UserId = activity.data.update.CreatedByUserId;
         activity.data.path = `/${activity.data.collective.slug}/updates/${activity.data.update.slug}`;
       }

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -248,7 +248,7 @@ export const addBackerToCollective = async (user, collective, TierId) => {
 };
 
 export const processMatchingFund = async (order, options) => {
-  const matchingFundCollective = await models.Collective.findById(order.matchingFund.CollectiveId);
+  const matchingFundCollective = await models.Collective.findByPk(order.matchingFund.CollectiveId);
   // if there is a matching fund, we execute the order
   // also adds the owner of the matching fund as a BACKER of collective
   const matchingOrder = {
@@ -417,7 +417,7 @@ const sendOrderConfirmedEmail = async order => {
 
     let matchingFundCollective;
     if (order.matchingFund) {
-      matchingFundCollective = await models.Collective.findById(order.matchingFund.CollectiveId);
+      matchingFundCollective = await models.Collective.findByPk(order.matchingFund.CollectiveId);
       data.matchingFund = {
         collective: pick(matchingFundCollective, ['slug', 'name', 'image']),
         matching: order.matchingFund.matching,

--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -134,7 +134,7 @@ export async function createFromPaidExpense(
 
   transaction.hostCurrencyFxRate = hostCurrencyFxRate;
   transaction.amountInHostCurrency = -Math.round(hostCurrencyFxRate * expense.amount); // amountInHostCurrency is an INTEGER (in cents)
-  const user = await models.User.findById(UserId);
+  const user = await models.User.findByPk(UserId);
   transaction.FromCollectiveId = user.CollectiveId;
   return models.Transaction.createDoubleEntry(transaction);
 }

--- a/server/middleware/security/auth.js
+++ b/server/middleware/security/auth.js
@@ -33,7 +33,7 @@ export async function checkClientApp(req, res, next) {
       req.clientApp = app;
       const collectiveId = app.CollectiveId;
       if (collectiveId) {
-        req.loggedInAccount = await models.Collective.findById(collectiveId);
+        req.loggedInAccount = await models.Collective.findByPk(collectiveId);
         req.remoteUser = await models.User.findOne({
           where: { CollectiveId: collectiveId },
         });

--- a/server/middleware/security/authentication.js
+++ b/server/middleware/security/authentication.js
@@ -84,7 +84,7 @@ export function authenticateUserByJwtNoExpiry() {
 export const _authenticateUserByJwt = (req, res, next) => {
   if (!req.jwtPayload) return next();
   const userid = req.jwtPayload.sub;
-  User.findById(userid)
+  User.findByPk(userid)
     .then(user => {
       if (!user) throw errors.Unauthorized(`User id ${userid} not found`);
       user.update({ seenAt: new Date() });

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -553,7 +553,7 @@ export default function(Sequelize, DataTypes) {
   Collective.prototype.getParentCollective = function() {
     if (!this.ParentCollectiveId) return Promise.resolve(null);
     if (this.parentCollective) return Promise.resolve(this.parentCollective);
-    return models.Collective.findById(this.ParentCollectiveId);
+    return models.Collective.findByPk(this.ParentCollectiveId);
   };
 
   Collective.prototype.getICS = function() {
@@ -677,7 +677,7 @@ export default function(Sequelize, DataTypes) {
   // I'd argue that we should store the event slug as `${parentCollectiveSlug}/events/${eventSlug}`
   Collective.prototype.getUrlPath = function() {
     if (this.type === types.EVENT) {
-      return models.Collective.findById(this.ParentCollectiveId, {
+      return models.Collective.findByPk(this.ParentCollectiveId, {
         attributes: ['id', 'slug'],
       }).then(parent => {
         return `/${parent.slug}/events/${this.slug}`;
@@ -692,7 +692,7 @@ export default function(Sequelize, DataTypes) {
     switch (this.type) {
       case types.USER:
       case types.ORGANIZATION:
-        return models.User.findById(this.CreatedByUserId);
+        return models.User.findByPk(this.CreatedByUserId);
       default:
         return Promise.resolve(null);
     }
@@ -1087,14 +1087,14 @@ export default function(Sequelize, DataTypes) {
     debug('addUserWithRole', user.id, role, 'member', member);
     return Promise.all([
       models.Member.create(member, sequelizeParams),
-      models.User.findById(
+      models.User.findByPk(
         member.CreatedByUserId,
         {
           include: [{ model: models.Collective, as: 'collective' }],
         },
         sequelizeParams,
       ),
-      models.User.findById(
+      models.User.findByPk(
         user.id,
         {
           include: [{ model: models.Collective, as: 'collective' }],
@@ -1111,7 +1111,7 @@ export default function(Sequelize, DataTypes) {
         case roles.ATTENDEE:
         case roles.FOLLOWER:
           return Promise.props({
-            memberCollective: models.Collective.findById(member.MemberCollectiveId, sequelizeParams),
+            memberCollective: models.Collective.findByPk(member.MemberCollectiveId, sequelizeParams),
             order: models.Order.findOne(
               {
                 where: {
@@ -1333,7 +1333,7 @@ export default function(Sequelize, DataTypes) {
     this.HostCollectiveId = null;
     this.isActive = false; // we should rename isActive to isApproved (by the host)
     if (newHostCollectiveId) {
-      const newHostCollective = await models.Collective.findById(newHostCollectiveId);
+      const newHostCollective = await models.Collective.findByPk(newHostCollectiveId);
       if (!newHostCollective) {
         throw new Error('Host not found');
       }
@@ -1837,7 +1837,7 @@ export default function(Sequelize, DataTypes) {
   // get the host of the parent collective if any, or of this collective
   Collective.prototype.getHostCollective = function() {
     if (this.HostCollectiveId) {
-      return models.Collective.findById(this.HostCollectiveId);
+      return models.Collective.findByPk(this.HostCollectiveId);
     }
     return models.Member.findOne({
       attributes: ['MemberCollectiveId'],

--- a/server/models/Comment.js
+++ b/server/models/Comment.js
@@ -192,7 +192,7 @@ export default function(Sequelize, DataTypes) {
 
   // Returns the User model of the User that created this Update
   Comment.prototype.getUser = function() {
-    return models.User.findById(this.CreatedByUserId);
+    return models.User.findByPk(this.CreatedByUserId);
   };
 
   Comment.createMany = (comments, defaultValues) => {

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -177,8 +177,8 @@ export default function(Sequelize, DataTypes) {
    * Instance Methods
    */
   Expense.prototype.createActivity = async function(type) {
-    const user = this.user || (await models.User.findById(this.UserId));
-    const userCollective = await models.Collective.findById(user.CollectiveId);
+    const user = this.user || (await models.User.findByPk(this.UserId));
+    const userCollective = await models.Collective.findByPk(user.CollectiveId);
     if (!this.collective) {
       this.collective = await this.getCollective();
     }

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -240,7 +240,7 @@ export default function(Sequelize, DataTypes) {
 
   Order.prototype.getUser = function() {
     if (this.createdByUser) return Promise.resolve(this.createdByUser);
-    return models.User.findById(this.CreatedByUserId).then(user => {
+    return models.User.findByPk(this.CreatedByUserId).then(user => {
       this.createdByUser = user;
       debug('getUser', user.dataValues);
       return user.populateRoles();
@@ -261,7 +261,7 @@ export default function(Sequelize, DataTypes) {
       const promise = () => {
         if (this[attribute]) return Promise.resolve(this[attribute]);
         if (!this[fk]) return Promise.resolve(null);
-        return models[model].findById(this[fk]);
+        return models[model].findByPk(this[fk]);
       };
       return promise().then(obj => {
         this[attribute] = obj;
@@ -273,7 +273,7 @@ export default function(Sequelize, DataTypes) {
     return user.populateRoles().then(() => {
       // this check is necessary to cover organizations as well as user collective
       if (user.isAdmin(this.FromCollectiveId)) {
-        return models.PaymentMethod.findById(this.PaymentMethodId);
+        return models.PaymentMethod.findByPk(this.PaymentMethodId);
       } else {
         return null;
       }

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -549,7 +549,7 @@ export default function(Sequelize, DataTypes) {
         if (!options.ForCollectiveId) {
           throw new Error('Please provide a ForCollectiveId');
         }
-        const collective = await models.Collective.findById(options.ForCollectiveId);
+        const collective = await models.Collective.findByPk(options.ForCollectiveId);
         if (intersection(collective.tags, pm.limitedToTags).length === 0) {
           throw new Error('This matching fund is not available to collectives in this category');
         }

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -221,12 +221,12 @@ export default (Sequelize, DataTypes) => {
    * Instance Methods
    */
   Transaction.prototype.getUser = function() {
-    return models.User.findById(this.CreatedByUserId);
+    return models.User.findByPk(this.CreatedByUserId);
   };
 
   Transaction.prototype.getVirtualCardEmitterCollective = function() {
     if (this.UsingVirtualCardFromCollectiveId) {
-      return models.Collective.findById(this.UsingVirtualCardFromCollectiveId);
+      return models.Collective.findByPk(this.UsingVirtualCardFromCollectiveId);
     }
   };
 
@@ -234,10 +234,10 @@ export default (Sequelize, DataTypes) => {
     let HostCollectiveId = this.HostCollectiveId;
     // if the transaction is from the perspective of the fromCollective
     if (!HostCollectiveId) {
-      const fromCollective = await models.Collective.findById(this.FromCollectiveId);
+      const fromCollective = await models.Collective.findByPk(this.FromCollectiveId);
       HostCollectiveId = await fromCollective.getHostCollectiveId();
     }
-    return models.Collective.findById(HostCollectiveId);
+    return models.Collective.findByPk(HostCollectiveId);
   };
 
   Transaction.prototype.getExpenseForViewer = function(viewer) {
@@ -279,7 +279,7 @@ export default (Sequelize, DataTypes) => {
 
   Transaction.prototype.getRefundTransaction = function() {
     if (!this.RefundTransactionId) return null;
-    return Transaction.findById(this.RefundTransactionId);
+    return Transaction.findByPk(this.RefundTransactionId);
   };
 
   /**
@@ -434,7 +434,7 @@ export default (Sequelize, DataTypes) => {
       return Promise.reject(new Error('transaction.amount cannot be null or zero'));
     }
 
-    return models.Collective.findById(CollectiveId)
+    return models.Collective.findByPk(CollectiveId)
       .then(c => c.getHostCollectiveId())
       .then(HostCollectiveId => {
         if (!HostCollectiveId && !transaction.HostCollectiveId) {
@@ -470,7 +470,7 @@ export default (Sequelize, DataTypes) => {
       return Promise.resolve();
     }
     return (
-      Transaction.findById(transaction.id, {
+      Transaction.findByPk(transaction.id, {
         include: [
           { model: models.Collective, as: 'fromCollective' },
           { model: models.Collective, as: 'collective' },

--- a/server/models/Update.js
+++ b/server/models/Update.js
@@ -211,7 +211,7 @@ export default function(Sequelize, DataTypes) {
   Update.prototype.edit = async function(remoteUser, newUpdateData) {
     mustHaveRole(remoteUser, 'ADMIN', this.CollectiveId, 'edit this update');
     if (newUpdateData.TierId) {
-      const tier = await models.Tier.findById(newUpdateData.TierId);
+      const tier = await models.Tier.findByPk(newUpdateData.TierId);
       if (!tier) {
         throw new errors.ValidationFailed({ message: 'Tier not found' });
       }
@@ -233,7 +233,7 @@ export default function(Sequelize, DataTypes) {
   Update.prototype.publish = async function(remoteUser) {
     mustHaveRole(remoteUser, 'ADMIN', this.CollectiveId, 'publish this update');
     this.publishedAt = new Date();
-    this.collective = this.collective || (await models.Collective.findById(this.CollectiveId));
+    this.collective = this.collective || (await models.Collective.findByPk(this.CollectiveId));
     models.Activity.create({
       type: activities.COLLECTIVE_UPDATE_PUBLISHED,
       UserId: remoteUser.id,
@@ -261,7 +261,7 @@ export default function(Sequelize, DataTypes) {
 
   // Returns the User model of the User that created this Update
   Update.prototype.getUser = function() {
-    return models.User.findById(this.CreatedByUserId);
+    return models.User.findByPk(this.CreatedByUserId);
   };
 
   /*

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -136,7 +136,7 @@ export default (Sequelize, DataTypes) => {
       getterMethods: {
         // Collective of type USER corresponding to this user
         userCollective() {
-          return models.Collective.findById(this.CollectiveId).then(userCollective => {
+          return models.Collective.findByPk(this.CollectiveId).then(userCollective => {
             if (!userCollective) {
               logger.info(
                 `No Collective attached to this user id ${this.id} (User.CollectiveId: ${this.CollectiveId})`,

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -73,7 +73,7 @@ async function getBalance(paymentMethod) {
  * @return {models.Transaction} the double entry generated transactions.
  */
 async function processOrder(order) {
-  const paymentMethod = await models.PaymentMethod.findById(order.paymentMethod.id);
+  const paymentMethod = await models.PaymentMethod.findByPk(order.paymentMethod.id);
   // check if payment Method has expired
   if (!paymentMethod.expiryDate || moment(paymentMethod.expiryDate) < moment()) {
     throw new Error('Payment method has already expired');
@@ -99,7 +99,7 @@ async function processOrder(order) {
     throw new Error('Gift Card payment method must have a value a "SourcePaymentMethodId" defined');
   }
   // finding Source Payment method and update order payment method properties
-  const sourcePaymentMethod = await models.PaymentMethod.findById(paymentMethod.SourcePaymentMethodId);
+  const sourcePaymentMethod = await models.PaymentMethod.findByPk(paymentMethod.SourcePaymentMethodId);
   // modifying original order to then process the order of the source payment method
   order.PaymentMethodId = sourcePaymentMethod.id;
   order.paymentMethod = sourcePaymentMethod;
@@ -152,7 +152,7 @@ async function processOrder(order) {
  */
 async function create(args, remoteUser) {
   const totalAmount = args.amount || args.monthlyLimitPerMember;
-  const collective = await models.Collective.findById(args.CollectiveId);
+  const collective = await models.Collective.findByPk(args.CollectiveId);
   if (!collective) {
     throw new Error('Collective does not exist');
   } else if (!(await checkCreateLimit(collective, 1, totalAmount))) {
@@ -184,7 +184,7 @@ export async function bulkCreateVirtualCards(args, remoteUser, count) {
 
   // Check rate limit
   const totalAmount = (args.amount || args.monthlyLimitPerMember) * count;
-  const collective = await models.Collective.findById(args.CollectiveId);
+  const collective = await models.Collective.findByPk(args.CollectiveId);
   if (!collective) {
     throw new Error('Collective does not exist');
   } else if (!(await checkCreateLimit(collective, count, totalAmount))) {
@@ -218,7 +218,7 @@ export async function createVirtualCardsForEmails(args, remoteUser, emails, cust
   }
   // Check rate limit
   const totalAmount = (args.amount || args.monthlyLimitPerMember) * emails.length;
-  const collective = await models.Collective.findById(args.CollectiveId);
+  const collective = await models.Collective.findByPk(args.CollectiveId);
   if (!collective) {
     throw new Error('Collective does not exist');
   } else if (!(await checkCreateLimit(collective, emails.length, totalAmount))) {
@@ -256,7 +256,7 @@ async function getSourcePaymentMethodFromCreateArgs(args, collective) {
       throw Error(`Collective id ${collective.id} needs to have a Credit Card attached to create Gift Cards.`);
     }
   } else {
-    paymentMethod = await models.PaymentMethod.findById(args.PaymentMethodId);
+    paymentMethod = await models.PaymentMethod.findByPk(args.PaymentMethodId);
     if (!paymentMethod || paymentMethod.CollectiveId !== collective.id) {
       throw Error('Invalid PaymentMethodId');
     }
@@ -469,7 +469,7 @@ async function claim(args, remoteUser) {
   if (!virtualCardPaymentMethod) {
     throw Error(`Gift Card code "${args.code}" is invalid`);
   }
-  const sourcePaymentMethod = await models.PaymentMethod.findById(virtualCardPaymentMethod.SourcePaymentMethodId);
+  const sourcePaymentMethod = await models.PaymentMethod.findByPk(virtualCardPaymentMethod.SourcePaymentMethodId);
   // if the virtual card PM Collective Id is different than the Source PM Collective Id
   // it means this virtual card was already claimend
   if (!sourcePaymentMethod || sourcePaymentMethod.CollectiveId !== virtualCardPaymentMethod.CollectiveId) {

--- a/server/paymentProviders/paypal/index.js
+++ b/server/paymentProviders/paypal/index.js
@@ -64,7 +64,7 @@ export default {
 
       let collective, response;
 
-      return models.Collective.findById(CollectiveId)
+      return models.Collective.findByPk(CollectiveId)
         .then(c => {
           collective = c;
           return convertToCurrency(2000, 'USD', collective.currency).then(limit => {

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -162,7 +162,7 @@ export default {
     const chargeId = _.result(transaction.data, 'charge.id');
 
     /* From which stripe account it's going to be refunded */
-    const collective = await models.Collective.findById(
+    const collective = await models.Collective.findByPk(
       transaction.type === 'CREDIT' ? transaction.CollectiveId : transaction.FromCollectiveId,
     );
     const hostStripeAccount = await collective.getHostStripeAccount();
@@ -199,7 +199,7 @@ export default {
     const chargeId = _.result(transaction.data, 'charge.id');
 
     /* From which stripe account it's going to be refunded */
-    const collective = await models.Collective.findById(
+    const collective = await models.Collective.findByPk(
       transaction.type === 'CREDIT' ? transaction.CollectiveId : transaction.FromCollectiveId,
     );
     const hostStripeAccount = await collective.getHostStripeAccount();

--- a/server/paymentProviders/stripe/index.js
+++ b/server/paymentProviders/stripe/index.js
@@ -135,7 +135,7 @@ export default {
         return collective.save();
       };
 
-      return models.Collective.findById(CollectiveId)
+      return models.Collective.findByPk(CollectiveId)
         .then(c => {
           collective = c;
           redirectUrl = redirectUrl || `${config.host.website}/${collective.slug}`;

--- a/test/collective.model.test.js
+++ b/test/collective.model.test.js
@@ -323,7 +323,7 @@ describe('Collective model', () => {
       website: 'https://opencollective.com',
     }).then(collective => {
       expect(collective.image).to.equal('https://logo.clearbit.com/opencollective.com');
-      models.Collective.findById(collective.id).then(c => {
+      models.Collective.findByPk(collective.id).then(c => {
         expect(c.image).to.equal('https://logo.clearbit.com/opencollective.com');
         done();
       });
@@ -352,7 +352,7 @@ describe('Collective model', () => {
     }).then(user => {
       expect(user.collective.image).to.equal(undefined);
       setTimeout(() => {
-        models.Collective.findById(user.collective.id).then(c => {
+        models.Collective.findByPk(user.collective.id).then(c => {
           expect(c.image).to.equal('https://www.gravatar.com/avatar/a97d0fcd96579015da610aa284f8d8df?default=404');
           done();
         });

--- a/test/graphql.collective.test.js
+++ b/test/graphql.collective.test.js
@@ -803,7 +803,7 @@ describe('graphql.collective.test.js', () => {
       expect(members[2].member.name).to.equal('member1');
       expect(members[2].member.email).to.equal('member1@hail.com');
 
-      const member = await models.User.findById(members[2].member.createdByUser.id);
+      const member = await models.User.findByPk(members[2].member.createdByUser.id);
       const res2 = await utils.graphqlQuery(query, { collective }, member);
       expect(res2.errors).to.exist;
       expect(res2.errors[0].message).to.equal(

--- a/test/graphql.comments.test.js
+++ b/test/graphql.comments.test.js
@@ -192,7 +192,7 @@ describe('graphql.comments.test', () => {
       });
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal('You must be logged in to delete this comment');
-      return models.Comment.findById(comment1.id).then(commentFound => {
+      return models.Comment.findByPk(comment1.id).then(commentFound => {
         expect(commentFound).to.not.be.null;
       });
     });
@@ -203,7 +203,7 @@ describe('graphql.comments.test', () => {
       expect(result.errors[0].message).to.equal(
         'You need to be logged in as a core contributor or as a host to delete this comment',
       );
-      return models.Comment.findById(comment1.id).then(commentFound => {
+      return models.Comment.findByPk(comment1.id).then(commentFound => {
         expect(commentFound).to.not.be.null;
       });
     });
@@ -212,7 +212,7 @@ describe('graphql.comments.test', () => {
       const res = await utils.graphqlQuery(deleteCommentQuery, { id: comment1.id }, collectiveAdmin);
       res.errors && console.error(res.errors[0]);
       expect(res.errors).to.not.exist;
-      return models.Comment.findById(comment1.id).then(commentFound => {
+      return models.Comment.findByPk(comment1.id).then(commentFound => {
         expect(commentFound).to.be.null;
       });
     });

--- a/test/graphql.createOrder.test.js
+++ b/test/graphql.createOrder.test.js
@@ -305,7 +305,7 @@ describe('createOrder', () => {
     const {
       createdByUser: { id },
     } = res.data.createOrder;
-    const user = await models.User.findById(id);
+    const user = await models.User.findByPk(id);
     expect(user.newsletterOptIn).to.be.true;
 
     // make sure the payment has been recorded in the connected Stripe Account of the host
@@ -430,7 +430,7 @@ describe('createOrder', () => {
     // make sure the payment has been recorded in the connected
     // Stripe Account of the host
     expect(transaction.data.charge.currency).to.equal('eur');
-    const createdOrder = await models.Order.findById(res.data.createOrder.id);
+    const createdOrder = await models.Order.findByPk(res.data.createOrder.id);
     expect(createdOrder.status).to.equal('PAID');
   });
 
@@ -538,7 +538,7 @@ describe('createOrder', () => {
     expect(transaction.FromCollectiveId).to.equal(xdamman.CollectiveId);
     expect(transaction.CollectiveId).to.equal(collective.id);
     expect(transaction.currency).to.equal(collective.currency);
-    const createdOrder = await models.Order.findById(res.data.createOrder.id);
+    const createdOrder = await models.Order.findByPk(res.data.createOrder.id);
     expect(createdOrder.status).to.equal('ACTIVE');
   });
 

--- a/test/graphql.expenses.test.js
+++ b/test/graphql.expenses.test.js
@@ -502,7 +502,7 @@ describe('GraphQL Expenses API', () => {
         ...data,
       });
       // And given that the above expense was already PAID
-      await (await models.Expense.findById(expense.id)).update({
+      await (await models.Expense.findByPk(expense.id)).update({
         status: 'PAID',
       });
       // When there's an attempt to approve an already paid expense
@@ -788,7 +788,7 @@ describe('GraphQL Expenses API', () => {
         expect(callPaypal.firstCall.args[1].memo).to.equal('Reimbursement from WWCode Berlin: Pizza');
         expect(res.errors).to.exist;
         expect(res.errors[0].message).to.contain('Not enough funds in your existing Paypal preapproval');
-        const updatedExpense = await models.Expense.findById(expense.id);
+        const updatedExpense = await models.Expense.findByPk(expense.id);
         expect(updatedExpense.status).to.equal('APPROVED');
         const transactions = await models.Transaction.findAll({ where: { ExpenseId: expense.id } });
         expect(transactions.length).to.equal(0);
@@ -1063,7 +1063,7 @@ describe('GraphQL Expenses API', () => {
       // Then there should be no errors
       expect(result.errors).to.not.exist;
       // And then the expense should be deleted from the database
-      expect(await models.Expense.findById(expense.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense.id)).to.be.null;
     }); /* End of "works if logged in as author" */
 
     it('works if logged in as admin of collective', async () => {
@@ -1092,7 +1092,7 @@ describe('GraphQL Expenses API', () => {
       // Then there should be no errors
       expect(result.errors).to.not.exist;
       // And then the expense should be deleted from the database
-      expect(await models.Expense.findById(expense.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense.id)).to.be.null;
     }); /* End of "works if logged in as admin of collective" */
 
     it('works if logged in as admin of host collective', async () => {
@@ -1118,7 +1118,7 @@ describe('GraphQL Expenses API', () => {
       // Then there should be no errors
       expect(result.errors).to.not.exist;
       // And then the expense should be deleted from the database
-      expect(await models.Expense.findById(expense.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense.id)).to.be.null;
     }); /* End of "works if logged in as admin of host collective" */
   }); /* End of "#deleteExpense" */
 }); /* End of "GraphQL Expenses API" */

--- a/test/graphql.matchingFund.test.js
+++ b/test/graphql.matchingFund.test.js
@@ -219,7 +219,7 @@ describe('graphql.matchingFund.test.js', () => {
     expect(subscriptions.length).to.equal(1);
     expect(subscriptions[0].interval).to.equal('month');
     expect(subscriptions[0].amount).to.equal(order.totalAmount);
-    const dbOrder = await models.Order.findById(orderCreated.id);
+    const dbOrder = await models.Order.findByPk(orderCreated.id);
     expect(dbOrder.SubscriptionId).to.equal(subscriptions[0].id);
     const matchingTransaction = await models.Transaction.findOne({
       where: {

--- a/test/graphql.mutation.test.js
+++ b/test/graphql.mutation.test.js
@@ -23,7 +23,7 @@ describe('Mutation Tests', () => {
     emailSendMessageSpy = sandbox.spy(emailLib, 'sendMessage');
     executeOrderStub = sandbox.stub(payments, 'executeOrder').callsFake((user, order) => {
       // assumes payment goes through and marks Order as confirmedAt
-      return models.Tier.findById(order.TierId)
+      return models.Tier.findByPk(order.TierId)
         .then(tier => {
           if (tier.interval) {
             return models.Subscription.create({
@@ -35,7 +35,7 @@ describe('Mutation Tests', () => {
           }
         })
         .then(SubscriptionId => order.update({ SubscriptionId, processedAt: new Date() }))
-        .then(() => models.Collective.findById(order.CollectiveId))
+        .then(() => models.Collective.findByPk(order.CollectiveId))
         .then(collective =>
           collective.addUserWithRole(user, roles.BACKER, {
             MemberCollectiveId: order.FromCollectiveId,
@@ -351,7 +351,7 @@ describe('Mutation Tests', () => {
       });
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal('You need to be logged in to delete a collective');
-      return models.Collective.findById(event1.id).then(event => {
+      return models.Collective.findByPk(event1.id).then(event => {
         expect(event).to.not.be.null;
       });
     });
@@ -362,7 +362,7 @@ describe('Mutation Tests', () => {
       expect(result.errors[0].message).to.equal(
         'You need to be logged in as a core contributor or as a host to delete this collective',
       );
-      return models.Collective.findById(event1.id).then(event => {
+      return models.Collective.findByPk(event1.id).then(event => {
         expect(event).to.not.be.null;
       });
     });
@@ -371,7 +371,7 @@ describe('Mutation Tests', () => {
       const res = await utils.graphqlQuery(deleteCollectiveQuery, { id: event1.id }, user1);
       res.errors && console.error(res.errors[0]);
       expect(res.errors).to.not.exist;
-      return models.Collective.findById(event1.id).then(event => {
+      return models.Collective.findByPk(event1.id).then(event => {
         expect(event).to.be.null;
       });
     });

--- a/test/graphql.orders.test.js
+++ b/test/graphql.orders.test.js
@@ -167,7 +167,7 @@ describe('graphql.orders.test.js', () => {
       expect(result.errors).to.not.exist;
       const { markOrderAsPaid } = result.data;
       expect(markOrderAsPaid.status).to.equal('PAID');
-      const order = await models.Order.findById(orders[0].id);
+      const order = await models.Order.findByPk(orders[0].id);
       expect(order.status).to.equal('PAID');
       expect(order.processedAt).to.not.equal(null);
       const transactions = await models.Transaction.findAll({

--- a/test/graphql.tiers.test.js
+++ b/test/graphql.tiers.test.js
@@ -237,7 +237,7 @@ describe('graphql.tiers.test', () => {
             CollectiveId: collective1.id,
           },
         });
-        // const subscription = await models.Subscription.findById(orders[0].SubscriptionId);
+        // const subscription = await models.Subscription.findByPk(orders[0].SubscriptionId);
         const transactions = await models.Transaction.findAll({
           where: {
             FromCollectiveId: user1.CollectiveId,

--- a/test/graphql.updateSubscription.test.js
+++ b/test/graphql.updateSubscription.test.js
@@ -260,7 +260,7 @@ describe('graphql.updateSubscriptions.test.js', () => {
               token: 'tok_1BvCA5DjPFcHOcTmg1234567',
             },
           });
-          const updatedOrder = await models.Order.findById(order.id);
+          const updatedOrder = await models.Order.findByPk(order.id);
           expect(updatedOrder.PaymentMethodId).to.equal(newPM.id);
         });
       });
@@ -269,7 +269,7 @@ describe('graphql.updateSubscriptions.test.js', () => {
         let pastDueSubscription, clock;
 
         beforeEach(async () => {
-          pastDueSubscription = await models.Subscription.findById(1);
+          pastDueSubscription = await models.Subscription.findByPk(1);
           const nextChargeDate = new Date('2018-01-29');
 
           pastDueSubscription = await pastDueSubscription.update({
@@ -412,7 +412,7 @@ describe('graphql.updateSubscriptions.test.js', () => {
             },
           ],
         });
-        const updatedOrder = await models.Order.findById(order.id);
+        const updatedOrder = await models.Order.findByPk(order.id);
         const activeOrder = activeOrders && activeOrders[0];
 
         expect(updatedOrder.totalAmount).to.equal(order.totalAmount);

--- a/test/graphql.updates.test.js
+++ b/test/graphql.updates.test.js
@@ -262,7 +262,7 @@ describe('graphql.updates.test', () => {
       });
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal('You must be logged in to delete this update');
-      return models.Update.findById(update1.id).then(updateFound => {
+      return models.Update.findByPk(update1.id).then(updateFound => {
         expect(updateFound).to.not.be.null;
       });
     });
@@ -271,7 +271,7 @@ describe('graphql.updates.test', () => {
       const result = await utils.graphqlQuery(deleteUpdateQuery, { id: update1.id }, user2);
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal("You don't have sufficient permissions to delete this update");
-      return models.Update.findById(update1.id).then(updateFound => {
+      return models.Update.findByPk(update1.id).then(updateFound => {
         expect(updateFound).to.not.be.null;
       });
     });
@@ -280,7 +280,7 @@ describe('graphql.updates.test', () => {
       const res = await utils.graphqlQuery(deleteUpdateQuery, { id: update1.id }, user1);
       res.errors && console.error(res.errors[0]);
       expect(res.errors).to.not.exist;
-      return models.Update.findById(update1.id).then(updateFound => {
+      return models.Update.findByPk(update1.id).then(updateFound => {
         expect(updateFound).to.be.null;
       });
     });

--- a/test/groups.routes.test.js
+++ b/test/groups.routes.test.js
@@ -236,7 +236,7 @@ describe('groups.routes.test.js', () => {
         .expect(200)
         .end((e, res) => {
           expect(e).to.not.exist;
-          models.Collective.findById(parseInt(res.body.id))
+          models.Collective.findByPk(parseInt(res.body.id))
             .then(g => {
               publicCollective = g;
               done();
@@ -450,7 +450,7 @@ describe('groups.routes.test.js', () => {
         .expect(200)
         .end((e, res) => {
           expect(e).to.not.exist;
-          models.Collective.findById(parseInt(res.body.id))
+          models.Collective.findByPk(parseInt(res.body.id))
             .then(g => {
               group = g;
               done();

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -268,7 +268,7 @@ describe('opencollective.virtualcard', () => {
         // and collective id of "original" virtual card should be different than the one returned
         expect(virtualCardPaymentMethod.CollectiveId).not.to.be.equal(paymentMethod.CollectiveId);
         // then find collective of created user
-        const userCollective = await models.Collective.findById(paymentMethod.CollectiveId);
+        const userCollective = await models.Collective.findByPk(paymentMethod.CollectiveId);
         // then find the user
         const user = await models.User.findOne({
           where: {
@@ -364,8 +364,8 @@ describe('opencollective.virtualcard', () => {
             code: virtualCardPaymentMethod.uuid.substring(0, 8),
           })
           .then(async pm => {
-            virtualCardPaymentMethod = await models.PaymentMethod.findById(pm.id);
-            userCollective = await models.Collective.findById(virtualCardPaymentMethod.CollectiveId);
+            virtualCardPaymentMethod = await models.PaymentMethod.findByPk(pm.id);
+            userCollective = await models.Collective.findByPk(virtualCardPaymentMethod.CollectiveId);
             user = await models.User.findOne({
               where: {
                 CollectiveId: userCollective.id,
@@ -586,7 +586,7 @@ describe('opencollective.virtualcard', () => {
         gqlResult.errors && console.error(gqlResult.errors[0]);
         expect(gqlResult.errors).to.be.undefined;
 
-        const paymentMethod = await models.PaymentMethod.findById(gqlResult.data.createPaymentMethod.id);
+        const paymentMethod = await models.PaymentMethod.findByPk(gqlResult.data.createPaymentMethod.id);
         expect(paymentMethod).to.exist;
         expect(paymentMethod.limitedToTags).to.contain('open source');
         expect(paymentMethod.CreatedByUserId).to.be.equal(user1.id);
@@ -740,7 +740,7 @@ describe('opencollective.virtualcard', () => {
         gqlResult.errors && console.error(gqlResult.errors[0]);
         expect(gqlResult.errors).to.be.undefined;
 
-        const paymentMethod = await models.PaymentMethod.findById(gqlResult.data.claimPaymentMethod.id);
+        const paymentMethod = await models.PaymentMethod.findByPk(gqlResult.data.claimPaymentMethod.id);
 
         // payment method should exist
         expect(paymentMethod).to.exist;
@@ -749,7 +749,7 @@ describe('opencollective.virtualcard', () => {
         // and collective id of "original" virtual card should be different than the one returned
         expect(virtualCardPaymentMethod.CollectiveId).not.to.be.equal(paymentMethod.CollectiveId);
         // then find collective of created user
-        const userCollective = await models.Collective.findById(paymentMethod.CollectiveId);
+        const userCollective = await models.Collective.findByPk(paymentMethod.CollectiveId);
         // then find the user
         const user = await models.User.findOne({
           where: {
@@ -869,8 +869,8 @@ describe('opencollective.virtualcard', () => {
             code: virtualCardPaymentMethod.uuid.substring(0, 8),
           })
           .then(async pm => {
-            virtualCardPaymentMethod = await models.PaymentMethod.findById(pm.id);
-            userVirtualCardCollective = await models.Collective.findById(virtualCardPaymentMethod.CollectiveId);
+            virtualCardPaymentMethod = await models.PaymentMethod.findByPk(pm.id);
+            userVirtualCardCollective = await models.Collective.findByPk(virtualCardPaymentMethod.CollectiveId);
             userVirtualCard = await models.User.findOne({
               where: {
                 CollectiveId: userVirtualCardCollective.id,

--- a/test/stripe.routes.test.js
+++ b/test/stripe.routes.test.js
@@ -193,7 +193,7 @@ describe('stripe.routes.test.js', () => {
           checkHost: [
             'checkStripeAccount',
             (cb, results) => {
-              return models.Collective.findById(results.checkStripeAccount.CollectiveId)
+              return models.Collective.findByPk(results.checkStripeAccount.CollectiveId)
                 .then(collective => {
                   expect(collective.id).to.be.equal(collective.id);
                   expect(collective.currency).to.equal('EUR');

--- a/test/w9.bot.test.js
+++ b/test/w9.bot.test.js
@@ -287,7 +287,7 @@ describe('w9.bot.test.js', () => {
       );
 
       // And then find Updated Host Collection to check if it includes the userId in its data.w9UserIds field
-      const updatedHostCollective = await models.Collective.findById(hostCollective.id);
+      const updatedHostCollective = await models.Collective.findByPk(hostCollective.id);
       expect(updatedHostCollective).to.exist;
       expect(updatedHostCollective.data).to.exist;
       expect(updatedHostCollective.data.W9.requestSentToUserIds).to.exist;
@@ -345,7 +345,7 @@ describe('w9.bot.test.js', () => {
       expect(emailSendMessageSpy.secondCall.args[1]).to.contain('New comment on your expense');
 
       // And then find Updated Host Collection to check if it includes the userId in its data.W9.requestSentToUserIds field
-      const updatedHostCollective = await models.Collective.findById(hostCollective.id);
+      const updatedHostCollective = await models.Collective.findByPk(hostCollective.id);
       expect(updatedHostCollective).to.exist;
       expect(updatedHostCollective.data).to.exist;
       expect(updatedHostCollective.data.W9.requestSentToUserIds).to.exist;
@@ -467,7 +467,7 @@ describe('w9.bot.test.js', () => {
       });
 
       // And then the host data has to be null
-      const updatedHost = await models.Collective.findById(hostCollective.id);
+      const updatedHost = await models.Collective.findByPk(hostCollective.id);
       expect(updatedHost.data).to.be.null;
     }); /* End of "Host Data must NOT include user in W9 Received List if he didn\'t spend more than W9 Threshold after Expense is Approved" */
 
@@ -519,7 +519,7 @@ describe('w9.bot.test.js', () => {
       expect(emailSendMessageSpy.firstCall.args[1]).to.contain('New comment');
 
       // And then the host must have the user included in his W9.requestSentToUserIds List
-      const hostAfterCreatedExpense = await models.Collective.findById(collective.HostCollectiveId);
+      const hostAfterCreatedExpense = await models.Collective.findByPk(collective.HostCollectiveId);
       expect(hostAfterCreatedExpense.data).to.exist;
       expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.exist;
       expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.have.lengthOf(1);
@@ -558,7 +558,7 @@ describe('w9.bot.test.js', () => {
       await utils.waitForCondition(() => emailSendMessageSpy.callCount > 3);
 
       // Refetching host data again after expense is approved
-      const hostAfterPaidExpense = await models.Collective.findById(collective.HostCollectiveId);
+      const hostAfterPaidExpense = await models.Collective.findByPk(collective.HostCollectiveId);
       // Host.data.W9.receivedFromUserIds must include user
       expect(hostAfterPaidExpense.data).to.exist;
       expect(get(hostAfterPaidExpense, 'data.W9.receivedFromUserIds')).to.exist;
@@ -603,7 +603,7 @@ describe('w9.bot.test.js', () => {
       expect(emailSendMessageSpy.firstCall.args[1]).to.contain('New comment');
 
       // And then the host must have the user included in his W9.requestSentToUserIds List
-      const hostAfterCreatedExpense = await models.Collective.findById(collective.HostCollectiveId);
+      const hostAfterCreatedExpense = await models.Collective.findByPk(collective.HostCollectiveId);
       expect(hostAfterCreatedExpense.data).to.exist;
       expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.exist;
       expect(get(hostAfterCreatedExpense, 'data.W9.requestSentToUserIds')).to.have.lengthOf(1);
@@ -642,7 +642,7 @@ describe('w9.bot.test.js', () => {
       await utils.waitForCondition(() => emailSendMessageSpy.callCount > 3);
 
       // Refetching host data again after expense is approved
-      const hostAfterPaidExpense = await models.Collective.findById(collective.HostCollectiveId);
+      const hostAfterPaidExpense = await models.Collective.findByPk(collective.HostCollectiveId);
       // Host.data.W9.receivedFromUserIds must include user
       expect(hostAfterPaidExpense.data).to.exist;
       expect(get(hostAfterPaidExpense, 'data.W9.receivedFromUserIds')).to.exist;
@@ -670,7 +670,7 @@ describe('w9.bot.test.js', () => {
       await utils.graphqlQuery(payExpenseQuery, parameters, hostAdmin);
 
       // Refetching host data again after expense is approved
-      const hostAfterThirdExpense = await models.Collective.findById(collective.HostCollectiveId);
+      const hostAfterThirdExpense = await models.Collective.findByPk(collective.HostCollectiveId);
       // Host.data.W9.receivedFromUserIds must include user ONLY ONE time
       expect(hostAfterThirdExpense.data).to.exist;
       expect(get(hostAfterThirdExpense, 'data.W9.receivedFromUserIds')).to.exist;


### PR DESCRIPTION
The latest Sequelize version deprecated `findById` and advise to use `findByPk` instead.