### PR TITLE
Tier API validation

### DIFF
--- a/migrations/20190509094659-add-amountType-column-to-tiers.js
+++ b/migrations/20190509094659-add-amountType-column-to-tiers.js
@@ -1,0 +1,58 @@
+'use strict';
+import { map } from 'bluebird';
+
+const colName = 'amountType';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const colParams = {
+      type: Sequelize.ENUM('FLEXIBLE', 'FIXED'),
+    };
+
+    return queryInterface
+      .addColumn('Tiers', colName, colParams)
+      .then(() => {
+        return queryInterface.sequelize.query(`
+          SELECT * FROM "Tiers"
+        `);
+      })
+      .then(results => {
+        const tiers = results[0];
+        return map(tiers, tier => {
+          const presets = tier.presets;
+          let amountType;
+          if (presets) {
+            amountType = 'FLEXIBLE';
+          } else {
+            amountType = 'FIXED';
+          }
+          return queryInterface.sequelize.query(
+            `
+              UPDATE "Tiers"
+                SET "amountType" = :amountType
+              WHERE "id" = :tierId
+            `,
+            {
+              replacements: {
+                amountType,
+                tierId: tier.id,
+              },
+            },
+          );
+        });
+      })
+      .then(() => {
+        console.log('>>> Done!');
+      })
+      .catch(async err => {
+        // Remove the table if any error occur in the process
+        // to prevent having inconsistent data
+        await queryInterface.removeColumn('Tiers', colName);
+        throw err;
+      });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Tiers', colName);
+  },
+};

--- a/migrations/20190509094659-add-amountType-column-to-tiers.js
+++ b/migrations/20190509094659-add-amountType-column-to-tiers.js
@@ -13,33 +13,17 @@ module.exports = {
       .addColumn('Tiers', colName, colParams)
       .then(() => {
         return queryInterface.sequelize.query(`
-          SELECT * FROM "Tiers"
+          UPDATE "Tiers"
+            SET "amountType" = 'FIXED'
+          WHERE "presets" IS NULL
         `);
       })
-      .then(results => {
-        const tiers = results[0];
-        return map(tiers, tier => {
-          const presets = tier.presets;
-          let amountType;
-          if (presets) {
-            amountType = 'FLEXIBLE';
-          } else {
-            amountType = 'FIXED';
-          }
-          return queryInterface.sequelize.query(
-            `
-              UPDATE "Tiers"
-                SET "amountType" = :amountType
-              WHERE "id" = :tierId
-            `,
-            {
-              replacements: {
-                amountType,
-                tierId: tier.id,
-              },
-            },
-          );
-        });
+      .then(() => {
+        return queryInterface.sequelize.query(`
+          UPDATE "Tiers"
+            SET "amountType" = 'FLEXIBLE'
+          WHERE "presets" IS NOT NULL
+        `);
       })
       .then(() => {
         console.log('>>> Done!');

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -262,6 +262,7 @@ export const TierInputType = new GraphQLInputObjectType({
     interval: { type: GraphQLString },
     maxQuantity: { type: GraphQLInt },
     minimumAmount: { type: GraphQLInt },
+    amountType: { type: GraphQLString },
     maxQuantityPerUser: { type: GraphQLInt },
     goal: {
       type: GraphQLInt,

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -391,7 +391,7 @@ export function editCollective(_, args, req) {
     }
 
     const amountType = tier.amountType;
-    const minPreset = Math.min(...presets);
+    const minPreset = presets ? Math.min(...presets) : null;
 
     if (!name || name.trim().length === 0) {
       throw new Error('Name field is required for all tiers');

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -382,9 +382,14 @@ export function editCollective(_, args, req) {
 
   const tiers = args.collective.tiers;
   forEach(tiers, tier => {
-    const presets = tier.presets || [];
+    const presets = tier.presets;
     const amount = tier.amount;
     const name = tier.name;
+
+    if (!tier.amountType) {
+      tier.amountType = presets ? 'FLEXIBLE' : 'FIXED';
+    }
+
     const amountType = tier.amountType;
     const minPreset = Math.min(...presets);
 

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -387,11 +387,11 @@ export function editCollective(_, args, req) {
     const amountType = tier.amountType;
     const minPreset = Math.min(...presets);
     if (amountType === 'FLEXIBLE' && presets.indexOf(amount) === -1) {
-      throw new Error('Default amount must be one of suggested values amounts');
+      throw new Error(`In ${tier.name}'s tier "Default amount" must be one of suggested values amounts`);
     }
 
     if (amountType === 'FLEXIBLE' && minPreset < tier.minimumAmount) {
-      throw new Error('Minimum amount cannot be less than minimum suggested amounts');
+      throw new Error(`In ${tier.name}'s tier minimum amount cannot be less than minimum suggested amounts`);
     }
 
     return tier;

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -392,6 +392,10 @@ export function editCollective(_, args, req) {
       throw new Error('Name field is required for all tiers');
     }
 
+    if (amountType === 'FIXED' && !amount) {
+      throw new Error(`In ${name}'s tier, "Amount" is required`);
+    }
+
     if (amountType === 'FLEXIBLE' && !tier.minimumAmount) {
       throw new Error(`In ${name}'s tier, "Minimum amount" is required`);
     }

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -384,14 +384,24 @@ export function editCollective(_, args, req) {
   forEach(tiers, tier => {
     const presets = tier.presets || [];
     const amount = tier.amount;
+    const name = tier.name;
     const amountType = tier.amountType;
     const minPreset = Math.min(...presets);
+
+    if (!name || name.trim().length === 0) {
+      throw new Error('Name field is required for all tiers');
+    }
+
+    if (amountType === 'FLEXIBLE' && !tier.minimumAmount) {
+      throw new Error(`In ${name}'s tier, "Minimum amount" is required`);
+    }
+
     if (amountType === 'FLEXIBLE' && presets.indexOf(amount) === -1) {
-      throw new Error(`In ${tier.name}'s tier "Default amount" must be one of suggested values amounts`);
+      throw new Error(`In ${name}'s tier, "Default amount" must be one of suggested values amounts`);
     }
 
     if (amountType === 'FLEXIBLE' && minPreset < tier.minimumAmount) {
-      throw new Error(`In ${tier.name}'s tier minimum amount cannot be less than minimum suggested amounts`);
+      throw new Error(`In ${name}'s tier, minimum amount cannot be less than minimum suggested amounts`);
     }
 
     return tier;

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -401,15 +401,11 @@ export function editCollective(_, args, req) {
       throw new Error(`In ${name}'s tier, "Amount" is required`);
     }
 
-    if (amountType === 'FLEXIBLE' && !tier.minimumAmount) {
-      throw new Error(`In ${name}'s tier, "Minimum amount" is required`);
-    }
-
     if (amountType === 'FLEXIBLE' && presets.indexOf(amount) === -1) {
       throw new Error(`In ${name}'s tier, "Default amount" must be one of suggested values amounts`);
     }
 
-    if (amountType === 'FLEXIBLE' && minPreset < tier.minimumAmount) {
+    if (amountType === 'FLEXIBLE' && tier.minimumAmount && minPreset < tier.minimumAmount) {
       throw new Error(`In ${name}'s tier, minimum amount cannot be less than minimum suggested amounts`);
     }
 

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -397,7 +397,7 @@ export function editCollective(_, args, req) {
       throw new Error('Name field is required for all tiers');
     }
 
-    if (amountType === 'FIXED' && !amount) {
+    if (tier.type !== 'TICKET' && amountType === 'FIXED' && !amount) {
       throw new Error(`In ${name}'s tier, "Amount" is required`);
     }
 

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1086,6 +1086,12 @@ export const TierType = new GraphQLObjectType({
           return tier.minimumAmount;
         },
       },
+      amountType: {
+        type: GraphQLInt,
+        resolve(tier) {
+          return tier.amountType;
+        },
+      },
       currency: {
         type: GraphQLString,
         resolve(tier) {

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1087,7 +1087,7 @@ export const TierType = new GraphQLObjectType({
         },
       },
       amountType: {
-        type: GraphQLInt,
+        type: GraphQLString,
         resolve(tier) {
           return tier.amountType;
         },

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -77,6 +77,7 @@ export const defaultTiers = (HostCollectiveId, currency) => {
       interval: 'month',
       currency: currency,
       minimumAmount: 500,
+      amountType: 'FLEXIBLE',
     });
     tiers.push({
       type: 'TIER',
@@ -87,6 +88,7 @@ export const defaultTiers = (HostCollectiveId, currency) => {
       interval: 'month',
       currency: currency,
       minimumAmount: 10000,
+      amountType: 'FLEXIBLE',
     });
   }
   return tiers;

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -88,6 +88,10 @@ export default function(Sequelize, DataTypes) {
         type: DataTypes.ARRAY(DataTypes.INTEGER),
       },
 
+      amountType: {
+        type: DataTypes.ENUM('FLEXIBLE', 'FIXED'),
+      },
+
       minimumAmount: {
         type: DataTypes.INTEGER,
         validate: {


### PR DESCRIPTION
In the effort to validate `tiers`, this PR:

- Add `amountType` (as `ENUM` of `('FLEXIBLE', 'FIXED')`) to `Tier` column and migration script that sets the value of `amountType` to `FIXED` when `tier.presets` is `NULL` and `FLEXIBLE` if otherwise.

- Adds validation to tiers, for each tiers, ensure the "default amount" (amount) is one of the presets when the amount type is "flexible amount" and there is no presets smaller than the "minimum amount" (minimum_amount)

Ref [#1905](https://github.com/opencollective/opencollective/issues/1905)