### PR TITLE
revamp(Collective): Move countryIso under location.country

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -499,10 +499,13 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
       expensePolicy: { type: GraphQLString },
       mission: { type: GraphQLString },
       tags: { type: new GraphQLList(GraphQLString) },
-      countryISO: { type: GraphQLString },
+      countryISO: {
+        deprecationReason: 'From 03/20/2019 - use `location.country` instead',
+        type: GraphQLString,
+      },
       location: {
         type: LocationType,
-        description: 'Name, address, lat, long of the location.',
+        description: 'Name, address, country, lat, long of the location.',
       },
       createdAt: { type: GraphQLString },
       startsAt: { type: GraphQLString },
@@ -744,6 +747,7 @@ const CollectiveFields = () => {
     },
     countryISO: {
       type: GraphQLString,
+      deprecationReason: 'From 03/20/2019 - use `location.country` instead',
       resolve(collective) {
         return collective.countryISO;
       },

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -129,7 +129,10 @@ export const CollectiveInputType = new GraphQLInputObjectType({
     longDescription: { type: GraphQLString },
     expensePolicy: { type: GraphQLString },
     location: { type: LocationInputType },
-    countryISO: { type: GraphQLString },
+    countryISO: {
+      type: GraphQLString,
+      deprecationReason: 'From 03/20/2019 - use `location.country` instead',
+    },
     startsAt: { type: GraphQLString },
     endsAt: { type: GraphQLString },
     timezone: { type: GraphQLString },
@@ -181,7 +184,10 @@ export const CollectiveAttributesInputType = new GraphQLInputObjectType({
     twitterHandle: { type: GraphQLString },
     githubHandle: { type: GraphQLString },
     location: { type: LocationInputType },
-    countryISO: { type: GraphQLString },
+    countryISO: {
+      type: GraphQLString,
+      deprecationReason: 'From 03/20/2019 - use `location.country` instead',
+    },
     startsAt: { type: GraphQLString },
     endsAt: { type: GraphQLString },
     timezone: { type: GraphQLString },
@@ -196,10 +202,26 @@ export const LocationInputType = new GraphQLInputObjectType({
   name: 'LocationInputType',
   description: 'Input type for Location',
   fields: () => ({
-    name: { type: GraphQLString },
-    address: { type: GraphQLString },
-    lat: { type: GraphQLFloat },
-    long: { type: GraphQLFloat },
+    name: {
+      type: GraphQLString,
+      description: 'A short name for the location (eg. Google Headquarters)',
+    },
+    address: {
+      type: GraphQLString,
+      description: 'Postal address without country (eg. 12 opensource avenue, 7500 Paris)',
+    },
+    country: {
+      type: GraphQLString,
+      description: 'Two letters country code (eg. FR, BE...etc)',
+    },
+    lat: {
+      type: GraphQLFloat,
+      description: 'Latitude',
+    },
+    long: {
+      type: GraphQLFloat,
+      description: 'Longitude',
+    },
   }),
 });
 

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -353,6 +353,7 @@ export function editCollective(_, args, req) {
     ...args.collective,
     locationName: location.name,
     address: location.address,
+    countryISO: location.country,
     LastEditedByUserId: req.remoteUser.id,
   };
 

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -347,23 +347,28 @@ export function editCollective(_, args, req) {
     return Promise.reject(new errors.ValidationFailed({ message: 'collective.id required' }));
   }
 
-  const location = args.collective.location || {};
-
   const newCollectiveData = {
-    ...args.collective,
-    locationName: location.name,
-    address: location.address,
-    countryISO: location.country,
+    ...omit(args.collective, ['location']),
     LastEditedByUserId: req.remoteUser.id,
+    type: args.collective.type || 'COLLECTIVE',
   };
 
-  newCollectiveData.type = newCollectiveData.type || 'COLLECTIVE';
-
+  // Set location values
+  const location = args.collective.location || {};
   if (location.lat) {
     newCollectiveData.geoLocationLatLong = {
       type: 'Point',
       coordinates: [location.lat, location.long],
     };
+  }
+  if (location.name !== undefined) {
+    newCollectiveData.locationName = location.name;
+  }
+  if (location.address !== undefined) {
+    newCollectiveData.address = location.address;
+  }
+  if (location.country !== undefined) {
+    newCollectiveData.countryISO = location.country;
   }
 
   let collective, parentCollective;

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -314,10 +314,26 @@ export const LocationType = new GraphQLObjectType({
   name: 'LocationType',
   description: 'Type for Location',
   fields: () => ({
-    name: { type: GraphQLString },
-    address: { type: GraphQLString },
-    lat: { type: GraphQLFloat },
-    long: { type: GraphQLFloat },
+    name: {
+      type: GraphQLString,
+      description: 'A short name for the location (eg. Google Headquarters)',
+    },
+    address: {
+      type: GraphQLString,
+      description: 'Postal address without country (eg. 12 opensource avenue, 7500 Paris)',
+    },
+    country: {
+      type: GraphQLString,
+      description: 'Two letters country code (eg. FR, BE...etc)',
+    },
+    lat: {
+      type: GraphQLFloat,
+      description: 'Latitude',
+    },
+    long: {
+      type: GraphQLFloat,
+      description: 'Longitude',
+    },
   }),
 });
 

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -402,6 +402,7 @@ export default function(Sequelize, DataTypes) {
           return {
             name: this.locationName,
             address: this.address,
+            country: this.countryISO,
             lat:
               this.geoLocationLatLong && this.geoLocationLatLong.coordinates && this.geoLocationLatLong.coordinates[0],
             long:
@@ -658,6 +659,9 @@ export default function(Sequelize, DataTypes) {
         let location = this.location.name || '';
         if (this.location.address) {
           location += `, ${this.location.address}`;
+        }
+        if (this.location.country) {
+          location += `, ${this.location.country}`;
         }
         const alarms = [
           {


### PR DESCRIPTION
See https://github.com/opencollective/opencollective/issues/1835

- [x] Accept `countryISO` in `LocationInputType`
- [x] Export `countryISO` in `LocationType`
- [x] Deprecate `countryISO` in `CollectiveInterface`

Also fix location update: before this PR any change to a single field of `location` would have erased the other location keys.