### PR TITLE
Move Tier validation to model 

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import slugify from 'limax';
-import { get, omit, forEach } from 'lodash';
+import { get, omit } from 'lodash';
 import { map } from 'bluebird';
 
 import models, { Op } from '../../../models';
@@ -379,38 +379,6 @@ export function editCollective(_, args, req) {
   }
 
   let collective, parentCollective;
-
-  const tiers = args.collective.tiers;
-  forEach(tiers, tier => {
-    const presets = tier.presets;
-    const amount = tier.amount;
-    const name = tier.name;
-
-    if (!tier.amountType) {
-      tier.amountType = presets ? 'FLEXIBLE' : 'FIXED';
-    }
-
-    const amountType = tier.amountType;
-    const minPreset = presets ? Math.min(...presets) : null;
-
-    if (!name || name.trim().length === 0) {
-      throw new Error('Name field is required for all tiers');
-    }
-
-    if (tier.type !== 'TICKET' && amountType === 'FIXED' && !amount) {
-      throw new Error(`In ${name}'s tier, "Amount" is required`);
-    }
-
-    if (amountType === 'FLEXIBLE' && presets.indexOf(amount) === -1) {
-      throw new Error(`In ${name}'s tier, "Default amount" must be one of suggested values amounts`);
-    }
-
-    if (amountType === 'FLEXIBLE' && tier.minimumAmount && minPreset < tier.minimumAmount) {
-      throw new Error(`In ${name}'s tier, minimum amount cannot be less than minimum suggested amounts`);
-    }
-
-    return tier;
-  });
 
   const promises = [
     req.loaders.collective.findById.load(args.collective.id).then(c => {


### PR DESCRIPTION
This PR [#2073](https://github.com/opencollective/opencollective/issues/2073) follows up to move tier validation from `editCollective` resolver to `Tier` model.