### PR TITLE
Consolidated yearly invoice #1783

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "test:server": "./scripts/db_restore.sh -d opencollective_dvl -f test/dbdumps/opencollective_dvl.pgsql && PG_DATABASE=opencollective_dvl npm run dev",
     "test:dev": "npm run test:unit:dev && npm run test:bdd:dev",
     "test:unit:dev": "mocha --reporter-options mochaFile=$(bash scripts/test_output_dir.sh junit)/junit.xml",
+    "test:unit:dev:grep": "mocha --reporter-options mochaFile=$(bash scripts/test_output_dir.sh junit)/junit.xml --grep ",
     "test:unit": "nyc mocha --reporter-options mochaFile=$(bash scripts/test_output_dir.sh junit)/junit.xml",
     "test:bdd:dev": "cucumber-js --require-module @babel/register --require-module @babel/polyfill --backtrace --order random ./test/features",
     "test:bdd": "nyc cucumber-js --require-module @babel/register --require-module @babel/polyfill --backtrace --order random ./test/features",

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -12,6 +12,7 @@ import {
 
 import GraphQLJSON from 'graphql-type-json';
 import { Kind } from 'graphql/language';
+import { IsoDateString } from './types';
 
 const EmailType = new GraphQLScalarType({
   name: 'Email',
@@ -388,6 +389,19 @@ export const ExpenseInputType = new GraphQLInputObjectType({
       attachment: { type: GraphQLString },
       user: { type: UserInputType },
       collective: { type: CollectiveAttributesInputType },
+    };
+  },
+});
+
+export const InvoiceInputType = new GraphQLInputObjectType({
+  name: 'InvoiceInputType',
+  description: 'Input dates and collectives for Invoice',
+  fields: () => {
+    return {
+      dateFrom: { type: IsoDateString },
+      dateTo: { type: IsoDateString },
+      collectiveSlug: { type: GraphQLString },
+      fromCollectiveSlug: { type: GraphQLString },
     };
   },
 });

--- a/test/graphql.invoicesByRange.test.js
+++ b/test/graphql.invoicesByRange.test.js
@@ -1,0 +1,181 @@
+/** @module test/graphql.invoices.test
+ *
+ * This tests all the GraphQL API methods that interact with user
+ * invoices. */
+
+import sinon from 'sinon';
+import { expect } from 'chai';
+import moment from 'moment';
+
+//The tests pass invalid ISO strings to moment and this gives an annoying deprecation warning.
+moment.suppressDeprecationWarnings = true;
+
+/* Test utilities */
+import * as utils from './utils';
+import * as store from './features/support/stores';
+
+const startOctober2017ISOString = moment('2017-10-01').toISOString(true);
+const startNovember2017ISOString = moment('2017-11-01').toISOString(true);
+
+/** Create host, collective, payment method and make a donation
+ *
+ * As a bonus feature, this helper freezes time at `createdAt' so all
+ * the objects created will have that date as their creation date.
+ *
+ * The payment method is always stripe for now.
+ */
+async function donate(user, currency, amount, createdAt, collective) {
+  const timer = sinon.useFakeTimers(new Date(createdAt).getTime());
+  try {
+    await store.stripeConnectedAccount(collective.HostCollectiveId);
+    await store.stripeOneTimeDonation({
+      remoteUser: user,
+      collective,
+      currency,
+      amount,
+    });
+  } finally {
+    timer.restore();
+  }
+}
+
+describe('graphql.invoicesByRange.test.js', () => {
+  let xdamman;
+
+  before(async () => {
+    // First reset the test database
+    await utils.resetTestDB();
+    // Given a user and its collective
+    const { user } = await store.newUser('xdamman');
+    xdamman = user;
+    // And given the collective (with their host)
+    const { collective } = await store.newCollectiveWithHost('brusselstogether', 'EUR', 'EUR', 10);
+    // And given some donations to that collective
+    await donate(user, 'EUR', 1000, '2017-09-03 00:00', collective);
+    await donate(user, 'EUR', 1000, '2017-10-05 00:00', collective);
+    await donate(user, 'EUR', 500, '2017-10-25 00:00', collective);
+    await donate(user, 'EUR', 500, '2017-11-05 00:00', collective);
+    await donate(user, 'EUR', 500, '2017-11-25 00:00', collective);
+  });
+
+  describe('return transactions', () => {
+    const query = `
+        query InvoiceByDateRange($invoiceInputType: InvoiceInputType!) {
+          InvoiceByDateRange(invoiceInputType: $invoiceInputType) {
+            dateFrom
+            dateTo
+            totalAmount
+            currency
+            host {
+              id
+              slug
+              location {
+                name
+                address
+              }
+            }
+            fromCollective {
+              id
+              slug
+              location {
+                name
+                address
+              }
+            }
+            transactions {
+              id
+              amount
+              description
+            }
+          }
+        }
+      `;
+
+    it('returns an error if the dateTo is before dateFrom', async () => {
+      const result = await utils.graphqlQuery(
+        query,
+        {
+          invoiceInputType: {
+            dateFrom: startNovember2017ISOString,
+            dateTo: startOctober2017ISOString,
+            collectiveSlug: 'brusselstogether-host',
+            fromCollectiveSlug: 'xdamman',
+          },
+        },
+        xdamman,
+      );
+
+      expect(result.errors[0].message).to.include('Invalid date');
+    });
+
+    it('returns an error if the date is an invalid ISO string', async () => {
+      const result = await utils.graphqlQuery(
+        query,
+        {
+          invoiceInputType: {
+            dateFrom: startNovember2017ISOString,
+            dateTo: 'notavalidtimestring',
+            collectiveSlug: 'brusselstogether-host',
+            fromCollectiveSlug: 'xdamman',
+          },
+        },
+        xdamman,
+      );
+
+      expect(result.errors[0].message).to.include('Invalid date');
+      const result2 = await utils.graphqlQuery(
+        query,
+        {
+          invoiceInputType: {
+            dateFrom: 'notavalidtimestring',
+            dateTo: startOctober2017ISOString,
+            collectiveSlug: 'brusselstogether-host',
+            fromCollectiveSlug: 'xdamman',
+          },
+        },
+        xdamman,
+      );
+
+      expect(result2.errors[0].message).to.include('Invalid date');
+    });
+
+    it('fails to return list of invoices for a given user if not logged in as that user', async () => {
+      const result = await utils.graphqlQuery(query, {
+        invoiceInputType: {
+          dateFrom: startOctober2017ISOString,
+          dateTo: startNovember2017ISOString,
+          collectiveSlug: 'brusselstogether-host',
+          fromCollectiveSlug: 'xdamman',
+        },
+      });
+
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.contain("You don't have permission to access invoices for this user");
+    });
+
+    it('returns invoice data for a given start and end date', async () => {
+      const result = await utils.graphqlQuery(
+        query,
+        {
+          invoiceInputType: {
+            dateFrom: startOctober2017ISOString,
+            dateTo: startNovember2017ISOString,
+            collectiveSlug: 'brusselstogether-host',
+            fromCollectiveSlug: 'xdamman',
+          },
+        },
+        xdamman,
+      );
+
+      expect(result.errors).to.not.exist;
+      const invoice = result.data.InvoiceByDateRange;
+      expect(invoice.host.slug).to.equal('brusselstogether-host');
+      expect(invoice.fromCollective.slug).to.equal('xdamman');
+      expect(invoice.totalAmount).to.equal(1500);
+      expect(invoice.currency).to.equal('EUR');
+      expect(invoice.transactions).to.have.length(2);
+      expect(invoice.dateFrom).to.equal(startOctober2017ISOString);
+      expect(invoice.dateTo).to.equal(startNovember2017ISOString);
+    });
+  });
+});


### PR DESCRIPTION
# [Consolidated yearly invoice](https://github.com/opencollective/opencollective/issues/1783)

Until now all invoices were generated for one month intervals. This feature needs invoices generated for one year intervals, but this PR goes a step further and allows querying over an arbitrary date range.

This PR:
- adds a new graphql endpoint `InvoiceByDateRange`.
- defines a new graphql scalar type `IsoDateString` which is used for validating date strings.
- defines a new graphql input type `InvoiceInputType`, the type passed as an argument to the `InvoiceByDateRange` query and has shape:

```js
{
      dateFrom: { type: IsoDateString },
      dateTo: { type: IsoDateString },
      collectiveSlug: { type: GraphQLString },
      fromCollectiveSlug: { type: GraphQLString },
}
```
