### PR TITLE
CreateOrder: Don't apply VAT if disabled

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -339,7 +339,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
       if (vatType === VAT_OPTIONS.OWN) {
         taxFromCountry = LibTaxes.getVatOriginCountry(tier.type, baseCountry, baseCountry);
         vatSettings = { ...get(parentCollective, 'settings.VAT'), ...get(collective, 'settings.VAT') };
-      } else {
+      } else if (vatType === VAT_OPTIONS.HOST) {
         const hostCountry = get(hostCollective, 'countryISO');
         taxFromCountry = LibTaxes.getVatOriginCountry(tier.type, hostCountry, baseCountry);
         vatSettings = get(hostCollective, 'settings.VAT') || {};


### PR DESCRIPTION
A last-over that I forgot to do in https://github.com/opencollective/opencollective-api/pull/2306: we shouldn't apply VAT at all if not set to `OWN` or `HOST` by the collective. This is an edge case because the only situation were it could have been applied was if the collective enabled then disabled VAT.