### PR TITLE
Fix: Stop sending "pending" email to automatically approved collective from Github

### DIFF
--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -5,7 +5,7 @@
 export default {
   ACTIVITY_ALL: 'all',
   CONNECTED_ACCOUNT_CREATED: 'connected_account.created',
-  GITHUB_COLLECTIVE_CREATED: 'github.collective.created',
+  COLLECTIVE_CREATED_GITHUB: 'collective.created.github',
   COLLECTIVE_APPLY: 'collective.apply',
   COLLECTIVE_APPROVED: 'collective.approved',
   COLLECTIVE_CREATED: 'collective.created',

--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -5,6 +5,7 @@
 export default {
   ACTIVITY_ALL: 'all',
   CONNECTED_ACCOUNT_CREATED: 'connected_account.created',
+  GITHUB_COLLECTIVE_CREATED: 'github.collective.created',
   COLLECTIVE_APPLY: 'collective.apply',
   COLLECTIVE_APPROVED: 'collective.approved',
   COLLECTIVE_CREATED: 'collective.created',

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -330,7 +330,7 @@ export async function createCollectiveFromGithub(_, args, req) {
   debugGithub('sending github.signup to', user.email, 'with data', data);
   await emailLib.send('github.signup', user.email, data);
   models.Activity.create({
-    type: activities.COLLECTIVE_CREATED,
+    type: activities.GITHUB_COLLECTIVE_CREATED,
     UserId: user.id,
     CollectiveId: collective.id,
     data: {

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -330,7 +330,7 @@ export async function createCollectiveFromGithub(_, args, req) {
   debugGithub('sending github.signup to', user.email, 'with data', data);
   await emailLib.send('github.signup', user.email, data);
   models.Activity.create({
-    type: activities.GITHUB_COLLECTIVE_CREATED,
+    type: activities.COLLECTIVE_CREATED_GITHUB,
     UserId: user.id,
     CollectiveId: collective.id,
     data: {

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -375,5 +375,13 @@ async function notifyByEmail(activity) {
         notifyAdminsOfCollective(activity.data.collective.id, activity);
       }
       break;
+
+    case activityType.GITHUB_COLLECTIVE_CREATED:
+      if ((get(activity, 'data.collective.tags') || []).includes('open source')) {
+        notifyAdminsOfCollective(activity.data.collective.id, activity, {
+          template: 'collective.created.opensource',
+        });
+      }
+      break;
   }
 }

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -367,16 +367,12 @@ async function notifyByEmail(activity) {
         notifyAdminsOfCollective(activity.data.collective.id, activity, {
           template: 'collective.created.meetup',
         });
-      } else if ((get(activity, 'data.collective.tags') || []).includes('open source')) {
-        notifyAdminsOfCollective(activity.data.collective.id, activity, {
-          template: 'collective.created.opensource',
-        });
       } else {
         notifyAdminsOfCollective(activity.data.collective.id, activity);
       }
       break;
 
-    case activityType.GITHUB_COLLECTIVE_CREATED:
+    case activityType.COLLECTIVE_CREATED_GITHUB:
       if ((get(activity, 'data.collective.tags') || []).includes('open source')) {
         notifyAdminsOfCollective(activity.data.collective.id, activity, {
           template: 'collective.created.opensource',

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -373,11 +373,9 @@ async function notifyByEmail(activity) {
       break;
 
     case activityType.COLLECTIVE_CREATED_GITHUB:
-      if ((get(activity, 'data.collective.tags') || []).includes('open source')) {
-        notifyAdminsOfCollective(activity.data.collective.id, activity, {
-          template: 'collective.created.opensource',
-        });
-      }
+      notifyAdminsOfCollective(activity.data.collective.id, activity, {
+        template: 'collective.created.opensource',
+      });
       break;
   }
 }


### PR DESCRIPTION
This PR fixes [#2063](https://github.com/opencollective/opencollective/issues/2063) by adding a new activity `GITHUB_COLLECTIVE_CREATED` (in `/constants/activities.js`) instead of using `COLLECTIVE_CREATED` causing the pending  email to be sent. 