### PR TITLE
Restrict unclaimed virtual cards UUID in graphql API

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1297,7 +1297,12 @@ export const PaymentMethodType = new GraphQLObjectType({
       },
       uuid: {
         type: GraphQLString,
-        resolve(paymentMethod) {
+        resolve(paymentMethod, _, req) {
+          const isUnconfirmedVirtualCard = paymentMethod.type === 'virtualcard' && !paymentMethod.confirmedAt;
+          if (isUnconfirmedVirtualCard && (!req.remoteUser || !req.remoteUser.isAdmin(paymentMethod.CollectiveId))) {
+            return null;
+          }
+
           return paymentMethod.uuid;
         },
       },


### PR DESCRIPTION
Virtual cards UUID could be accessed directly by anyone making a graphql query. This could allow people to discover then use virtual cards that are not meant to be used by them.