### PR TITLE
chore(Paypal): better error message when pre-approval is expired

### DIFF
--- a/server/paymentProviders/paypal/adaptiveGateway.js
+++ b/server/paymentProviders/paypal/adaptiveGateway.js
@@ -27,7 +27,15 @@ paypalAdaptive.callPaypal = (endpointName, payload) => {
     paypalAdaptiveClient[endpointName](Object.assign({}, payload, { requestEnvelope }), (err, res) => {
       console.log(`Paypal ${endpointName} response: ${JSON.stringify(res)}`); // leave this in permanently
       if (get(res, 'responseEnvelope.ack') === 'Failure') {
-        return reject(new Error(`PayPal error: ${res.error[0].message} (error id: ${res.error[0].errorId})`));
+        if (res.error[0].errorId === '579024') {
+          return reject(
+            new Error(
+              `Your PayPal pre-approval has expired, please reconnect your account by clicking on 'Refill Balance'.`,
+            ),
+          );
+        } else {
+          return reject(new Error(`PayPal error: ${res.error[0].message} (error id: ${res.error[0].errorId})`));
+        }
       }
       if (err) {
         console.log(`Paypal ${endpointName} error: ${JSON.stringify(err)}`); // leave this in permanently


### PR DESCRIPTION
This PR will improve the error message displayed when PayPal pre-approval is expired. Note that since https://github.com/opencollective/opencollective-frontend/pull/1553 we also display a big error message on the top when pre-approval is expired.

**Before**

![image](https://user-images.githubusercontent.com/1556356/60332602-80b57d80-9997-11e9-81d5-de0d24e3f962.png)

**After**

![image](https://user-images.githubusercontent.com/1556356/60332621-890db880-9997-11e9-851d-c9d15aee8ac5.png)
