### PR TITLE
[Don't merge] Change PayPal pre-approval max validity to 10 months

### DIFF
--- a/server/paymentProviders/paypal/index.js
+++ b/server/paymentProviders/paypal/index.js
@@ -61,7 +61,7 @@ export default {
       if (!redirect) {
         throw new Error('Please provide a redirect url as a query parameter (?redirect=)');
       }
-      const expiryDate = moment().add(1, 'years');
+      const expiryDate = moment().add(10, 'months');
 
       let collective, response;
 


### PR DESCRIPTION
In an attempt to fix https://github.com/opencollective/opencollective/issues/2277, this changes the max validity of the pre-approval code to 10 months instead of one year.

Edit: Issue seems fixed, let's wait for more feedback before merging