### PR TITLE
Add sign in with publicKey

### DIFF
--- a/migrations/20190527130523-add-publicKey-to-user.js
+++ b/migrations/20190527130523-add-publicKey-to-user.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const colName = 'publicKey';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Users', colName, { type: Sequelize.STRING });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Users', colName);
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10875,7 +10875,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10903,6 +10904,7 @@
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10917,7 +10919,8 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -10928,7 +10931,8 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11045,7 +11049,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11057,6 +11062,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11071,6 +11077,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11078,12 +11085,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11102,6 +11111,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11182,7 +11192,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11194,6 +11205,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11279,7 +11291,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11315,6 +11328,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11334,6 +11348,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11377,12 +11392,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,6 +2112,16 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
+    "asn1.js": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+      "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
@@ -2368,6 +2378,14 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
+      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base32-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.0.tgz",
@@ -2377,6 +2395,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -2416,6 +2439,11 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
+    "bech32": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
+      "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
+    },
     "becke-ch--regex--s0-0-v1--base--pl--lib": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/becke-ch--regex--s0-0-v1--base--pl--lib/-/becke-ch--regex--s0-0-v1--base--pl--lib-1.4.0.tgz",
@@ -2430,6 +2458,75 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip32": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
+      "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
+      "requires": {
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      }
+    },
+    "bip39": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.6.0.tgz",
+      "integrity": "sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==",
+      "requires": {
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "unorm": "^1.3.3"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+    },
+    "bitcoinjs-lib": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.5.tgz",
+      "integrity": "sha512-gYs7K2hiY4Xb96J8AIF+Rx+hqbwjVlp5Zt6L6AnHOdzfe/2tODdmDxsEytnaxVCdhOUg0JnsGpl+KowBpGLxtA==",
+      "requires": {
+        "bech32": "^1.1.2",
+        "bip32": "^1.0.4",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.1",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      }
     },
     "bitsyntax": {
       "version": "0.1.0",
@@ -2456,10 +2553,146 @@
       "resolved": "https://registry.npmjs.org/bitwise-xor/-/bitwise-xor-0.0.0.tgz",
       "integrity": "sha1-BAqBcrW7jMVisLcRnyMLKhp4Dj0="
     },
+    "blockstack": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-19.1.0.tgz",
+      "integrity": "sha512-ULyPhFLZncIb4Qf+nlBvJ9zH+Ii8xn7DhoXWKBQU959Ur9Xy86cPgKkZ06oFZAGOQjQ2AshMZZ+hnS5TyqAt1g==",
+      "requires": {
+        "ajv": "^4.11.5",
+        "bip32": "^1.0.2",
+        "bip39": "^2.5.0",
+        "bitcoinjs-lib": "^4.0.3",
+        "bn.js": "^4.11.8",
+        "cheerio": "^0.22.0",
+        "cross-fetch": "^2.2.2",
+        "elliptic": "^6.4.1",
+        "form-data": "^2.3.3",
+        "jsontokens": "^1.0.0",
+        "query-string": "^6.3.0",
+        "request": "^2.88.0",
+        "ripemd160": "^2.0.2",
+        "schema-inspector": "^1.6.8",
+        "triplesec": "^3.0.26",
+        "uuid": "^3.3.2",
+        "zone-file": "^1.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.10.0",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+              "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            }
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "mime-db": {
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+        },
+        "mime-types": {
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+          "requires": {
+            "mime-db": "1.40.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
       "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -2649,6 +2882,11 @@
         }
       }
     },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -2663,6 +2901,24 @@
         "caniuse-lite": "^1.0.30000967",
         "electron-to-chromium": "^1.3.133",
         "node-releases": "^1.1.19"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "btoa-lite": {
@@ -3037,6 +3293,15 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -3652,6 +3917,47 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
         "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        }
       }
     },
     "cross-spawn": {
@@ -4300,6 +4606,20 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
+    },
+    "elliptic": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -5509,8 +5829,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -5563,6 +5882,12 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -7280,6 +7605,24 @@
         }
       }
     },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "hasha": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
@@ -7357,6 +7700,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.0.0.tgz",
       "integrity": "sha1-SoWtZYgfYoV/xwr3F0oRhNzM4ys="
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "hoek": {
       "version": "6.1.2",
@@ -7595,6 +7948,24 @@
           }
         }
       }
+    },
+    "iced-error": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/iced-error/-/iced-error-0.0.13.tgz",
+      "integrity": "sha512-yEEaG8QfyyRL0SsbNNDw3rVgTyqwHFMCuV6jDvD43f/2shmdaFXkqvFLGhDlsYNSolzYHwVLM/CrXt9GygYopA=="
+    },
+    "iced-lock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iced-lock/-/iced-lock-1.1.0.tgz",
+      "integrity": "sha1-YRbvHKs6zW5rEIk7snumIv0/3nI=",
+      "requires": {
+        "iced-runtime": "^1.0.0"
+      }
+    },
+    "iced-runtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/iced-runtime/-/iced-runtime-1.0.3.tgz",
+      "integrity": "sha1-LU9PuZmreqVDCxk8d6f85BGDGc4="
     },
     "iconv-lite": {
       "version": "0.4.15",
@@ -8605,6 +8976,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8665,10 +9044,34 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "jsontokens": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-1.0.0.tgz",
+      "integrity": "sha512-cC5q2qnJfwFQfN/P30Lo/m2v3x2D/JLUxli5tGP2367yRY5ZyEZSFpu+HQEBf2C8xlHL6DjQMYNFPdCFgQTmgA==",
+      "requires": {
+        "asn1.js": "^5.0.1",
+        "base64url": "^3.0.1",
+        "elliptic": "^6.4.1",
+        "key-encoder": "^1.1.7",
+        "validator": "^10.9.0"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+          "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+        }
+      }
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -8789,6 +9192,16 @@
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "optional": true
+    },
+    "key-encoder": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/key-encoder/-/key-encoder-1.1.7.tgz",
+      "integrity": "sha512-7qjnX+t+l1kPeozKAm3/UO216/HseXw7xxXd8WkT2i/moFIZIN46RzoaCeScBoEwGF2mUUuPRu4j8EHP0BGfpg==",
+      "requires": {
+        "asn1.js": "^5.0.1",
+        "bn.js": "^4.11.8",
+        "elliptic": "^6.4.1"
+      }
     },
     "keypress": {
       "version": "0.1.0",
@@ -9533,6 +9946,16 @@
         "is-buffer": "~1.1.1"
       }
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -9611,6 +10034,11 @@
         }
       }
     },
+    "merkle-lib": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
+      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9678,6 +10106,16 @@
       "requires": {
         "dom-walk": "^0.1.0"
       }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -10053,6 +10491,14 @@
         "moment": ">= 2.9.0"
       }
     },
+    "more-entropy": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/more-entropy/-/more-entropy-0.0.7.tgz",
+      "integrity": "sha1-Z7/G96hvJvvDeqyD/UbYjGHRCbU=",
+      "requires": {
+        "iced-runtime": ">=0.0.1"
+      }
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -10301,23 +10747,27 @@
         "tar": "^4"
       },
       "dependencies": {
-        "needle": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "ms": "^2.1.1"
           }
         },
-        "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "needle": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+          "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "debug": "^3.2.6",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         }
       }
@@ -10425,8 +10875,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10454,7 +10903,6 @@
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10469,8 +10917,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -10481,8 +10928,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10599,8 +11045,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10612,7 +11057,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10627,7 +11071,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10635,14 +11078,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10661,7 +11102,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -10742,8 +11182,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10755,7 +11194,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10841,8 +11279,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10878,7 +11315,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10898,7 +11334,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10942,14 +11377,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11886,6 +12319,18 @@
         "semver": "^5.0.3"
       }
     },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -12316,6 +12761,11 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "psl": {
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
+    },
     "pstree.remy": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
@@ -12336,10 +12786,28 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+      "requires": {
+        "bitcoin-ops": "^1.3.0"
+      }
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.5.0.tgz",
+      "integrity": "sha512-TYC4hDjZSvVxLMEucDMySkuAS9UIzSbAiYGyA9GWCjLKB8fQpviFbjd20fD7uejCDxZS+ftSdBKE6DS+xucJFg==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -12366,6 +12834,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -12863,6 +13339,15 @@
         "glob": "^7.0.5"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -12963,6 +13448,21 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "schema-inspector": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/schema-inspector/-/schema-inspector-1.6.8.tgz",
+      "integrity": "sha1-ueU5g8xV/y29e2Xj2+CF2dEoXyo=",
+      "requires": {
+        "async": "^1.5.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
       }
     },
     "seed-random": {
@@ -13611,6 +14111,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -13744,6 +14249,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.0.2",
@@ -14145,6 +14655,35 @@
         }
       }
     },
+    "tiny-secp256k1": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.2.tgz",
+      "integrity": "sha512-InukePecGvfngAEmPR/AIVpAmBTBCdO7tFuMKCpQDE6Zr+lQVT/hDArPkUUolPPpCgwbN/yk2rSAGhJsoIl4hA==",
+      "requires": {
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "tiny-secp256k1-native": "1.1.x"
+      }
+    },
+    "tiny-secp256k1-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1-native/-/tiny-secp256k1-native-1.1.0.tgz",
+      "integrity": "sha512-ZEt41e4pvq52Zs6MqNZpbDH3qg5fQkOCH9bzGsVPtlLeo9tdfNFz2XfjiKzo1Rc+Yvv4cb0lzy7ClQ3FbE4kKg==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "optional": true
+        }
+      }
+    },
     "title-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
@@ -14274,6 +14813,26 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "triplesec": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/triplesec/-/triplesec-3.0.27.tgz",
+      "integrity": "sha512-FDhkxa3JYnPOerOd+8k+SBmm7cb7KkyX+xXwNFV3XV6dsQgHuRvjtbnzWfPJ2kimeR8ErjZfPd/6r7RH6epHDw==",
+      "requires": {
+        "iced-error": ">=0.0.9",
+        "iced-lock": "^1.0.1",
+        "iced-runtime": "^1.0.2",
+        "more-entropy": ">=0.0.7",
+        "progress": "~1.1.2",
+        "uglify-js": "^3.1.9"
+      },
+      "dependencies": {
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        }
+      }
+    },
     "ts-invariant": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
@@ -14352,11 +14911,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+    },
     "uglify-js": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
       "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
-      "optional": true,
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
@@ -14365,14 +14928,12 @@
         "commander": {
           "version": "2.20.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-          "optional": true
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -14495,6 +15056,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "unorm": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.5.0.tgz",
+      "integrity": "sha512-sMfSWoiRaXXeDZSXC+YRZ23H4xchQpwxjpw1tmfR+kgbBCaOgln4NI0LXejJIhnBuKINrB3WRn+ZI8IWssirVw=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -14631,7 +15197,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -14779,6 +15344,14 @@
       "resolved": "https://registry.npmjs.org/validator/-/validator-11.0.0.tgz",
       "integrity": "sha512-+wnGLYqaKV2++nUv60uGzUJyJQwYVOin6pn1tgEiFCeCQO60yeu3Og9/yPccbBX574kxIcEJicogkzx6s6eyag=="
     },
+    "varuint-bitcoin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
+      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -14858,6 +15431,14 @@
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
       }
     },
     "windows-release": {
@@ -15206,6 +15787,11 @@
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
       }
+    },
+    "zone-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zone-file/-/zone-file-1.0.0.tgz",
+      "integrity": "sha512-dJynTf/5XCobE6diQBpNWQQRBzXE8d1QhHKemzrkffrZ36F9uKlbBVyIXXbG2CJoaTGZGh8zt2AHX/mG4txtqA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-add-module-exports": "1.0.2",
     "babel-plugin-lodash": "3.3.4",
     "bcrypt": "3.0.6",
+    "blockstack": "^19.1.0",
     "bluebird": "3.5.5",
     "body-parser": "1.19.0",
     "child-process-promise": "2.2.1",

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -21,11 +21,35 @@ export const exists = async (req, res) => {
   if (!isValidEmail(email)) {
     return res.send({ exists: false });
   } else {
-    const user = await models.User.findOne({
-      attributes: ['id'],
-      where: { email },
+    const publicKey = req.query.publicKey;
+    if (publicKey) {
+      const user = await models.User.findOne({
+        attributes: ['id', 'email'],
+        where: { publicKey },
+      });
+      const exists = user && user.email === email;
+      return res.send({ exists: Boolean(exists) });
+    } else {
+      const user = await models.User.findOne({
+        attributes: ['id'],
+        where: { email },
+      });
+      return res.send({ exists: Boolean(user) });
+    }
+  }
+};
+
+const findOne = user => {
+  if (user.publicKey) {
+    return models.User.findOne({ where: { publicKey: user.publicKey } }).then(u => {
+      if (u.email === user.email.toLowerCase()) {
+        return u;
+      } else {
+        return null;
+      }
     });
-    return res.send({ exists: Boolean(user) });
+  } else {
+    return models.User.findOne({ where: { email: user.email.toLowerCase() } });
   }
 };
 
@@ -35,7 +59,7 @@ export const exists = async (req, res) => {
 export const signin = (req, res, next) => {
   const { user, redirect, websiteUrl } = req.body;
   let loginLink;
-  return models.User.findOne({ where: { email: user.email.toLowerCase() } })
+  return findOne(user)
     .then(u => u || models.User.createUserWithCollective(user))
     .then(u => {
       loginLink = u.generateLoginLink(redirect || '/', websiteUrl);

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -99,6 +99,7 @@ export const UserInputType = new GraphQLInputObjectType({
     website: { type: GraphQLString },
     paypalEmail: { type: GraphQLString },
     newsletterOptIn: { type: GraphQLBoolean },
+    publicKey: { type: GraphQLString },
   }),
 });
 

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -33,6 +33,7 @@ import * as applicationMutations from './mutations/applications';
 import { updateUserEmail, confirmUserEmail } from './mutations/users';
 
 import statuses from '../../constants/expense_status';
+import { encryptLink } from '../../lib/blockstack';
 
 import { GraphQLNonNull, GraphQLList, GraphQLString, GraphQLInt, GraphQLBoolean, GraphQLObjectType } from 'graphql';
 
@@ -176,6 +177,7 @@ const mutations = {
       fields: {
         user: { type: UserType },
         organization: { type: CollectiveInterfaceType },
+        redirect: { type: GraphQLString },
       },
     }),
     args: {
@@ -204,12 +206,25 @@ const mutations = {
           throw new Error('User already exists for given email');
         }
 
+        if (
+          args.user.publicKey &&
+          (await models.User.findOne({ where: { publicKey: args.user.publicKey } }, { transaction }))
+        ) {
+          throw new Error('User already exists for given public key');
+        }
+
         const user = await models.User.createUserWithCollective(args.user, transaction);
         const loginLink = user.generateLoginLink(args.redirect, args.websiteUrl);
 
         if (!args.organization) {
           emailLib.send('user.new.token', user.email, { loginLink }, { sendEvenIfNotProduction: true });
-          return { user, organization: null };
+          let redirect;
+          if (args.user.publicKey) {
+            redirect = encryptLink(args.user.publicKey, loginLink);
+          } else {
+            redirect = null;
+          }
+          return { user, organization: null, redirect };
         }
 
         // Create organization
@@ -221,7 +236,13 @@ const mutations = {
         await organization.addUserWithRole(user, roles.ADMIN, { CreatedByUserId: user.id }, transaction);
 
         emailLib.send('user.new.token', user.email, { loginLink }, { sendEvenIfNotProduction: true });
-        return { user, organization };
+        let redirect;
+        if (args.user.publicKey) {
+          redirect = encryptLink(args.user.publicKey, loginLink);
+        } else {
+          redirect = null;
+        }
+        return { user, organization, redirect };
       });
     },
   },

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -30,7 +30,7 @@ import * as paymentMethodsMutation from './mutations/paymentMethods';
 import * as updateMutations from './mutations/updates';
 import * as commentMutations from './mutations/comments';
 import * as applicationMutations from './mutations/applications';
-import { updateUserEmail, confirmUserEmail } from './mutations/users';
+import { updateUserEmail, confirmUserEmail, updateUserPublicKey } from './mutations/users';
 
 import statuses from '../../constants/expense_status';
 import blockstackLib from '../../lib/blockstack';
@@ -318,6 +318,19 @@ const mutations = {
     },
     resolve: (_, { token }) => {
       return confirmUserEmail(token);
+    },
+  },
+  updateUserPublicKey: {
+    type: UserType,
+    description: 'Update the public key for logged in user',
+    args: {
+      publicKey: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: 'The new public key for user',
+      },
+    },
+    resolve: (_, { publicKey }, { remoteUser }) => {
+      return updateUserPublicKey(remoteUser, publicKey);
     },
   },
   editConnectedAccount: {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -33,6 +33,7 @@ import * as applicationMutations from './mutations/applications';
 import { updateUserEmail, confirmUserEmail } from './mutations/users';
 
 import statuses from '../../constants/expense_status';
+import blockstackLib from '../../lib/blockstack';
 
 import { GraphQLNonNull, GraphQLList, GraphQLString, GraphQLInt, GraphQLBoolean, GraphQLObjectType } from 'graphql';
 
@@ -222,6 +223,74 @@ const mutations = {
 
         emailLib.send('user.new.token', user.email, { loginLink }, { sendEvenIfNotProduction: true });
         return { user, organization };
+      });
+    },
+  },
+  createUserByPublicKey: {
+    description: 'Create a user by public key and with an optional organization.',
+    type: new GraphQLObjectType({
+      name: 'CreateUserByPublicKeyResult',
+      fields: {
+        user: { type: UserType },
+        organization: { type: CollectiveInterfaceType },
+        redirect: { type: GraphQLString },
+      },
+    }),
+    args: {
+      user: {
+        type: new GraphQLNonNull(UserInputType),
+        description: 'The user info',
+      },
+      organization: {
+        type: CollectiveInputType,
+        description: 'An optional organization to create alongside the user',
+      },
+      redirect: {
+        type: GraphQLString,
+        description: 'The redirect URL for the login email sent to the user',
+        defaultValue: '/',
+      },
+      websiteUrl: {
+        type: GraphQLString,
+        description: 'The website URL originating the request',
+      },
+    },
+    resolve(_, args) {
+      return sequelize.transaction(async transaction => {
+        // Create user
+        if (!args.user.publicKey) {
+          throw new Error('user.publicKey must have a value');
+        }
+
+        if (await models.User.findOne({ where: { email: args.user.email.toLowerCase() } }, { transaction })) {
+          throw new Error('User already exists for given email');
+        }
+
+        if (
+          args.user.publicKey &&
+          (await models.User.findOne({ where: { publicKey: args.user.publicKey } }, { transaction }))
+        ) {
+          throw new Error('User already exists for given public key');
+        }
+
+        const user = await models.User.createUserWithCollective(args.user, transaction);
+        const loginLink = user.generateLoginLink(args.redirect, args.websiteUrl);
+
+        if (!args.organization) {
+          const redirect = blockstackLib.encryptLink(args.user.publicKey, loginLink);
+          return { user, organization: null, redirect };
+        }
+
+        // Create organization
+        const organizationParams = {
+          type: 'ORGANIZATION',
+          ...pick(args.organization, ['name', 'website', 'twitterHandle', 'githubHandle']),
+        };
+        const organization = await models.Collective.create(organizationParams, { transaction });
+        await organization.addUserWithRole(user, roles.ADMIN, { CreatedByUserId: user.id }, transaction);
+
+        const redirect = blockstackLib.encryptLink(args.user.publicKey, loginLink);
+        return { user, organization, redirect };
       });
     },
   },

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -325,8 +325,8 @@ const mutations = {
     description: 'Update the public key for logged in user',
     args: {
       publicKey: {
-        type: new GraphQLNonNull(GraphQLString),
-        description: 'The new public key for user',
+        type: GraphQLString,
+        description: 'The new public key for user or null',
       },
     },
     resolve: (_, { publicKey }, { remoteUser }) => {

--- a/server/graphql/v1/mutations/users.js
+++ b/server/graphql/v1/mutations/users.js
@@ -79,3 +79,27 @@ export const confirmUserEmail = async emailConfirmationToken => {
     emailConfirmationToken: null,
   });
 };
+
+/**
+ * Sets `publicKey` to `newPublicKey` for `user`.
+ */
+export const updateUserPublicKey = async (user, newPublicKey) => {
+  if (!user) {
+    throw new Unauthorized();
+  }
+
+  // If somehow user tries to update the public key to its existing value then we don't do anything
+  if (user.publicKey === newPublicKey) {
+    return user;
+  }
+
+  // Ensure this public key is not already used by another user
+  const existingPublicKey = await models.User.findOne({ where: { publicKey: newPublicKey } });
+  if (existingPublicKey) {
+    throw new ValidationFailed({ message: 'A user with that public key already exists' });
+  }
+
+  return user.update({
+    publicKey: newPublicKey,
+  });
+};

--- a/server/graphql/v1/mutations/users.js
+++ b/server/graphql/v1/mutations/users.js
@@ -94,9 +94,11 @@ export const updateUserPublicKey = async (user, newPublicKey) => {
   }
 
   // Ensure this public key is not already used by another user
-  const existingPublicKey = await models.User.findOne({ where: { publicKey: newPublicKey } });
-  if (existingPublicKey) {
-    throw new ValidationFailed({ message: 'A user with that public key already exists' });
+  if (newPublicKey) {
+    const existingPublicKey = await models.User.findOne({ where: { publicKey: newPublicKey } });
+    if (existingPublicKey) {
+      throw new ValidationFailed({ message: 'A user with that public key already exists' });
+    }
   }
 
   return user.update({

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -126,6 +126,14 @@ export const UserType = new GraphQLObjectType({
           return user.getPersonalDetails(req.remoteUser).then(user => user.emailWaitingForValidation);
         },
       },
+      publicKey: {
+        type: GraphQLString,
+        resolve(user, args, req) {
+          return user.getPersonalDetails(req.remoteUser).then(user => {
+            return user.publicKey;
+          });
+        },
+      },
       memberOf: {
         type: new GraphQLList(MemberType),
         resolve(user) {

--- a/server/lib/blockstack.js
+++ b/server/lib/blockstack.js
@@ -1,5 +1,6 @@
 import debugLib from 'debug';
 import blockstack from 'blockstack';
+import models from '../models';
 const debug = debugLib('blockstack');
 
 /*
@@ -10,8 +11,22 @@ const encryptLink = (publicKey, loginLink) => {
   return blockstack.encryptContent(loginLink, { publicKey });
 };
 
+const findOne = user => {
+  if (user.publicKey) {
+    return models.User.findOne({ where: { publicKey: user.publicKey } }).then(u => {
+      if (u.email === user.email.toLowerCase()) {
+        return u;
+      } else {
+        return null;
+      }
+    });
+  } else {
+    return models.User.findOne({ where: { email: user.email.toLowerCase() } });
+  }
+};
 const blockstackLib = {
   encryptLink,
+  findOne,
 };
 
 export default blockstackLib;

--- a/server/lib/blockstack.js
+++ b/server/lib/blockstack.js
@@ -14,7 +14,7 @@ const encryptLink = (publicKey, loginLink) => {
 const findOne = user => {
   if (user.publicKey) {
     return models.User.findOne({ where: { publicKey: user.publicKey } }).then(u => {
-      if (u.email === user.email.toLowerCase()) {
+      if (u && u.email === user.email.toLowerCase()) {
         return u;
       } else {
         return null;

--- a/server/lib/blockstack.js
+++ b/server/lib/blockstack.js
@@ -1,0 +1,17 @@
+import debugLib from 'debug';
+import blockstack from 'blockstack';
+const debug = debugLib('blockstack');
+
+/*
+ * encrypts login link
+ */
+const encryptLink = (publicKey, loginLink) => {
+  debug('Encrypting ', loginLink, 'with', publicKey);
+  return blockstack.encryptContent(loginLink, { publicKey });
+};
+
+const blockstackLib = {
+  encryptLink,
+};
+
+export default blockstackLib;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -199,6 +199,7 @@ export default (Sequelize, DataTypes) => {
             lastName: this.lastName,
             email: this.email,
             emailWaitingForValidation: this.emailWaitingForValidation,
+            publicKey: this.publicKey,
             createdAt: this.createdAt,
             updatedAt: this.updatedAt,
             paypalEmail: this.paypalEmail,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -122,6 +122,8 @@ export default (Sequelize, DataTypes) => {
 
       resetPasswordSentAt: DataTypes.DATE,
 
+      publicKey: DataTypes.STRING,
+
       createdAt: {
         type: DataTypes.DATE,
         defaultValue: Sequelize.NOW,

--- a/server/routes.js
+++ b/server/routes.js
@@ -204,6 +204,11 @@ export default app => {
   app.get('/users/exists', required('email'), users.exists); // Checks the existence of a user based on email.
 
   /**
+   * Users with public key
+   */
+  app.get('/users/exists-with-public-key', required('email', 'publicKey'), users.existsWithPublicKey); // Checks the existence of a user based on email and public key.
+
+  /**
    * Create a payment method.
    *
    *  Let's assume for now a paymentMethod is linked to a user.

--- a/server/routes.js
+++ b/server/routes.js
@@ -123,6 +123,7 @@ export default app => {
    * User reset password or new token flow (no jwt verification)
    */
   app.post('/users/signin', required('user'), users.signin);
+  app.post('/users/signin-public-key', required('user'), users.signinPublicKey);
   app.post('/users/update-token', auth.mustBeLoggedIn, users.updateToken);
 
   /**


### PR DESCRIPTION
This PR
- adds field `publicKey` to UserInputType
- adds `redirect` to sign in requests if the user input comes with a `publicKey` value. The `redirect` value is the encrypted redirect link.

This is a proof of concept towards 
https://github.com/opencollective/opencollective/issues/1749

Corresponding UI looks like this:
https://github.com/opencollective/opencollective-frontend/pull/1833

Probably it is not necessary to include blockstack.js as only function `encryptContent` is needed. 

After sign in the user name contains the blockstack id of the user:
![Screenshot from 2019-05-27 11-07-28](https://user-images.githubusercontent.com/1449049/58409756-07153180-8071-11e9-959b-74b4c8f6a265.png)

