### PR TITLE
Create a PM with correct currency when changing host

### DIFF
--- a/test/graphql.transaction.test.js.snap
+++ b/test/graphql.transaction.test.js.snap
@@ -19,7 +19,7 @@ Object {
           },
           "id": 20,
           "paymentMethod": Object {
-            "id": 12,
+            "id": 13,
             "name": null,
           },
           "subscription": null,
@@ -37,7 +37,7 @@ Object {
           },
           "id": 18,
           "paymentMethod": Object {
-            "id": 11,
+            "id": 12,
             "name": null,
           },
           "subscription": null,
@@ -55,7 +55,7 @@ Object {
           },
           "id": 16,
           "paymentMethod": Object {
-            "id": 10,
+            "id": 11,
             "name": null,
           },
           "subscription": null,
@@ -73,7 +73,7 @@ Object {
           },
           "id": 14,
           "paymentMethod": Object {
-            "id": 9,
+            "id": 10,
             "name": null,
           },
           "subscription": null,
@@ -91,7 +91,7 @@ Object {
           },
           "id": 12,
           "paymentMethod": Object {
-            "id": 8,
+            "id": 9,
             "name": null,
           },
           "subscription": null,
@@ -109,7 +109,7 @@ Object {
           },
           "id": 10,
           "paymentMethod": Object {
-            "id": 7,
+            "id": 8,
             "name": null,
           },
           "subscription": null,
@@ -127,7 +127,7 @@ Object {
           },
           "id": 8,
           "paymentMethod": Object {
-            "id": 6,
+            "id": 7,
             "name": null,
           },
           "subscription": null,
@@ -145,7 +145,7 @@ Object {
           },
           "id": 6,
           "paymentMethod": Object {
-            "id": 5,
+            "id": 6,
             "name": null,
           },
           "subscription": null,
@@ -163,7 +163,7 @@ Object {
           },
           "id": 4,
           "paymentMethod": Object {
-            "id": 4,
+            "id": 5,
             "name": null,
           },
           "subscription": null,
@@ -181,7 +181,7 @@ Object {
           },
           "id": 2,
           "paymentMethod": Object {
-            "id": 3,
+            "id": 4,
             "name": null,
           },
           "subscription": null,
@@ -223,7 +223,7 @@ Object {
           },
           "id": 4,
           "paymentMethod": Object {
-            "id": 4,
+            "id": 5,
             "name": null,
           },
           "subscription": null,
@@ -251,7 +251,7 @@ Object {
           },
           "id": 8,
           "paymentMethod": Object {
-            "id": 6,
+            "id": 7,
             "name": null,
           },
           "subscription": null,
@@ -279,7 +279,7 @@ Object {
           },
           "id": 12,
           "paymentMethod": Object {
-            "id": 8,
+            "id": 9,
             "name": null,
           },
           "subscription": null,
@@ -307,7 +307,7 @@ Object {
           },
           "id": 16,
           "paymentMethod": Object {
-            "id": 10,
+            "id": 11,
             "name": null,
           },
           "subscription": null,
@@ -335,7 +335,7 @@ Object {
           },
           "id": 20,
           "paymentMethod": Object {
-            "id": 12,
+            "id": 13,
             "name": null,
           },
           "subscription": null,
@@ -422,7 +422,7 @@ Object {
           },
           "id": 6,
           "paymentMethod": Object {
-            "id": 5,
+            "id": 6,
             "name": null,
           },
           "subscription": null,
@@ -472,7 +472,7 @@ Object {
           },
           "id": 2,
           "paymentMethod": Object {
-            "id": 3,
+            "id": 4,
             "name": null,
           },
           "subscription": null,
@@ -513,7 +513,7 @@ Object {
           },
           "id": 18,
           "paymentMethod": Object {
-            "id": 11,
+            "id": 12,
             "name": null,
           },
           "subscription": null,
@@ -540,7 +540,7 @@ Object {
           },
           "id": 14,
           "paymentMethod": Object {
-            "id": 9,
+            "id": 10,
             "name": null,
           },
           "subscription": null,
@@ -567,7 +567,7 @@ Object {
           },
           "id": 10,
           "paymentMethod": Object {
-            "id": 7,
+            "id": 8,
             "name": null,
           },
           "subscription": null,
@@ -594,7 +594,7 @@ Object {
           },
           "id": 6,
           "paymentMethod": Object {
-            "id": 5,
+            "id": 6,
             "name": null,
           },
           "subscription": null,
@@ -621,7 +621,7 @@ Object {
           },
           "id": 2,
           "paymentMethod": Object {
-            "id": 3,
+            "id": 4,
             "name": null,
           },
           "subscription": null,
@@ -685,7 +685,7 @@ Object {
           },
           "id": 18,
           "paymentMethod": Object {
-            "id": 11,
+            "id": 12,
             "name": null,
           },
           "subscription": null,
@@ -735,7 +735,7 @@ Object {
           },
           "id": 14,
           "paymentMethod": Object {
-            "id": 9,
+            "id": 10,
             "name": null,
           },
           "subscription": null,
@@ -762,7 +762,7 @@ Object {
           },
           "id": 10,
           "paymentMethod": Object {
-            "id": 7,
+            "id": 8,
             "name": null,
           },
           "subscription": null,
@@ -835,7 +835,7 @@ Object {
           },
           "id": 6,
           "paymentMethod": Object {
-            "id": 5,
+            "id": 6,
             "name": null,
           },
           "subscription": null,
@@ -885,7 +885,7 @@ Object {
           },
           "id": 2,
           "paymentMethod": Object {
-            "id": 3,
+            "id": 4,
             "name": null,
           },
           "subscription": null,
@@ -912,7 +912,7 @@ Object {
           },
           "id": 20,
           "paymentMethod": Object {
-            "id": 12,
+            "id": 13,
             "name": null,
           },
           "subscription": null,
@@ -985,7 +985,7 @@ Object {
           },
           "id": 16,
           "paymentMethod": Object {
-            "id": 10,
+            "id": 11,
             "name": null,
           },
           "subscription": null,
@@ -1035,7 +1035,7 @@ Object {
           },
           "id": 12,
           "paymentMethod": Object {
-            "id": 8,
+            "id": 9,
             "name": null,
           },
           "subscription": null,
@@ -1085,7 +1085,7 @@ Object {
           },
           "id": 8,
           "paymentMethod": Object {
-            "id": 6,
+            "id": 7,
             "name": null,
           },
           "subscription": null,
@@ -1112,7 +1112,7 @@ Object {
           },
           "id": 4,
           "paymentMethod": Object {
-            "id": 4,
+            "id": 5,
             "name": null,
           },
           "subscription": null,
@@ -1187,7 +1187,7 @@ Object {
       },
       "id": 2,
       "paymentMethod": Object {
-        "id": 3,
+        "id": 4,
         "name": null,
       },
       "subscription": null,
@@ -1350,7 +1350,7 @@ Object {
         },
         "id": 18,
         "paymentMethod": Object {
-          "id": 11,
+          "id": 12,
           "name": null,
         },
         "subscription": null,
@@ -1377,7 +1377,7 @@ Object {
         },
         "id": 14,
         "paymentMethod": Object {
-          "id": 9,
+          "id": 10,
           "name": null,
         },
         "subscription": null,
@@ -1404,7 +1404,7 @@ Object {
         },
         "id": 10,
         "paymentMethod": Object {
-          "id": 7,
+          "id": 8,
           "name": null,
         },
         "subscription": null,
@@ -1431,7 +1431,7 @@ Object {
         },
         "id": 6,
         "paymentMethod": Object {
-          "id": 5,
+          "id": 6,
           "name": null,
         },
         "subscription": null,
@@ -1458,7 +1458,7 @@ Object {
         },
         "id": 2,
         "paymentMethod": Object {
-          "id": 3,
+          "id": 4,
           "name": null,
         },
         "subscription": null,
@@ -1485,7 +1485,7 @@ Object {
         },
         "id": 20,
         "paymentMethod": Object {
-          "id": 12,
+          "id": 13,
           "name": null,
         },
         "subscription": null,
@@ -1512,7 +1512,7 @@ Object {
         },
         "id": 16,
         "paymentMethod": Object {
-          "id": 10,
+          "id": 11,
           "name": null,
         },
         "subscription": null,
@@ -1539,7 +1539,7 @@ Object {
         },
         "id": 12,
         "paymentMethod": Object {
-          "id": 8,
+          "id": 9,
           "name": null,
         },
         "subscription": null,
@@ -1566,7 +1566,7 @@ Object {
         },
         "id": 8,
         "paymentMethod": Object {
-          "id": 6,
+          "id": 7,
           "name": null,
         },
         "subscription": null,
@@ -1593,7 +1593,7 @@ Object {
         },
         "id": 4,
         "paymentMethod": Object {
-          "id": 4,
+          "id": 5,
           "name": null,
         },
         "subscription": null,


### PR DESCRIPTION
This PR resolve the last part of https://github.com/opencollective/opencollective/issues/1914
It is also the root cause for https://github.com/opencollective/opencollective/issues/1865

As of today if a collective changes host then its `currency` is changed to the host currency, but the `collective` PaymentMethod linked to it is not updated.

With this PR, the `collective` payment method is marked as deleted and we create a new one with the host's currency.

Not only this will fix the bug but it is also a clearer separation of concerns.