### PR TITLE
PayPal: Add additional fixes for float amounts

### DIFF
--- a/server/lib/math.js
+++ b/server/lib/math.js
@@ -2,3 +2,11 @@
 export function toNegative(v) {
   return v > 0 ? -v : v;
 }
+
+/**
+ * Converts a float amount to cents. Also takes care of rounding the number
+ * to avoid floating numbers issues like `0.29 * 100 === 28.999999999999996`
+ */
+export function floatAmountToCents(floatAmount) {
+  return Math.round(floatAmount * 100);
+}

--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -7,6 +7,7 @@ import roles from '../../constants/roles';
 import * as constants from '../../constants/transactions';
 import * as libpayments from '../../lib/payments';
 import logger from '../../lib/logger';
+import { floatAmountToCents } from '../../lib/math';
 
 /** Build an URL for the PayPal API */
 export function paypalUrl(path) {
@@ -103,8 +104,8 @@ export async function createTransaction(order, paymentInfo) {
   const transaction = paymentInfo.transactions[0];
   const amountFromPayPal = parseFloat(transaction.amount.total);
   const paypalFee = parseFloat(get(transaction, 'related_resources.0.sale.transaction_fee.value', '0.0'));
-  const amountFromPayPalInCents = Math.trunc(amountFromPayPal * 100);
-  const paypalFeeInCents = Math.trunc(paypalFee * 100);
+  const amountFromPayPalInCents = floatAmountToCents(amountFromPayPal);
+  const paypalFeeInCents = floatAmountToCents(paypalFee);
   const currencyFromPayPal = transaction.amount.currency;
 
   const hostFeeInHostCurrency = libpayments.calcFee(amountFromPayPalInCents, order.collective.hostFeePercent);


### PR DESCRIPTION
Following up on https://github.com/opencollective/opencollective-api/pull/2390#discussion_r312370201 this PR:
- Adds a `floatAmountToCents` helper to have one single way to do it
- Applies it to the recent fixes for PayPal
- Adds unit tests with different float amounts to ensure it always works correctly