### PR TITLE
PaymentMethods: Remove with `destroy` method

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -1009,7 +1009,7 @@ export async function addFundsToCollective(order, remoteUser) {
   } catch (e) {
     // Don't save new card for user if order failed
     if (!order.paymentMethod.id && !order.paymentMethod.uuid) {
-      await orderCreated.paymentMethod.update({ CollectiveId: null });
+      await orderCreated.paymentMethod.destroy();
     }
     throw e;
   }

--- a/server/graphql/v1/mutations/paymentMethods.js
+++ b/server/graphql/v1/mutations/paymentMethods.js
@@ -182,7 +182,7 @@ export async function removePaymentMethod(paymentMethodId, remoteUser) {
     });
   }
 
-  return paymentMethod.update({ archivedAt: new Date() });
+  return paymentMethod.destroy();
 }
 
 /** Update payment method with given args */


### PR DESCRIPTION
Change the behaviour introduced in https://github.com/opencollective/opencollective-api/pull/1823 to remove payment methods rather than setting their `CollectiveId` to `null` (we probably want to keep this info). I've checked to ensure payment methods are properly soft-deleted (`deletedAt = NOW()`).

Also changed this for `removePaymentMethod` (the endpoint called from /edit) to use `deletedAt` rather than `archivedAt`.

@znarf do you know what's supposed to be the difference between `archivedAt` and `deletedAt`? Is it just legacy or does it have a meaning?