### PR TITLE
Feat/add expense type

### DIFF
--- a/migrations/20190723034059-add-type-to-expense-table.js
+++ b/migrations/20190723034059-add-type-to-expense-table.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Expenses', 'type', {
+      type: Sequelize.STRING(),
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Expenses', 'type');
+  },
+};

--- a/migrations/20190723034059-add-type-to-expense-table.js
+++ b/migrations/20190723034059-add-type-to-expense-table.js
@@ -5,6 +5,7 @@ module.exports = {
     return Promise.all([
       queryInterface.addColumn('Expenses', 'type', {
         type: Sequelize.ENUM('RECEIPT', 'INVOICE', 'UNCLASSIFIED'),
+        defaultValue: 'UNCLASSIFIED',
       }),
       queryInterface.sequelize.query(`
         UPDATE "Expenses"

--- a/migrations/20190723034059-add-type-to-expense-table.js
+++ b/migrations/20190723034059-add-type-to-expense-table.js
@@ -13,6 +13,11 @@ module.exports = {
           SET "type" = 'UNCLASSIFIED'
         WHERE "type" IS NULL
       `);
+    await queryInterface.sequelize.query(`
+        UPDATE "ExpenseHistories"
+          SET "type" = 'UNCLASSIFIED'
+        WHERE "type" IS NULL
+      `);
   },
   down: async (queryInterface, Sequelize) => {
     await queryInterface.removeColumn('Expenses', 'type');

--- a/migrations/20190723034059-add-type-to-expense-table.js
+++ b/migrations/20190723034059-add-type-to-expense-table.js
@@ -2,9 +2,16 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('Expenses', 'type', {
-      type: Sequelize.ENUM('RECEIPT', 'INVOICE', 'UNCLASSIFIED'),
-    });
+    return Promise.all([
+      queryInterface.addColumn('Expenses', 'type', {
+        type: Sequelize.ENUM('RECEIPT', 'INVOICE', 'UNCLASSIFIED'),
+      }),
+      queryInterface.sequelize.query(`
+        UPDATE "Expenses"
+          SET "type" = 'UNCLASSIFIED'
+        WHERE "type" IS NULL
+      `),
+    ]);
   },
   down: (queryInterface, Sequelize) => {
     return Promise.all([

--- a/migrations/20190723034059-add-type-to-expense-table.js
+++ b/migrations/20190723034059-add-type-to-expense-table.js
@@ -3,10 +3,13 @@
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.addColumn('Expenses', 'type', {
-      type: Sequelize.STRING(),
+      type: Sequelize.ENUM('RECEIPT', 'INVOICE', 'UNCLASSIFIED'),
     });
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn('Expenses', 'type');
+    return Promise.all([
+      queryInterface.removeColumn('Expenses', 'type'),
+      queryInterface.sequelize.query('DROP TYPE "enum_Expenses_type";'),
+    ]);
   },
 };

--- a/migrations/20190723034059-add-type-to-expense-table.js
+++ b/migrations/20190723034059-add-type-to-expense-table.js
@@ -1,23 +1,23 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.addColumn('Expenses', 'type', {
-        type: Sequelize.ENUM('RECEIPT', 'INVOICE', 'UNCLASSIFIED'),
-        defaultValue: 'UNCLASSIFIED',
-      }),
-      queryInterface.sequelize.query(`
+  up: async (queryInterface, Sequelize) => {
+    const colParams = {
+      type: Sequelize.ENUM('RECEIPT', 'INVOICE', 'UNCLASSIFIED'),
+      defaultValue: 'UNCLASSIFIED',
+    };
+    await queryInterface.addColumn('Expenses', 'type', colParams);
+    await queryInterface.addColumn('ExpenseHistories', 'type', colParams);
+    await queryInterface.sequelize.query(`
         UPDATE "Expenses"
           SET "type" = 'UNCLASSIFIED'
         WHERE "type" IS NULL
-      `),
-    ]);
+      `);
   },
-  down: (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.removeColumn('Expenses', 'type'),
-      queryInterface.sequelize.query('DROP TYPE "enum_Expenses_type";'),
-    ]);
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Expenses', 'type');
+    await queryInterface.removeColumn('ExpenseHistories', 'type');
+    await queryInterface.sequelize.query('DROP TYPE "enum_Expenses_type";');
+    await queryInterface.sequelize.query('DROP TYPE "enum_ExpenseHistories_type";');
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1457,7 +1457,7 @@
     },
     "@types/debug": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
       "integrity": "sha1-oeUUrfvZLwOiJLpU1pMRHb8fN1Q="
     },
     "@types/events": {
@@ -1669,7 +1669,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1680,7 +1680,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -2747,7 +2747,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -2991,12 +2991,12 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -3070,7 +3070,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -3300,7 +3300,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
             "minimist": "^1.2.0"
@@ -3308,7 +3308,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -3607,7 +3607,7 @@
     },
     "csv-stringify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
         "lodash.get": "^4.0.0"
@@ -5150,7 +5150,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -5805,7 +5805,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         },
         "babel-runtime": {
@@ -5819,7 +5819,7 @@
         },
         "bluebird": {
           "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz",
           "integrity": "sha1-94D+Q+GnplEPZ6vX0NeVM6QN3eY="
         },
         "body-parser": {
@@ -5854,7 +5854,7 @@
         },
         "colors": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         },
         "cors": {
@@ -6085,12 +6085,12 @@
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
           "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
         },
         "winston": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
           "integrity": "sha1-LIU92Hq1UqjoSF1yy7+aIobwKbc=",
           "requires": {
             "async": "~1.0.0",
@@ -6130,7 +6130,7 @@
         },
         "bluebird": {
           "version": "2.9.25",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
           "integrity": "sha1-bja9BAZNlTTAcWC59/JsWnOP4Wo="
         },
         "depd": {
@@ -11974,7 +11974,7 @@
       "dependencies": {
         "commander": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
           "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
           "requires": {
             "keypress": "0.1.x"
@@ -12357,7 +12357,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }

--- a/server/constants/expense_type.js
+++ b/server/constants/expense_type.js
@@ -1,0 +1,9 @@
+/**
+ * Constants for the expense type
+ *
+ */
+
+export default {
+  INVOICE: 'INVOICE',
+  RECEIPT: 'RECEIPT',
+};

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -429,6 +429,7 @@ export const ExpenseInputType = new GraphQLInputObjectType({
       description: { type: GraphQLString },
       category: { type: GraphQLString },
       status: { type: GraphQLString },
+      type: { type: GraphQLString },
       payoutMethod: {
         type: GraphQLString,
         description: 'Can be paypal, donation, manual, other',

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -26,6 +26,7 @@ import models, { Op, sequelize } from '../../models';
 import { getContributorsForTier } from '../../lib/contributors';
 import { strip_tags } from '../../lib/utils';
 import status from '../../constants/expense_status';
+import expenseType from '../../constants/expense_type';
 import orderStatus from '../../constants/order_status';
 import { maxInteger } from '../../constants/math';
 import intervals from '../../constants/intervals';
@@ -641,6 +642,12 @@ export const ExpenseType = new GraphQLObjectType({
         type: GraphQLString,
         resolve(expense) {
           return expense.status;
+        },
+      },
+      type: {
+        type: GraphQLString,
+        resolve(expense) {
+          return expense.type;
         },
       },
       payoutMethod: {

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -26,7 +26,6 @@ import models, { Op, sequelize } from '../../models';
 import { getContributorsForTier } from '../../lib/contributors';
 import { strip_tags } from '../../lib/utils';
 import status from '../../constants/expense_status';
-import expenseType from '../../constants/expense_type';
 import orderStatus from '../../constants/order_status';
 import { maxInteger } from '../../constants/math';
 import intervals from '../../constants/intervals';

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -28,6 +28,7 @@ import activities from '../constants/activities';
 import { HOST_FEE_PERCENT } from '../constants/transactions';
 import { types } from '../constants/collectives';
 import expenseStatus from '../constants/expense_status';
+import expenseTypes from '../constants/expense_type';
 
 const debug = debugLib('collective');
 const debugcollectiveImage = debugLib('collectiveImage');
@@ -2144,8 +2145,8 @@ export default function(Sequelize, DataTypes) {
     const since = moment({ year });
     const until = moment({ year }).add(1, 'y');
     const status = [PENDING, APPROVED, PAID];
-    const excludedType = ['RECEIPT'];
-    const expenses = await this.getExpenses(status, since, until, UserId, excludedType);
+    const excludedTypes = [expenseTypes.RECEIPT];
+    const expenses = await this.getExpenses(status, since, until, UserId, excludedTypes);
 
     const userTotal = sumBy(expenses, 'amount');
 
@@ -2157,8 +2158,8 @@ export default function(Sequelize, DataTypes) {
     const since = moment({ year });
     const until = moment({ year }).add(1, 'y');
     const status = [PENDING, APPROVED, PAID];
-    const excludedType = ['RECEIPT'];
-    const expenses = await this.getExpenses(status, since, until, null, excludedType);
+    const excludedTypes = [expenseTypes.RECEIPT];
+    const expenses = await this.getExpenses(status, since, until, null, excludedTypes);
 
     const userTotals = expenses.reduce((totals, expense) => {
       const { UserId } = expense;

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1647,7 +1647,7 @@ export default function(Sequelize, DataTypes) {
       .then(() => this.getTiers());
   };
 
-  Collective.prototype.getExpenses = function(status, startDate, endDate = new Date(), createdByUserId) {
+  Collective.prototype.getExpenses = function(status, startDate, endDate = new Date(), createdByUserId, excludedTypes) {
     const where = {
       createdAt: { [Op.lt]: endDate },
       CollectiveId: this.id,
@@ -1655,6 +1655,7 @@ export default function(Sequelize, DataTypes) {
     if (status) where.status = status;
     if (startDate) where.createdAt[Op.gte] = startDate;
     if (createdByUserId) where.UserId = createdByUserId;
+    if (excludedTypes) where.type = { [Op.or]: [{ [Op.eq]: null }, { [Op.notIn]: excludedTypes }] };
 
     return models.Expense.findAll({
       where,
@@ -2143,7 +2144,8 @@ export default function(Sequelize, DataTypes) {
     const since = moment({ year });
     const until = moment({ year }).add(1, 'y');
     const status = [PENDING, APPROVED, PAID];
-    const expenses = await this.getExpenses(status, since, until, UserId);
+    const excludedType = ['RECEIPT'];
+    const expenses = await this.getExpenses(status, since, until, UserId, excludedType);
 
     const userTotal = sumBy(expenses, 'amount');
 
@@ -2155,7 +2157,8 @@ export default function(Sequelize, DataTypes) {
     const since = moment({ year });
     const until = moment({ year }).add(1, 'y');
     const status = [PENDING, APPROVED, PAID];
-    const expenses = await this.getExpenses(status, since, until);
+    const excludedType = ['RECEIPT'];
+    const expenses = await this.getExpenses(status, since, until, null, excludedType);
 
     const userTotals = expenses.reduce((totals, expense) => {
       const { UserId } = expense;

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -94,13 +94,9 @@ export default function(Sequelize, DataTypes) {
       },
 
       type: {
-        type: DataTypes.STRING,
-        validate: {
-          isIn: {
-            args: [Object.keys(expenseType)],
-            msg: `Must be in ${Object.keys(expenseType)}`,
-          },
-        },
+        type: DataTypes.ENUM(Object.keys(expenseType)),
+        defaultValue: expenseType.UNCLASSIFIED,
+        allowNull: false,
       },
 
       incurredAt: {

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -84,7 +84,7 @@ export default function(Sequelize, DataTypes) {
       status: {
         type: DataTypes.STRING,
         defaultValue: status.PENDING,
-        allowNull: true,
+        allowNull: false,
         validate: {
           isIn: {
             args: [Object.keys(status)],

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -3,6 +3,7 @@ import Historical from 'sequelize-historical';
 import { TransactionTypes } from '../constants/transactions';
 import activities from '../constants/activities';
 import status from '../constants/expense_status';
+import expenseType from '../constants/expense_type';
 import CustomDataTypes from '../models/DataTypes';
 import { reduceArrayToCurrency } from '../lib/currency';
 import models, { Op } from './';
@@ -83,11 +84,21 @@ export default function(Sequelize, DataTypes) {
       status: {
         type: DataTypes.STRING,
         defaultValue: status.PENDING,
-        allowNull: false,
+        allowNull: true,
         validate: {
           isIn: {
             args: [Object.keys(status)],
             msg: `Must be in ${Object.keys(status)}`,
+          },
+        },
+      },
+
+      type: {
+        type: DataTypes.STRING,
+        validate: {
+          isIn: {
+            args: [Object.keys(expenseType)],
+            msg: `Must be in ${Object.keys(expenseType)}`,
           },
         },
       },

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -96,7 +96,6 @@ export default function(Sequelize, DataTypes) {
       type: {
         type: DataTypes.ENUM(Object.keys(expenseType)),
         defaultValue: expenseType.UNCLASSIFIED,
-        allowNull: false,
       },
 
       incurredAt: {

--- a/test/lib.taxForms.test.js
+++ b/test/lib.taxForms.test.js
@@ -46,7 +46,7 @@ describe('lib.taxForms', () => {
     year: moment().year(),
   };
 
-  function ExpenseOverThreshold({ incurredAt, UserId, CollectiveId, amount }) {
+  function ExpenseOverThreshold({ incurredAt, UserId, CollectiveId, amount, type }) {
     return {
       description: 'pizza',
       amount: amount || US_TAX_FORM_THRESHOLD + 100e2,
@@ -56,6 +56,7 @@ describe('lib.taxForms', () => {
       incurredAt,
       createdAt: incurredAt,
       CollectiveId,
+      type,
     };
   }
 
@@ -136,6 +137,15 @@ describe('lib.taxForms', () => {
         UserId: users[0].id,
         CollectiveId: hostCollectives[0].id,
         incurredAt: moment(),
+      }),
+    );
+    // An expense from this year over the threshold BUT it's of type receipt so it should not be counted
+    await Expense.create(
+      ExpenseOverThreshold({
+        UserId: users[2].id,
+        CollectiveId: hostCollectives[0].id,
+        incurredAt: moment(),
+        type: 'RECEIPT',
       }),
     );
     // An expense from this year over the threshold

--- a/test/lib.taxForms.test.js
+++ b/test/lib.taxForms.test.js
@@ -11,7 +11,8 @@ import {
   isUserTaxFormRequiredBeforePayment,
 } from '../server/lib/taxForms';
 
-import { RECEIPT, INVOICE } from '../server/constants/expense_type';
+import expenseTypes from '../server/constants/expense_type';
+const { RECEIPT, INVOICE } = expenseTypes;
 
 const { RequiredLegalDocument, LegalDocument, Collective, User, Expense } = models;
 const {

--- a/test/lib.taxForms.test.js
+++ b/test/lib.taxForms.test.js
@@ -11,6 +11,8 @@ import {
   isUserTaxFormRequiredBeforePayment,
 } from '../server/lib/taxForms';
 
+import { RECEIPT, INVOICE } from '../server/constants/expense_type';
+
 const { RequiredLegalDocument, LegalDocument, Collective, User, Expense } = models;
 const {
   documentType: { US_TAX_FORM },
@@ -56,7 +58,7 @@ describe('lib.taxForms', () => {
       incurredAt,
       createdAt: incurredAt,
       CollectiveId,
-      type,
+      type: type || INVOICE,
     };
   }
 
@@ -145,7 +147,7 @@ describe('lib.taxForms', () => {
         UserId: users[2].id,
         CollectiveId: hostCollectives[0].id,
         incurredAt: moment(),
-        type: 'RECEIPT',
+        type: RECEIPT,
       }),
     );
     // An expense from this year over the threshold

--- a/test/lib.taxForms.test.js
+++ b/test/lib.taxForms.test.js
@@ -277,7 +277,7 @@ describe('lib.taxForms', () => {
       sinon.restore();
     });
 
-    it('sets updates the documents status to requested when the client request succeeds', async () => {
+    it('updates the documents status to requested when the client request succeeds', async () => {
       const legalDoc = Object.assign({}, documentData, {
         CollectiveId: userCollective.id,
       });


### PR DESCRIPTION
Adds a migration for an expense type so that we can record whether an expense is a "Receipt" or an "Invoice".

Expenses of type "Receipt" should not be counted towards tax form totals and this PR tests that too.

This will need to merge at the same time as [this PR](https://github.com/opencollective/opencollective-frontend/pull/2232)