### PR TITLE
Archive Collective: Remove "delete tiers" from archiveCollective

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -656,16 +656,9 @@ export async function archiveCollective(_, args, req) {
   }
 
   return collective
-    .getTiers()
-    .then(tiers => {
-      return map(tiers, tier => tier.destroy(), { concurrency: 3 });
-    })
-    .then(() => {
-      debugArchive('deleteCollectiveTiers');
-      return collective.getIncomingOrders({
-        where: { status: status.ACTIVE, [Op.and]: { status: status.PENDING } },
-        include: [{ model: models.Subscription }, { model: models.Collective, as: 'collective' }],
-      });
+    .getIncomingOrders({
+      where: { status: status.ACTIVE, [Op.and]: { status: status.PENDING } },
+      include: [{ model: models.Subscription }, { model: models.Collective, as: 'collective' }],
     })
     .then(orders => {
       // Map through the `orders` but only create 3 promises to update/cancel orders at a time


### PR DESCRIPTION
Currently we are deleting tiers in [`archiveCollective`](https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v1/mutations/collectives.js#L661) mutation resolver, this PR removes that as explained in ([#1824](https://github.com/opencollective/opencollective/issues/1824))