### PR TITLE
Collective updates: Sort by createdAt DESC by default

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1372,7 +1372,7 @@ const CollectiveFields = () => {
         onlyPublishedUpdates: { type: GraphQLBoolean },
       },
       resolve(collective, args) {
-        const query = { where: { CollectiveId: collective.id } };
+        const query = { where: { CollectiveId: collective.id }, order: [['createdAt', 'DESC']] };
         if (args.limit) query.limit = args.limit;
         if (args.offset) query.offset = args.offset;
         if (args.onlyPublishedUpdates) query.where.publishedAt = { [Op.ne]: null };


### PR DESCRIPTION
This query is only used in the new collective page so there's no risk of breaking anything.