### PR TITLE
Remove findOrCreate for collective pledge in createOrder

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -189,10 +189,10 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
         defaults: order.collective,
       }))[0];
     } else if (order.collective.githubHandle) {
-      collective = (await models.Collective.findOrCreate({
-        where: { githubHandle: order.collective.githubHandle },
-        defaults: { ...order.collective, isPledged: true },
-      }))[0];
+      collective = await models.Collective.findOne({ where: { githubHandle: order.collective.githubHandle } });
+      if (!collective) {
+        collective = await models.Collective.create({ ...order.collective, isPledged: true });
+      }
     }
 
     if (!collective) {


### PR DESCRIPTION
When a new collective is created, a hook is expected to run to set the default [opencollective service paymentMethod](https://github.com/opencollective/opencollective-api/blob/master/server/models/Collective.js#L566-L583), the hook triggers a foreign key constraint error when a collective is created using `findOrCreate` method but doesn't using standalone `create` method. Basically, creation with `create` method behaves differently to `findOrCreate`. 

While the main cause of this hasn't been figured out but this PR fix the [issue](https://github.com/opencollective/opencollective/issues/2098) 