### PR TITLE
Increase authentication token expiry to 75 minutes

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -10,7 +10,7 @@ const daysToSeconds = days => moment.duration({ days }).asSeconds();
 const minutesToSeconds = minutes => moment.duration({ minutes }).asSeconds();
 
 /* Constants that determin token expiration */
-export const TOKEN_EXPIRATION_LOGIN = minutesToSeconds(15);
+export const TOKEN_EXPIRATION_LOGIN = minutesToSeconds(75);
 export const TOKEN_EXPIRATION_CONNECTED_ACCOUNT = daysToSeconds(1);
 export const TOKEN_EXPIRATION_SESSION = daysToSeconds(90);
 


### PR DESCRIPTION
15 minutes is not enough in some setups.