### PR TITLE
chore: Move publicMessage from orders to members

### DIFF
--- a/migrations/20190702220933-move-publicMessage-from-orders-to-members.js
+++ b/migrations/20190702220933-move-publicMessage-from-orders-to-members.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Move `publicMessage` from `Orders` to `Members`.
+ * See https://github.com/opencollective/opencollective/issues/2138
+ */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Add column to `Members`
+    await queryInterface.addColumn('Members', 'publicMessage', Sequelize.STRING);
+
+    // Add public messages from orders to members
+    await queryInterface.sequelize.query(
+      `
+        UPDATE 	"Members" m
+        SET		  "publicMessage" = o."publicMessage"
+        FROM 	  "Orders" o
+        WHERE	  o."CollectiveId" = m."CollectiveId" AND o."FromCollectiveId" = m."MemberCollectiveId"
+        AND     o."publicMessage" IS NOT NULL
+        AND     LENGTH(o."publicMessage") > 0
+      `,
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Members', 'publicMessage');
+  },
+};

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -22,7 +22,7 @@ import {
   markOrderAsPaid,
   updateOrderInfo,
 } from './mutations/orders';
-import { createMember, removeMember } from './mutations/members';
+import { createMember, removeMember, editMembership } from './mutations/members';
 import { editTiers, editTier } from './mutations/tiers';
 import { editConnectedAccount } from './mutations/connectedAccounts';
 import { createWebhook, deleteNotification, editWebhooks } from './mutations/notifications';
@@ -372,6 +372,17 @@ const mutations = {
       return removeMember(_, args, req);
     },
   },
+  editMembership: {
+    type: MemberType,
+    description: 'A mutation to edit membership. Dedicated to the user, not the collective admin.',
+    args: {
+      id: { type: GraphQLNonNull(GraphQLInt) },
+      publicMessage: { type: GraphQLString },
+    },
+    resolve(_, args, req) {
+      return editMembership(_, args, req);
+    },
+  },
   createOrder: {
     type: OrderType,
     args: {
@@ -409,6 +420,7 @@ const mutations = {
   updateOrderInfo: {
     type: OrderType,
     description: 'Update the non-sensitive information of an order, like the public message',
+    deprecationReason: '2019-07-03: The public message is now stored at the Member level',
     args: {
       id: {
         type: new GraphQLNonNull(GraphQLInt),

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -423,7 +423,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
       taxAmount: taxFromCountry ? order.taxAmount : null,
       interval: order.interval,
       description: order.description || defaultDescription,
-      publicMessage: order.publicMessage,
+      publicMessage: order.publicMessage, // deprecated: '2019-07-03: This info is now stored at the Member level'
       privateMessage: order.privateMessage,
       processedAt: paymentRequired || !collective.isActive ? null : new Date(),
       MatchingPaymentMethodId: order.MatchingPaymentMethodId,
@@ -548,6 +548,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
 /**
  * Update the non-sensitive information of an order, like the public message
+ * @deprecated: '2019-07-03: Public message is now stored at the Member level'
  */
 export async function updateOrderInfo(req, orderParams) {
   const order = await models.Order.findByPk(orderParams.id);

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -327,6 +327,13 @@ export const MemberType = new GraphQLObjectType({
           return member.description;
         },
       },
+      publicMessage: {
+        description: 'Custom user message from member to the collective',
+        type: GraphQLString,
+        resolve(member) {
+          return member.publicMessage;
+        },
+      },
       tier: {
         type: TierType,
         resolve(member, args, req) {

--- a/server/lib/contributors.js
+++ b/server/lib/contributors.js
@@ -21,6 +21,7 @@ export const getContributorsForCollective = (collectiveId, { limit = 5000 } = {}
         mc.slug as "collectiveSlug",
         mc.image,
         MIN(m.since) as since,
+        MAX(m."publicMessage") as "publicMessage",
         ARRAY_AGG(DISTINCT m."role") as roles,
         COALESCE(SUM(t."netAmountInCollectiveCurrency"), 0) AS "totalAmountDonated",
         COALESCE(MAX(m.description), MAX(tier.name)) as description
@@ -67,6 +68,7 @@ export const getContributorsForTier = (tierId, { limit = 5000 } = {}) => {
         mc.slug as "collectiveSlug",
         mc.image,
         MIN(m.since) as since,
+        MAX(m."publicMessage") as "publicMessage",
         ARRAY_AGG(DISTINCT m."role") as roles,
         COALESCE(SUM(t."netAmountInCollectiveCurrency"), 0) AS "totalAmountDonated",
         COALESCE(MAX(m.description), MAX(tier.name)) as description

--- a/server/models/Member.js
+++ b/server/models/Member.js
@@ -78,6 +78,10 @@ export default function(Sequelize, DataTypes) {
 
       description: DataTypes.STRING,
 
+      publicMessage: {
+        type: DataTypes.STRING,
+      },
+
       // Dates.
       createdAt: {
         type: DataTypes.DATE,
@@ -106,6 +110,7 @@ export default function(Sequelize, DataTypes) {
           return {
             role: this.role,
             description: this.description,
+            publicMessage: this.publicMessage,
             CreatedByUserId: this.CreatedByUserId,
             CollectiveId: this.CollectiveId,
             MemberCollectiveId: this.MemberCollectiveId,


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2138

---

This PR does not remove the publicMessage from `Orders` to ensure smooth rollback and avoid possible side effects.