### PR TITLE
Fix tests and permissions checks for webhooks

### DIFF
--- a/server/graphql/v1/mutations/notifications.js
+++ b/server/graphql/v1/mutations/notifications.js
@@ -97,13 +97,15 @@ export async function createWebhook(args, remoteUser) {
  * Deletes a notification by ID.
  */
 export async function deleteNotification(args, remoteUser) {
-  if (!(remoteUser && remoteUser.isAdmin(args.collectiveId))) {
+  if (!remoteUser) {
     throw new Unauthorized({ message: 'You need to be logged in as admin to delete a notification.' });
   }
 
   const notification = await models.Notification.findOne({ where: { id: args.id } });
   if (!notification) {
     throw new NotFound({ message: `Notification with ID ${args.id} not found.` });
+  } else if (!remoteUser.isAdmin(notification.CollectiveId)) {
+    throw new Unauthorized({ message: 'You need to be logged in as admin to delete this notification.' });
   }
 
   if (!(remoteUser.id === notification.UserId || remoteUser.isAdmin(notification.CollectiveId))) {

--- a/test/graphql.notifications.test.js
+++ b/test/graphql.notifications.test.js
@@ -4,7 +4,7 @@ import config from 'config';
 import * as utils from './utils';
 import models from '../server/models';
 import channels from '../server/constants/channels';
-import { activities } from '../server/constants';
+import { activities, roles } from '../server/constants';
 import { randUrl } from './features/support/stores';
 
 describe('graphql.notifications.test', () => {
@@ -20,6 +20,9 @@ describe('graphql.notifications.test', () => {
 
   // Create test collective
   beforeEach(() => models.Collective.create(utils.data('collective1')).tap(c => (collective1 = c)));
+
+  // Set `user1` as collective admin
+  beforeEach(() => collective1.addUserWithRole(user1, roles.ADMIN));
 
   // Create test notification
   beforeEach(() =>
@@ -140,7 +143,7 @@ describe('graphql.notifications.test', () => {
       const result = await utils.graphqlQuery(deleteWebhookQuery, { id: notification.id });
 
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal('You need to be logged in to delete a notification.');
+      expect(result.errors[0].message).to.equal('You need to be logged in as admin to delete a notification.');
       return models.Notification.findByPk(notification.id).then(notification => {
         expect(notification).to.not.be.null;
       });
@@ -157,9 +160,7 @@ describe('graphql.notifications.test', () => {
       const result = await utils.graphqlQuery(deleteWebhookQuery, { id: notification.id }, user2);
 
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal(
-        "This notification does not exist or you don't have the permission to edit it.",
-      );
+      expect(result.errors[0].message).to.equal('You need to be logged in as admin to delete this notification.');
       return models.Notification.findByPk(notification.id).then(notification => {
         expect(notification).to.not.be.null;
       });


### PR DESCRIPTION
Merging https://github.com/opencollective/opencollective-api/pull/1854 broke the tests on `master`. We missed it because CI doesn't run on forks.

Also fixes the permission check on `deleteNotification` which wasn't working.