### PR TITLE
User: Enforce email address

### DIFF
--- a/migrations/20190830121917-enforce-users-emails.js
+++ b/migrations/20190830121917-enforce-users-emails.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Add a default email to all users with active memberships
+    await queryInterface.sequelize.query(`
+      UPDATE  "Users" AS u
+      SET     "email" = FORMAT('missing-email-%s@opencollective.com', u.id)
+      FROM    "Members" AS m
+      WHERE   m."MemberCollectiveId" = u."CollectiveId"
+      AND     m.id IS NOT NULL
+      AND     m."deletedAt" IS NULL
+      AND     u.email IS NULL
+    `);
+
+    // All the other users without email currently in the DB have no transactions
+    // nor expenses, thus it should be safe to delete them all directly.
+    await queryInterface.sequelize.query(`
+      UPDATE  "Collectives" c
+      SET     "deletedAt" = NOW()
+      FROM    "Users" u
+      WHERE   u."CollectiveId" = c.id
+      AND     u.id IS NOT NULL
+      AND     u."email" IS NULL
+      AND     u."deletedAt" IS NULL
+      AND     c."deletedAt" IS NULL
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE  "Users"
+      SET     "deletedAt" = NOW()
+      WHERE   "email" IS NULL
+      AND     "deletedAt" IS NULL
+    `);
+
+    // Add default emails to remove any null values
+    await queryInterface.sequelize.query(`
+      UPDATE  "Users"
+      SET     "email" = FORMAT('missing-email-%s@opencollective.com', id)
+      WHERE   "email" IS NULL
+    `);
+
+    // Let's change the column to ensure email will never be null again
+    await queryInterface.changeColumn('Users', 'email', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      unique: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('Users', 'email', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      unique: true,
+    });
+  },
+};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -34,6 +34,7 @@ export default (Sequelize, DataTypes) => {
 
       email: {
         type: DataTypes.STRING,
+        allowNull: false,
         unique: true, // need that? http://stackoverflow.com/questions/16356856/sequelize-js-custom-validator-check-for-unique-username-password
         set(val) {
           if (val && val.toLowerCase) {

--- a/test/graphql.connectedAccounts.test.js
+++ b/test/graphql.connectedAccounts.test.js
@@ -1,6 +1,7 @@
 import * as utils from './utils';
 import models from '../server/models';
 import { expect } from 'chai';
+import { randEmail } from './stores';
 
 describe('graphql.connectedAccounts.test.js', () => {
   let user, admin, backer, collective, connectedAccount, connectedAccountData;
@@ -16,11 +17,9 @@ describe('graphql.connectedAccounts.test.js', () => {
   before(() => utils.resetTestDB());
 
   before(async () => {
-    user = await models.User.createUserWithCollective({ name: 'random user' });
-    backer = await models.User.createUserWithCollective({
-      name: 'backer user',
-    });
-    admin = await models.User.createUserWithCollective({ name: 'admin user' });
+    user = await models.User.createUserWithCollective({ email: randEmail(), name: 'random user' });
+    backer = await models.User.createUserWithCollective({ email: randEmail(), name: 'backer user' });
+    admin = await models.User.createUserWithCollective({ email: randEmail(), name: 'admin user' });
     collective = await models.Collective.create({ name: 'testcollective' });
     collective.addUserWithRole(admin, 'ADMIN');
     collective.addUserWithRole(backer, 'BACKER');

--- a/test/graphql.createOrder.opencollective.test.js
+++ b/test/graphql.createOrder.opencollective.test.js
@@ -76,9 +76,7 @@ describe('graphql.createOrder.opencollective', () => {
         await utils.resetTestDB();
         ({ user, userCollective } = await store.newUser('new user'));
         // for some obscure reason, it doesn't work to copy paste previous line for user2
-        user2 = await models.User.createUserWithCollective({
-          name: 'new user 2',
-        });
+        user2 = await models.User.createUserWithCollective({ email: store.randEmail(), name: 'new user 2' });
         ({ hostCollective, collective } = await store.newCollectiveWithHost('test', 'USD', 'USD', 10));
       }); /* End of "beforeEach" */
 

--- a/test/graphql.expenses.test.js
+++ b/test/graphql.expenses.test.js
@@ -1090,9 +1090,7 @@ describe('GraphQL Expenses API', () => {
         ...data,
       });
       // And a backer user
-      const backer = await models.User.createUserWithCollective({
-        name: 'test backer user',
-      });
+      const backer = await models.User.createUserWithCollective({ email: store.randEmail(), name: 'test backer user' });
       await models.Member.create({
         CollectiveId: collective.id,
         MemberCollectiveId: backer.CollectiveId,

--- a/test/lib.subscriptions.test.js
+++ b/test/lib.subscriptions.test.js
@@ -10,6 +10,7 @@ import models from '../server/models';
 import emailLib from '../server/lib/email';
 import * as paymentsLib from '../server/lib/payments';
 import status from '../server/constants/order_status';
+import { randEmail } from './stores';
 
 // What's being tested
 import {
@@ -24,12 +25,8 @@ import {
 
 async function createOrderWithSubscription(interval, date, quantity = 1) {
   const payment = { amount: 1000, currency: 'USD', interval };
-  const user = await models.User.createUserWithCollective({
-    name: 'Test McTesterson',
-  });
-  const fromCollective = await models.Collective.create({
-    name: 'Donor Collective',
-  });
+  const user = await models.User.createUserWithCollective({ email: randEmail(), name: 'Test McTesterson' });
+  const fromCollective = await models.Collective.create({ email: randEmail(), name: 'Donor Collective' });
   const collective = await models.Collective.create({ name: 'Parcel' });
   const tier = await models.Tier.create({ name: 'backer', amount: 0 });
   const subscription = await models.Subscription.create({
@@ -506,9 +503,7 @@ describe('LibSubscription', () => {
 
     beforeEach(async () => {
       await utils.resetTestDB();
-      user = await models.User.createUserWithCollective({
-        name: 'Test McTesterson',
-      });
+      user = await models.User.createUserWithCollective({ email: randEmail(), name: 'Test McTesterson' });
       collective = await models.Collective.create({ name: 'Parcel' });
       tier = await models.Tier.create({ name: 'backer', amount: 0 });
     });

--- a/test/order.model.test.js
+++ b/test/order.model.test.js
@@ -1,11 +1,17 @@
 import { expect } from 'chai';
 import * as utils from '../test/utils';
 import models from '../server/models';
+import { randEmail } from './stores';
 
 describe('order.model.test.js', () => {
   let user, collective, tier, order;
   before(() => utils.resetTestDB());
-  before('create a user', () => models.User.createUserWithCollective({ name: 'Xavier' }).then(u => (user = u)));
+  before('create a user', () =>
+    models.User.createUserWithCollective({
+      email: randEmail(),
+      name: 'Xavier',
+    }).then(u => (user = u)),
+  );
   before('create a collective', () => models.Collective.create({ name: 'Webpack' }).then(c => (collective = c)));
   before('create a tier', () => models.Tier.create({ name: 'backer', amount: 0 }).then(t => (tier = t)));
   before('create an order', () =>

--- a/test/paymentMethods.collective.to.collective.test.js
+++ b/test/paymentMethods.collective.to.collective.test.js
@@ -69,9 +69,19 @@ describe('paymentMethods.collective.to.collective.test.js', () => {
   });
 
   describe('Collective to Collective Transactions', () => {
-    before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+    before('creates User 1', () =>
+      models.User.createUserWithCollective({
+        email: store.randEmail(),
+        name: 'User 1',
+      }).then(u => (user1 = u)),
+    );
 
-    before('creates User 2', () => models.User.createUserWithCollective({ name: 'User 2' }).then(u => (user2 = u)));
+    before('creates User 2', () =>
+      models.User.createUserWithCollective({
+        email: store.randEmail(),
+        name: 'User 2',
+      }).then(u => (user2 = u)),
+    );
 
     before('create Host 1(USD)', () =>
       models.Collective.create({

--- a/test/paymentMethods.model.test.js
+++ b/test/paymentMethods.model.test.js
@@ -1,9 +1,10 @@
 import config from 'config';
 import sinon from 'sinon';
 import { expect } from 'chai';
+import nock from 'nock';
 import * as utils from '../test/utils';
 import models from '../server/models';
-import nock from 'nock';
+import { randEmail } from './stores';
 
 nock('https://data.fixer.io')
   .get(/.*/)
@@ -32,7 +33,12 @@ describe('paymentmethod.model.test.js', () => {
   });
 
   describe('instance methods', () => {
-    before('create a user', () => models.User.createUserWithCollective({ name: 'Xavier' }).then(u => (user = u)));
+    before('create a user', () =>
+      models.User.createUserWithCollective({
+        email: randEmail(),
+        name: 'Xavier',
+      }).then(u => (user = u)),
+    );
     before('create a collective', () =>
       models.Collective.create({
         name: 'BrusselsTogether',

--- a/test/paymentMethods.opencollective.virtualcard.js
+++ b/test/paymentMethods.opencollective.virtualcard.js
@@ -103,7 +103,12 @@ describe('opencollective.virtualcard', () => {
           isActive: true,
         }).then(c => (collective1 = c)),
       );
-      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+      before('creates User 1', () =>
+        models.User.createUserWithCollective({
+          email: store.randEmail(),
+          name: 'User 1',
+        }).then(u => (user1 = u)),
+      );
       before('user1 to become Admin of collective1', () => {
         return models.Member.create({
           CreatedByUserId: user1.id,
@@ -234,7 +239,12 @@ describe('opencollective.virtualcard', () => {
         }).then(pm => (paymentMethod1 = pm)),
       );
 
-      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+      before('creates User 1', () =>
+        models.User.createUserWithCollective({
+          email: store.randEmail(),
+          name: 'User 1',
+        }).then(u => (user1 = u)),
+      );
       before('user1 to become Admin of collective1', () => {
         return models.Member.create({
           CreatedByUserId: user1.id,
@@ -324,7 +334,12 @@ describe('opencollective.virtualcard', () => {
         }).then(c => (collective2 = c)),
       );
 
-      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+      before('creates User 1', () =>
+        models.User.createUserWithCollective({
+          email: store.randEmail(),
+          name: 'User 1',
+        }).then(u => (user1 = u)),
+      );
       before('user1 to become Admin of collective1', () => {
         return models.Member.create({
           CreatedByUserId: user1.id,
@@ -630,7 +645,12 @@ describe('opencollective.virtualcard', () => {
           isActive: true,
         }).then(c => (collective2 = c)),
       );
-      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+      before('creates User 1', () =>
+        models.User.createUserWithCollective({
+          email: store.randEmail(),
+          name: 'User 1',
+        }).then(u => (user1 = u)),
+      );
       before('user1 to become Admin of collective1', () =>
         models.Member.create({
           CreatedByUserId: user1.id,
@@ -740,7 +760,12 @@ describe('opencollective.virtualcard', () => {
         }).then(pm => (paymentMethod1 = pm)),
       );
 
-      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+      before('creates User 1', () =>
+        models.User.createUserWithCollective({
+          email: store.randEmail(),
+          name: 'User 1',
+        }).then(u => (user1 = u)),
+      );
       before('user1 to become Admin of collective1', () => {
         return models.Member.create({
           CreatedByUserId: user1.id,
@@ -824,6 +849,7 @@ describe('opencollective.virtualcard', () => {
 
       it('Existing User should claim a virtual card', async () => {
         const existingUser = await models.User.createUserWithCollective({
+          email: store.randEmail(),
           name: 'Existing User',
         });
         // setting correct code to claim virtual card by new User
@@ -922,7 +948,12 @@ describe('opencollective.virtualcard', () => {
         await collective2.addHost(host2);
         await collective2.update({ isActive: true });
       });
-      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+      before('creates User 1', () =>
+        models.User.createUserWithCollective({
+          email: store.randEmail(),
+          name: 'User 1',
+        }).then(u => (user1 = u)),
+      );
       before('user1 to become Admin of collective1', () => {
         return models.Member.create({
           CreatedByUserId: user1.id,
@@ -1099,7 +1130,12 @@ describe('opencollective.virtualcard', () => {
           isActive: true,
         }).then(c => (collective1 = c)),
       );
-      before('creates User 1', () => models.User.createUserWithCollective({ name: 'User 1' }).then(u => (user1 = u)));
+      before('creates User 1', () =>
+        models.User.createUserWithCollective({
+          email: store.randEmail(),
+          name: 'User 1',
+        }).then(u => (user1 = u)),
+      );
       before('user1 to become Admin of collective1', () =>
         models.Member.create({
           CreatedByUserId: user1.id,

--- a/test/user.model.test.js
+++ b/test/user.model.test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import config from 'config';
 import { expect } from 'chai';
 import { URL } from 'url';
+import { SequelizeValidationError } from 'sequelize';
 
 import models from '../server/models';
 import * as auth from '../server/lib/auth';
@@ -13,7 +14,7 @@ const userData = utils.data('user1');
 
 const { User } = models;
 
-describe('user.models.test.js', () => {
+describe('user.model.test.js', () => {
   let sandbox;
 
   before(() => {
@@ -33,10 +34,12 @@ describe('user.models.test.js', () => {
    * Create a user.
    */
   describe('#create', () => {
-    it('succeeds without email', () =>
-      User.create({ firstName: userData.firstName }).tap(user =>
-        expect(user).to.have.property('firstName', userData.firstName),
-      ));
+    it('fails without email', () => {
+      return expect(User.create({ firstName: userData.firstName })).to.be.rejectedWith(
+        SequelizeValidationError,
+        'notNull Violation: User.email cannot be null',
+      );
+    });
 
     it('fails if invalid email', () =>
       User.create({ firstName: userData.firstName, email: 'johndoe' }).catch(err => expect(err).to.exist));


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2039
Probably caused by https://github.com/opencollective/opencollective/issues/1179

`null` emails were allowed in https://github.com/opencollective/opencollective-api/pull/344 but the code where it was required isn't there anymore.

All tests updated by this PR are just added an `email: randEmail()` except https://github.com/opencollective/opencollective-api/pull/2493/files#diff-c91eac63018a8e6fd82d82d8873413a2 where the logic was clearly changed to ensure we don't accept null emails.