### PR TITLE
Change login tokens to 15min expiration

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -7,9 +7,10 @@ import * as errors from '../graphql/errors';
 
 // Helper
 const daysToSeconds = days => moment.duration({ days }).asSeconds();
+const minutesToSeconds = minutes => moment.duration({ minutes }).asSeconds();
 
 /* Constants that determin token expiration */
-export const TOKEN_EXPIRATION_LOGIN = daysToSeconds(1);
+export const TOKEN_EXPIRATION_LOGIN = minutesToSeconds(15);
 export const TOKEN_EXPIRATION_CONNECTED_ACCOUNT = daysToSeconds(1);
 export const TOKEN_EXPIRATION_SESSION = daysToSeconds(90);
 


### PR DESCRIPTION
Based on an issue https://github.com/opencollective/opencollective/issues/2192 raised by the community, we discussed internally the login situation.

Updating the login token mechanism (making it one-time, cancellable) is not easy but will be prioritized.

An easy action is to lower the expiration time, there is no reason to have it 24 hours today. This PR propose 15 minutes as a new expiration time for login tokens.