### PR TITLE
Allow users to receive sign in emails out of production env

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -249,9 +249,15 @@ export default (Sequelize, DataTypes) => {
     return auth.createJwt(this.id, data, expiration);
   };
 
-  User.prototype.generateLoginLink = function(redirect) {
+  User.prototype.generateLoginLink = function(redirect = '/', websiteUrl) {
     const token = this.jwt({ scope: 'login' });
-    return `${config.host.website}/signin/${token}?next=${redirect}`;
+    // if a different websiteUrl is passed
+    // we don't accept that in production to avoid fishing related issues
+    if (websiteUrl && config.env !== 'production') {
+      return `${websiteUrl}/signin/${token}?next=${redirect}`;
+    } else {
+      return `${config.host.website}/signin/${token}?next=${redirect}`;
+    }
   };
 
   User.prototype.generateConnectedAccountVerifiedToken = function(connectedAccountId, username) {


### PR DESCRIPTION
We're usually not sending emails while in staging environment. We're creating an exception for signin/createUser emails through the `sendEvenIfNotProduction` parameter. Also, we make `websiteUrl` configurable in `generateLoginLink`, but this will be skipped in production to avoid fishing issues.

Fix: https://github.com/opencollective/opencollective/issues/1695