### PR TITLE
Ability to precisely count active unique donators in Tiers

### DIFF
--- a/server/graphql/loaders.js
+++ b/server/graphql/loaders.js
@@ -271,6 +271,25 @@ export const loaders = req => {
           .then(results => sortResults(ids, results, 'TierId'))
           .map(result => get(result, 'dataValues.count') || 0),
       ),
+      totalActiveDistinctOrders: new DataLoader(ids =>
+        models.Order.findAll({
+          attributes: [
+            'TierId',
+            [
+              sequelize.fn(
+                'COALESCE',
+                sequelize.fn('COUNT', sequelize.fn('DISTINCT', sequelize.col('FromCollectiveId'))),
+                0,
+              ),
+              'count',
+            ],
+          ],
+          where: { TierId: { [Op.in]: ids }, processedAt: { [Op.ne]: null }, status: { [Op.in]: ['ACTIVE', 'PAID'] } },
+          group: ['TierId'],
+        })
+          .then(results => sortResults(ids, results, 'TierId'))
+          .map(result => get(result, 'dataValues.count') || 0),
+      ),
     },
     paymentMethods: {
       findById: new DataLoader(ids =>

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -989,7 +989,9 @@ export const TierType = new GraphQLObjectType({
             query.where = { processedAt: { [Op.ne]: null } };
           }
           if (args.isActive) {
-            query.include = [{ model: models.Subscription, where: { isActive: true } }];
+            if (tier.interval) {
+              query.include = [{ model: models.Subscription, where: { isActive: true } }];
+            }
           }
           return tier.getOrders(query);
         },

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -836,6 +836,13 @@ export const TierStatsType = new GraphQLObjectType({
           return req.loaders.tiers.totalDistinctOrders.load(tier.id);
         },
       },
+      totalActiveDistinctOrders: {
+        description: 'total number of active people/organizations in this tier',
+        type: GraphQLInt,
+        resolve(tier, args, req) {
+          return req.loaders.tiers.totalActiveDistinctOrders.load(tier.id);
+        },
+      },
       availableQuantity: {
         type: GraphQLInt,
         resolve(tier) {


### PR DESCRIPTION
Related Frontend issue: https://github.com/opencollective/opencollective-frontend/pull/1313

We would like to only display the active members for Tiers that are a subscription.

The displayed total should also be consistent with that.