### PR TITLE
Store taxes/VAT information in orders and transactions

### DIFF
--- a/migrations/20190227000000-add-tax-to-transactions-and-orders.js
+++ b/migrations/20190227000000-add-tax-to-transactions-and-orders.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const colName = 'taxAmount';
+
+/**
+ * Add a `taxAmount` column to Transactions / Orders that will be used to store
+ * possibly applied VAT (for Europe) or any local tax that may be applied to
+ * a transaction.
+ */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const colParams = { type: Sequelize.INTEGER };
+    await queryInterface.addColumn('Transactions', colName, colParams);
+    await queryInterface.addColumn('Orders', colName, colParams);
+    await queryInterface.addColumn('OrderHistories', colName, colParams);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('Transactions', colName);
+    await queryInterface.removeColumn('Orders', colName);
+    await queryInterface.removeColumn('OrderHistories', colName);
+  },
+};

--- a/migrations/20190227000001-add-taxes-to-collectives.js
+++ b/migrations/20190227000001-add-taxes-to-collectives.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const colName = 'taxes';
+
+/**
+ * Add a `taxes` column to collectives, meant to be used only for hosts.
+ */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const colParams = { type: Sequelize.JSON };
+    await queryInterface.addColumn('Collectives', colName, colParams);
+    await queryInterface.addColumn('CollectiveHistories', colName, colParams);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('Collectives', colName);
+    await queryInterface.removeColumn('CollectiveHistories', colName);
+  },
+};

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -514,6 +514,7 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
       image: { type: GraphQLString },
       backgroundImage: { type: GraphQLString },
       settings: { type: GraphQLJSON },
+      taxes: { type: GraphQLJSON },
       data: { type: GraphQLJSON },
       slug: { type: GraphQLString },
       path: { type: GraphQLString },
@@ -811,6 +812,12 @@ const CollectiveFields = () => {
       type: GraphQLJSON,
       resolve(collective) {
         return collective.settings || {};
+      },
+    },
+    taxes: {
+      type: GraphQLJSON,
+      resolve(collective) {
+        return collective.taxes || {};
       },
     },
     data: {

--- a/server/graphql/v1/TransactionInterface.js
+++ b/server/graphql/v1/TransactionInterface.js
@@ -40,6 +40,7 @@ export const TransactionInterfaceType = new GraphQLInterfaceType({
       hostFeeInHostCurrency: { type: GraphQLInt },
       platformFeeInHostCurrency: { type: GraphQLInt },
       paymentProcessorFeeInHostCurrency: { type: GraphQLInt },
+      taxAmount: { type: GraphQLInt },
       createdByUser: { type: UserType },
       host: { type: CollectiveInterfaceType },
       paymentMethod: { type: PaymentMethodType },
@@ -142,6 +143,10 @@ const TransactionFields = () => {
       resolve(transaction) {
         return transaction.paymentProcessorFeeInHostCurrency;
       },
+    },
+    taxAmount: {
+      type: GraphQLInt,
+      description: 'The amount paid in tax (for example VAT) for this transaction',
     },
     netAmountInCollectiveCurrency: {
       type: GraphQLInt,

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -241,7 +241,10 @@ export const OrderInputType = new GraphQLInputObjectType({
   description: 'Input type for OrderType',
   fields: () => ({
     id: { type: GraphQLInt },
-    quantity: { type: GraphQLInt },
+    quantity: {
+      type: GraphQLInt,
+      defaultValue: 1,
+    },
     totalAmount: { type: GraphQLInt },
     hostFeePercent: { type: GraphQLInt },
     platformFeePercent: { type: GraphQLInt },
@@ -264,6 +267,20 @@ export const OrderInputType = new GraphQLInputObjectType({
     collective: { type: new GraphQLNonNull(CollectiveAttributesInputType) },
     tier: { type: TierInputType },
     recaptchaToken: { type: GraphQLString },
+    // For taxes
+    taxAmount: {
+      type: GraphQLInt,
+      description: 'The amount of taxes that were included in totalAmount',
+      defaultValue: 0,
+    },
+    countryISO: {
+      type: GraphQLString,
+      description: 'User country, to know which tax applies',
+    },
+    taxIDNumber: {
+      type: GraphQLString,
+      description: 'User tax ID number',
+    },
   }),
 });
 

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1067,6 +1067,10 @@ export const OrderType = new GraphQLObjectType({
           return order.totalAmount;
         },
       },
+      taxAmount: {
+        type: GraphQLInt,
+        description: 'The amount paid in tax (for example VAT) for this order',
+      },
       interval: {
         description: "frequency of the subscription if any (could be either null, 'month' or 'year')",
         type: GraphQLString,

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -244,6 +244,10 @@ export default function(Sequelize, DataTypes) {
         type: DataTypes.JSON,
       },
 
+      taxes: {
+        type: DataTypes.JSON,
+      },
+
       data: {
         type: DataTypes.JSON,
         allowNull: true,

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -75,6 +75,10 @@ export default function(Sequelize, DataTypes) {
         type: DataTypes.INTEGER, // Total amount of the order in cents
       },
 
+      taxAmount: {
+        type: DataTypes.INTEGER,
+      },
+
       description: DataTypes.STRING,
 
       publicMessage: DataTypes.STRING,

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -137,6 +137,7 @@ export default (Sequelize, DataTypes) => {
       platformFeeInHostCurrency: DataTypes.INTEGER,
       hostFeeInHostCurrency: DataTypes.INTEGER,
       paymentProcessorFeeInHostCurrency: DataTypes.INTEGER,
+      taxAmount: { type: DataTypes.INTEGER },
       netAmountInCollectiveCurrency: DataTypes.INTEGER, // stores the net amount received by the collective (after fees) or removed from the collective (including fees)
 
       data: DataTypes.JSON,

--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -182,6 +182,7 @@ paymentMethodProvider.processOrder = async (order, options = {}) => {
     amountInHostCurrency: totalAmountInPaymentMethodCurrency,
     hostFeeInHostCurrency,
     platformFeeInHostCurrency,
+    taxAmount: order.taxAmount,
     paymentProcessorFeeInHostCurrency: 0,
     description: order.description,
   };

--- a/server/paymentProviders/opencollective/giftcard.js
+++ b/server/paymentProviders/opencollective/giftcard.js
@@ -66,6 +66,7 @@ export async function processOrder(order) {
       hostFeeInHostCurrency: 0,
       platformFeeInHostCurrency: 0, // we don't charge a fee until the money is used by User
       paymentProcessorFeeInHostCurrency: 0,
+      taxAmount: order.taxAmount,
       description: order.paymentMethod.name,
       HostCollectiveId,
     },

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -49,6 +49,7 @@ async function processOrder(order) {
     hostFeeInHostCurrency,
     platformFeeInHostCurrency,
     paymentProcessorFeeInHostCurrency,
+    taxAmount: order.taxAmount,
     description: order.description,
   };
 

--- a/server/paymentProviders/opencollective/prepaid.js
+++ b/server/paymentProviders/opencollective/prepaid.js
@@ -99,6 +99,7 @@ async function processOrder(order) {
       hostFeeInHostCurrency,
       platformFeeInHostCurrency,
       paymentProcessorFeeInHostCurrency: 0,
+      taxAmount: order.taxAmount,
       description: order.description,
     },
   });

--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -113,6 +113,7 @@ export async function createTransaction(order, paymentInfo) {
     hostFeeInHostCurrency,
     platformFeeInHostCurrency,
     paymentProcessorFeeInHostCurrency: paypalFee,
+    taxAmount: order.taxAmount,
     description: order.description,
     data: paymentInfo,
   };

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -124,6 +124,7 @@ export default {
             hostFeeInHostCurrency,
             platformFeeInHostCurrency: fees.applicationFee,
             paymentProcessorFeeInHostCurrency: fees.stripeFee,
+            taxAmount: order.taxAmount,
             description: order.description,
             data: { charge, balanceTransaction },
           };

--- a/test/graphql.tiers.test.js
+++ b/test/graphql.tiers.test.js
@@ -7,7 +7,8 @@ import * as utils from './utils';
 import models from '../server/models';
 
 describe('graphql.tiers.test', () => {
-  let user1, user2, host, collective1, collective2, tier1, paymentMethod1;
+  const productTax = { name: 'VAT', description: 'European unified VAT', percentage: 20.4 };
+  let user1, user2, host, collective1, collective2, tier1, tierProduct, paymentMethod1;
   let sandbox;
 
   beforeEach(() => utils.resetTestDB());
@@ -16,11 +17,23 @@ describe('graphql.tiers.test', () => {
    * Setup:
    * - User1 is a member of collective2 has a payment method on file
    * - User1 will become a backer of collective1
-   * - Host is the host of both collective1 and collective2
+   * - Host is the host of both collective1 and collective2. It has a tax on "PRODUCT" tiers.
    */
+  // Create users
   beforeEach(() => models.User.createUserWithCollective(utils.data('user1')).tap(u => (user1 = u)));
   beforeEach(() => models.User.createUserWithCollective(utils.data('user2')).tap(u => (user2 = u)));
-  beforeEach(() => models.User.createUserWithCollective(utils.data('host1')).tap(u => (host = u)));
+
+  // Create host
+  beforeEach(async () => {
+    host = await models.User.createUserWithCollective(utils.data('host1'));
+    await host.collective.update({
+      taxes: {
+        PRODUCT: productTax,
+      },
+    });
+  });
+
+  // Create payment method
   beforeEach(() =>
     models.PaymentMethod.create({
       ...utils.data('paymentMethod2'),
@@ -29,12 +42,15 @@ describe('graphql.tiers.test', () => {
     }).tap(c => (paymentMethod1 = c)),
   );
 
+  // Create test collectives
   beforeEach(() => models.Collective.create(utils.data('collective1')).tap(g => (collective1 = g)));
-
   beforeEach(() => models.Collective.create(utils.data('collective2')).tap(g => (collective2 = g)));
 
+  // Create tiers
   beforeEach(() => collective1.createTier(utils.data('tier1')).tap(t => (tier1 = t)));
+  beforeEach(() => collective1.createTier(utils.data('tierProduct')).tap(t => (tierProduct = t)));
 
+  // Add hosts to collectives
   beforeEach(() => collective1.addHost(host.collective, host));
   beforeEach(() => collective2.addHost(host.collective, host));
   beforeEach(() => collective2.addUserWithRole(user1, 'ADMIN'));
@@ -128,7 +144,7 @@ describe('graphql.tiers.test', () => {
         res.errors && console.error(res.errors[0]);
         expect(res.errors).to.not.exist;
         const tiers = res.data.Collective.tiers;
-        expect(tiers).to.have.length(3);
+        expect(tiers).to.have.length(4);
       });
 
       it('filter tiers by slug', async () => {
@@ -270,6 +286,56 @@ describe('graphql.tiers.test', () => {
           where: { CreatedByUserId: user1.id },
         });
         expect(paymentMethods).to.have.length(2);
+      });
+    });
+
+    describe('taxes', () => {
+      const createOrderQuery = `
+        mutation createOrder($order: OrderInputType!) {
+          createOrder(order: $order) {
+            taxAmount
+            transactions {
+              taxAmount
+            }
+          }
+        }`;
+
+      it('stores tax in order and transaction', async () => {
+        const taxAmount = Math.round(tierProduct.amount * (productTax.percentage / 100));
+        const order = {
+          description: 'test order with tax',
+          collective: { id: collective1.id },
+          tier: { id: tierProduct.id },
+          paymentMethod: { uuid: paymentMethod1.uuid },
+          totalAmount: tierProduct.amount + taxAmount,
+          taxAmount,
+          countryISO: 'FR', // Required when order has tax
+        };
+        const queryResult = await utils.graphqlQuery(createOrderQuery, { order }, user1);
+        const createdOrder = queryResult.data.createOrder;
+        expect(createdOrder.taxAmount).to.equal(taxAmount);
+        createdOrder.transactions.map(transaction => {
+          expect(transaction.taxAmount).to.equal(taxAmount);
+        });
+      });
+
+      it("doesn't have tax when tax id number is set", async () => {
+        const order = {
+          description: 'test order with tax',
+          collective: { id: collective1.id },
+          tier: { id: tierProduct.id },
+          paymentMethod: { uuid: paymentMethod1.uuid },
+          totalAmount: tierProduct.amount,
+          taxAmount: 0,
+          countryISO: 'FR', // Required when order has tax
+          taxIDNumber: '012345678',
+        };
+        const queryResult = await utils.graphqlQuery(createOrderQuery, { order }, user1);
+        const createdOrder = queryResult.data.createOrder;
+        expect(createdOrder.taxAmount).to.equal(0);
+        createdOrder.transactions.map(transaction => {
+          expect(transaction.taxAmount).to.equal(0);
+        });
       });
     });
   });

--- a/test/mocks/data.js
+++ b/test/mocks/data.js
@@ -678,6 +678,17 @@ export default {
     maxQuantity: 100,
   },
 
+  tierProduct: {
+    name: 'Test T-Shirt',
+    type: 'PRODUCT',
+    slug: 'tshirt',
+    description: 'A testing tshirt',
+    amount: 5000,
+    interval: null,
+    currency: 'USD',
+    maxQuantity: 100,
+  },
+
   ticket1: {
     name: 'Free ticket',
     type: 'TICKET',


### PR DESCRIPTION
To setup taxes on a tier, host `taxes` must be configured.

**Example**
```json
{
	"PRODUCT": {
		"name": "VAT",
		"description": "Value-added tax for Europe.",
		"percentage": 20
	}
}
```

See https://docs.opencollective.com/help/hosts/taxes-support-vat