### PR TITLE
Fix host collectives GraphQL error

### DIFF
--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -355,8 +355,7 @@ const getCollectivesWithBalance = async (where = {}, options) => {
     sequelize.query(`${sql(allFields)} LIMIT ${limit} OFFSET ${offset}`, params),
   ]);
 
-  const total = totalResult ? get(totalResult, 'dataValues.total') : 0;
-
+  const total = get(totalResult, 'dataValues.total', 0);
   return { total, collectives };
 };
 

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -350,17 +350,12 @@ const getCollectivesWithBalance = async (where = {}, options) => {
     ORDER BY ${orderBy} ${orderDirection} NULLS LAST
   `.replace(/\s\s+/g, ' '); // remove the new lines and save log space
 
-  const [
-    [
-      {
-        dataValues: { total },
-      },
-    ],
-    collectives,
-  ] = await Promise.all([
+  const [[totalResult], collectives] = await Promise.all([
     sequelize.query(`${sql('COUNT(c.*) OVER() as "total"')} LIMIT 1`, params),
     sequelize.query(`${sql(allFields)} LIMIT ${limit} OFFSET ${offset}`, params),
   ]);
+
+  const total = totalResult ? get(totalResult, 'dataValues.total') : 0;
 
   return { total, collectives };
 };


### PR DESCRIPTION
This PR removes `dataValues` destructure causing the error and followed existing pattern used by other methods.
Ref([#1926](https://github.com/opencollective/opencollective/issues/1926))