### PR TITLE
Introduce minimum amount in Tier management

### DIFF
--- a/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
+++ b/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
@@ -26,10 +26,12 @@ module.exports = {
           let minimumAmount = null;
           if (!presets && amount) {
             minimumAmount = amount;
-          } else if (presets && !amount) {
+          } else if (presets && presets.length > 0 && !amount) {
             minimumAmount = Math.min(...presets);
-          } else if (presets && amount) {
+          } else if (presets && presets.length > 0 && amount) {
             minimumAmount = Math.min(amount, ...presets);
+          } else if (presets.length === 0 && amount) {
+            minimumAmount = amount;
           }
 
           return queryInterface.sequelize.query(

--- a/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
+++ b/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
@@ -1,0 +1,64 @@
+'use strict';
+import { map } from 'bluebird';
+const colName = 'minimumAmount';
+
+/**
+ * Add a `minimumAmount` column to tiers to remove ambiguity.
+ */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const colParams = {
+      type: Sequelize.INTEGER,
+    };
+
+    return queryInterface
+      .addColumn('Tiers', colName, colParams)
+      .then(() => {
+        return queryInterface.sequelize.query(`
+        SELECT * FROM "Tiers"
+      `);
+      })
+      .then(results => {
+        const tiers = results[0];
+        return map(tiers, tier => {
+          const presets = tier.presets;
+          const amount = tier.amount;
+          let minimumAmount = null;
+          if (!presets && amount) {
+            minimumAmount = amount;
+          } else if (presets && !amount) {
+            minimumAmount = Math.min(presets[0], presets[1]);
+          } else if (presets && amount) {
+            minimumAmount = Math.min(amount, presets[0]);
+          }
+
+          return queryInterface.sequelize.query(
+            `
+          UPDATE "Tiers"
+            SET "minimumAmount" = :minimumAmount
+          WHERE "id" = :tierId
+        `,
+            {
+              replacements: {
+                minimumAmount,
+                tierId: tier.id,
+              },
+            },
+          );
+        });
+      })
+      .then(() => {
+        console.log('>>> Done!');
+      })
+      .catch(async err => {
+        // Remove the table if any error occur in the process
+        // to prevent having inconsistent data
+        await queryInterface.removeColumn('Tiers', colName);
+        throw err;
+      });
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('Tiers', colName);
+  },
+};

--- a/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
+++ b/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
@@ -27,9 +27,9 @@ module.exports = {
           if (!presets && amount) {
             minimumAmount = amount;
           } else if (presets && !amount) {
-            minimumAmount = Math.min(presets[0], presets[1]);
+            minimumAmount = Math.min(...presets);
           } else if (presets && amount) {
-            minimumAmount = Math.min(amount, presets[0]);
+            minimumAmount = Math.min(amount, ...presets);
           }
 
           return queryInterface.sequelize.query(

--- a/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
+++ b/migrations/20190418120035-add_minmumAmount_column_to_tiers.js
@@ -24,13 +24,11 @@ module.exports = {
           const presets = tier.presets;
           const amount = tier.amount;
           let minimumAmount = null;
-          if (!presets && amount) {
-            minimumAmount = amount;
+          if (presets && presets.length > 0 && amount) {
+            minimumAmount = Math.min(amount, ...presets);
           } else if (presets && presets.length > 0 && !amount) {
             minimumAmount = Math.min(...presets);
-          } else if (presets && presets.length > 0 && amount) {
-            minimumAmount = Math.min(amount, ...presets);
-          } else if (presets.length === 0 && amount) {
+          } else if (amount) {
             minimumAmount = amount;
           }
 

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -242,6 +242,7 @@ export const TierInputType = new GraphQLInputObjectType({
     presets: { type: new GraphQLList(GraphQLInt) },
     interval: { type: GraphQLString },
     maxQuantity: { type: GraphQLInt },
+    minimumAmount: { type: GraphQLInt },
     maxQuantityPerUser: { type: GraphQLInt },
     goal: {
       type: GraphQLInt,

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -393,7 +393,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
     // If using a tier, amount can never be less than the minimum amount
     if (tier && tier.presets) {
-      const minValue = tier.minimumAmount || min(isNil(tier.amount) ? tier.presets : [...tier.presets, tier.amount]);
+      const minValue = tier.minimumAmount;
       const minAmount = minValue * order.quantity;
       const minTotalAmount = taxPercent ? Math.round(minAmount * (1 + taxPercent / 100)) : minAmount;
       if ((order.totalAmount || 0) < minTotalAmount) {

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -3,7 +3,7 @@ import uuidv4 from 'uuid/v4';
 import debugLib from 'debug';
 import md5 from 'md5';
 import Promise from 'bluebird';
-import { pick, omit, get, min, isNil } from 'lodash';
+import { pick, omit, get, isNil } from 'lodash';
 import config from 'config';
 import * as LibTaxes from '@opencollective/taxes';
 

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -393,7 +393,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
     // If using a tier, amount can never be less than the minimum amount
     if (tier && tier.presets) {
-      const minValue = min(isNil(tier.amount) ? tier.presets : [...tier.presets, tier.amount]);
+      const minValue = tier.minimumAmount || min(isNil(tier.amount) ? tier.presets : [...tier.presets, tier.amount]);
       const minAmount = minValue * order.quantity;
       const minTotalAmount = taxPercent ? Math.round(minAmount * (1 + taxPercent / 100)) : minAmount;
       if ((order.totalAmount || 0) < minTotalAmount) {

--- a/server/graphql/v1/mutations/tiers.js
+++ b/server/graphql/v1/mutations/tiers.js
@@ -1,3 +1,4 @@
+import { map } from 'lodash';
 import errors from '../../../lib/errors';
 
 export function editTiers(_, args, req) {
@@ -5,6 +6,21 @@ export function editTiers(_, args, req) {
   if (!req.remoteUser) {
     throw new errors.Unauthorized('You need to be logged in to edit tiers');
   }
+
+  const tiers = map(args.tiers, tier => {
+    if (!tier.minimumAmount) {
+      if (tier.presets && tier.presets.length > 0 && tier.amount) {
+        tier.minimumAmount = Math.min(tier.amount, ...tier.presets);
+      } else if (tier.presets && tier.presets.length > 0 && !tier.amount) {
+        tier.minimumAmount = Math.min(...tier.presets);
+      } else if (!tier.presets && tier.amount) {
+        tier.minimumAmount = tier.amount;
+      } else if (tier.presets.length === 0 && tier.amount) {
+        tier.minimumAmount = tier.amount;
+      }
+    }
+    return tier;
+  });
 
   return req.loaders.collective.findById
     .load(args.id)
@@ -19,5 +35,5 @@ export function editTiers(_, args, req) {
           `You need to be logged in as a core contributor or as a host of the ${collective.name} collective`,
         );
     })
-    .then(() => collective.editTiers(args.tiers));
+    .then(() => collective.editTiers(tiers));
 }

--- a/server/graphql/v1/mutations/tiers.js
+++ b/server/graphql/v1/mutations/tiers.js
@@ -8,7 +8,8 @@ export function editTiers(_, args, req) {
   }
 
   const tiers = map(args.tiers, tier => {
-    if (!tier.minimumAmount) {
+    // Compute a minimumAmount if no one is passed
+    if (typeof tier.minimumAmount === 'undefined') {
       if (tier.presets && tier.presets.length > 0 && tier.amount) {
         tier.minimumAmount = Math.min(tier.amount, ...tier.presets);
       } else if (tier.presets && tier.presets.length > 0 && !tier.amount) {
@@ -16,6 +17,10 @@ export function editTiers(_, args, req) {
       } else if (tier.amount) {
         tier.minimumAmount = tier.amount;
       }
+    }
+    // Make minimumAmount null if it's falsey (likely 0)
+    if (!tier.minimumAmount) {
+      tier.minimumAmount = null;
     }
     return tier;
   });

--- a/server/graphql/v1/mutations/tiers.js
+++ b/server/graphql/v1/mutations/tiers.js
@@ -13,9 +13,7 @@ export function editTiers(_, args, req) {
         tier.minimumAmount = Math.min(tier.amount, ...tier.presets);
       } else if (tier.presets && tier.presets.length > 0 && !tier.amount) {
         tier.minimumAmount = Math.min(...tier.presets);
-      } else if (!tier.presets && tier.amount) {
-        tier.minimumAmount = tier.amount;
-      } else if (tier.presets.length === 0 && tier.amount) {
+      } else if (tier.amount) {
         tier.minimumAmount = tier.amount;
       }
     }

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -964,6 +964,12 @@ export const TierType = new GraphQLObjectType({
           return tier.amount;
         },
       },
+      minimumAmount: {
+        type: GraphQLInt,
+        resolve(tier) {
+          return tier.minimumAmount;
+        },
+      },
       currency: {
         type: GraphQLString,
         resolve(tier) {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -78,6 +78,7 @@ export const defaultTiers = (HostCollectiveId, currency) => {
       presets: [500, 1000, 2500, 5000],
       interval: 'month',
       currency: currency,
+      minimumAmount: 500,
     });
     tiers.push({
       type: 'TIER',
@@ -87,6 +88,7 @@ export const defaultTiers = (HostCollectiveId, currency) => {
       presets: [10000, 25000, 50000],
       interval: 'month',
       currency: currency,
+      minimumAmount: 10000,
     });
   }
   return tiers;

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -71,6 +71,9 @@ export default function(Sequelize, DataTypes) {
 
       minimumAmount: {
         type: DataTypes.INTEGER,
+        validate: {
+          min: 0,
+        },
       },
 
       currency: CustomDataTypes(DataTypes).currency,

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -69,6 +69,10 @@ export default function(Sequelize, DataTypes) {
         type: DataTypes.ARRAY(DataTypes.INTEGER),
       },
 
+      minimumAmount: {
+        type: DataTypes.INTEGER,
+      },
+
       currency: CustomDataTypes(DataTypes).currency,
 
       interval: {

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -169,13 +169,7 @@ export default function(Sequelize, DataTypes) {
         },
 
         amountStr() {
-          let str;
-          if (this.presets) {
-            const minimumAmount = Math.min(this.presets[0], this.amount);
-            str = `${formatCurrency(minimumAmount, this.currency)}+`;
-          } else {
-            str = formatCurrency(this.amount, this.currency);
-          }
+          let str = `${formatCurrency(this.minimumAmount, this.currency)}+`;
           if (this.interval) {
             str += ` per ${this.interval}`;
           }


### PR DESCRIPTION
This PR introduces `minimumAmount` to tier data replacing the need to use `Min(amount, presets[0])`. 

Ref ([#1938](https://github.com/opencollective/opencollective/issues/1938))
