### PR TITLE
chore(Tiers): Add `hasLongDescription` field

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1115,6 +1115,13 @@ export const TierType = new GraphQLObjectType({
         type: GraphQLString,
         description: 'A long, html-formatted description.',
       },
+      hasLongDescription: {
+        type: GraphQLBoolean,
+        description: 'Returns true if the tier has a long description',
+        resolve(tier) {
+          return Boolean(tier.longDescription);
+        },
+      },
       videoUrl: {
         type: GraphQLString,
         description: 'Link to a video (YouTube, Vimeo).',


### PR DESCRIPTION
Tier's long description can be quite heavy (it's HTML content). On the tiers page and the new collective page, we display a `Read More` link towards the tier page if there is a long description but we actually don't need the full content, we just need to know if it exists.