### PR TITLE
WIP: Daily cron to dispatch donation to dependencies collectives

### DIFF
--- a/cron/daily/dispatch_prepaid_subscription.js
+++ b/cron/daily/dispatch_prepaid_subscription.js
@@ -1,17 +1,14 @@
 #!/usr/bin/env node
-import fetch from 'isomorphic-fetch';
-import uuidV4 from 'uuid/v4';
 import debugLib from 'debug';
 import moment from 'moment';
-import { map, filter } from 'bluebird';
+import { filter } from 'bluebird';
 import { Op } from 'sequelize';
 
 import '../../server/env';
 
 import models from '../../server/models';
-import * as libPayments from '../../server/lib/payments';
 import status from '../../server/constants/order_status';
-
+import { dispatchFunds, getNextDispatchingDate } from '../../server/lib/subscriptions';
 const debug = debugLib('dispatch_prepaid_subscription');
 
 async function run() {
@@ -44,57 +41,14 @@ async function run() {
   return filter(allOrders, order => {
     return order.Subscription.data && needsDispatching(order.Subscription.data.nextDispatchDate);
   }).map(async order => {
-    // Amount shareable amongst dependencies
-    const shareableAmount = order.totalAmount;
-    const jsonUrl = order.data.customData.jsonUrl;
-    const depRecommendation = await fetchDependcies(jsonUrl);
-    const sumOfWeights = depRecommendation.reduce((sum, dependency) => dependency.weigh + sum, 0);
-    const HostCollectiveId = await order.collective.getHostCollectiveId();
-
-    const paymentMethod = await models.PaymentMethod.create({
-      initialBalance: shareableAmount,
-      currency: order.currency,
-      CollectiveId: order.FromCollectiveId,
-      customerId: order.fromCollective.slug,
-      service: 'opencollective',
-      type: 'prepaid',
-      uuid: uuidV4(),
-      data: { HostCollectiveId },
-    });
-
-    return map(depRecommendation, async dependency => {
-      // Check if the collective is avaliable
-      const collective = await models.Collective.findByPk(dependency.opencollective.id);
-      const totalAmount = computeAmount(shareableAmount, sumOfWeights, dependency.weigh);
-
-      const orderData = {
-        CreatedByUserId: order.CreatedByUserId,
-        FromCollectiveId: order.FromCollectiveId,
-        CollectiveId: collective.id,
-        quantity: order.quantity,
-        description: order.description,
-        totalAmount,
-        currency: order.currency,
-        status: status.PENDING,
-      };
-      const orderCreated = await models.Order.create(orderData);
-      await orderCreated.setPaymentMethod(paymentMethod);
-      await orderCreated.reload();
-
-      try {
-        await libPayments.executeOrder(order.createdByUser, orderCreated);
-      } catch (e) {
-        debug(`Error occured excuting order ${orderCreated.id}`, e);
-        throw e;
-      }
-      return;
-    })
-      .then(async () => {
+    return dispatchFunds(order)
+      .then(async createdOrdersId => {
         const nextDispatchDate = getNextDispatchingDate(
           order.Subscription.interval,
           order.Subscription.data.nextDispatchDate,
         );
         order.Subscription.data = { nextDispatchDate };
+        order.data = Object.assign(order.data, { lastDispatchedOrdersId: createdOrdersId });
         await order.Subscription.save();
         await order.save();
       })
@@ -105,29 +59,9 @@ async function run() {
   });
 }
 
-const computeAmount = (totalAmount, sumOfWeights, dependencyWeight) => {
-  // Express each weight as percentage
-  const percentage = (dependencyWeight / sumOfWeights) * 100;
-  return Math.round((percentage / 100) * totalAmount);
-};
-
-const fetchDependcies = jsonUrl => {
-  return fetch(jsonUrl).then(res => res.json());
-};
-
 function needsDispatching(nextDispatchDate) {
   const needs = moment(nextDispatchDate).isSameOrBefore();
   return needs;
-}
-
-function getNextDispatchingDate(interval, currentDispatchDate) {
-  const nextDispatchDate = moment(currentDispatchDate);
-  if (interval === 'month') {
-    nextDispatchDate.add(1, 'months');
-  } else if (interval === 'year') {
-    nextDispatchDate.add(1, 'years');
-  }
-  return nextDispatchDate.toDate();
 }
 
 run()

--- a/cron/daily/dispatch_prepaid_subscription.js
+++ b/cron/daily/dispatch_prepaid_subscription.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
+import fetch from 'isomorphic-fetch';
 import { map } from 'bluebird';
+import { Op } from 'sequelize';
+
 import '../../server/env';
 
 import models from '../../server/models';
 import * as libPayments from '../../server/lib/payments';
+import { getNextChargeAndPeriodStartDates } from '../../server/lib/subscriptions';
 import status from '../../server/constants/order_status';
 
 async function run() {
@@ -11,6 +15,8 @@ async function run() {
   const allOrders = await models.Order.findAll({
     where: {
       status: status.ACTIVE,
+      SubscriptionId: { [Op.ne]: null },
+      deletedAt: null,
     },
     include: [
       {
@@ -18,27 +24,35 @@ async function run() {
         where: { type: 'PREPAID' },
       },
       { model: models.Collective, as: 'fromCollective' },
+      { model: models.Collective, as: 'collective' },
+      {
+        model: models.Subscription,
+        where: {
+          isActive: true,
+          deletedAt: null,
+          deactivatedAt: null,
+          activatedAt: { [Op.lte]: new Date() },
+          nextChargeDate: { [Op.lte]: new Date() },
+        },
+      },
     ],
   });
 
-  map(allOrders, order => {
+  map(allOrders, async order => {
     // Amount shareable amongst dependencies
     const shareableAmount = order.totalAmount;
-    // Dependecies reciving money
-    // - get the url from `order.custonField.jsonUrl`
-    // - fetch the dependecies
-    const sampleDependecies = [
-      { weigh: 50, opencollective: { id: 43, name: 'Apex', slug: 'apex' } },
-      { weigh: 100, opencollective: { id: 10887, name: 'Nodejs Tech', slug: 'nodejs-tech' } },
-    ];
-    const sumOfWeights = sampleDependecies.reduce((sum, dependency) => dependency.weigh + sum, 0);
-    map(sampleDependecies, async dependency => {
+    const jsonUrl = order.data.customData.jsonUrl;
+    const depRecommendation = await fetchDependcies(jsonUrl);
+    const sumOfWeights = depRecommendation.reduce((sum, dependency) => dependency.weigh + sum, 0);
+
+    map(depRecommendation, async dependency => {
       // Check if the collective is avaliable
       const collective = await models.Collective.findByPk(dependency.opencollective.id);
-      const fromHostId = await order.fromCollective.getHostCollectiveId();
       const totalAmount = computeAmount(shareableAmount, sumOfWeights, dependency.weigh);
+      const pm = await order.collective.getPaymentMethod({ service: 'opencollective', type: 'prepaid' }, false);
+
       const orderData = {
-        createdByUserId: order.createdByUserId,
+        CreatedByUserId: order.CreatedByUserId,
         FromCollectiveId: order.FromCollectiveId,
         CollectiveId: collective.id,
         quantity: order.quantity,
@@ -47,19 +61,10 @@ async function run() {
         totalAmount,
         currency: order.currency,
         status: status.PENDING,
-        paymentMethod: {
-          primary: false,
-          initalBalance: shareableAmount - totalAmount,
-          type: 'prepaid',
-          CollectiveId: order.FromCollectiveId,
-          service: 'opencollective',
-          customerId: order.FromCollectiveId.slug,
-          currency: order.currency,
-          data: { HostCollectiveId: fromHostId },
-        },
       };
+
       const orderCreated = await models.Order.create(orderData);
-      await orderCreated.setPaymentMethod(orderData.paymentMethod);
+      await orderCreated.setPaymentMethod(pm.uuid);
       try {
         await libPayments.executeOrder(
           // order.fromCollective, Order needs instance of user here not collective
@@ -74,6 +79,9 @@ async function run() {
       }
     });
     // Update the original order subscription for next charge period
+    order.Subscription = Object.assign(order.Subscription, getNextChargeAndPeriodStartDates('success', order));
+    await order.Subscription.save();
+    await order.save();
   });
 }
 
@@ -81,6 +89,10 @@ const computeAmount = (totalAmount, sumOfWeights, dependencyWeight) => {
   // Express each weight as percentage
   const percentage = (dependencyWeight / sumOfWeights) * 100;
   return Math.round((percentage / 100) * totalAmount);
+};
+
+const fetchDependcies = jsonUrl => {
+  return fetch(jsonUrl).then(res => res.json());
 };
 
 run().catch(err => {

--- a/cron/daily/dispatch_prepaid_subscription.js
+++ b/cron/daily/dispatch_prepaid_subscription.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import debugLib from 'debug';
-import moment from 'moment';
 import { filter } from 'bluebird';
 import { Op } from 'sequelize';
 
@@ -8,7 +7,7 @@ import '../../server/env';
 
 import models from '../../server/models';
 import status from '../../server/constants/order_status';
-import { dispatchFunds, getNextDispatchingDate } from '../../server/lib/dispatcher';
+import { dispatchFunds, getNextDispatchingDate, needsDispatching } from '../../server/lib/dispatcher';
 const debug = debugLib('dispatch_prepaid_subscription');
 
 async function run() {
@@ -56,11 +55,6 @@ async function run() {
         console.error(error);
       });
   });
-}
-
-function needsDispatching(nextDispatchDate) {
-  const needs = moment(nextDispatchDate).isSameOrBefore();
-  return needs;
 }
 
 run()

--- a/cron/daily/dispatch_prepaid_subscription.js
+++ b/cron/daily/dispatch_prepaid_subscription.js
@@ -8,7 +8,7 @@ import '../../server/env';
 
 import models from '../../server/models';
 import status from '../../server/constants/order_status';
-import { dispatchFunds, getNextDispatchingDate } from '../../server/lib/subscriptions';
+import { dispatchFunds, getNextDispatchingDate } from '../../server/lib/dispatcher';
 const debug = debugLib('dispatch_prepaid_subscription');
 
 async function run() {
@@ -42,13 +42,12 @@ async function run() {
     return order.Subscription.data && needsDispatching(order.Subscription.data.nextDispatchDate);
   }).map(async order => {
     return dispatchFunds(order)
-      .then(async createdOrdersId => {
+      .then(async () => {
         const nextDispatchDate = getNextDispatchingDate(
           order.Subscription.interval,
           order.Subscription.data.nextDispatchDate,
         );
         order.Subscription.data = { nextDispatchDate };
-        order.data = Object.assign(order.data, { lastDispatchedOrdersId: createdOrdersId });
         await order.Subscription.save();
         await order.save();
       })

--- a/cron/daily/dispatch_prepaid_subscription.js
+++ b/cron/daily/dispatch_prepaid_subscription.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import { map } from 'bluebird';
+import '../../server/env';
+
+import models from '../../server/models';
+import * as libPayments from '../../server/lib/payments';
+import status from '../../server/constants/order_status';
+
+async function run() {
+  // fetch orders created from PREPAID tier
+  const allOrders = await models.Order.findAll({
+    where: {
+      status: status.ACTIVE,
+    },
+    include: [
+      {
+        model: models.Tier,
+        where: { type: 'PREPAID' },
+      },
+      { model: models.Collective, as: 'fromCollective' },
+    ],
+  });
+
+  map(allOrders, order => {
+    // Amount shareable amongst dependencies
+    const shareableAmount = order.totalAmount;
+    // Dependecies reciving money
+    // - get the url from `order.custonField.jsonUrl`
+    // - fetch the dependecies
+    const sampleDependecies = [
+      { weigh: 50, opencollective: { id: 43, name: 'Apex', slug: 'apex' } },
+      { weigh: 100, opencollective: { id: 10887, name: 'Nodejs Tech', slug: 'nodejs-tech' } },
+    ];
+    const sumOfWeights = sampleDependecies.reduce((sum, dependency) => dependency.weigh + sum, 0);
+    map(sampleDependecies, async dependency => {
+      // Check if the collective is avaliable
+      const collective = await models.Collective.findByPk(dependency.opencollective.id);
+      const fromHostId = await order.fromCollective.getHostCollectiveId();
+      const totalAmount = computeAmount(shareableAmount, sumOfWeights, dependency.weigh);
+      const orderData = {
+        createdByUserId: order.createdByUserId,
+        FromCollectiveId: order.FromCollectiveId,
+        CollectiveId: collective.id,
+        quantity: order.quantity,
+        description: order.description,
+        processedAt: new Date(),
+        totalAmount,
+        currency: order.currency,
+        status: status.PENDING,
+        paymentMethod: {
+          primary: false,
+          initalBalance: shareableAmount - totalAmount,
+          type: 'prepaid',
+          CollectiveId: order.FromCollectiveId,
+          service: 'opencollective',
+          customerId: order.FromCollectiveId.slug,
+          currency: order.currency,
+          data: { HostCollectiveId: fromHostId },
+        },
+      };
+      const orderCreated = await models.Order.create(orderData);
+      await orderCreated.setPaymentMethod(orderData.paymentMethod);
+      try {
+        await libPayments.executeOrder(
+          // order.fromCollective, Order needs instance of user here not collective
+          orderCreated,
+        );
+      } catch (e) {
+        // Don't save new card for user if order failed
+        if (!order.paymentMethod.id && !order.paymentMethod.uuid) {
+          await orderCreated.paymentMethod.update({ CollectiveId: null });
+        }
+        throw e;
+      }
+    });
+    // Update the original order subscription for next charge period
+  });
+}
+
+const computeAmount = (totalAmount, sumOfWeights, dependencyWeight) => {
+  // Express each weight as percentage
+  const percentage = (dependencyWeight / sumOfWeights) * 100;
+  return Math.round((percentage / 100) * totalAmount);
+};
+
+run().catch(err => {
+  console.error(err);
+});

--- a/cron/daily/dispatch_prepaid_subscription.js
+++ b/cron/daily/dispatch_prepaid_subscription.js
@@ -39,22 +39,25 @@ async function run() {
 
   return filter(allOrders, order => {
     return order.Subscription.data && needsDispatching(order.Subscription.data.nextDispatchDate);
-  }).map(async order => {
-    return dispatchFunds(order)
-      .then(async () => {
-        const nextDispatchDate = getNextDispatchingDate(
-          order.Subscription.interval,
-          order.Subscription.data.nextDispatchDate,
-        );
-        order.Subscription.data = { nextDispatchDate };
-        await order.Subscription.save();
-        await order.save();
-      })
-      .catch(error => {
-        debug(`Error occured processing and dispatching order ${order.id}`, error);
-        console.error(error);
-      });
-  });
+  }).map(
+    async order => {
+      return dispatchFunds(order)
+        .then(async () => {
+          const nextDispatchDate = getNextDispatchingDate(
+            order.Subscription.interval,
+            order.Subscription.data.nextDispatchDate,
+          );
+          order.Subscription.data = { nextDispatchDate };
+          await order.Subscription.save();
+          await order.save();
+        })
+        .catch(error => {
+          debug(`Error occured processing and dispatching order ${order.id}`, error);
+          console.error(error);
+        });
+    },
+    { concurrency: 3 },
+  );
 }
 
 run()

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -21,6 +21,7 @@ import {
   completePledge,
   markOrderAsPaid,
   updateOrderInfo,
+  createOrderForDispatch,
 } from './mutations/orders';
 import { createMember, removeMember, editMembership } from './mutations/members';
 import { editTiers, editTier } from './mutations/tiers';
@@ -392,6 +393,17 @@ const mutations = {
     },
     resolve(_, args, req) {
       return createOrder(args.order, req.loaders, req.remoteUser, req.ip);
+    },
+  },
+  createOrderForDispatch: {
+    type: OrderType,
+    args: {
+      order: {
+        type: new GraphQLNonNull(OrderInputType),
+      },
+    },
+    resolve(_, args, req) {
+      return createOrderForDispatch(args.order, req.loaders, req.remoteUser, req.ip);
     },
   },
   addFundsToCollective: {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -21,7 +21,7 @@ import {
   completePledge,
   markOrderAsPaid,
   updateOrderInfo,
-  createOrderForDispatch,
+  dispatchOrder,
 } from './mutations/orders';
 import { createMember, removeMember, editMembership } from './mutations/members';
 import { editTiers, editTier } from './mutations/tiers';
@@ -395,15 +395,15 @@ const mutations = {
       return createOrder(args.order, req.loaders, req.remoteUser, req.ip);
     },
   },
-  createOrderForDispatch: {
-    type: OrderType,
+  dispatchOrder: {
+    type: new GraphQLList(OrderType),
     args: {
-      order: {
-        type: new GraphQLNonNull(OrderInputType),
+      id: {
+        type: new GraphQLNonNull(GraphQLInt),
       },
     },
-    resolve(_, args, req) {
-      return createOrderForDispatch(args.order, req.loaders, req.remoteUser, req.ip);
+    resolve(_, args) {
+      return dispatchOrder(args.id);
     },
   },
   addFundsToCollective: {

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -977,7 +977,7 @@ export async function dispatchOrder(orderId) {
     throw new Error(`Order was created but not active`);
   }
 
-  if (subscription.data.nextDispatchDate && !needsDispatching(subscription.data.nextDispatchDate)) {
+  if (subscription.data && !needsDispatching(subscription.data.nextDispatchDate)) {
     throw new Error(`Order is not up for dispatching, next dispatching date is ${subscription.data.nextDispatchDate}`);
   }
 
@@ -990,8 +990,9 @@ export async function dispatchOrder(orderId) {
   }
 
   if (dispatchedOrders) {
+    const currentDispatchDate = subscription.data.nextDispatchDate || new Date();
     subscription.data = {
-      nextDispatchDate: getNextDispatchingDate(order.interval, new Date()),
+      nextDispatchDate: getNextDispatchingDate(subscription.interval, currentDispatchDate),
     };
 
     await subscription.save();

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -508,6 +508,14 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
     order = await models.Order.findByPk(orderCreated.id);
 
+    if (tier && tier.type === 'PREPAID' && order.status === status.ACTIVE) {
+      const subscription = await models.Subscription.findByPk(order.SubscriptionId);
+      subscription.data = {
+        nextDispatchDate: new Date(),
+      };
+      await subscription.save();
+    }
+
     // If there was a referral for this order, we add it as a FUNDRAISER role
     if (order.ReferralCollectiveId && order.ReferralCollectiveId !== user.CollectiveId) {
       collective.addUserWithRole({ id: user.id, CollectiveId: order.ReferralCollectiveId }, roles.FUNDRAISER);

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -15,12 +15,8 @@ import recaptcha from '../../../lib/recaptcha';
 import slackLib from '../../../lib/slack';
 import * as libPayments from '../../../lib/payments';
 import { capitalize, pluralize, formatCurrency } from '../../../lib/utils';
-import {
-  getNextChargeAndPeriodStartDates,
-  getChargeRetryCount,
-  dispatchFunds,
-  getNextDispatchingDate,
-} from '../../../lib/subscriptions';
+import { getNextChargeAndPeriodStartDates, getChargeRetryCount } from '../../../lib/subscriptions';
+import { dispatchFunds, getNextDispatchingDate } from '../../../lib/dispatcher';
 
 import roles from '../../../constants/roles';
 import status from '../../../constants/order_status';
@@ -966,40 +962,36 @@ export async function addFundsToCollective(order, remoteUser) {
   return models.Order.findByPk(orderCreated.id);
 }
 
-export async function createOrderForDispatch(order, loaders, remoteUser, reqIp) {
-  let tier;
-  // Ensure prepaid tier is avaliable
-  if (order.tier) {
-    tier = await models.Tier.findByPk(order.tier.id);
-
-    if (!tier || tier.type !== 'PREPAID') {
-      throw new Error(`No tier found with tier id: ${order.tier.id} for collective slug ${order.collective.slug}`);
-    }
+export async function dispatchOrder(orderId) {
+  const order = await models.Order.findByPk(orderId);
+  if (!order) {
+    throw new Error(`No order with id ${orderId} found`);
   }
 
-  let dispatchedOrdersId;
-  const createdOrder = await createOrder(order, loaders, remoteUser, reqIp);
-  const subscription = await models.Subscription.findByPk(createdOrder.SubscriptionId);
-  if (!subscription.isActive || createdOrder.status !== status.ACTIVE) {
+  if (!order.data.customData || !order.data.customData.jsonUrl) {
+    throw new Error('Requires customData jsonUrl to dispatch order');
+  }
+
+  const subscription = await models.Subscription.findByPk(order.SubscriptionId);
+  if (!subscription.isActive || order.status !== status.ACTIVE) {
     throw new Error(`Order was created but not active`);
   }
 
+  let dispatchedOrders;
   try {
-    dispatchedOrdersId = await dispatchFunds(createdOrder);
+    dispatchedOrders = await dispatchFunds(order);
   } catch (err) {
     console.error(err);
-    throw new Error(`Unable to dispatch funds to collectves but your order was created.`);
+    throw new Error(`Unable to dispatch funds to collectves.`);
   }
 
-  if (dispatchedOrdersId) {
+  if (dispatchedOrders) {
     subscription.data = {
-      nextDispatchDate: getNextDispatchingDate(createdOrder.interval, new Date()),
+      nextDispatchDate: getNextDispatchingDate(order.interval, new Date()),
     };
-    createdOrder.data = Object.assign(createdOrder.data, { lastDispatchedOrdersId: dispatchedOrdersId });
+
     await subscription.save();
-    await createdOrder.save();
-    await createdOrder.reload();
   }
 
-  return createdOrder;
+  return dispatchedOrders;
 }

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -15,7 +15,12 @@ import recaptcha from '../../../lib/recaptcha';
 import slackLib from '../../../lib/slack';
 import * as libPayments from '../../../lib/payments';
 import { capitalize, pluralize, formatCurrency } from '../../../lib/utils';
-import { getNextChargeAndPeriodStartDates, getChargeRetryCount } from '../../../lib/subscriptions';
+import {
+  getNextChargeAndPeriodStartDates,
+  getChargeRetryCount,
+  dispatchFunds,
+  getNextDispatchingDate,
+} from '../../../lib/subscriptions';
 
 import roles from '../../../constants/roles';
 import status from '../../../constants/order_status';
@@ -508,14 +513,6 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
     order = await models.Order.findByPk(orderCreated.id);
 
-    if (tier && tier.type === 'PREPAID' && order.status === status.ACTIVE) {
-      const subscription = await models.Subscription.findByPk(order.SubscriptionId);
-      subscription.data = {
-        nextDispatchDate: new Date(),
-      };
-      await subscription.save();
-    }
-
     // If there was a referral for this order, we add it as a FUNDRAISER role
     if (order.ReferralCollectiveId && order.ReferralCollectiveId !== user.CollectiveId) {
       collective.addUserWithRole({ id: user.id, CollectiveId: order.ReferralCollectiveId }, roles.FUNDRAISER);
@@ -967,4 +964,42 @@ export async function addFundsToCollective(order, remoteUser) {
   }
 
   return models.Order.findByPk(orderCreated.id);
+}
+
+export async function createOrderForDispatch(order, loaders, remoteUser, reqIp) {
+  let tier;
+  // Ensure prepaid tier is avaliable
+  if (order.tier) {
+    tier = await models.Tier.findByPk(order.tier.id);
+
+    if (!tier || tier.type !== 'PREPAID') {
+      throw new Error(`No tier found with tier id: ${order.tier.id} for collective slug ${order.collective.slug}`);
+    }
+  }
+
+  let dispatchedOrdersId;
+  const createdOrder = await createOrder(order, loaders, remoteUser, reqIp);
+  const subscription = await models.Subscription.findByPk(createdOrder.SubscriptionId);
+  if (!subscription.isActive || createdOrder.status !== status.ACTIVE) {
+    throw new Error(`Order was created but not active`);
+  }
+
+  try {
+    dispatchedOrdersId = await dispatchFunds(createdOrder);
+  } catch (err) {
+    console.error(err);
+    throw new Error(`Unable to dispatch funds to collectves but your order was created.`);
+  }
+
+  if (dispatchedOrdersId) {
+    subscription.data = {
+      nextDispatchDate: getNextDispatchingDate(createdOrder.interval, new Date()),
+    };
+    createdOrder.data = Object.assign(createdOrder.data, { lastDispatchedOrdersId: dispatchedOrdersId });
+    await subscription.save();
+    await createdOrder.save();
+    await createdOrder.reload();
+  }
+
+  return createdOrder;
 }

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -16,7 +16,6 @@ import { Kind } from 'graphql/language';
 import GraphQLJSON from 'graphql-type-json';
 import he from 'he';
 import { pick } from 'lodash';
-import { map } from 'bluebird';
 import moment from 'moment';
 
 import { CollectiveInterfaceType, CollectiveSearchResultsType } from './CollectiveInterface';
@@ -1690,19 +1689,7 @@ export const OrderType = new GraphQLObjectType({
         type: GraphQLJSON,
         description: 'Additional information on order: tax and custom fields',
         async resolve(order) {
-          const data = pick(order.data, ['tax', 'customData', 'lastDispatchedOrdersId']) || null;
-          if (data.lastDispatchedOrdersId && data.lastDispatchedOrdersId.length !== 0) {
-            const dispatchedOrders = await map(data.lastDispatchedOrdersId, id =>
-              models.Order.findOne({
-                where: { id, status: status.PAID },
-                include: [{ model: models.Collective, as: 'collective' }],
-              }),
-            );
-            data.dispatchedOrders = dispatchedOrders;
-            return data;
-          } else {
-            return data;
-          }
+          return pick(order.data, ['tax', 'customData']) || null;
         },
       },
     };

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -16,6 +16,7 @@ import { Kind } from 'graphql/language';
 import GraphQLJSON from 'graphql-type-json';
 import he from 'he';
 import { pick } from 'lodash';
+import { map } from 'bluebird';
 import moment from 'moment';
 
 import { CollectiveInterfaceType, CollectiveSearchResultsType } from './CollectiveInterface';
@@ -1688,8 +1689,20 @@ export const OrderType = new GraphQLObjectType({
       data: {
         type: GraphQLJSON,
         description: 'Additional information on order: tax and custom fields',
-        resolve(order) {
-          return pick(order.data, ['tax', 'customData']) || null;
+        async resolve(order) {
+          const data = pick(order.data, ['tax', 'customData', 'lastDispatchedOrdersId']) || null;
+          if (data.lastDispatchedOrdersId && data.lastDispatchedOrdersId.length !== 0) {
+            const dispatchedOrders = await map(data.lastDispatchedOrdersId, id =>
+              models.Order.findOne({
+                where: { id, status: status.PAID },
+                include: [{ model: models.Collective, as: 'collective' }],
+              }),
+            );
+            data.dispatchedOrders = dispatchedOrders;
+            return data;
+          } else {
+            return data;
+          }
         },
       },
     };

--- a/server/lib/dispatcher.js
+++ b/server/lib/dispatcher.js
@@ -93,7 +93,7 @@ export async function dispatchFunds(order) {
         FromCollectiveId: order.FromCollectiveId,
         CollectiveId: collective.id,
         quantity: order.quantity,
-        description: order.description,
+        description: `Monthly donation to ${collective.name} through BackYourStack`,
         totalAmount,
         currency: order.currency,
         status: status.PENDING,

--- a/server/lib/dispatcher.js
+++ b/server/lib/dispatcher.js
@@ -20,6 +20,11 @@ export function getNextDispatchingDate(interval, currentDispatchDate) {
   return nextDispatchDate.toDate();
 }
 
+export function needsDispatching(nextDispatchDate) {
+  const needs = moment(nextDispatchDate).isSameOrBefore();
+  return needs;
+}
+
 function computeAmount(totalAmount, sumOfWeights, dependencyWeight) {
   // Express each weight as percentage
   const percentage = (dependencyWeight / sumOfWeights) * 100;
@@ -31,7 +36,6 @@ function fetchDependencies(jsonUrl) {
 }
 
 export async function dispatchFunds(order) {
-  console.log(order);
   const debug = debugLib('dispatch_prepaid_subscription');
   // Amount shareable amongst dependencies
   const transaction = await models.Transaction.findOne({

--- a/server/lib/dispatcher.js
+++ b/server/lib/dispatcher.js
@@ -1,0 +1,108 @@
+/** @module lib/subscriptions */
+
+import fetch from 'isomorphic-fetch';
+import uuidV4 from 'uuid/v4';
+import debugLib from 'debug';
+import { map } from 'bluebird';
+import models from '../models';
+import moment from 'moment';
+
+import status from '../constants/order_status';
+import * as paymentsLib from './payments';
+
+export function getNextDispatchingDate(interval, currentDispatchDate) {
+  const nextDispatchDate = moment(currentDispatchDate);
+  if (interval === 'month') {
+    nextDispatchDate.add(1, 'months');
+  } else if (interval === 'year') {
+    nextDispatchDate.add(1, 'years');
+  }
+  return nextDispatchDate.toDate();
+}
+
+function computeAmount(totalAmount, sumOfWeights, dependencyWeight) {
+  // Express each weight as percentage
+  const percentage = (dependencyWeight / sumOfWeights) * 100;
+  return Math.round((percentage / 100) * totalAmount);
+}
+
+function fetchDependencies(jsonUrl) {
+  return fetch(jsonUrl).then(res => res.json());
+}
+
+export async function dispatchFunds(order) {
+  console.log(order);
+  const debug = debugLib('dispatch_prepaid_subscription');
+  // Amount shareable amongst dependencies
+  const transaction = await models.Transaction.findOne({
+    where: { OrderId: order.id, type: 'CREDIT' },
+  });
+  const shareableAmount = transaction.netAmountInCollectiveCurrency;
+  const jsonUrl = order.data.customData.jsonUrl;
+  let depRecommendation;
+
+  try {
+    depRecommendation = await fetchDependencies(jsonUrl);
+  } catch (err) {
+    debug('Error fetching dependcies', err);
+    console.error(err);
+    throw new Error('Unable to fetch dependencies, please ensure the url is correct');
+  }
+
+  const sumOfWeights = depRecommendation.reduce((sum, dependency) => dependency.weight + sum, 0);
+  let HostCollectiveId;
+  if (!order.collective) {
+    const collective = await models.Collective.findByPk(order.CollectiveId);
+    HostCollectiveId = await collective.getHostCollectiveId();
+  } else {
+    HostCollectiveId = await order.collective.getHostCollectiveId();
+  }
+
+  if (!order.fromCollective) {
+    order.fromCollective = await models.Collective.findByPk(order.FromCollectiveId);
+  }
+
+  if (!order.createdByUser) {
+    order.createdByUser = await models.User.findByPk(order.CreatedByUserId);
+  }
+
+  const paymentMethod = await models.PaymentMethod.create({
+    initialBalance: shareableAmount,
+    currency: order.currency,
+    CollectiveId: order.FromCollectiveId,
+    customerId: order.fromCollective.slug,
+    service: 'opencollective',
+    type: 'prepaid',
+    uuid: uuidV4(),
+    data: { HostCollectiveId },
+  });
+
+  return map(depRecommendation, async dependency => {
+    // Check if the collective is avaliable
+    const collective = await models.Collective.findByPk(dependency.opencollective.id);
+    const totalAmount = computeAmount(shareableAmount, sumOfWeights, dependency.weight);
+
+    const orderData = {
+      CreatedByUserId: order.CreatedByUserId,
+      FromCollectiveId: order.FromCollectiveId,
+      CollectiveId: collective.id,
+      quantity: order.quantity,
+      description: order.description,
+      totalAmount,
+      currency: order.currency,
+      status: status.PENDING,
+    };
+
+    const orderCreated = await models.Order.create(orderData);
+    await orderCreated.setPaymentMethod(paymentMethod);
+    await orderCreated.reload();
+
+    try {
+      await paymentsLib.executeOrder(order.createdByUser, orderCreated);
+    } catch (e) {
+      debug(`Error occured excuting order ${orderCreated.id}`, e);
+      throw e;
+    }
+    return orderCreated;
+  });
+}

--- a/server/lib/subscriptions.js
+++ b/server/lib/subscriptions.js
@@ -1,8 +1,11 @@
 /** @module lib/subscriptions */
-
+import fetch from 'isomorphic-fetch';
+import uuidV4 from 'uuid/v4';
 import config from 'config';
 import moment from 'moment';
+import debugLib from 'debug';
 import { Op } from 'sequelize';
+import { map } from 'bluebird';
 
 import models from '../models';
 import emailLib from './email';
@@ -327,4 +330,99 @@ export async function sendThankYouEmail(order, transaction) {
       from: `${order.collective.name} <hello@${order.collective.slug}.opencollective.com>`,
     },
   );
+}
+
+export function getNextDispatchingDate(interval, currentDispatchDate) {
+  const nextDispatchDate = moment(currentDispatchDate);
+  if (interval === 'month') {
+    nextDispatchDate.add(1, 'months');
+  } else if (interval === 'year') {
+    nextDispatchDate.add(1, 'years');
+  }
+  return nextDispatchDate.toDate();
+}
+
+function computeAmount(totalAmount, sumOfWeights, dependencyWeight) {
+  // Express each weight as percentage
+  const percentage = (dependencyWeight / sumOfWeights) * 100;
+  return Math.round((percentage / 100) * totalAmount);
+}
+
+function fetchDependencies(jsonUrl) {
+  return fetch(jsonUrl).then(res => res.json());
+}
+
+export async function dispatchFunds(order) {
+  const debug = debugLib('dispatch_prepaid_subscription');
+  // Amount shareable amongst dependencies
+  const transaction = await models.Transaction.findOne({
+    where: { OrderId: order.id, type: 'CREDIT' },
+  });
+  const shareableAmount = transaction.netAmountInCollectiveCurrency;
+  const jsonUrl = order.data.customData.jsonUrl;
+  let depRecommendation;
+
+  try {
+    depRecommendation = await fetchDependencies(jsonUrl);
+  } catch (err) {
+    debug('Error fetching dependcies', err);
+    console.error(err);
+    throw new Error('Unable to fetch dependencies, please ensure the url is correct');
+  }
+
+  const sumOfWeights = depRecommendation.reduce((sum, dependency) => dependency.weight + sum, 0);
+  let HostCollectiveId;
+  if (!order.collective) {
+    const collective = await models.Collective.findByPk(order.CollectiveId);
+    HostCollectiveId = await collective.getHostCollectiveId();
+  } else {
+    HostCollectiveId = await order.collective.getHostCollectiveId();
+  }
+
+  if (!order.fromCollective) {
+    order.fromCollective = await models.Collective.findByPk(order.FromCollectiveId);
+  }
+
+  if (!order.createdByUser) {
+    order.createdByUser = await models.User.findByPk(order.CreatedByUserId);
+  }
+
+  const paymentMethod = await models.PaymentMethod.create({
+    initialBalance: shareableAmount,
+    currency: order.currency,
+    CollectiveId: order.FromCollectiveId,
+    customerId: order.fromCollective.slug,
+    service: 'opencollective',
+    type: 'prepaid',
+    uuid: uuidV4(),
+    data: { HostCollectiveId },
+  });
+
+  return map(depRecommendation, async dependency => {
+    // Check if the collective is avaliable
+    const collective = await models.Collective.findByPk(dependency.opencollective.id);
+    const totalAmount = computeAmount(shareableAmount, sumOfWeights, dependency.weigh);
+
+    const orderData = {
+      CreatedByUserId: order.CreatedByUserId,
+      FromCollectiveId: order.FromCollectiveId,
+      CollectiveId: collective.id,
+      quantity: order.quantity,
+      description: order.description,
+      totalAmount,
+      currency: order.currency,
+      status: status.PENDING,
+    };
+    const orderCreated = await models.Order.create(orderData);
+    await orderCreated.setPaymentMethod(paymentMethod);
+    await orderCreated.reload();
+
+    try {
+      await paymentsLib.executeOrder(order.createdByUser, orderCreated);
+    } catch (e) {
+      debug(`Error occured excuting order ${orderCreated.id}`, e);
+      throw e;
+    }
+    return orderCreated.id;
+  });
 }

--- a/server/lib/subscriptions.js
+++ b/server/lib/subscriptions.js
@@ -1,11 +1,7 @@
 /** @module lib/subscriptions */
-import fetch from 'isomorphic-fetch';
-import uuidV4 from 'uuid/v4';
 import config from 'config';
 import moment from 'moment';
-import debugLib from 'debug';
 import { Op } from 'sequelize';
-import { map } from 'bluebird';
 
 import models from '../models';
 import emailLib from './email';
@@ -330,99 +326,4 @@ export async function sendThankYouEmail(order, transaction) {
       from: `${order.collective.name} <hello@${order.collective.slug}.opencollective.com>`,
     },
   );
-}
-
-export function getNextDispatchingDate(interval, currentDispatchDate) {
-  const nextDispatchDate = moment(currentDispatchDate);
-  if (interval === 'month') {
-    nextDispatchDate.add(1, 'months');
-  } else if (interval === 'year') {
-    nextDispatchDate.add(1, 'years');
-  }
-  return nextDispatchDate.toDate();
-}
-
-function computeAmount(totalAmount, sumOfWeights, dependencyWeight) {
-  // Express each weight as percentage
-  const percentage = (dependencyWeight / sumOfWeights) * 100;
-  return Math.round((percentage / 100) * totalAmount);
-}
-
-function fetchDependencies(jsonUrl) {
-  return fetch(jsonUrl).then(res => res.json());
-}
-
-export async function dispatchFunds(order) {
-  const debug = debugLib('dispatch_prepaid_subscription');
-  // Amount shareable amongst dependencies
-  const transaction = await models.Transaction.findOne({
-    where: { OrderId: order.id, type: 'CREDIT' },
-  });
-  const shareableAmount = transaction.netAmountInCollectiveCurrency;
-  const jsonUrl = order.data.customData.jsonUrl;
-  let depRecommendation;
-
-  try {
-    depRecommendation = await fetchDependencies(jsonUrl);
-  } catch (err) {
-    debug('Error fetching dependcies', err);
-    console.error(err);
-    throw new Error('Unable to fetch dependencies, please ensure the url is correct');
-  }
-
-  const sumOfWeights = depRecommendation.reduce((sum, dependency) => dependency.weight + sum, 0);
-  let HostCollectiveId;
-  if (!order.collective) {
-    const collective = await models.Collective.findByPk(order.CollectiveId);
-    HostCollectiveId = await collective.getHostCollectiveId();
-  } else {
-    HostCollectiveId = await order.collective.getHostCollectiveId();
-  }
-
-  if (!order.fromCollective) {
-    order.fromCollective = await models.Collective.findByPk(order.FromCollectiveId);
-  }
-
-  if (!order.createdByUser) {
-    order.createdByUser = await models.User.findByPk(order.CreatedByUserId);
-  }
-
-  const paymentMethod = await models.PaymentMethod.create({
-    initialBalance: shareableAmount,
-    currency: order.currency,
-    CollectiveId: order.FromCollectiveId,
-    customerId: order.fromCollective.slug,
-    service: 'opencollective',
-    type: 'prepaid',
-    uuid: uuidV4(),
-    data: { HostCollectiveId },
-  });
-
-  return map(depRecommendation, async dependency => {
-    // Check if the collective is avaliable
-    const collective = await models.Collective.findByPk(dependency.opencollective.id);
-    const totalAmount = computeAmount(shareableAmount, sumOfWeights, dependency.weigh);
-
-    const orderData = {
-      CreatedByUserId: order.CreatedByUserId,
-      FromCollectiveId: order.FromCollectiveId,
-      CollectiveId: collective.id,
-      quantity: order.quantity,
-      description: order.description,
-      totalAmount,
-      currency: order.currency,
-      status: status.PENDING,
-    };
-    const orderCreated = await models.Order.create(orderData);
-    await orderCreated.setPaymentMethod(paymentMethod);
-    await orderCreated.reload();
-
-    try {
-      await paymentsLib.executeOrder(order.createdByUser, orderCreated);
-    } catch (e) {
-      debug(`Error occured excuting order ${orderCreated.id}`, e);
-      throw e;
-    }
-    return orderCreated.id;
-  });
 }

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -62,7 +62,7 @@ export default function(Sequelize, DataTypes) {
       },
 
       type: {
-        type: DataTypes.STRING, // TIER, TICKET, DONATION, SERVICE, PRODUCT, MEMBERSHIP
+        type: DataTypes.STRING, // TIER, TICKET, DONATION, SERVICE, PRODUCT, MEMBERSHIP, PREPAID
         defaultValue: 'TIER',
       },
 


### PR DESCRIPTION
Following up [#2129](https://github.com/opencollective/opencollective/issues/2129).
PS: This is experimental as most of the data used are dummy.

My understanding of this feature is to create a custom Tier as type `PREPAID` on "host collective", like every other tiers, using it follows the same contribution process except later on a `customField` will be shown on the contribution `details`  step to get the json url of dependencies that would benefits. The order goes through the process (`createOrder` mutation resolver process), payment is executed and the "host collective" gets the money initially. 
Now comes the daily cron which this PR is trying to address, sequentially following:

- The `orders` are fetched with the following conditions, `order.status === ACTIVE`,  `order.Tier.type === PREPAID` && `order.Subscription.nextChargeDate === Date.now()`.  (The subscription has been added yet to the PR).

- Using `bluebird` `map` method, the orders are iterated through and each `order` goes through the following operation: 
                    - First thing is to get the dependencies that would be benefiting as expected to be provided in `order.data.customFields.jsonUrl`, using the url in a fetch function, the dependencies data is expected to be returned in below structure.
```js
const sampleDependecies = [
      { weight: 50, opencollective: { id: 43, name: 'Apex', slug: 'apex' } },
      { weight: 100, opencollective: { id: 10887, name: 'Nodejs Tech', slug: 'nodejs-tech' } },
    ];
```
- Next is iterating through the dependencies using the `map` method (using this method allows us to handle concurrency properly), and for each dependency, we compute their share of the original donation using their `weight` property. To compute their share, the sum of all dependencies weight is used to  express each dependency `weight` as percentage of their shares from the `amount`. An order (call it sub order :slightly_smiling_face: ) with `paymentMethod` is created in order is to dispatch donation to the current dependency collective. All information needed to create the order will be fetched, like dependency collective information, the order data looks like below:
```js
const orderData = {
        createdByUserId: order.createdByUserId,
        FromCollectiveId: order.FromCollectiveId,
        CollectiveId: collective.id,
        quantity: order.quantity,
        description: order.description,
        processedAt: new Date(),
        totalAmount,
        currency: order.currency,
        status: status.PENDING,
        paymentMethod: {
          primary: false,
          initalBalance: shareableAmount - totalAmount,
          type: 'prepaid',
          CollectiveId: order.FromCollectiveId,
          service: 'opencollective',
          customerId: order.FromCollectiveId.slug,
          currency: order.currency,
          data: { HostCollectiveId: fromHostId },
        },
      };
```
The next part will be setting `paymentMethod`, currently the [`libPayments.executeOrder` ](https://github.com/opencollective/opencollective-api/blob/master/server/lib/payments.js#L310) method needed to process the order, requires `models.User` instance in it's argument which isn't available in this context and it is where I'm stuck currently in this PR. I also don't know if the function can process order with this type of `paymentMethod` unless it is further expanded. At this stage, if the payment goes through for all dependencies the original `order` subscription `nextChargeDate` should be updated.

The explanation above only gives overview of what is happening in this PR, the cron would further need some constraints to be added in order to handle cases of where a charge doesn't go through or dependencies collective doesn't exist or handling concurrency, error management. 

This is the state of the code & my understanding of what I'm working, let me know what I'm not getting or missing. 
 
 



