### PR TITLE
Purge Cloudflare's cache from frontend_url

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -82,6 +82,7 @@
     "api": "API_URL",
     "images": "IMAGES_URL",
     "webapp": "WEBAPP_URL",
+    "frontend": "FRONTEND_URL",
     "website": "WEBSITE_URL",
     "invoices": "INVOICES_URL"
   },

--- a/config/production.json
+++ b/config/production.json
@@ -15,6 +15,7 @@
   },
   "host": {
     "api": "https://api.opencollective.com",
+    "frontend": "https://frontend.opencollective.com",
     "webapp": "https://app.opencollective.com",
     "website": "https://opencollective.com",
     "images": "https://images.opencollective.com",

--- a/config/staging.json
+++ b/config/staging.json
@@ -14,6 +14,7 @@
   },
   "host": {
     "api": "https://api-staging.opencollective.com",
+    "frontend": "https://frontend-staging.opencollective.com",
     "website": "https://staging.opencollective.com"
   },
   "stripe": {

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -28,6 +28,7 @@
 | API_URL                 | .host.api                              | API exposed url                               |
 | WEBAPP_URL              | .host.webapp                           | webapp URL                                    |
 | WEBSITE_URL             | .host.website                          | UI URL                                        |
+| FRONTEND_URL            | .host.frontend                         | URL of the frontend service (for caching)     |
 | SLACK_HOOK_URL          | .slack.webhookUrl                      | slack hook url                                |
 | CLEARBIT_KEY            | .clearbit.key                          | clearbit key                                  |
 | GITHUB_CLIENT_ID        | .github.clientId                       | github client ID                              |


### PR DESCRIPTION
- Also purge frontend URL (eg. `https://frontend.opencollective.com/___`)
- Add two versions of the URL - with and without trailing `/`

**Example**

```es6
> purgeCacheForPage('/babel')
```

```
Asking cloudflare to purge the cache for [
  'https://opencollective.com/babel',
  'https://opencollective.com/babel/',
  'https://frontend.opencollective.com/babel',
  'https://frontend.opencollective.com/babel/',
]
```