### PR TITLE
Extend Github handle and allow URLs

### DIFF
--- a/migrations/20190212154818-extend-github-handle.js
+++ b/migrations/20190212154818-extend-github-handle.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const githubHandleColumn = 'githubHandle';
+
+module.exports = {
+  /**
+   * Max length for Github username is 39. Max length for repository name is
+   * 100, so `username/repo` will be at max 140 characters.
+   * The default Sequelize.String length, 255, is large enough for this.
+   */
+  up: (queryInterface, Sequelize) => {
+    return queryInterface
+      .changeColumn('Collectives', githubHandleColumn, {
+        type: Sequelize.STRING(255),
+      })
+      .then(() => {
+        queryInterface.changeColumn('CollectiveHistories', githubHandleColumn, {
+          type: Sequelize.STRING(255),
+        });
+      });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    // Rollbacking this presents a risk of curupting the data. As the length
+    // of the varchar has no perfomances impact (it's only used for validation)
+    // the tradeoff is not worth it.
+  },
+};

--- a/migrations/20190212154818-extend-github-handle.js
+++ b/migrations/20190212154818-extend-github-handle.js
@@ -17,6 +17,19 @@ module.exports = {
         queryInterface.changeColumn('CollectiveHistories', githubHandleColumn, {
           type: Sequelize.STRING(255),
         });
+      })
+      .then(() => {
+        return queryInterface.sequelize.query(`
+          UPDATE
+            "Collectives" 
+          SET
+            "twitterHandle" = regexp_replace("twitterHandle", '(https?://)?twitter.com/', ''),
+            "githubHandle" = regexp_replace("githubHandle", '(https?://)?github.com/', '')
+          WHERE
+            "twitterHandle" like '%twitter.com/%'
+          OR
+            "githubHandle" like '%github.com/%'
+      `);
       });
   },
 

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -279,8 +279,20 @@ export default function(Sequelize, DataTypes) {
       twitterHandle: {
         type: DataTypes.STRING, // without the @ symbol. Ex: 'asood123'
         set(twitterHandle) {
-          if (typeof twitterHandle !== 'string') return;
-          this.setDataValue('twitterHandle', twitterHandle.replace(/^@/, ''));
+          if (!twitterHandle || twitterHandle.length === 0) {
+            this.setDataValue('twitterHandle', null);
+            return;
+          }
+
+          // Try to parse Twitter URL, fallback on regular string
+          const twitterRegex = /https?:\/\/twitter\.com\/([^/\s]+)/;
+          const regexResult = twitterHandle.match(twitterRegex);
+          if (regexResult) {
+            const [, username] = regexResult;
+            this.setDataValue('twitterHandle', username);
+          } else {
+            this.setDataValue('twitterHandle', twitterHandle.replace(/^@/, ''));
+          }
         },
       },
 

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -287,8 +287,21 @@ export default function(Sequelize, DataTypes) {
       githubHandle: {
         type: DataTypes.STRING,
         set(githubHandle) {
-          if (typeof githubHandle !== 'string') return;
-          this.setDataValue('githubHandle', githubHandle.replace(/^@/, ''));
+          if (!githubHandle || githubHandle.length === 0) {
+            this.setDataValue('githubHandle', null);
+            return;
+          }
+
+          // Try to parse github URL, fallback on regular string
+          const githubUrlRegex = /https?:\/\/github\.com\/([^/\s]+)(\/([^/\s]+))?/;
+          const regexResult = githubHandle.match(githubUrlRegex);
+          if (regexResult) {
+            const [, username, , repository] = regexResult;
+            const formattedHandle = repository ? `${username}/${repository}` : username;
+            this.setDataValue('githubHandle', formattedHandle);
+          } else {
+            this.setDataValue('githubHandle', githubHandle.replace(/^@/, ''));
+          }
         },
       },
 


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/1700

---

- Extends the `githubHandle` column size to 255 characters
- Allow for repositories: something like `opencollective/opencollective-api` is now considered valid
- Allow for an URL to be given. It will be formatted before insert to the DB.

I've also applied the URL feature to `twitterHandle`, so pasting an URL like https://twitter.com/opencollective in the form will now result in the value `opencollective` being stored for Twitter handle.
Before that, we would have stored the entire URL and ended up with an incorrect link on the frontend.