### PR TITLE
fix(tax forms) 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,7 +1576,7 @@
     },
     "@types/debug": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",
       "integrity": "sha1-oeUUrfvZLwOiJLpU1pMRHb8fN1Q="
     },
     "@types/events": {
@@ -2885,7 +2885,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -3129,12 +3129,12 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -3208,7 +3208,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -3539,7 +3539,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
             "minimist": "^1.2.0"
@@ -3547,7 +3547,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -3830,7 +3830,7 @@
     },
     "csv-stringify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
         "lodash.get": "^4.0.0"
@@ -5441,7 +5441,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -6124,7 +6124,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         },
         "babel-runtime": {
@@ -6138,7 +6138,7 @@
         },
         "bluebird": {
           "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz",
           "integrity": "sha1-94D+Q+GnplEPZ6vX0NeVM6QN3eY="
         },
         "body-parser": {
@@ -6173,7 +6173,7 @@
         },
         "colors": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         },
         "cors": {
@@ -6404,12 +6404,12 @@
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
           "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
         },
         "winston": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
           "integrity": "sha1-LIU92Hq1UqjoSF1yy7+aIobwKbc=",
           "requires": {
             "async": "~1.0.0",
@@ -6449,7 +6449,7 @@
         },
         "bluebird": {
           "version": "2.9.25",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
           "integrity": "sha1-bja9BAZNlTTAcWC59/JsWnOP4Wo="
         },
         "depd": {
@@ -7589,8 +7589,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "helloworks-sdk": {
-      "version": "github:pietgeursen/helloworks-nodejs-sdk#c18332110685656fb1534ae71c177d0fb5478b17",
-      "from": "github:pietgeursen/helloworks-nodejs-sdk#c18332110685656fb1534ae71c177d0fb5478b17",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/helloworks-sdk/-/helloworks-sdk-1.1.0.tgz",
+      "integrity": "sha512-087YXBMtQYpTXqWFY1nuVflYySBWfmNpzwxjPvCLmw7xnBOoa062+neGqeraJZW74zVVyytAP5v/UTjAYp5PNA==",
       "requires": {
         "form-data": "^2.3.3",
         "node-fetch": "^2.3.0"
@@ -12332,7 +12333,7 @@
       "dependencies": {
         "commander": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
           "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
           "requires": {
             "keypress": "0.1.x"
@@ -12710,7 +12711,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "handlebars": "4.1.2",
     "hashids": "1.2.2",
     "he": "1.2.0",
-    "helloworks-sdk": "pietgeursen/helloworks-nodejs-sdk#c18332110685656fb1534ae71c177d0fb5478b17",
+    "helloworks-sdk": "1.1.0",
     "helmet": "3.20.0",
     "html-pdf": "2.2.0",
     "ics": "2.16.0",

--- a/server/controllers/helloworks.js
+++ b/server/controllers/helloworks.js
@@ -22,12 +22,12 @@ const HELLO_WORKS_WORKFLOW_ID = get(config, 'helloworks.workflowId');
 const HELLO_WORKS_S3_BUCKET = get(config, 'helloworks.aws.s3.bucket');
 const ENCRYPTION_KEY = get(config, 'helloworks.documentEncryptionKey');
 
-const client = new HelloWorks({
-  apiKeyId: HELLO_WORKS_KEY,
-  apiKeySecret: HELLO_WORKS_SECRET,
-});
-
 async function callback(req, res) {
+  const client = new HelloWorks({
+    apiKeyId: HELLO_WORKS_KEY,
+    apiKeySecret: HELLO_WORKS_SECRET,
+  });
+
   const {
     body: { status, workflow_id: workflowId, data, id, metadata },
   } = req;

--- a/server/lib/encryption.js
+++ b/server/lib/encryption.js
@@ -16,7 +16,7 @@ export const encrypt = (buff, key) => {
   fullMessage.set(nonce);
   fullMessage.set(box, nonce.length);
 
-  return fullMessage;
+  return Buffer.from(fullMessage);
 };
 
 export const decrypt = (buffWithNonce, key) => {

--- a/test/lib.encryption.test.js
+++ b/test/lib.encryption.test.js
@@ -9,6 +9,8 @@ describe('lib.encryption', () => {
 
     const encrypted = encrypt(buff, key);
 
+    expect(Buffer.isBuffer(encrypted)).to.be.true;
+
     expect(encrypted).to.not.eq(message);
 
     const result = decrypt(encrypted, key);


### PR DESCRIPTION
1. The encrypt function needs to return a `Buffer` otherwise s3 explodes. 

2. Instantiate a new hello works client every time we handle a request in the hello works callback controller. I think there is a bug in the hello works sdk that doesn't re-generate its auth tokens correctly. Creating a new client for every request is a way to avoid this.

3. Use the latest official version of the helloworks sdk that now supports sending metadata with the request.
