### PR TITLE
Fixes tax form queries on host collectives.

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -705,7 +705,7 @@ export const ExpenseType = new GraphQLObjectType({
           return isUserTaxFormRequiredBeforePayment({
             year: incurredYear,
             invoiceTotalThreshold: 600e2,
-            HostCollectiveId: expense.CollectiveId,
+            expenseCollectiveId: expense.CollectiveId,
             UserId: expense.UserId,
           });
         },

--- a/server/lib/taxForms.js
+++ b/server/lib/taxForms.js
@@ -25,8 +25,15 @@ export async function findUsersThatNeedToBeSentTaxForm({ invoiceTotalThreshold, 
   return uniqBy(users, 'id');
 }
 
-export async function isUserTaxFormRequiredBeforePayment({ invoiceTotalThreshold, year, HostCollectiveId, UserId }) {
-  const host = await Collective.findByPk(HostCollectiveId);
+export async function isUserTaxFormRequiredBeforePayment({ invoiceTotalThreshold, year, expenseCollectiveId, UserId }) {
+  const collective = await Collective.findOne({
+    where: { id: expenseCollectiveId },
+    include: {
+      association: 'HostCollective',
+    },
+  });
+
+  const { HostCollective: host } = collective;
   const user = await User.findByPk(UserId);
   const requiredDocuments = await host.getRequiredLegalDocuments({
     where: {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1690,7 +1690,7 @@ export default function(Sequelize, DataTypes) {
       .then(() => this.getTiers());
   };
 
-  // Where `this` collective is a type == Host collective.
+  // Where `this` collective is a type == ORGANIZATION collective.
   Collective.prototype.getExpensesForHost = function(
     status,
     startDate,

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1714,7 +1714,7 @@ export default function(Sequelize, DataTypes) {
           association: 'collective',
           include: [
             {
-              association: 'hostCollective',
+              association: 'HostCollective',
               where: { id: this.id },
             },
           ],
@@ -2404,7 +2404,7 @@ export default function(Sequelize, DataTypes) {
     Collective.hasMany(m.LegalDocument);
     Collective.hasMany(m.RequiredLegalDocument, { foreignKey: 'HostCollectiveId' });
     Collective.hasMany(m.Collective, { as: 'hostedCollectives', foreignKey: 'HostCollectiveId' });
-    Collective.belongsTo(m.Collective, { as: 'hostCollective' });
+    Collective.belongsTo(m.Collective, { as: 'HostCollective' });
   };
 
   Historical(Collective, Sequelize);

--- a/test/lib.taxForms.test.js
+++ b/test/lib.taxForms.test.js
@@ -242,7 +242,7 @@ describe('lib.taxForms', () => {
       const result = await isUserTaxFormRequiredBeforePayment({
         invoiceTotalThreshold: US_TAX_FORM_THRESHOLD,
         year: moment().year(),
-        HostCollectiveId: hostCollective.id,
+        expenseCollectiveId: organisationCollectives[0].id,
         UserId: user.id,
       });
       expect(result).to.be.true;
@@ -257,7 +257,7 @@ describe('lib.taxForms', () => {
       const result = await isUserTaxFormRequiredBeforePayment({
         invoiceTotalThreshold: US_TAX_FORM_THRESHOLD,
         year: moment().year(),
-        HostCollectiveId: hostCollective.id,
+        expenseCollectiveId: organisationCollectives[0].id,
         UserId: user.id,
       });
       expect(result).to.be.false;
@@ -268,7 +268,7 @@ describe('lib.taxForms', () => {
       const result = await isUserTaxFormRequiredBeforePayment({
         invoiceTotalThreshold: US_TAX_FORM_THRESHOLD,
         year: moment().year(),
-        HostCollectiveId: hostCollective.id,
+        expenseCollectiveId: organisationCollectives[0].id,
         UserId: user.id,
       });
       expect(result).to.be.false;
@@ -279,7 +279,7 @@ describe('lib.taxForms', () => {
       const result = await isUserTaxFormRequiredBeforePayment({
         invoiceTotalThreshold: US_TAX_FORM_THRESHOLD,
         year: moment().year(),
-        HostCollectiveId: hostCollective.id,
+        expenseCollectiveId: organisationCollectives[0].id,
         UserId: user.id,
       });
       expect(result).to.be.false;


### PR DESCRIPTION
Fixes a mistake with the Tax form work.

Now, when a Host collective has a `RequiredLegalDocument`, all `Expense`s to the hosted collectives count towards triggering the tax form warning.