### PR TITLE
Archive Collective: check balance before archiving

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -661,6 +661,12 @@ export async function archiveCollective(_, args, req) {
     });
   }
 
+  const balance = await collective.getBalance();
+
+  if (balance > 0) {
+    throw new Error('Cannot archive collective with balance > 0');
+  }
+
   return collective
     .getIncomingOrders({
       where: { status: status.ACTIVE, [Op.and]: { status: status.PENDING } },


### PR DESCRIPTION
This PR checks collective balance. Throws error if collective balance is greater than zero.

Ref ([#1823](https://github.com/opencollective/opencollective/issues/1823))