### PR TITLE
Orders: Add graphql query to update publicMessage

### DIFF
--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -13,8 +13,9 @@ import {
   updateSubscription,
   refundTransaction,
   addFundsToOrg,
-  updateOrder,
+  completePledge,
   markOrderAsPaid,
+  updateOrderInfo,
 } from './mutations/orders';
 import { createMember, removeMember } from './mutations/members';
 import { editTiers } from './mutations/tiers';
@@ -299,6 +300,7 @@ const mutations = {
     },
   },
   updateOrder: {
+    // TODO: Should be renamed to completePledge.
     type: OrderType,
     args: {
       order: {
@@ -306,7 +308,24 @@ const mutations = {
       },
     },
     resolve(_, args, req) {
-      return updateOrder(req.remoteUser, args.order);
+      return completePledge(req.remoteUser, args.order);
+    },
+  },
+  updateOrderInfo: {
+    type: OrderType,
+    description: 'Update the non-sensitive information of an order, like the public message',
+    args: {
+      id: {
+        type: new GraphQLNonNull(GraphQLInt),
+        description: 'ID of the order to update',
+      },
+      publicMessage: {
+        type: GraphQLString,
+        description: 'Public message to motivate others to contribute',
+      },
+    },
+    resolve: async (_, args, req) => {
+      return updateOrderInfo(req, args);
     },
   },
   createUpdate: {

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -516,7 +516,20 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
   }
 }
 
-export async function updateOrder(remoteUser, order) {
+/**
+ * Update the non-sensitive information of an order, like the public message
+ */
+export async function updateOrderInfo(req, orderParams) {
+  const order = await models.Order.findByPk(orderParams.id);
+  if (!order || !req.remoteUser || !req.remoteUser.isAdmin(order.FromCollectiveId)) {
+    throw Error("This order does not exists or you don't have the permission to edit it");
+  }
+
+  // Update order with a field whitelist
+  return order.update(pick(orderParams, ['publicMessage']));
+}
+
+export async function completePledge(remoteUser, order) {
   if (!remoteUser) {
     throw new errors.Unauthorized({
       message: 'You need to be logged in to update an order',


### PR DESCRIPTION
The existing `updateOrder` could not be re-used as all the logic in it is made to complete a pledge. I've renamed the function to make that intent clearer, and created a `updateOrderInfo` that will be used to update public order info - that is only public message for now.