### PR TITLE
chore(EditCollective): Remove "paymentMethods" endpoint

### DIFF
--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -187,7 +187,6 @@ export const CollectiveInputType = new GraphQLInputObjectType({
     data: { type: GraphQLJSON },
     members: { type: new GraphQLList(MemberInputType) },
     notifications: { type: new GraphQLList(NotificationInputType) },
-    paymentMethods: { type: new GraphQLList(PaymentMethodInputType) },
     HostCollectiveId: { type: GraphQLInt },
     hostFeePercent: { type: GraphQLInt },
     ParentCollectiveId: { type: GraphQLInt },

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -115,9 +115,6 @@ export async function createCollective(_, args, req) {
     collective.addUserWithRole(req.remoteUser, roles.ADMIN, {
       CreatedByUserId: req.remoteUser.id,
     }),
-    collective.editPaymentMethods(args.collective.paymentMethods, {
-      CreatedByUserId: req.remoteUser.id,
-    }),
   ];
 
   if (collectiveData.HostCollectiveId) {
@@ -429,16 +426,6 @@ export function editCollective(_, args, req) {
         CreatedByUserId: req.remoteUser.id,
       }),
     )
-    .then(() => {
-      // TODO Deprecated since 2019-02-06 - We now use specific graphql queries
-      if (args.collective.paymentMethods) {
-        return collective.editPaymentMethods(args.collective.paymentMethods, {
-          CreatedByUserId: req.remoteUser.id,
-        });
-      } else {
-        return collective;
-      }
-    })
     .then(() => {
       // Ask cloudflare to refresh the cache for this collective's page
       purgeCacheForPage(`/${collective.slug}`);

--- a/test/features/support/stores/index.js
+++ b/test/features/support/stores/index.js
@@ -24,7 +24,7 @@ import * as libpayments from '../../../../server/lib/payments';
  * > randEmail('foo@bar.com')
  * 'foo-lwfi9uaq9ua@bar.com'
  */
-export function randEmail(email) {
+export function randEmail(email = 'test-user@emailprovider.com') {
   const [user, domain] = email.replace(/\s/g, '-').split('@');
   const rand = Math.random()
     .toString(36)

--- a/test/mocks/data.js
+++ b/test/mocks/data.js
@@ -178,6 +178,18 @@ export default {
     },
   },
 
+  validCreditCard: {
+    service: 'stripe',
+    name: '4242',
+    token: 'tok_visa',
+    data: {
+      brand: 'VISA',
+      funding: 'credit',
+      expMonth: 1,
+      expYear: 2022,
+    },
+  },
+
   activities1: {
     activities: [
       {


### PR DESCRIPTION
Since https://github.com/opencollective/opencollective-frontend/pull/1372 payment methods now use their own endpoints.

I've also started writting tests for the currently used endpoints but I don't have much time right now, I'll work on that later.