### PR TITLE
Don't trigger build in postinstall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           key: dependency-cache-
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - run: npm ci
+      - run: npm run build
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/package.json
+++ b/package.json
@@ -187,8 +187,7 @@
     "db:sanitize": "babel-node scripts/replace_stripe_accounts",
     "db:reset": "babel-node scripts/reset",
     "postdb:migrate:dev": "npm run db:clean",
-    "postinstall": "npm run postinstall:build && sh ./scripts/postinstall.sh",
-    "postinstall:build": "if test \"$NODE_ENV\" = \"\" || test \"$NODE_ENV\" = \"development\" ; then echo \"Skipping postinstall build because NODE_ENV is '${NODE_ENV}'\" ; else npm run build ; fi",
+    "postinstall": "./scripts/postinstall.sh",
     "git:clean": "./scripts/git_clean.sh",
     "deploy:staging": "./scripts/pre-deploy.sh staging && bash -x scripts/deploy.sh staging",
     "deploy:production": "./scripts/pre-deploy.sh production && bash -x scripts/deploy.sh production",
@@ -231,5 +230,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/opencollective/opencollective-api.git"
-  }
+  },
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
We were doing that because the way Heroku was building projects. Heroku is changing its behavior, so we don't need it anymore.

Fix: https://github.com/opencollective/opencollective/issues/1729