### PR TITLE
chore(User): Remove duplicate isRoot

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -361,12 +361,6 @@ export default (Sequelize, DataTypes) => {
     return result;
   };
 
-  User.prototype.isRoot = function() {
-    const result = this.hasRole([roles.ADMIN], 1);
-    debug('isRoot ?', result);
-    return result;
-  };
-
   User.prototype.getPersonalDetails = function(remoteUser) {
     if (!remoteUser) return Promise.resolve(this.public);
     return this.populateRoles()


### PR DESCRIPTION
https://github.com/opencollective/opencollective-api/commit/50857010008e591efe40d0f5fea5d335f758a0ee introduced a duplicate of the `isRoot` function with the same prototype.

Original function is on line 351.