### PR TITLE
Fix: Prevent collective from having zero admin.

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -424,6 +424,7 @@ export function editCollective(_, args, req) {
     .then(() =>
       collective.editMembers(args.collective.members, {
         CreatedByUserId: req.remoteUser.id,
+        remoteUserCollectiveId: req.remoteUser.CollectiveId,
       }),
     )
     .then(() => {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1600,11 +1600,7 @@ export default function(Sequelize, DataTypes) {
     })
       .then(oldMembers => {
         // remove the members that are not present anymore
-        const diff = differenceBy(
-          oldMembers.map(t => ({ id: t.id, MemberCollectiveId: t.MemberCollectiveId })),
-          members.map(t => ({ id: t.id, MemberCollectiveId: t.MemberCollectiveId })),
-          'id',
-        );
+        const diff = differenceBy(oldMembers, members, 'id');
         if (diff.length === 0) {
           return null;
         } else {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -8,7 +8,20 @@ import debugLib from 'debug';
 import fetch from 'isomorphic-fetch';
 import moment from 'moment';
 import * as ics from 'ics';
-import { get, difference, uniqBy, pick, pickBy, sumBy, keys, omit, defaults, includes, isNull } from 'lodash';
+import {
+  get,
+  difference,
+  differenceBy,
+  uniqBy,
+  pick,
+  pickBy,
+  sumBy,
+  keys,
+  omit,
+  defaults,
+  includes,
+  isNull,
+} from 'lodash';
 import uuid from 'uuid/v4';
 import { isISO31661Alpha2 } from 'validator';
 import { Op } from 'sequelize';
@@ -1587,12 +1600,22 @@ export default function(Sequelize, DataTypes) {
     })
       .then(oldMembers => {
         // remove the members that are not present anymore
-        const diff = difference(oldMembers.map(t => t.id), members.map(t => t.id));
+        const diff = differenceBy(
+          oldMembers.map(t => ({ id: t.id, MemberCollectiveId: t.MemberCollectiveId })),
+          members.map(t => ({ id: t.id, MemberCollectiveId: t.MemberCollectiveId })),
+          'id',
+        );
         if (diff.length === 0) {
           return null;
         } else {
           debug('editMembers', 'delete', diff);
-          return models.Member.update({ deletedAt: new Date() }, { where: { id: { [Op.in]: diff } } });
+          const diffMemberIds = diff.map(m => m.id);
+          const diffMemberCollectiveIds = diff.map(m => m.MemberCollectiveId);
+          const { remoteUserCollectiveId } = defaultAttributes;
+          if (remoteUserCollectiveId && diffMemberCollectiveIds.indexOf(remoteUserCollectiveId) !== -1) {
+            throw new Error('You cannot remove yourself from collective, ask any other admin members to remove you.');
+          }
+          return models.Member.update({ deletedAt: new Date() }, { where: { id: { [Op.in]: diffMemberIds } } });
         }
       })
       .then(() => {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1609,7 +1609,9 @@ export default function(Sequelize, DataTypes) {
           const diffMemberCollectiveIds = diff.map(m => m.MemberCollectiveId);
           const { remoteUserCollectiveId } = defaultAttributes;
           if (remoteUserCollectiveId && diffMemberCollectiveIds.indexOf(remoteUserCollectiveId) !== -1) {
-            throw new Error('You cannot remove yourself from collective, ask any other admin members to remove you.');
+            throw new Error(
+              'You cannot remove yourself as a Collective admin. If you are the only admin, please add a new one and ask them to remove you.',
+            );
           }
           return models.Member.update({ deletedAt: new Date() }, { where: { id: { [Op.in]: diffMemberIds } } });
         }

--- a/test/graphql.collective.test.js
+++ b/test/graphql.collective.test.js
@@ -816,7 +816,7 @@ describe('graphql.collective.test.js', () => {
       const adminMember = await models.User.findByPk(members[3].member.createdByUser.id);
       const res3 = await utils.graphqlQuery(query, { collective }, adminMember);
       expect(res3.errors[0].message).to.equal(
-        'You cannot remove yourself from collective, ask any other admin members to remove you.',
+        'You cannot remove yourself as a Collective admin. If you are the only admin, please add a new one and ask them to remove you.',
       );
     });
 

--- a/test/graphql.collective.test.js
+++ b/test/graphql.collective.test.js
@@ -765,6 +765,13 @@ describe('graphql.collective.test.js', () => {
               email: 'member1@hail.com',
             },
           },
+          {
+            role: 'ADMIN',
+            member: {
+              name: 'member2',
+              email: 'member2@hail.com',
+            },
+          },
         ],
         location: {},
       };
@@ -794,7 +801,7 @@ describe('graphql.collective.test.js', () => {
       res.errors && console.error(res.errors);
       expect(res.errors).to.not.exist;
       const members = res.data.editCollective.members;
-      expect(members.length).to.equal(3);
+      expect(members.length).to.equal(4);
       expect(members[2].role).to.equal('MEMBER');
       expect(members[2].member.name).to.equal('member1');
       expect(members[2].member.email).to.equal('member1@hail.com');
@@ -804,6 +811,12 @@ describe('graphql.collective.test.js', () => {
       expect(res2.errors).to.exist;
       expect(res2.errors[0].message).to.equal(
         'You must be logged in as an admin or as the host of this collective collective to edit it',
+      );
+
+      const adminMember = await models.User.findByPk(members[3].member.createdByUser.id);
+      const res3 = await utils.graphqlQuery(query, { collective }, adminMember);
+      expect(res3.errors[0].message).to.equal(
+        'You cannot remove yourself from collective, ask any other admin members to remove you.',
       );
     });
 


### PR DESCRIPTION
This PR fix [#2289](https://github.com/opencollective/opencollective/issues/2289), by basically adding a condition that prevents a collective admin member from removing self from a collective.