### PR TITLE
Fix collective events query

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1339,7 +1339,7 @@ const CollectiveFields = () => {
         offset: { type: GraphQLInt },
       },
       resolve(collective, args) {
-        const query = { type: 'EVENT', ParentCollectiveId: collective.id };
+        const query = { where: { type: 'EVENT', ParentCollectiveId: collective.id } };
         if (args.limit) query.limit = args.limit;
         if (args.offset) query.offset = args.offset;
         return models.Collective.findAll(query);


### PR DESCRIPTION
The query was missing a `where` clause, so all collective's events were returned. It had no significant impact however because this field is not used anywhere (but it will be for the new collective page).