### PR TITLE
Remove remaining loginLinks

### DIFF
--- a/cron/monthly/user-report.js
+++ b/cron/monthly/user-report.js
@@ -236,7 +236,7 @@ const processBacker = async FromCollectiveId => {
         month,
         fromCollective: backerCollective,
         collectives: collectivesWithOrders,
-        manageSubscriptionsUrl: user.generateLoginLink('/subscriptions'),
+        manageSubscriptionsUrl: '/subscriptions',
         relatedCollectives,
         stats,
         tags: stats.allTags || {},

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -412,7 +412,7 @@ const sendOrderConfirmedEmail = async order => {
       recommendedCollectives,
       monthlyInterval: interval === 'month',
       firstPayment: true,
-      subscriptionsLink: interval && user.generateLoginLink(`/${fromCollective.slug}/subscriptions`),
+      subscriptionsLink: interval && `/${fromCollective.slug}/subscriptions`,
     };
 
     let matchingFundCollective;
@@ -455,7 +455,7 @@ const sendOrderProcessingEmail = async order => {
     collective: collective.info,
     host: host.info,
     fromCollective: fromCollective.minimal,
-    subscriptionsLink: user.generateLoginLink(`/${fromCollective.slug}/subscriptions`),
+    subscriptionsLink: `/${fromCollective.slug}/subscriptions`,
   };
   const instructions = get(host, 'settings.paymentMethods.manual.instructions');
   if (instructions) {

--- a/server/lib/subscriptions.js
+++ b/server/lib/subscriptions.js
@@ -264,7 +264,7 @@ export async function sendFailedEmail(order, lastAttempt) {
       order: order.info,
       collective: order.collective.info,
       fromCollective: order.fromCollective.minimal,
-      subscriptionsLink: user.generateLoginLink(`/${order.fromCollective.slug}/subscriptions`),
+      subscriptionsLink: `/${order.fromCollective.slug}/subscriptions`,
     },
     {
       from: `${order.collective.name} <hello@${order.collective.slug}.opencollective.com>`,
@@ -291,7 +291,7 @@ export async function sendThankYouEmail(order, transaction) {
       recommendedCollectives,
       config: { host: config.host },
       interval: order.Subscription.interval,
-      subscriptionsLink: user.generateLoginLink(`/${order.fromCollective.slug}/subscriptions`),
+      subscriptionsLink: `/${order.fromCollective.slug}/subscriptions`,
     },
     {
       from: `${order.collective.name} <hello@${order.collective.slug}.opencollective.com>`,

--- a/test/lib.subscriptions.test.js
+++ b/test/lib.subscriptions.test.js
@@ -212,8 +212,8 @@ describe('LibSubscription', () => {
       const order = {
         Subscription: { chargeRetryCount: 0 },
         collective: { getRelatedCollectives: () => Promise.resolve(null) },
-        fromCollective: {},
-        createdByUser: { email: 'test@oc.com', generateLoginLink: () => '/' },
+        fromCollective: { slug: 'cslug' },
+        createdByUser: { email: 'test@oc.com' },
       };
 
       // And given that we expect the method send from the mock to be
@@ -235,8 +235,8 @@ describe('LibSubscription', () => {
       const order = {
         Subscription: { chargeRetryCount: 1 },
         collective: {},
-        fromCollective: {},
-        createdByUser: { email: 'test@oc.com', generateLoginLink: () => '/' },
+        fromCollective: { slug: 'cslug' },
+        createdByUser: { email: 'test@oc.com' },
       };
 
       // And given that we expect the method send from the mock to be
@@ -249,7 +249,7 @@ describe('LibSubscription', () => {
           order: order.info,
           collective: order.collective.info,
           fromCollective: order.fromCollective.minimal,
-          subscriptionsLink: '/',
+          subscriptionsLink: '/cslug/subscriptions',
         });
 
       // When the status of the order is handled
@@ -264,8 +264,8 @@ describe('LibSubscription', () => {
       const order = {
         Subscription: { chargeRetryCount: MAX_RETRIES },
         collective: {},
-        fromCollective: {},
-        createdByUser: { email: 'test@oc.com', generateLoginLink: () => '/' },
+        fromCollective: { slug: 'cslug' },
+        createdByUser: { email: 'test@oc.com' },
       };
 
       // And given that we expect the method send from the mock to be
@@ -278,7 +278,7 @@ describe('LibSubscription', () => {
           order: order.info,
           collective: order.collective.info,
           fromCollective: order.fromCollective.minimal,
-          subscriptionsLink: '/',
+          subscriptionsLink: '/cslug/subscriptions',
         });
 
       // When the status of the order is handled


### PR DESCRIPTION
Following up on: https://github.com/opencollective/opencollective-api/pull/1822

Quoting @Betree 

> Including login links in notifications emails may be more convenient for the user, but it's a security issue: user have no way to know that the email can include sensitive information and could transfer it to someone else without knowing that it is dangerous.

> **It should be explicit that sensitive emails **are** sensitive.**

> Also we're not protected from bugs and the best way to avoid them on such a sensitive feature as login is to keep it as contained, small and tested as possible.