### PR TITLE
 Don't store declined credit cards

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -446,11 +446,19 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
         await orderCreated.setPaymentMethod(order.paymentMethod);
       }
       // also adds the user as a BACKER of collective
-      await libPayments.executeOrder(
-        remoteUser || user,
-        orderCreated,
-        pick(order, ['hostFeePercent', 'platformFeePercent']),
-      );
+      try {
+        await libPayments.executeOrder(
+          remoteUser || user,
+          orderCreated,
+          pick(order, ['hostFeePercent', 'platformFeePercent']),
+        );
+      } catch (e) {
+        // Don't save new card for user if order failed
+        if (!order.paymentMethod.id && !order.paymentMethod.uuid) {
+          await orderCreated.paymentMethod.update({ CollectiveId: null });
+        }
+        throw e;
+      }
     } else if (!paymentRequired && order.interval && collective.type === types.COLLECTIVE) {
       // create inactive subscription to hold the interval info for the pledge
       const subscription = await models.Subscription.create({

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -181,13 +181,7 @@ export default function(Sequelize, DataTypes) {
               throw new Error(`${instance.service} payment method requires a token`);
             }
             if (instance.service === 'stripe' && !instance.token.match(/^(tok|src)_[a-zA-Z0-9]{24}/)) {
-              if (
-                process.env.NODE_ENV !== 'production' &&
-                instance.token === 'tok_bypassPending' &&
-                instance.data.expMonth === 11 &&
-                instance.data.expYear === 23 &&
-                instance.data.zip === 10014
-              ) {
+              if (process.env.NODE_ENV !== 'production' && stripe.isTestToken(instance.token)) {
                 // test token for end to end tests
               } else {
                 throw new Error(`Invalid Stripe token ${instance.token}`);

--- a/server/paymentProviders/stripe/gateway.js
+++ b/server/paymentProviders/stripe/gateway.js
@@ -237,3 +237,16 @@ export const extractFees = balance => {
   });
   return fees;
 };
+
+/**
+ * Returns true if token is a valid stripe test token.
+ * See https://stripe.com/docs/testing#cards
+ */
+export const isTestToken = token => {
+  return [
+    'tok_bypassPending',
+    'tok_chargeDeclined',
+    'tok_chargeDeclinedExpiredCard',
+    'tok_chargeDeclinedProcessingError',
+  ].includes(token);
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -213,9 +213,15 @@ export function stubStripeCreate(sandbox, overloadDefaults) {
   /* Little helper function that returns the stub with a given
    * value. */
   const factory = name => async () => values[name];
-  sandbox.stub(stripeGateway, 'createCustomer').callsFake(factory('customer'));
   sandbox.stub(stripeGateway, 'createToken').callsFake(factory('token'));
   sandbox.stub(stripeGateway, 'createCharge').callsFake(factory('charge'));
+  sandbox.stub(stripeGateway, 'createCustomer').callsFake(async (account, token) => {
+    if (token.startsWith('tok_chargeDeclined')) {
+      throw new Error('Your card was declined.');
+    }
+
+    return values.customer;
+  });
 }
 
 export function stubStripeBalance(sandbox, amount, currency, applicationFee = 0, stripeFee = 0) {


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/1813
---

As the information contained in the payment method may be useful for example in case of attacks, the payment method is not deleted but we remove it from the user's payment methods list so it won't appear for future orders.