### PR TITLE
Add character validation to collective slug

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -149,6 +149,11 @@ export default function(Sequelize, DataTypes) {
             args: [collectiveSlugBlacklist],
             msg: 'The slug given for this collective is a reserved keyword',
           },
+          isValid(value) {
+            if (!/^[\w-]+$/.test(value)) {
+              throw new Error('Slug may only contain alphanumeric characters or hyphens.');
+            }
+          },
         },
       },
 
@@ -2054,7 +2059,9 @@ export default function(Sequelize, DataTypes) {
         if (!stripeAccount || !stripeAccount.token) {
           return Promise.reject(
             new Error(
-              `The host for the ${this.name} collective has no Stripe account set up (HostCollectiveId: ${HostCollectiveId})`,
+              `The host for the ${
+                this.name
+              } collective has no Stripe account set up (HostCollectiveId: ${HostCollectiveId})`,
             ),
           );
         } else if (process.env.NODE_ENV !== 'production' && includes(stripeAccount.token, 'live')) {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2059,9 +2059,7 @@ export default function(Sequelize, DataTypes) {
         if (!stripeAccount || !stripeAccount.token) {
           return Promise.reject(
             new Error(
-              `The host for the ${
-                this.name
-              } collective has no Stripe account set up (HostCollectiveId: ${HostCollectiveId})`,
+              `The host for the ${this.name} collective has no Stripe account set up (HostCollectiveId: ${HostCollectiveId})`,
             ),
           );
         } else if (process.env.NODE_ENV !== 'production' && includes(stripeAccount.token, 'live')) {


### PR DESCRIPTION
This PR adds character validation to `Collective` model in `slug` field, the validation ensures no characters other than alphanumeric and hyphens are contained in collective slug.

![Screenshot from 2019-06-14 15-47-17](https://user-images.githubusercontent.com/15707013/59518701-1fcd7600-8ebe-11e9-815e-4322db1f01cd.png)

Ref [#2077](https://github.com/opencollective/opencollective/issues/2077)