### PR TITLE
Softer limits for virtual cards on CI

### DIFF
--- a/config/circleci.json
+++ b/config/circleci.json
@@ -14,6 +14,10 @@
       "apiKey": "circleci-1510egmf4a23d80342403fb599qd"
     }
   },
+  "virtualCards": {
+    "maxPerDay": 1000,
+    "maxAmountPerDay": 5000000
+  },
   "log": {
     "level": "warn"
   }


### PR DESCRIPTION
Frontend cypress tests are often failing on CI because we reach limitation for creating virtual cards. This adds softer limitations to avoid that.

![selection_999 028](https://user-images.githubusercontent.com/1556356/51356809-4c6e9480-1abc-11e9-8037-3ac983cd6c9c.png)
![cypress-screenshot](https://user-images.githubusercontent.com/1556356/51356813-4f698500-1abc-11e9-97e7-d6a152730c15.png)
