### PR TITLE
Enable host collective admin to refund transaction 

### DIFF
--- a/test/graphql.refundTransaction.test.js
+++ b/test/graphql.refundTransaction.test.js
@@ -159,7 +159,7 @@ describe('Refund Transaction', () => {
 
     // Then it should error out with the right error
     const [{ message }] = result.errors;
-    expect(message).to.equal('Not a site admin');
+    expect(message).to.equal('Not a site admin or host collective admin');
   });
 
   describe('Save CreatedByUserId', () => {


### PR DESCRIPTION
Following [#1864](https://github.com/opencollective/opencollective-frontend/pull/1864), this PR allows collective host admin to refund transaction.