### PR TITLE
Update expense invalid link in collective expense approved email template

### DIFF
--- a/templates/emails/collective.expense.approved.hbs
+++ b/templates/emails/collective.expense.approved.hbs
@@ -7,7 +7,7 @@ Subject: Your expense to {{collective.name}} for {{{currency expense.amount curr
 
 <center>
   <h1>{{{currency expense.amount currency=expense.currency precision=2}}}</h1>
-  <div><a href="{{config.host.website}}/expenses/{{expense.id}}">{{expense.description}}</a></div>
+  <div><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></div>
 </center>
 
 <br />

--- a/templates/emails/collective.expense.approved.hbs
+++ b/templates/emails/collective.expense.approved.hbs
@@ -2,7 +2,7 @@ Subject: Your expense to {{collective.name}} for {{{currency expense.amount curr
 
 {{> header}}
 
-<p>Quick message to let you know that your expense for <a href="{{config.host.website}}/expenses/{{expense.id}}">{{expense.description}}</a> has been approved.</p>
+<p>Quick message to let you know that your expense for <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a> has been approved.</p>
 <p>Next step: the host of the <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}} collective</a> (<a href="{{config.host.website}}/{{host.slug}}">{{host.name}}</a>) will reimburse your expense shortly (may take a couple of days depending on the host)</p>
 
 <center>


### PR DESCRIPTION
This PR fix the invalid expense link pointed out in [#1675 ](https://github.com/opencollective/opencollective/issues/1675)


cc @Betree 