### PR TITLE
Validate tier default amount is not negative

### DIFF
--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -63,7 +63,9 @@ export default function(Sequelize, DataTypes) {
 
       amount: {
         type: DataTypes.INTEGER, // In cents
-        min: 0,
+        validate: {
+          min: 0,
+        },
       },
 
       presets: {

--- a/test/tier.model.test.js
+++ b/test/tier.model.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { SequelizeValidationError } from 'sequelize';
 import models from '../server/models';
 import * as utils from '../test/utils';
 
@@ -82,4 +83,28 @@ describe('Collective model', () => {
       .then(available => {
         expect(available).to.be.false;
       }));
+
+  describe('amount', () => {
+    it('cannot have a negative value', () => {
+      return expect(
+        models.Tier.create({
+          type: 'TIER',
+          name: 'sponsor',
+          amount: -5,
+          interval: 'year',
+        }),
+      ).to.be.rejectedWith(SequelizeValidationError, 'Validation min on amount failed');
+    });
+
+    it('can have a null value', () => {
+      return expect(
+        models.Tier.create({
+          type: 'TIER',
+          name: 'sponsor',
+          amount: null,
+          interval: 'year',
+        }),
+      ).to.be.fulfilled;
+    });
+  });
 });


### PR DESCRIPTION
Following up on https://github.com/opencollective/opencollective-api/pull/1919#discussion_r281251716

An attempt at validating tier's `amount` to ensure that the value is always positive was added in https://github.com/opencollective/opencollective-api/commit/616100eedd229548224810f599539846d81ce9e3 but it wasn't properly implemented.

This PR adds unit tests for the model to ensure we properly cover the validation.