### PR TITLE
Fix: Tax bot counting rejected expenses toward $600 threshold

### DIFF
--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -276,7 +276,10 @@ export default function(Sequelize, DataTypes) {
       if (expense.status === status.PAID) {
         entry.date = expense.updatedAt;
       }
-      arr.push(entry);
+
+      if (expense.status !== status.REJECTED) {
+        arr.push(entry);
+      }
     }
     return reduceArrayToCurrency(arr, baseCurrency);
   };


### PR DESCRIPTION
This PR fixes [#2061](https://github.com/opencollective/opencollective/issues/2061) by skipping expenses with `status === REJECTED` in `getTotalExpensesFromUserIdInBaseCurrency` method.