### PR TITLE
Typescript proof of concept

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "@babel/preset-typescript",
     [
       "@babel/preset-env",
       {
@@ -13,9 +14,12 @@
     "add-module-exports",
     "lodash",
     "@babel/plugin-proposal-class-properties",
-    ["@babel/plugin-transform-async-to-generator", {
-      "module": "bluebird",
-      "method": "coroutine"
-    }]
+    [
+      "@babel/plugin-transform-async-to-generator",
+      {
+        "module": "bluebird",
+        "method": "coroutine"
+      }
+    ]
   ]
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
       - run: npm ci --ignore-scripts
       - <<: *persist_cache
       - run: npm run lint
+
   prettier:
     docker:
       - image: circleci/node:11.8.0
@@ -54,6 +55,18 @@ jobs:
       - run: npm ci --ignore-scripts
       - <<: *persist_cache
       - run: npm run prettier:check
+
+  typescript:
+    docker:
+      - image: circleci/node:11.8.0
+    environment:
+      NODE_ENV: circleci
+    steps:
+      - checkout
+      - <<: *restore_cache
+      - run: npm ci --ignore-scripts
+      - <<: *persist_cache
+      - run: npm run type:check
 
   test:
     docker:
@@ -81,6 +94,8 @@ workflows:
       - lint:
           <<: *test_filters
       - prettier:
+          <<: *test_filters
+      - typescript:
           <<: *test_filters
       - test:
           <<: *test_filters

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
-  "extends": ["opencollective"],
+  "extends": ["plugin:@typescript-eslint/recommended", "plugin:import/typescript", "opencollective"],
+  "parser": "@typescript-eslint/parser",
   "env": { "mocha": true },
   "plugins": ["mocha"],
   "rules": {
@@ -13,6 +14,23 @@
     "node/shebang": "off",
     "no-useless-escape": "off",
     // relaxing because we have many errors
-    "require-atomic-updates": "warn"
+    "require-atomic-updates": "warn",
+    // typescript
+    "node/no-missing-import": ["error", { "tryExtensions": [".js", ".ts"] }]
+  },
+  // Disable typescript checks in JS
+  "overrides": [
+    {
+      "files": ["*.js"],
+      "rules": {
+        "@typescript-eslint/camelcase": "off",
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/indent": "off"
+      }
+    }
+  ],
+  "settings": {
+    // Ignore .d.ts files for import (they just define the types)
+    "import/ignore": [".d.ts$"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -694,6 +694,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+      "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
@@ -961,6 +970,17 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz",
+      "integrity": "sha512-pehKf4m640myZu5B2ZviLaiBlxMCjSZ1qTEO459AXKX5GnPueyulJeCqZFs1nz/Ya2dDzXQ1NxZ/kKNWyD4h6w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
@@ -1059,6 +1079,16 @@
             "to-fast-properties": "^2.0.0"
           }
         }
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
+      "integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.3.2"
       }
     },
     "@babel/register": {
@@ -1573,8 +1603,14 @@
     },
     "@types/debug": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
       "integrity": "sha1-oeUUrfvZLwOiJLpU1pMRHb8fN1Q="
+    },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
@@ -1635,6 +1671,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
       "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ=="
+    },
+    "@types/json-schema": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
     },
     "@types/keygrip": {
       "version": "1.0.1",
@@ -1709,6 +1751,64 @@
       "integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
+      "integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "1.13.0",
+        "eslint-utils": "^1.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-scope": "^4.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+      "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "1.13.0",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
       }
     },
     "@wry/equality": {
@@ -2896,7 +2996,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -3146,12 +3246,12 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -3226,7 +3326,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -3554,7 +3654,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
             "minimist": "^1.2.0"
@@ -3562,7 +3662,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -3841,7 +3941,7 @@
     },
     "csv-stringify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
         "lodash.get": "^4.0.0"
@@ -5492,7 +5592,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -12373,7 +12473,7 @@
       "dependencies": {
         "commander": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
           "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
           "requires": {
             "keypress": "0.1.x"
@@ -12737,7 +12837,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -14540,6 +14640,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -14613,6 +14722,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,10 @@
   "devDependencies": {
     "@babel/cli": "7.5.5",
     "@babel/polyfill": "7.4.4",
+    "@babel/preset-typescript": "^7.3.3",
     "@babel/register": "7.5.5",
+    "@typescript-eslint/eslint-plugin": "^1.13.0",
+    "@typescript-eslint/parser": "^1.13.0",
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -133,7 +136,8 @@
     "react-dom": "^16.9.0",
     "sinon": "^7.4.2",
     "supertest": "^4.0.2",
-    "supertest-as-promised": "^4.0.2"
+    "supertest-as-promised": "^4.0.2",
+    "typescript": "^3.5.3"
   },
   "scripts": {
     "build": "npm run build:clean && npm run build:updates && npm run build:server",
@@ -165,7 +169,7 @@
     "db:setup": "babel-node ./scripts/db_setup.js",
     "deploy:production": "./scripts/pre-deploy.sh production && bash -x scripts/deploy.sh production",
     "deploy:staging": "./scripts/pre-deploy.sh staging && bash -x scripts/deploy.sh staging",
-    "dev": "nodemon server/index.js -x babel-node . -e js,hbs",
+    "dev": "nodemon server/index.js -x \"babel-node --extensions .js,.ts\" . -e js,hbs,ts",
     "export:csv": "babel-node scripts/monthly_data_exports.js",
     "git:clean": "./scripts/git_clean.sh",
     "hint": "npm run lint:quiet",
@@ -183,7 +187,8 @@
     "start": "node ./dist/index.js",
     "test": "TZ=UTC nyc mocha --reporter-options mochaFile=$(bash scripts/test_output_dir.sh junit)/junit.xml",
     "test:clean": "rm -rf .nyc_output coverage test/output",
-    "test:watch": "TZ=UTC nyc mocha --watch"
+    "test:watch": "TZ=UTC nyc mocha --watch",
+    "type:check": "tsc"
   },
   "nyc": {
     "reporter": [

--- a/server/constants/channels.js
+++ b/server/constants/channels.js
@@ -1,6 +1,0 @@
-export default {
-  GITTER: 'gitter',
-  SLACK: 'slack',
-  TWITTER: 'twitter',
-  WEBHOOK: 'webhook',
-};

--- a/server/constants/channels.ts
+++ b/server/constants/channels.ts
@@ -1,0 +1,8 @@
+enum Channels {
+  GITTER = 'gitter',
+  SLACK = 'slack',
+  TWITTER = 'twitter',
+  WEBHOOK = 'webhook',
+}
+
+export default Channels;

--- a/server/constants/currencies.ts
+++ b/server/constants/currencies.ts
@@ -1,5 +1,12 @@
+type CurrenciesMap = {
+  [s: string]: {
+    fxrate: Number;
+    format: (value: string | Number) => string;
+  };
+};
+
 // FX Rates as of 10/3/2017
-export default {
+const fxRates: CurrenciesMap = {
   AUD: { fxrate: 1.25, format: value => `${value} AUD` },
   CAD: { fxrate: 1.23, format: value => `${value} CAD` },
   EUR: { fxrate: 0.83, format: value => `€${value}` },
@@ -10,3 +17,5 @@ export default {
   USD: { fxrate: 1, format: value => `$${value}` },
   UYU: { fxrate: 29.17, format: value => `$U ${value}` },
 };
+
+export default fxRates;

--- a/server/lib/validators.ts
+++ b/server/lib/validators.ts
@@ -4,7 +4,9 @@
 
 // --- Validators for videos ---
 
-const ProvidersRegexs = {
+type RegexMap = { [s: string]: RegExp };
+
+const ProvidersRegexs: RegexMap = {
   YouTube: /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/ ]{11})/i,
   Vimeo: /:\/\/(www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|)(\d+)(?:|\/\?)/i,
 };
@@ -19,7 +21,7 @@ export const supportedVideoProviders = Object.keys(ProvidersRegexs);
  *
  * Returns `false` if `url` is null, undefined or empty.
  */
-export const isSupportedVideoProvider = url => {
+export const isSupportedVideoProvider = (url: string): boolean => {
   if (!url) {
     return false;
   }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,7 @@
 --timeout 20000
 --reporter mocha-circleci-reporter
---require @babel/register
+--extension js,ts
+--require ./test/setup-babel.js
 --file ./test/setup.js
 --file ./server/env.js
 --exit

--- a/test/setup-babel.js
+++ b/test/setup-babel.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line node/no-unpublished-require
+require('@babel/register')({ extensions: ['.js', '.ts'] });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    // Target latest version of ECMAScript.
+    "target": "esnext",
+    // Search under node_modules for non-relative imports.
+    "moduleResolution": "node",
+    // Process & infer types from .js files.
+    "allowJs": true,
+    // Don't emit; allow Babel to transform files.
+    "noEmit": true,
+    // Enable strictest settings like strictNullChecks & noImplicitAny.
+    "strict": false,
+    // Import non-ES modules as default imports.
+    "esModuleInterop": true,
+    "checkJs": false,
+    "downlevelIteration": true,
+    "lib": ["esnext", "dom"],
+    "module": "commonjs",
+    "noUnusedLocals": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["server"]
+}


### PR DESCRIPTION
This PR is now ready to be reviewed. If merged, it will add support for typescript with the configuration described below. Feel free to ask questions or suggest modifications to the default settings that we should use. I've also converted three files to demonstrate how to migrate them from JS to TS (see https://github.com/opencollective/opencollective-api/pull/2183/commits/763da766aaa0a304a6f3dd92e3e4d2994441edf5).

# Typescript configuration

The way typescript is implemented here works like this:
- All the code is still compiled with babel (thanks to `@babel/preset-typescript`)
- Added a test to CI to do the types check
- Typescript will only report errors with `npm run type:check` and in the IDE

![](https://user-images.githubusercontent.com/1556356/62208914-6ad11900-b398-11e9-830c-e0c11adbef48.png)

# Possible future improvements

## Enable `checkJS`

By setting this, typescript will report type inconsistencies from libraries definitions and inferred types (typescript infers types from code and JSDoc). For example:

```ts
const x = 42;
const s = x.toLowerCase(); // TS error: Property 'toLowerCase' does not exist on type
```

If enabled, we'll have to fix existing errors in the code (134 to this day). Most of them are pretty straightforward. For example, we get a warning here because sequelize `literal` function only takes 1 parameter, the second one is useless:

https://github.com/opencollective/opencollective-api/blob/27c8503c1cf62d89e73d3237b90fa84605a90253/server/graphql/v1/CollectiveInterface.js#L1148

## Enable `strict`

This would bring additional safety, but we're now talking about 4083 errors instead of 134.