### PR TITLE
fix(CollectiveInterface): Updates invalid type

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -29,6 +29,7 @@ import {
   NotificationType,
   DateString,
   ContributorType,
+  UpdateType,
 } from './types';
 
 import { OrderDirectionType, TransactionInterfaceType } from './TransactionInterface';
@@ -672,7 +673,7 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
       githubHandle: { type: GraphQLString },
       website: { type: GraphQLString },
       updates: {
-        type: new GraphQLList(EventCollectiveType),
+        type: new GraphQLList(UpdateType),
         args: {
           limit: { type: GraphQLInt },
           offset: { type: GraphQLInt },
@@ -1346,7 +1347,7 @@ const CollectiveFields = () => {
       },
     },
     updates: {
-      type: new GraphQLList(EventCollectiveType),
+      type: new GraphQLList(UpdateType),
       args: {
         limit: { type: GraphQLInt },
         offset: { type: GraphQLInt },


### PR DESCRIPTION
Endpoint was not used anymore, but we're going to use it for the new collective page