### PR TITLE
Add createCollectiveFromGithub to GraphQL mutation resolver

### DIFF
--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -9,6 +9,7 @@ import paymentProviders from '../paymentProviders';
 import * as github from '../lib/github';
 
 const { ConnectedAccount, User } = models;
+const GITHUB_REPO_MIN_STAR = 100;
 
 export const list = (req, res, next) => {
   const slug = req.params.slug.toLowerCase();
@@ -179,7 +180,12 @@ const getGithubAccount = async req => {
 export const fetchAllRepositories = async (req, res, next) => {
   const githubAccount = await getGithubAccount(req);
   try {
-    const repos = await github.getAllUserPublicRepos(githubAccount.token);
+    let repos = await github.getAllUserPublicRepos(githubAccount.token);
+    if (repos.length !== 0) {
+      repos = repos.filter(repo => {
+        return repo.stargazers_count >= GITHUB_REPO_MIN_STAR && repo.fork === false;
+      });
+    }
     res.send(repos);
   } catch (e) {
     next(e);

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -5,6 +5,7 @@ import {
   editCollective,
   deleteCollective,
   approveCollective,
+  createCollectiveFromGithub,
 } from './mutations/collectives';
 import {
   createOrder,
@@ -75,6 +76,15 @@ const mutations = {
     },
     resolve(_, args, req) {
       return createCollective(_, args, req);
+    },
+  },
+  createCollectiveFromGithub: {
+    type: CollectiveInterfaceType,
+    args: {
+      collective: { type: new GraphQLNonNull(CollectiveInputType) },
+    },
+    resolve(_, args, req) {
+      return createCollectiveFromGithub(_, args, req);
     },
   },
   editCollective: {

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -194,6 +194,18 @@ export async function createCollectiveFromGithub(_, args, req) {
   const user = req.remoteUser;
   const githubHandle = collectiveData.githubHandle;
 
+  // For e2e testing, we enable testuser+(admin|member)@opencollective.com to create collective without github validation
+  if (process.env.NODE_ENV !== 'production' && user.email.match(/.*test.*@opencollective.com$/)) {
+    const existingCollective = models.Collective.findOne({
+      where: { slug: collectiveData.slug.toLowerCase() },
+    });
+    collectiveData.HostCollectiveId = defaultHostCollective('opensource').CollectiveId;
+    if (existingCollective) {
+      collectiveData.slug = `${collectiveData.slug}-${Math.floor(Math.random() * 1000 + 1)}`;
+    }
+    return models.Collective.create(collectiveData);
+  }
+
   const existingCollective = await models.Collective.findOne({
     where: { slug: collectiveData.slug.toLowerCase() },
   });

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -191,7 +191,7 @@ export async function createCollectiveFromGithub(_, args, req) {
 
   let collective;
   const collectiveData = { ...args.collective };
-  const user = await models.User.findByPk(req.remoteUser.id);
+  const user = await models.User.findByPk(user.id);
   if (!user) {
     return Promise.reject(new Error(`No user with Id ${req.remoteUser.id} found`));
   }
@@ -230,7 +230,7 @@ export async function createCollectiveFromGithub(_, args, req) {
     lastName: user.lastName,
     collective: collective.info,
   };
-  debug('sending github.signup to', user.email, 'with data', data);
+  debugGithub('sending github.signup to', user.email, 'with data', data);
   await emailLib.send('github.signup', user.email, data);
   models.Activity.create({
     type: activities.COLLECTIVE_CREATED,

--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -18,11 +18,13 @@ const compactRepo = repo => {
   ]);
   repo.owner = pick(repo.owner, [
     'login', // (1)
+    'type',
   ]);
   // 1) Required for the old website, according to:
   // https://github.com/opencollective/opencollective-website/blob/master/frontend/src/reducers/github.js
   // 2) Required for the pledge feature in /graphql/v1/orders.js
   // 3) Required for update-contributions
+  // 4) Required in the frontend for choosing repo to create collective from
   return repo;
 };
 


### PR DESCRIPTION
This PR is needed for the Revamping of creating opensource collective from Gihub. [#1699](https://github.com/opencollective/opencollective/issues/1699).

It's basically refactors [`createFromGithub`](https://github.com/opencollective/opencollective-api/blob/master/server/controllers/collectives.js#L274) available in REST API to GraphQL. 
