### PR TITLE
EditCollective: Remove dead code from a merging mistake

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -120,14 +120,6 @@ export async function createCollective(_, args, req) {
     promises.push(collective.editTiers(collectiveData.tiers));
   }
 
-  if (collectiveData.paymentMethods) {
-    promises.push(
-      collective.editPaymentMethods(collectiveData.paymentMethods, {
-        CreatedByUserId: req.remoteUser.id,
-      }),
-    );
-  }
-
   if (collectiveData.HostCollectiveId) {
     promises.push(collective.addHost(hostCollective, req.remoteUser));
   }


### PR DESCRIPTION
The `editPaymentMethods` function was removed in https://github.com/opencollective/opencollective-api/pull/2257 but re-introduced in https://github.com/opencollective/opencollective-api/pull/2144, probably as part as a bad merge with master.