### PR TITLE
Set default expiration date for virtual cards to 2 years

### DIFF
--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -346,11 +346,11 @@ function getCreateParams(args, collective, sourcePaymentMethod, remoteUser) {
     throw Error('Min monthly limit per member for gift card is $5');
   }
 
-  // Set a default expirity date to 3 months by default
+  // Set a default expirity date to 2 years by default
   const expiryDate = args.expiryDate
     ? moment(args.expiryDate).format()
     : moment()
-        .add(3, 'months')
+        .add(24, 'months')
         .format();
 
   // If monthlyLimitPerMember is defined, we ignore the amount field and

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -137,7 +137,7 @@ describe('opencollective.virtualcard', () => {
         expect(paymentMethod.type).to.be.equal('virtualcard');
         expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(
           moment()
-            .add(3, 'months')
+            .add(24, 'months')
             .format('YYYY-MM-DD'),
         );
         expect(paymentMethod.description).to.be.equal(args.description);
@@ -177,7 +177,7 @@ describe('opencollective.virtualcard', () => {
         expect(paymentMethod.type).to.be.equal('virtualcard');
         expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(
           moment()
-            .add(3, 'months')
+            .add(24, 'months')
             .format('YYYY-MM-DD'),
         );
         expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);
@@ -597,7 +597,7 @@ describe('opencollective.virtualcard', () => {
         expect(paymentMethod.type).to.be.equal('virtualcard');
         expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(
           moment()
-            .add(3, 'months')
+            .add(24, 'months')
             .format('YYYY-MM-DD'),
         );
       }); /** End of "should create a U$100 virtual card payment method" */
@@ -1097,7 +1097,7 @@ describe('opencollective.virtualcard', () => {
             expect(paymentMethod.limitedToHostCollectiveIds[0]).to.be.equal(args.limitedToHostCollectiveIds[0]);
             expect(moment(paymentMethod.expiryDate).format('YYYY-MM-DD')).to.be.equal(
               moment()
-                .add(3, 'months')
+                .add(24, 'months')
                 .format('YYYY-MM-DD'),
             );
             expect(paymentMethod.monthlyLimitPerMember).to.be.equal(args.monthlyLimitPerMember);


### PR DESCRIPTION
Previous default was 3 months, there's no reason to be that strict.