### PR TITLE
Use native md5 implementation instead of npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2766,7 +2766,8 @@
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
     },
     "check-error": {
       "version": "1.0.2",
@@ -3207,7 +3208,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
             "minimist": "^1.2.0"
@@ -3487,7 +3488,8 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -9236,6 +9238,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
       "requires": {
         "charenc": "~0.0.1",
         "crypt": "~0.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "limax": "1.7.0",
     "lodash": "4.17.14",
     "lru-cache": "5.1.1",
-    "md5": "2.2.1",
     "memjs": "1.2.2",
     "merge-options": "1.0.1",
     "moment": "2.24.0",

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import uuidv4 from 'uuid/v4';
 import debugLib from 'debug';
-import md5 from 'md5';
 import Promise from 'bluebird';
 import { pick, omit, get, isNil } from 'lodash';
 import config from 'config';
@@ -14,7 +13,7 @@ import * as github from '../../../lib/github';
 import recaptcha from '../../../lib/recaptcha';
 import slackLib from '../../../lib/slack';
 import * as libPayments from '../../../lib/payments';
-import { capitalize, pluralize, formatCurrency } from '../../../lib/utils';
+import { capitalize, pluralize, formatCurrency, md5 } from '../../../lib/utils';
 import { getNextChargeAndPeriodStartDates, getChargeRetryCount } from '../../../lib/subscriptions';
 
 import roles from '../../../constants/roles';

--- a/server/lib/cache/index.js
+++ b/server/lib/cache/index.js
@@ -1,4 +1,3 @@
-import md5 from 'md5';
 import config from 'config';
 import debug from 'debug';
 import { get } from 'lodash';
@@ -9,6 +8,7 @@ import makeRedisProvider from './redis';
 
 import logger from '../logger';
 import models from '../../models';
+import { md5 } from '../utils';
 
 export const PROVIDER_TYPES = {
   MEMCACHE: 'MEMCACHE',


### PR DESCRIPTION
The npm `md5` package  is a browser/node package and more complicated for that reason.