### PR TITLE
chore(graphql): Remove deprecated ocPaymentMethod endpoint

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -1234,27 +1234,6 @@ const queries = {
   },
 
   /*
-   * Deprecated: Given a prepaid code, return validity and amount
-   */
-  ocPaymentMethod: {
-    type: PaymentMethodType,
-    args: {
-      token: { type: new GraphQLNonNull(GraphQLString) },
-    },
-    resolve(_, args) {
-      return models.PaymentMethod.findOne({
-        where: {
-          token: args.token,
-          expiryDate: {
-            [Op.gt]: new Date(),
-          },
-          archivedAt: null, // archived PMs are assumed to be used or inactive
-        },
-      });
-    },
-  },
-
-  /*
    * Given a prepaid code, return validity and amount
    */
   PaymentMethod: {


### PR DESCRIPTION
Was deprecated in https://github.com/opencollective/opencollective-api/pull/1415
There's no reference for this in frontend.