### PR TITLE
Ensure collective exist before setting inTheContextOfCollectiveId

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -318,7 +318,9 @@ export const MemberType = new GraphQLObjectType({
         resolve(member, args, req) {
           const memberCollective =
             member.memberCollective || req.loaders.collective.findById.load(member.MemberCollectiveId);
-          memberCollective.inTheContextOfCollectiveId = member.CollectiveId;
+          if (memberCollective) {
+            memberCollective.inTheContextOfCollectiveId = member.CollectiveId;
+          }
           return memberCollective;
         },
       },
@@ -1517,7 +1519,9 @@ export const OrderType = new GraphQLObjectType({
             return null;
           }
           const fromCollective = await req.loaders.collective.findById.load(order.FromCollectiveId);
-          fromCollective.inTheContextOfCollectiveId = order.CollectiveId;
+          if (fromCollective) {
+            fromCollective.inTheContextOfCollectiveId = order.CollectiveId;
+          }
           return fromCollective;
         },
       },


### PR DESCRIPTION
https://opencollective.com/opensourcedesign had their page crashing because of the issue.
Related ticket: https://opencollective.freshdesk.com/a/tickets/990

![image](https://user-images.githubusercontent.com/1556356/61934757-58ff0880-af89-11e9-9309-f16e88aed148.png)
