### PR TITLE
Add a dataloader for collective's pending orders

### DIFF
--- a/server/graphql/loaders.js
+++ b/server/graphql/loaders.js
@@ -321,6 +321,17 @@ export const loaders = req => {
           order: [['createdAt', 'DESC']],
         }).then(results => sortResults(combinedKeys, results, 'CollectiveId:FromCollectiveId', [])),
       ),
+      findPendingOrdersForCollective: new DataLoader(CollectiveIds => {
+        return models.Order.findAll({
+          where: {
+            CollectiveId: { [Op.in]: CollectiveIds },
+            status: 'PENDING',
+          },
+          order: [['createdAt', 'DESC']],
+        }).then(results => {
+          return sortResults(CollectiveIds, results, 'CollectiveId', []);
+        });
+      }),
       stats: {
         transactions: new DataLoader(ids =>
           models.Transaction.findAll({

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1072,10 +1072,12 @@ const CollectiveFields = () => {
       args: {
         status: { type: OrderStatusType },
       },
-      resolve(collective, args = {}) {
+      resolve(collective, args = {}, req) {
         const where = {};
 
-        if (args.status) {
+        if (args.status === 'PENDING') {
+          return req.loaders.orders.findPendingOrdersForCollective.load(collective.id);
+        } else if (args.status) {
           where.status = args.status;
         } else {
           where.processedAt = { [Op.ne]: null };


### PR DESCRIPTION
This will optimize the existing "Pledged Collective" page and will ensure we have decent performances when we refactor the `/discover` to use the graphql API.