### PR TITLE
Ability to query the collective of an host

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -525,6 +525,7 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
       isArchived: { type: GraphQLBoolean },
       isDeletable: { type: GraphQLBoolean },
       host: { type: CollectiveInterfaceType },
+      collective: { type: CollectiveInterfaceType },
       members: {
         type: new GraphQLList(MemberType),
         description:
@@ -904,6 +905,16 @@ const CollectiveFields = () => {
             );
         }
 
+        return null;
+      },
+    },
+    collective: {
+      description: 'A host might have a collective attached to it',
+      type: CollectiveInterfaceType,
+      resolve(collective, args, req) {
+        if (has(collective.settings, 'collective.id')) {
+          return req.loaders.collective.findById.load(get(collective.settings, 'collective.id'));
+        }
         return null;
       },
     },

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -525,7 +525,7 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
       isArchived: { type: GraphQLBoolean },
       isDeletable: { type: GraphQLBoolean },
       host: { type: CollectiveInterfaceType },
-      collective: { type: CollectiveInterfaceType },
+      hostCollective: { type: CollectiveInterfaceType },
       members: {
         type: new GraphQLList(MemberType),
         description:
@@ -908,12 +908,12 @@ const CollectiveFields = () => {
         return null;
       },
     },
-    collective: {
+    hostCollective: {
       description: 'A host might have a collective attached to it',
       type: CollectiveInterfaceType,
       resolve(collective, args, req) {
-        if (has(collective.settings, 'collective.id')) {
-          return req.loaders.collective.findById.load(get(collective.settings, 'collective.id'));
+        if (has(collective.settings, 'hostCollective.id')) {
+          return req.loaders.collective.findById.load(get(collective.settings, 'hostCollective.id'));
         }
         return null;
       },


### PR DESCRIPTION
To enable that, add the collective id to the host settings, ie: `{"hostCollective":{"id":83}}`.

Related:
https://github.com/opencollective/opencollective/issues/1884
https://github.com/opencollective/opencollective-frontend/pull/1622
