### PR TITLE
fix(graphql): add isActive condition to host collective stat

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -184,7 +184,7 @@ export const CollectivesStatsType = new GraphQLObjectType({
               {
                 model: models.Collective,
                 as: 'collective',
-                where: { type: types.COLLECTIVE },
+                where: { type: types.COLLECTIVE, isActive: true },
               },
             ],
           });


### PR DESCRIPTION
In order to hide "We are hosting X collectives" , this PR adds `isActive: true` to the host collective stat. 

Ref([#1990](https://github.com/opencollective/opencollective/issues/1990))