### PR TITLE
Delete account

### DIFF
--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -4,6 +4,7 @@ import {
   createCollective,
   editCollective,
   deleteEvent,
+  deleteCollective,
   approveCollective,
   createCollectiveFromGithub,
   archiveCollective,
@@ -106,6 +107,15 @@ const mutations = {
     },
     resolve(_, args, req) {
       return deleteEvent(_, args, req);
+    },
+  },
+  deleteCollective: {
+    type: CollectiveInterfaceType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+    resolve(_, args, req) {
+      return deleteCollective(_, args, req);
     },
   },
   claimCollective: {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -3,7 +3,7 @@ import {
   claimCollective,
   createCollective,
   editCollective,
-  deleteCollective,
+  deleteEvent,
   approveCollective,
   createCollectiveFromGithub,
   archiveCollective,
@@ -99,13 +99,13 @@ const mutations = {
       return editCollective(_, args, req);
     },
   },
-  deleteCollective: {
+  deleteEvent: {
     type: CollectiveInterfaceType,
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
-      return deleteCollective(_, args, req);
+      return deleteEvent(_, args, req);
     },
   },
   claimCollective: {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -3,8 +3,9 @@ import {
   claimCollective,
   createCollective,
   editCollective,
-  deleteEvent,
+  deleteEventCollective,
   deleteCollective,
+  deleteUserCollective,
   approveCollective,
   createCollectiveFromGithub,
   archiveCollective,
@@ -100,13 +101,13 @@ const mutations = {
       return editCollective(_, args, req);
     },
   },
-  deleteEvent: {
+  deleteEventCollective: {
     type: CollectiveInterfaceType,
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
-      return deleteEvent(_, args, req);
+      return deleteEventCollective(_, args, req);
     },
   },
   deleteCollective: {
@@ -116,6 +117,15 @@ const mutations = {
     },
     resolve(_, args, req) {
       return deleteCollective(_, args, req);
+    },
+  },
+  deleteUserCollective: {
+    type: CollectiveInterfaceType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+    resolve(_, args, req) {
+      return deleteUserCollective(_, args, req);
     },
   },
   claimCollective: {

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -511,7 +511,7 @@ export async function approveCollective(remoteUser, CollectiveId) {
   return collective.update({ isActive: true });
 }
 
-export function deleteCollective(_, args, req) {
+export function deleteEvent(_, args, req) {
   if (!req.remoteUser) {
     throw new errors.Unauthorized({
       message: 'You need to be logged in to delete a collective',

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -17,7 +17,7 @@ import { types } from '../../../constants/collectives';
 const debugClaim = debug('claim');
 const debugGithub = debug('github');
 const debugArchive = debug('archive');
-const debugDeleteCollective = debug('delete');
+const debugDelete = debug('delete');
 
 export async function createCollective(_, args, req) {
   if (!req.remoteUser) {
@@ -279,7 +279,7 @@ export async function createCollectiveFromGithub(_, args, req) {
   collectiveData.currency = 'USD';
   collectiveData.CreatedByUserId = user.id;
   collectiveData.LastEditedByUserId = user.id;
-  collectiveData.tiers = [
+  collectiveData.teirs = [
     {
       name: 'backer',
       title: 'Backers',
@@ -512,7 +512,7 @@ export async function approveCollective(remoteUser, CollectiveId) {
   return collective.update({ isActive: true });
 }
 
-export function deleteEvent(_, args, req) {
+export function deleteEventCollective(_, args, req) {
   if (!req.remoteUser) {
     throw new errors.Unauthorized({
       message: 'You need to be logged in to delete a collective',
@@ -767,7 +767,7 @@ export async function deleteCollective(_, args, req) {
         { concurrency: 3 },
       );
     })
-    .then(() => debugDeleteCollective('deleteCollectiveMembers'))
+    .then(() => debugDelete('deleteCollectiveMembers'))
     .then(async () => {
       const expenses = await models.Expense.findAll({
         where: { CollectiveId: collective.id },
@@ -780,7 +780,7 @@ export async function deleteCollective(_, args, req) {
         { concurrency: 3 },
       );
     })
-    .then(() => debugDeleteCollective('deleteCollectiveExpenses'))
+    .then(() => debugDelete('deleteCollectiveExpenses'))
     .then(async () => {
       const tiers = await models.Tier.findAll({
         where: { CollectiveId: collective.id },
@@ -793,7 +793,7 @@ export async function deleteCollective(_, args, req) {
         { concurrency: 3 },
       );
     })
-    .then(() => debugDeleteCollective('deleteCollectiveTiers'))
+    .then(() => debugDelete('deleteCollectiveTiers'))
     .then(async () => {
       const paymentMethods = await models.PaymentMethod.findAll({
         where: { CollectiveId: collective.id },
@@ -806,7 +806,7 @@ export async function deleteCollective(_, args, req) {
         { concurrency: 3 },
       );
     })
-    .then(() => debugDeleteCollective('deleteCollectivePaymentMethods'))
+    .then(() => debugDelete('deleteCollectivePaymentMethods'))
     .then(async () => {
       const connectedAccounts = await models.ConnectedAccount.findAll({
         where: { CollectiveId: collective.id },
@@ -819,6 +819,114 @@ export async function deleteCollective(_, args, req) {
         { concurrency: 3 },
       );
     })
-    .then(() => debugDeleteCollective('deleteCollectiveConnectedAccounts'))
-    .then(() => collective.destroy());
+    .then(() => debugDelete('deleteCollectiveConnectedAccounts'))
+    .then(() => {
+      // Update collective slug to free the current slug for future
+      const newSlug = `${collective.slug}-${Date.now()}`;
+      return collective.update({ slug: newSlug });
+    })
+    .then(() => collective.destroy())
+    .then(() => collective);
+}
+
+export async function deleteUserCollective(_, args, req) {
+  if (!req.remoteUser) {
+    throw new errors.Unauthorized({
+      message: 'You need to be logged in to delete your account',
+    });
+  }
+  const user = await models.User.findOne({ where: { id: req.remoteUser.id } });
+  const userCollective = await models.Collective.findOne({
+    where: { id: args.id },
+  });
+  const transactionCount = await models.Transaction.count({
+    where: { FromCollectiveId: userCollective.id },
+  });
+  const orderCount = await models.Order.count({
+    where: { FromCollectiveId: userCollective.id },
+  });
+
+  if (transactionCount > 0 || orderCount > 0) {
+    throw new Error('Can not delete user with existing orders.');
+  }
+
+  const expenseCount = await models.Expense.count({
+    where: { UserId: user.id, status: 'PAID' },
+  });
+
+  if (expenseCount > 0) {
+    throw new Error('Can not delete user with paid expenses.');
+  }
+
+  return models.Member.findAll({
+    where: { MemberCollectiveId: userCollective.id },
+  })
+    .then(members => {
+      return map(
+        members,
+        member => {
+          return member.destroy();
+        },
+        { concurrency: 3 },
+      );
+    })
+    .then(() => debugDelete('deleteUserMemberships'))
+    .then(async () => {
+      const expenses = await models.Expense.findAll({ where: { UserId: user.id } });
+      return map(
+        expenses,
+        expense => {
+          return expense.destroy();
+        },
+        { concurrency: 3 },
+      );
+    })
+    .then(() => debugDelete('deleteUserExpenses'))
+    .then(async () => {
+      const paymentMethods = await models.PaymentMethod.findAll({
+        where: { CollectiveId: userCollective.id },
+      });
+      return map(
+        paymentMethods,
+        paymentMethod => {
+          return paymentMethod.destroy();
+        },
+        { concurrency: 3 },
+      );
+    })
+    .then(() => debugDelete('deleteUserPaymentMethods'))
+    .then(async () => {
+      const connectedAccounts = await models.ConnectedAccount.findAll({
+        where: { CollectiveId: userCollective.id },
+      });
+      return map(
+        connectedAccounts,
+        connectedAccount => {
+          return connectedAccount.destroy();
+        },
+        { concurrency: 3 },
+      );
+    })
+    .then(() => debugDelete('deleteUserConnectedAccounts'))
+    .then(() => {
+      // Update collective slug to free the current slug for future
+      const newSlug = `${userCollective.slug}-${Date.now()}`;
+      return userCollective.update({ slug: newSlug });
+    })
+    .then(() => {
+      return userCollective.destroy();
+    })
+    .then(() => debugDelete('deleteUserCollective'))
+    .then(() => {
+      // Update user email in order to free up for future reuse
+      // Split the email, username from host domain
+      const splitedEmail = user.email.split('@');
+      // Add the current timestamp to email username
+      const newEmail = `${splitedEmail[0]}-${Date.now()}@${splitedEmail[1]}`;
+      return user.update({ email: newEmail });
+    })
+    .then(() => {
+      return user.destroy();
+    })
+    .then(() => userCollective);
 }

--- a/test/graphql.mutation.test.js
+++ b/test/graphql.mutation.test.js
@@ -390,16 +390,16 @@ describe('Mutation Tests', () => {
   });
 
   describe('delete Collective', () => {
-    const deleteCollectiveQuery = `
-      mutation deleteCollective($id: Int!) {
-        deleteCollective(id: $id) {
+    const deleteEventCollectiveQuery = `
+      mutation deleteEventCollective($id: Int!) {
+        deleteEventCollective(id: $id) {
           id,
           name
         }
       }`;
 
     it('fails to delete a collective if not logged in', async () => {
-      const result = await utils.graphqlQuery(deleteCollectiveQuery, {
+      const result = await utils.graphqlQuery(deleteEventCollectiveQuery, {
         id: event1.id,
       });
       expect(result.errors).to.exist;
@@ -410,7 +410,7 @@ describe('Mutation Tests', () => {
     });
 
     it('fails to delete a collective if logged in as another user', async () => {
-      const result = await utils.graphqlQuery(deleteCollectiveQuery, { id: event1.id }, user2);
+      const result = await utils.graphqlQuery(deleteEventCollectiveQuery, { id: event1.id }, user2);
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal(
         'You need to be logged in as a core contributor or as a host to delete this collective',
@@ -421,7 +421,7 @@ describe('Mutation Tests', () => {
     });
 
     it('deletes a collective', async () => {
-      const res = await utils.graphqlQuery(deleteCollectiveQuery, { id: event1.id }, user1);
+      const res = await utils.graphqlQuery(deleteEventCollectiveQuery, { id: event1.id }, user1);
       res.errors && console.error(res.errors[0]);
       expect(res.errors).to.not.exist;
       return models.Collective.findByPk(event1.id).then(event => {


### PR DESCRIPTION
This PR:
 - Renames the current [`deleteCollective`](https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v1/mutations/collectives.js#L514-L535) to `deleteCollectiveEvent` because it is essentially used to delete collective event in the frontend. 

- Adds a new `deleteCollective` to collective mutation resolver that:
             - Checks the user is logged in, collective is available, user is collective admin.
             - Checks the collective is deletable by making sure the collective has no transaction, order and PAID expense.
              - Sequentially soft deletes collective `members`, `tiers`, `expenses`, `paymentMethods`, `connectedAccounts` and `collective` itself. Each with concurrency limit of `3`. 

-  Adds `deleteUserCollective` to collective mutation resolver that:
           -  Checks the user is logged in
            - Checks the user collective is deletable by making sure the user has no transaction, order and PAID expense.
             - Sequentially soft deletes user `membership`, `expenses`, `paymentMethods`,  `connectedAccounts`, `userCollective` and `user`. Each with concurrency limit of `3`. 

- Adds `isDeletable` to collective property.

Ref ([#1793](https://github.com/opencollective/opencollective/issues/1793))