### PR TITLE
Add sanitizer for 'collective.member.created'

### DIFF
--- a/server/lib/webhooks.js
+++ b/server/lib/webhooks.js
@@ -41,6 +41,26 @@ export const sanitizeActivity = activity => {
       'expense.amount',
       'expense.currency',
     ]);
+  } else if (type === activities.COLLECTIVE_MEMBER_CREATED) {
+    cleanActivity.data = pick(activity.data, [
+      'member.role',
+      'member.description',
+      'member.since',
+      'member.memberCollective.id',
+      'member.memberCollective.type',
+      'member.memberCollective.slug',
+      'member.memberCollective.name',
+      'member.memberCollective.company',
+      'member.memberCollective.website',
+      'member.memberCollective.twitterHandle',
+      'member.memberCollective.githubHandle',
+      'member.memberCollective.description',
+      'member.memberCollective.previewImage',
+      'member.order.id',
+      'member.order.totalAmount',
+      'member.order.currency',
+      'member.order.description',
+    ]);
   }
 
   return cleanActivity;


### PR DESCRIPTION
@Betree Please let me know which fields are unnecessary.
A JSON dump of the activity is [here](https://gist.github.com/eloyekunle/c2f6c1335d4ce5d660d700fd3490936a).

Ref: https://github.com/opencollective/opencollective-zapier/pull/12