### PR TITLE
remove custom template for ticket confirmed for sustain

### DIFF
--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -249,7 +249,7 @@ const generateEmailFromTemplate = (template, recipient, data = {}, options = {})
   }
 
   if (template === 'ticket.confirmed') {
-    if (slug === 'sustainoss') template += '.sustainoss';
+    // if (slug === 'sustainoss') template += '.sustainoss';
     if (slug === 'fearlesscitiesbrussels') template += '.fearlesscitiesbrussels';
   }
   if (template.match(/^host\.(monthly|yearly)report$/)) {


### PR DESCRIPTION
We just created a community event for Sustain: https://opencollective.com/sustainoss/events/sustain-community-meetup-442ev

But it is still sending the old custom template that we did for the Summit in London.

This PR makes sure that we fall back to the default confirmation email.