### PR TITLE
Set tax to null instead of 0 if VAT is not applicable

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -421,7 +421,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
       quantity: order.quantity,
       totalAmount: order.totalAmount,
       currency,
-      taxAmount: order.taxAmount,
+      taxAmount: taxFromCountry ? order.taxAmount : null,
       interval: order.interval,
       description: order.description || defaultDescription,
       publicMessage: order.publicMessage,


### PR DESCRIPTION
This will clearly set a difference between "this host/tier has no tax applicable" and "this user doesn't pay taxes because they have a VAT number, or are not a taxed country...".

This is an important difference because we need to add a mention on the invoice when VAT wasn't applied because the client provided a VAT number. 