### PR TITLE
chore(pre-deploy): Display only merged pull requests in log

### DIFF
--- a/scripts/pre-deploy.sh
+++ b/scripts/pre-deploy.sh
@@ -50,7 +50,7 @@ PRE_DEPLOY_BRANCH="master"
 
 GIT_LOG_FORMAT_SHELL='short'
 GIT_LOG_FORMAT_SLACK='format:<https://github.com/opencollective/opencollective-api/commit/%H|[%ci]> *%an* %n_%<(80,trunc)%s_%n'
-GIT_LOG_COMPARISON="$PRE_DEPLOY_ORIGIN/$PRE_DEPLOY_BRANCH..$LOCAL_ORIGIN/$LOCAL_BRANCH"
+GIT_LOG_ARGS=(--grep "^Merge pull request #" "$PRE_DEPLOY_ORIGIN/$PRE_DEPLOY_BRANCH..$LOCAL_ORIGIN/$LOCAL_BRANCH")
 
 # ---- Utils ----
 
@@ -78,17 +78,17 @@ function exit_success()
 
 # ---- Ensure we have a reference to the remote ----
 
-git remote add $PRE_DEPLOY_ORIGIN $DEPLOY_ORIGIN_URL &> /dev/null
+git remote add "$PRE_DEPLOY_ORIGIN" "$DEPLOY_ORIGIN_URL" &> /dev/null
 
 # ---- Show the commits about to be pushed ----
 
 # Update deploy remote
 echo "ℹ️  Fetching remote $1 state..."
-git fetch $PRE_DEPLOY_ORIGIN > /dev/null
+git fetch "$PRE_DEPLOY_ORIGIN" > /dev/null
 
 echo ""
 echo "-------------- New commits --------------"
-git --no-pager log --pretty="${GIT_LOG_FORMAT_SHELL}" $GIT_LOG_COMPARISON
+git --no-pager log --pretty="${GIT_LOG_FORMAT_SHELL}" "${GIT_LOG_ARGS[@]}"
 echo "-----------------------------------------"
 echo ""
 
@@ -110,12 +110,12 @@ if [ -z "$OC_SLACK_USER_TOKEN" ]; then
 fi
 
 ESCAPED_CHANGELOG=$(
-  git log --pretty="${GIT_LOG_FORMAT_SLACK}" $GIT_LOG_COMPARISON \
+  git log --pretty="${GIT_LOG_FORMAT_SLACK}" "${GIT_LOG_ARGS[@]}" \
   | sed 's/"/\\\\"/g'
 )
 
 if [ ! -z "$DEPLOY_MSG" ]; then
-  CUSTOM_MESSAGE="-- _$(echo $DEPLOY_MSG | sed 's/"/\\\\"/g' | sed "s/'/\\\\'/g")_"
+  CUSTOM_MESSAGE="-- _$(echo "$DEPLOY_MSG" | sed 's/"/\\\\"/g' | sed "s/'/\\\\'/g")_"
 fi
 
 read -d '' PAYLOAD << EOF


### PR DESCRIPTION
We're not supposed to commit without creating pull requests. So showing all the commits in pre-deploy logs is just creating noise and we miss the important information.

**New logs (5 entries)**

![image](https://user-images.githubusercontent.com/1556356/55071680-914d1380-5089-11e9-8df3-bfbced4d5173.png)


> 
> [2019-03-27 11:38:58 +0100] *Benjamin Piouffle*
> _Merge pull request #1828 from opencollective/chore/collective-slugs-blacklist-2_
> 
> [2019-03-27 09:59:05 +0100] *François Hodierne*
> _Merge pull request #1830 from opencollective/greenkeeper/@octokit/rest-16.21.0_  
> 
> [2019-03-27 09:52:26 +0100] *François Hodierne*
> _Merge pull request #1829 from opencollective/greenkeeper/json2csv-4.4.1_        
> 
> [2019-03-26 11:05:20 +0100] *François Hodierne*
> _Merge pull request #1808 from opencollective/greenkeeper/monorepo.babel7-20190.._
> 
> [2019-03-26 11:04:38 +0100] *François Hodierne*
> _Merge pull request #1824 from opencollective/check-balance_   

           

**Previous logs (20 entries)**

![image](https://user-images.githubusercontent.com/1556356/55071652-7a0e2600-5089-11e9-978b-360394883ec8.png)


> [2019-03-27 11:43:22 +0100] *Benjamin Piouffle*
> _2.0.330_                                                                        
> 
> [2019-03-27 11:38:58 +0100] *Benjamin Piouffle*
> _Merge pull request #1828 from opencollective/chore/collective-slugs-blacklist-2_
> 
> [2019-03-27 09:59:05 +0100] *François Hodierne*
> _Merge pull request #1830 from opencollective/greenkeeper/@octokit/rest-16.21.0_  
> 
> [2019-03-27 09:52:26 +0100] *François Hodierne*
> _Merge pull request #1829 from opencollective/greenkeeper/json2csv-4.4.1_        
> 
> [2019-03-27 08:51:00 +0000] *greenkeeper[bot]*
> _chore(package): update lockfile package-lock.json_                              
> 
> [2019-03-27 08:50:57 +0000] *greenkeeper[bot]*
> _fix(package): update @octokit/rest to version 16.21.0_                          
> 
> [2019-03-27 07:52:31 +0000] *greenkeeper[bot]*
> _chore(package): update lockfile package-lock.json_                              
> 
> [2019-03-27 07:52:27 +0000] *greenkeeper[bot]*
> _fix(package): update json2csv to version 4.4.1_                                  
> 
> [2019-03-26 23:31:00 +0100] *Benjamin Piouffle*
> _chore(Collective): Add event and events to blacklisted slugs_                    
> 
> [2019-03-26 11:05:20 +0100] *François Hodierne*
> _Merge pull request #1808 from opencollective/greenkeeper/monorepo.babel7-20190.._
> 
> [2019-03-26 11:04:38 +0100] *François Hodierne*
> _Merge pull request #1824 from opencollective/check-balance_                      
> 
> [2019-03-26 08:29:42 +0100] *François Hodierne*
> _package: update @babel/preset-env to version 7.4.2_                              
> 
> [2019-03-26 08:28:43 +0100] *greenkeeper[bot]*
> _chore(package): update lockfile package-lock.json_                              
> 
> [2019-03-26 08:28:27 +0100] *greenkeeper[bot]*
> _chore(package): update @babel/register to version 7.4.0_                        
> 
> [2019-03-26 08:28:26 +0100] *greenkeeper[bot]*
> _fix(package): update @babel/preset-env to version 7.4.0_                        
> 
> [2019-03-26 08:26:19 +0100] *greenkeeper[bot]*
> _chore(package): update @babel/polyfill to version 7.4.0_                        
> 
> [2019-03-26 08:26:19 +0100] *greenkeeper[bot]*
> _fix(package): update @babel/plugin-transform-async-to-generator to version 7.4.0_
> 
> [2019-03-26 08:26:18 +0100] *greenkeeper[bot]*
> _fix(package): update @babel/plugin-proposal-class-properties to version 7.4.0_  
> 
> [2019-03-26 08:26:17 +0100] *greenkeeper[bot]*
> _fix(package): update @babel/core to version 7.4.0_                              
> 
> [2019-03-25 15:54:04 +0100] *flickz*
> _feat(archiveCollective): check collective balance before archiving_  