### PR TITLE
Don't reset isPledged when claiming the collective

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -600,7 +600,6 @@ export async function claimCollective(_, args, req) {
   collective = await collective.update({
     CreatedByUserId: req.remoteUser.id,
     LastEditedByUserId: req.remoteUser.id,
-    isPledged: false,
   });
 
   // add opensource collective as host


### PR DESCRIPTION
The rational behind this is that we don't need the flag to be true in the frontend to decide on our actions, we can rely on `isActive` to know if the collective is up.

On the other hand, it's good for us to keep the information that collective is born from a pledge for statistics and maintenance, and tags are not a reliable way to do it (users can edit tags).

The query to fetch all unclaimed pledges stays mostly the same, we just need to add `isActive: false`:

```graphql
{
  allCollectives(isPledged: true, isActive: false) {
    collectives {
      slug
    }
  }
}
```