### PR TITLE
Add cron job to request US tax forms via Helloworks.

### DIFF
--- a/cron/daily/sendTaxFormRequests.js
+++ b/cron/daily/sendTaxFormRequests.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import config from 'config';
+import HelloWorks from 'helloworks-sdk';
+import moment from 'moment';
+import { findUsersThatNeedToBeSentTaxForm, SendHelloWorksTaxForm } from '../../server/lib/taxForms';
+import { sequelize } from '../../server/models';
+
+const US_TAX_FORM_THRESHOLD = 600e2;
+const HELLO_WORKS_KEY = config.get('helloworks.key');
+const HELLO_WORKS_SECRET = config.get('helloworks.secret');
+const HELLO_WORKS_WORKFLOW_ID = config.get('helloworks.workflowId');
+const HELLO_WORKS_CALLBACK_PATH = config.get('helloworks.callbackPath');
+
+const HELLO_WORKS_CALLBACK_URL = `${config.get('host.api')}${HELLO_WORKS_CALLBACK_PATH}`;
+
+const year = moment().year();
+
+const client = new HelloWorks({
+  apiKeyId: HELLO_WORKS_KEY,
+  apiKeySecret: HELLO_WORKS_SECRET,
+});
+
+const sendHelloWorksUsTaxForm = SendHelloWorksTaxForm({
+  client,
+  callbackUrl: HELLO_WORKS_CALLBACK_URL,
+  workflowId: HELLO_WORKS_WORKFLOW_ID,
+  year,
+});
+
+const init = async () => {
+  console.log('>>>> Running tax form job');
+  // Filter unique users
+  await findUsersThatNeedToBeSentTaxForm({
+    invoiceTotalThreshold: US_TAX_FORM_THRESHOLD,
+    year,
+  }).map(sendHelloWorksUsTaxForm);
+};
+
+init()
+  .catch(console.log)
+  .finally(() => {
+    sequelize.close();
+  });

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "handlebars": "4.1.2",
     "hashids": "1.2.2",
     "he": "1.2.0",
-    "helloworks-sdk": "1.0.3",
+    "helloworks-sdk": "pietgeursen/helloworks-nodejs-sdk",
     "helmet": "3.20.0",
     "html-pdf": "2.2.0",
     "ics": "2.15.1",


### PR DESCRIPTION
This is ready for review. **But don't deploy yet.**

This is blocked by this PR getting merged: https://github.com/hellosign/helloworks-nodejs-sdk/pull/5

We could just use my fork of that repo if we want to get this deployed.

Note that when this is deployed to production it will need some new env vars set:

- `helloworks.aws.s3.bucket` must be set to `opencollective-production-us-tax-forms`

And some production secrets:

- `helloworks.documentEncryptionKey`
- `helloworks.secret`
- `helloworks.key`
