### PR TITLE
(fix): hide empty fields in email templates

### DIFF
--- a/templates/emails/collective.expense.approved.for.host.hbs
+++ b/templates/emails/collective.expense.approved.for.host.hbs
@@ -13,7 +13,9 @@ Subject: New expense approved on {{collective.name}}: {{{currency expense.amount
 <table>
   <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
   <tr><th>Payout method:</th><td>{{expense.payoutMethod}}</td></tr>
-  <tr><th valign="top">Private instructions:</th><td>{{expense.privateMessage}}</td></tr>
+  {{#if expense.privateMessage}}
+    <tr><th valign="top">Private instructions:</th><td>{{expense.privateMessage}}</td></tr>
+  {{/if}}
 </table>
 
 <br />

--- a/templates/emails/collective.expense.approved.hbs
+++ b/templates/emails/collective.expense.approved.hbs
@@ -16,7 +16,9 @@ Subject: Your expense to {{collective.name}} for {{{currency expense.amount curr
 <table>
   <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
   <tr><th>Payout method:</th><td>{{expense.payoutMethod}}</td></tr>
-  <tr><th valign="top">Private instructions:</th><td>{{expense.privateMessage}}</td></tr>
+  {{#if expense.privateMessage}}
+    <tr><th valign="top">Private instructions:</th><td>{{expense.privateMessage}}</td></tr>
+  {{/if}}
 </table>
 
 <br />

--- a/templates/emails/collective.member.created.hbs
+++ b/templates/emails/collective.member.created.hbs
@@ -61,11 +61,15 @@ Subject: {{member.memberCollective.name}} joined {{collective.name}} as {{{toLow
     {{/if}}
     <tr><th>Amount:</th><td>{{{currency order.totalAmount currency=order.currency}}}</td></tr>
     {{#if order.subscription}}
-    <tr><th>Frequency:</th><td>{{order.subscription.interval}}</td></tr>
+      {{#if order.subscription.interval}}
+        <tr><th>Frequency:</th><td>{{order.subscription.interval}}</td></tr>
+      {{/if}}
     {{else}}
     <tr><th>Frequency:</th><td>one time</td></tr>
     {{/if}}
+    {{#if order.publicMessage}}
     <tr><th>Public message:</th><td>{{order.publicMessage}}</td></tr>
+    {{/if}}
     {{#if order.referral}}
     <tr><th>Referral:</th><td><a href="{{config.host.website}}/{{order.referral.slug}}">{{order.referral.name}}</a> {{#if order.referral.twitterHandle}}<a href="https://twitter.com/{{order.referral.twitterHandle}}">@{{order.referral.twitterHandle}}</a>{{/if}}</td></tr>
     {{/if}}

--- a/templates/emails/collective.newmember.hbs
+++ b/templates/emails/collective.newmember.hbs
@@ -27,9 +27,15 @@ Subject: {{remoteUser.collective.name}} added you as a {{role}} to {{collective.
   <tr><th>Avatar:</th><td>No avatar</td></tr>
   {{/if}}
   <tr><th>Name:</th><td>{{recipient.collective.name}}</td></tr>
-  <tr><th>Short description:</th><td>{{recipient.collective.description}}</td></tr>
-  <tr><th>Website:</th><td>{{recipient.collective.website}}</td></tr>
-  <tr><th>Twitter:</th><td>{{recipient.collective.twitterHandle}}</td></tr>
+  {{#if recipient.collective.description}}
+    <tr><th>Short description:</th><td>{{recipient.collective.description}}</td></tr>
+  {{/if}}
+  {{#if recipient.collective.website}}
+    <tr><th>Website:</th><td>{{recipient.collective.website}}</td></tr>
+  {{/if}}
+  {{#if recipient.collective.twitterHandle}}
+    <tr><th>Twitter:</th><td>{{recipient.collective.twitterHandle}}</td></tr>
+  {{/if}}
 </table>
 
 <p>You can login and edit your profile by <a href="{{loginLink}}">clicking here</a></p>


### PR DESCRIPTION
This PR hides empty fields in email template as reported in [#1113](https://github.com/opencollective/opencollective/issues/1113).