### PR TITLE
Update API to json2csv version 4

### DIFF
--- a/cron/daily/charge_subscriptions.js
+++ b/cron/daily/charge_subscriptions.js
@@ -63,7 +63,7 @@ async function run(options) {
   if (data.length > 0) {
     vprint(options, 'Writing the output to a CSV file');
     try {
-      const csv = json2csv({ data, fields: csvFields });
+      const csv = json2csv(data, { fields: csvFields });
       if (options.dryRun) {
         fs.writeFileSync('charge_subscriptions.output.csv', csv);
       } else {

--- a/cron/daily/charge_subscriptions.js
+++ b/cron/daily/charge_subscriptions.js
@@ -2,7 +2,7 @@
 import '../../server/env';
 
 import fs from 'fs';
-import json2csv from 'json2csv';
+import { parse as json2csv } from 'json2csv';
 import { ArgumentParser } from 'argparse';
 
 import emailLib from '../../server/lib/email';
@@ -61,26 +61,26 @@ async function run(options) {
   );
 
   if (data.length > 0) {
-    await json2csv({ data, fields: csvFields }, async (err, csv) => {
-      vprint(options, 'Writing the output to a CSV file');
-      if (err) console.log(err);
-      else {
-        if (options.dryRun) {
-          fs.writeFileSync('charge_subscriptions.output.csv', csv);
-        } else {
-          if (!options.dryRun) {
-            vprint(options, 'Sending email report');
-            const attachments = [
-              {
-                filename: `${new Date().toLocaleDateString()}.csv`,
-                content: csv,
-              },
-            ];
-            await emailReport(start, orders, groupProcessedOrders(data), attachments);
-          }
+    vprint(options, 'Writing the output to a CSV file');
+    try {
+      const csv = json2csv({ data, fields: csvFields });
+      if (options.dryRun) {
+        fs.writeFileSync('charge_subscriptions.output.csv', csv);
+      } else {
+        if (!options.dryRun) {
+          vprint(options, 'Sending email report');
+          const attachments = [
+            {
+              filename: `${new Date().toLocaleDateString()}.csv`,
+              content: csv,
+            },
+          ];
+          await emailReport(start, orders, groupProcessedOrders(data), attachments);
         }
       }
-    });
+    } catch (err) {
+      console.log(err);
+    }
   } else {
     vprint(options, 'Not generating CSV file');
     if (!options.dryRun) await emailReportNoCharges(start);

--- a/cron/daily/check_ledger_health.js
+++ b/cron/daily/check_ledger_health.js
@@ -6,7 +6,7 @@ import '../../server/env';
  */
 
 import Promise from 'bluebird';
-// import json2csv from 'json2csv';
+// import { parse as json2csv } from 'json2csv';
 import models, { sequelize, Op } from '../../server/models';
 import emailLib from '../../server/lib/email';
 // import * as transactionsLib from '../../server/lib/transactions';
@@ -432,10 +432,7 @@ const checkTransactions = () => {
         if (funkyTransactions.length > 0) {
           attachments.push({
             filename: `${moment(new Date()).format('YYYYMMDD')}-invalid-transactions.csv`,
-            content: await Promise.promisify(json2csv)({
-              data: funkyTransactions,
-              fields,
-            }),
+            content: json2csv(funkyTransactions, {fields}),
           });
         }
         subHeader("Transactions that don't add up", funkyTransactions.length);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3999,21 +3999,6 @@
         "restore-cursor": "^2.0.0"
       }
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        }
-      }
-    },
     "cli-table3": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
@@ -6744,25 +6729,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
@@ -6772,13 +6757,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "optional": true,
           "requires": {
@@ -6788,37 +6773,37 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
@@ -6827,25 +6812,25 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
@@ -6854,13 +6839,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -6876,7 +6861,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
@@ -6890,13 +6875,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "optional": true,
           "requires": {
@@ -6905,7 +6890,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
@@ -6914,7 +6899,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -6924,19 +6909,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "optional": true,
           "requires": {
@@ -6945,13 +6930,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
@@ -6960,13 +6945,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "optional": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "optional": true,
           "requires": {
@@ -6976,7 +6961,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "optional": true,
           "requires": {
@@ -6985,7 +6970,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "optional": true,
           "requires": {
@@ -6994,13 +6979,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "optional": true,
           "requires": {
@@ -7011,7 +6996,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "optional": true,
           "requires": {
@@ -7029,7 +7014,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -7039,13 +7024,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "optional": true,
           "requires": {
@@ -7055,7 +7040,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -7067,19 +7052,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "optional": true,
           "requires": {
@@ -7088,19 +7073,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -7110,19 +7095,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "optional": true,
           "requires": {
@@ -7134,7 +7119,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -7142,7 +7127,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
@@ -7157,7 +7142,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "optional": true,
           "requires": {
@@ -7166,43 +7151,43 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "optional": true,
           "requires": {
@@ -7213,7 +7198,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -7222,7 +7207,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -7231,13 +7216,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "optional": true,
           "requires": {
@@ -7252,13 +7237,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
@@ -7267,13 +7252,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "optional": true
         }
@@ -8985,43 +8970,13 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json2csv": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-3.4.2.tgz",
-      "integrity": "sha1-7v1r47EH+kcJR483MZ2KGCdOacA=",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-4.3.5.tgz",
+      "integrity": "sha512-p7h3IFPDIWzXEGnBFa7ksXtDaT5wGC0vZOh0CGgmNkQxOtI4O9AZOQ/XfV9JiWERbh5jubqc3nzXziZ4S763jw==",
       "requires": {
-        "cli-table": "^0.3.1",
-        "commander": "^2.8.1",
-        "debug": "^2.2.0",
-        "flat": "^1.6.0",
-        "lodash.get": "^3.7.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "flat": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/flat/-/flat-1.6.1.tgz",
-          "integrity": "sha1-R2udu3DV6TQNu8A4veCEoglFkhw=",
-          "requires": {
-            "is-buffer": "~1.1.2"
-          }
-        },
-        "lodash.get": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-3.7.0.tgz",
-          "integrity": "sha1-POaK4skWg7KBzFOUEoMDy/deaR8=",
-          "requires": {
-            "lodash._baseget": "^3.0.0",
-            "lodash._topath": "^3.0.0"
-          }
-        }
+        "commander": "^2.15.1",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
       }
     },
     "json5": {
@@ -9073,6 +9028,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonwebtoken": {
       "version": "5.7.0",
@@ -9590,19 +9550,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash._baseget": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/lodash._baseget/-/lodash._baseget-3.7.2.tgz",
-      "integrity": "sha1-G2rh1frPPCVTI1ChPBGXy4u2dPQ="
-    },
-    "lodash._topath": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/lodash._topath/-/lodash._topath-3.8.1.tgz",
-      "integrity": "sha1-PsXiYGAU9MuX91X+aRTt2L/ADqw=",
-      "requires": {
-        "lodash.isarray": "^3.0.0"
-      }
-    },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -9662,11 +9609,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isboolean": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "intl-messageformat": "2.2.0",
     "isomorphic-fetch": "2.2.1",
     "joi": "14.3.1",
-    "json2csv": "^4.3.5",
+    "json2csv": "4.3.5",
     "jsonwebtoken": "5.7.0",
     "juice": "5.1.0",
     "knox": "github:automattic/knox#278337d7673341658efcc81e631c3f63fa53d374",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "intl-messageformat": "2.2.0",
     "isomorphic-fetch": "2.2.1",
     "joi": "14.3.1",
-    "json2csv": "3.4.2",
+    "json2csv": "^4.3.5",
     "jsonwebtoken": "5.7.0",
     "juice": "5.1.0",
     "knox": "github:automattic/knox#278337d7673341658efcc81e631c3f63fa53d374",

--- a/scripts/calc_new_backers_per_collective.js
+++ b/scripts/calc_new_backers_per_collective.js
@@ -8,7 +8,7 @@ import '../server/env';
 import Promise from 'bluebird';
 import fs from 'fs';
 import moment from 'moment';
-import json2csv from 'json2csv';
+import { parse as json2csv } from 'json2csv';
 import models, { sequelize, Op } from '../server/models';
 
 const done = err => {
@@ -145,11 +145,13 @@ const calculateBackersPerCollective = () => {
 
       console.log('data', data);
 
-      json2csv({ data, fields: csvFields }, (err, csv) => {
-        console.log('Writing the output to', outputFilename);
-        if (err) console.log(err);
+      console.log('Writing the output to', outputFilename);
+      try {
+        const csv = json2csv(data, { fields: csvFields });
         fs.writeFileSync(outputFilename, csv);
-      });
+      } catch (err) {
+        console.log(err);
+      }
     });
 };
 

--- a/scripts/calc_new_backers_per_month.js
+++ b/scripts/calc_new_backers_per_month.js
@@ -8,7 +8,7 @@ import '../server/env';
 import Promise from 'bluebird';
 import fs from 'fs';
 import moment from 'moment';
-import json2csv from 'json2csv';
+import { parse as json2csv } from 'json2csv';
 import models, { sequelize, Op } from '../server/models';
 
 const done = err => {
@@ -73,11 +73,14 @@ const calculateNewBackersPerMonth = () => {
         oldBackers: results[result].oldBackers,
       }));
       console.log(data);
-      json2csv({ data, fields: csvFields }, (err, csv) => {
-        console.log('Writing the output to', outputFilename);
-        if (err) console.log(err);
+
+      console.log('Writing the output to', outputFilename);
+      try {
+        const csv = json2csv(data, { fields: csvFields });
         fs.writeFileSync(outputFilename, csv);
-      });
+      } catch (err) {
+        console.log(err);
+      }
     });
 };
 

--- a/scripts/monthly_data_exports.js
+++ b/scripts/monthly_data_exports.js
@@ -1,5 +1,5 @@
 import models, { sequelize } from '../server/models';
-import json2csv from 'json2csv';
+import { parse as json2csv } from 'json2csv';
 import fs from 'fs';
 import Promise from 'bluebird';
 import moment from 'moment';
@@ -129,10 +129,12 @@ async function run() {
       return row;
     });
 
-    return json2csv({ data: res }, (err, csv) => {
-      if (err) console.log(err);
-      else fs.writeFileSync(`${path}/${query.filename}`, csv);
-    });
+    try {
+      const csv = json2csv(res);
+      fs.writeFileSync(`${path}/${query.filename}`, csv);
+    } catch (err) {
+      console.log(err);
+    }
   });
   console.log('done');
   process.exit(0);

--- a/scripts/move_subscriptions_from_stripe.js
+++ b/scripts/move_subscriptions_from_stripe.js
@@ -3,7 +3,7 @@ import '../server/env';
 
 import fs from 'fs';
 import moment from 'moment';
-import json2csv from 'json2csv';
+import { parse as json2csv } from 'json2csv';
 import { ArgumentParser } from 'argparse';
 import { Op } from 'sequelize';
 
@@ -159,11 +159,13 @@ async function run(options) {
   );
 
   if (data.length > 0) {
-    json2csv({ data, fields: csvFields }, (err, csv) => {
-      vprint(options, 'Writing the output to a CSV file');
-      if (err) console.log(err);
-      else fs.writeFileSync('move_subscriptions_from_stripe.output.csv', csv);
-    });
+    vprint(options, 'Writing the output to a CSV file');
+    try {
+      const csv = json2csv(data, { fields: csvFields });
+      fs.writeFileSync('move_subscriptions_from_stripe.output.csv', csv);
+    } catch (err) {
+      console.log(err);
+    }
   } else {
     vprint(options, 'Not generating CSV file');
   }

--- a/server/controllers/middlewares.js
+++ b/server/controllers/middlewares.js
@@ -1,5 +1,5 @@
 import { paginateOffset } from '../lib/utils';
-import json2csv from 'json2csv';
+import { parse as json2csv } from 'json2csv';
 import moment from 'moment';
 import _ from 'lodash';
 import queries from '../lib/queries';
@@ -41,10 +41,9 @@ export const format = format => {
             return row;
           });
           const fields = data.length > 0 ? Object.keys(data[0]) : [];
-          json2csv({ data, fields }, (err, csv) => {
-            res.setHeader('content-type', 'text/csv');
-            send.call(res, csv);
-          });
+          const csv = json2csv(data, { fields });
+          res.setHeader('content-type', 'text/csv');
+          send.call(res, csv);
         };
         return next();
       }


### PR DESCRIPTION
v4 Changes that concern us:

- The actual JSON parson is now done via a `parse` method (i.e. From `json2csv(...)` to `json2csv.parse(...)`.
- The arguments accepted by the `parse` method is slightly different from that accepted by the previous `json2csv` function (From `json2csv({data, fields})` to `json2csv.parse(data, {fields})`.
- The parse is no longer done asynchronously, but the `parse` method generates and returns the CSV synchronously.

Fixes opencollective/opencollective#1777
Closes #1770 