### PR TITLE
Use inclusive selector for dateTo in invoices

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -283,7 +283,7 @@ const queries = {
           { UsingVirtualCardFromCollectiveId: fromCollective.id },
         ],
         HostCollectiveId: host.id,
-        createdAt: { [Op.gte]: dateFrom, [Op.lt]: dateTo },
+        createdAt: { [Op.gte]: dateFrom, [Op.lte]: dateTo },
         type: 'CREDIT',
       };
 


### PR DESCRIPTION
It makes more sense for `dateTo` to be inclusive: if you ask for transactions from 1st January to 7th January, you expect transactions made on 7th January to be returned too.