### PR TITLE
Fixes on PayPal adaptive

### DIFF
--- a/migrations/20190418080351-set-paypal-adaptive-type.js
+++ b/migrations/20190418080351-set-paypal-adaptive-type.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * `migrations/20171214165000-add-payment-type.js` properly set the type to 'adaptive'
+ * for PayPal adaptive payment methods, but the change was not reflected in the code,
+ * thus all PayPal pre-approvals generated after 2017-12-14 have not type set.
+ */
+module.exports = {
+  up: queryInterface => {
+    return queryInterface.sequelize.query(`
+      UPDATE "PaymentMethods"
+      SET type = 'adaptive'
+      WHERE type is NULL and service = 'paypal'
+    `);
+  },
+
+  down: () => {
+    /* No downgrade possible */
+  },
+};

--- a/migrations/20190418094738-invalidate-old-paypal-adaptive-pms.js
+++ b/migrations/20190418094738-invalidate-old-paypal-adaptive-pms.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * This migration will invalidate all paypal adaptives that are not used anymore.
+ */
+module.exports = {
+  up: queryInterface => {
+    return queryInterface.sequelize.query(`
+      UPDATE "PaymentMethods"
+      SET "deletedAt" = NOW()
+      WHERE id IN (
+        SELECT id FROM "PaymentMethods" pm 
+        WHERE service = 'paypal'
+        AND ("type" IS NULL OR "type" = 'adaptive')
+        AND pm."deletedAt" IS NULL
+        AND id NOT IN (
+          SELECT max(id) AS id FROM "PaymentMethods" pm 
+          WHERE service = 'paypal'
+          AND ("type" IS NULL OR "type" = 'adaptive')
+          AND pm."deletedAt" IS NULL
+          GROUP BY "CollectiveId"
+        )
+      )
+    `);
+  },
+
+  down: () => {
+    /* No downgrade possible */
+  },
+};

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -234,7 +234,6 @@ async function payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, fe
       expense.paypalEmail,
       paymentMethod.token,
     );
-    paymentMethod.updateBalance();
     await createTransactionFromPaidExpense(
       host,
       paymentMethod,
@@ -246,6 +245,7 @@ async function payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, fe
       fees.platformFeeInHostCurrency,
     );
     expense.setPaid(remoteUser.id);
+    await paymentMethod.updateBalance();
   } catch (err) {
     debug('paypal> error', JSON.stringify(err, null, '  '));
     if (

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -367,7 +367,9 @@ export default function(Sequelize, DataTypes) {
    * Updates the paymentMethod.data with the balance on the preapproved paypal card
    */
   PaymentMethod.prototype.updateBalance = async function() {
-    if (!this.service !== 'paypal') throw new Error('Can only update balance for paypal preapproved cards');
+    if (this.service !== 'paypal') {
+      throw new Error('Can only update balance for paypal preapproved cards');
+    }
     const paymentProvider = libpayments.findPaymentMethodProvider(this);
     return await paymentProvider.updateBalance(this);
   };

--- a/server/paymentProviders/paypal/index.js
+++ b/server/paymentProviders/paypal/index.js
@@ -96,6 +96,7 @@ export default {
             CreatedByUserId: remoteUser.id,
             currency: collective.currency,
             service: 'paypal',
+            type: 'adaptive',
             CollectiveId,
             token: response.preapprovalKey,
             data: {

--- a/server/paymentProviders/paypal/index.js
+++ b/server/paymentProviders/paypal/index.js
@@ -166,7 +166,7 @@ export default {
                     service: 'paypal',
                     type: 'adaptive',
                     CollectiveId: paymentMethod.CollectiveId,
-                    token: { [Op.ne]: req.query.preapprovalkey },
+                    id: { [Op.ne]: paymentMethod.id },
                   },
                 }),
               )

--- a/server/paymentProviders/paypal/index.js
+++ b/server/paymentProviders/paypal/index.js
@@ -113,6 +113,7 @@ export default {
       return models.PaymentMethod.findOne({
         where: {
           service: 'paypal',
+          type: 'adaptive',
           token: req.query.preapprovalKey,
         },
         order: [['createdAt', 'DESC']],
@@ -163,6 +164,7 @@ export default {
                 models.PaymentMethod.findAll({
                   where: {
                     service: 'paypal',
+                    type: 'adaptive',
                     CollectiveId: paymentMethod.CollectiveId,
                     token: { [Op.ne]: req.query.preapprovalkey },
                   },
@@ -188,6 +190,7 @@ export default {
       const pm = await models.PaymentMethod.findOne({
         where: {
           service: 'paypal',
+          type: 'adaptive',
           token: req.query.preapprovalKey,
         },
         order: [['createdAt', 'DESC']],

--- a/test/graphql.paymentMethods.test.js
+++ b/test/graphql.paymentMethods.test.js
@@ -325,7 +325,7 @@ describe('graphql.paymentMethods.test.js', () => {
     before(() => {
       preapprovalDetailsStub = sinon.stub(paypalAdaptive, 'preapprovalDetails').callsFake(() => {
         return Promise.resolve({
-          ...paypalMock.adaptive.preapprovalDetails.created,
+          ...paypalMock.adaptive.preapprovalDetails.completed,
           curPaymentsAmount: '12.50',
           maxTotalAmountOfAllPayments: '2000.00',
         });


### PR DESCRIPTION
## Properly invalidate old pre-approvals 

There was a typo in the code for almost [two years](https://github.com/opencollective/opencollective-api/commit/202567edb5c3b1914179d95af44b5bbae9632384#diff-acfa91efcaa89b8ce2d7627de0c7d244R156 ) (`preapprovalkey` instead of `preapprovalKey`) so the code to delete old pre-approvals never worked.

As a consequence and because we were calculating balance for all `LoggedInUser`'s payment methods (see https://github.com/opencollective/opencollective-api/pull/1907) **every call to `LoggedInUser` for an Admin of the Open Source collective was triggering 209 calls to `getBalance` of old payment methods**, each one requesting the full history of the transactions for this payment method to calculate the balance.

## Fix updateBalance

I found out that a feature to fetch PayPal balance had already been implemented [in the past](https://github.com/opencollective/opencollective-api/commit/4488af9f27552f9f75d6e9a0d3f247fb0ba16797#diff-c1db1fb770be3dd8faa360b7605a5e35R354) but there's no chance it ever worked:

```es6
if (!this.service !== 'paypal') throw new Error('Can only update balance for paypal preapproved cards');
```

## Properly set payment method type to adaptive when required

[Two years ago](https://github.com/opencollective/opencollective-api/pull/1062/files#diff-4225408821aef7005b29621de466b31a) the `type` was to 'adaptive' for PayPal adaptive payment methods, but the change was not reflected in the code thus all PayPal pre-approvals generated after 2017-12-14 had not type set.

## Improve PayPal adaptive queries

We were not filtering on `type=adaptive` in `server/paymentProviders/paypal/index.js` so we could have encountered bugs if a host has a PayPal PM for paying and another for payouts.

---

# Side note

- The code for pre-approvals is messy and badly documented. We should have a plan to refactor this.

- `server/paymentProviders/paypal/index.js` and `server/paymentProviders/paypal/adaptive.js` actually refers to the same thing. The code from `server/paymentProviders/paypal/index.js` should be migrated.