### PR TITLE
fix(Updates): CanSeeUpdate always true when update is public

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -671,6 +671,9 @@ export const UpdateType = new GraphQLObjectType({
         description: 'Indicates whether or not the user is allowed to see the content of this update',
         type: GraphQLBoolean,
         resolve(update, _, req) {
+          if (!update.isPrivate) {
+            return true;
+          }
           return req.remoteUser && req.remoteUser.canSeeUpdates(update.CollectiveId);
         },
       },


### PR DESCRIPTION
Fix an issue where all updates were marked as private for users

![image](https://user-images.githubusercontent.com/1556356/59550474-5ca37680-8f6b-11e9-85d8-dc5984ce51ac.png)
