### PR TITLE
fix(GithubFlow): Truncate description

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import slugify from 'limax';
-import { get, omit } from 'lodash';
+import { get, omit, truncate } from 'lodash';
 import { map } from 'bluebird';
 
 import models, { Op } from '../../../models';
@@ -253,7 +253,8 @@ export async function createCollectiveFromGithub(_, args, req) {
     }
     collectiveData.tags = repo.topics || [];
     collectiveData.tags.push('open source');
-    collectiveData.description = repo.description;
+    collectiveData.description = truncate(repo.description, { length: 255 });
+    collectiveData.longDescription = repo.description;
     collectiveData.settings = {
       githubRepo: githubHandle,
     };


### PR DESCRIPTION
Fix for support ticket https://opencollective.freshdesk.com/a/tickets/985

A Github description longer than 255 was crashing the Github flow. 