### PR TITLE
Applications management improvements

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -44,6 +44,7 @@
       "update": 10,
       "confirmToken": 15
     },
+    "maxNumberOfAppsPerUser": 15,
     "maxWebhooksPerUserPerCollective": 50
   },
   "email": {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -538,20 +538,6 @@ const mutations = {
       return applicationMutations.createApplication(_, args, req);
     },
   },
-  updateApplication: {
-    type: ApplicationType,
-    args: {
-      id: {
-        type: new GraphQLNonNull(GraphQLString),
-      },
-      application: {
-        type: new GraphQLNonNull(ApplicationInputType),
-      },
-    },
-    resolve(_, args, req) {
-      return applicationMutations.updateApplication(_, args, req);
-    },
-  },
   deleteApplication: {
     type: ApplicationType,
     args: {

--- a/server/graphql/v1/mutations/applications.js
+++ b/server/graphql/v1/mutations/applications.js
@@ -41,33 +41,16 @@ export async function createApplication(_, args, req) {
   return app;
 }
 
-export async function updateApplication(_, args, req) {
-  const app = await Application.findByPk(args.id);
-  if (!app) {
-    throw new errors.NotFound({
-      message: `Application with id ${args.id} not found`,
-    });
-  }
-
-  if (!req.remoteUser) {
-    throw new errors.Unauthorized('You need to be authenticated to update an application.');
-  } else if (req.remoteUser.id !== app.CreatedByUserId) {
-    throw new errors.Forbidden('Authenticated user is not the application owner.');
-  }
-
-  return await app.update(args.application);
-}
-
 export async function deleteApplication(_, args, req) {
+  if (!req.remoteUser) {
+    throw new errors.Unauthorized('You need to be authenticated to delete an application.');
+  }
+
   const app = await Application.findByPk(args.id);
   if (!app) {
     throw new errors.NotFound({
       message: `Application with id ${args.id} not found`,
     });
-  }
-
-  if (!req.remoteUser) {
-    throw new errors.Unauthorized('You need to be authenticated to update an application.');
   } else if (req.remoteUser.id !== app.CreatedByUserId) {
     throw new errors.Forbidden('Authenticated user is not the application owner.');
   }


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-frontend/pull/1749

- Remove `updateApplication` query (was unused)
- Add a limit on the number of applications per user (default=15)