### PR TITLE
Authentication enhancements

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -15,6 +15,7 @@ export const TOKEN_EXPIRATION_CONNECTED_ACCOUNT = daysToSeconds(1);
 export const TOKEN_EXPIRATION_SESSION = daysToSeconds(90);
 
 const ALGORITHM = 'HS256';
+const KID = 'HS256-2019-09-02';
 
 /** Generate a JWToken with the received parameters */
 export function createJwt(subject, payload, expiresIn) {
@@ -22,6 +23,9 @@ export function createJwt(subject, payload, expiresIn) {
     expiresIn,
     subject: String(subject),
     algorithm: ALGORITHM,
+    header: {
+      kid: KID,
+    },
   });
 }
 

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -14,14 +14,22 @@ export const TOKEN_EXPIRATION_LOGIN = minutesToSeconds(75);
 export const TOKEN_EXPIRATION_CONNECTED_ACCOUNT = daysToSeconds(1);
 export const TOKEN_EXPIRATION_SESSION = daysToSeconds(90);
 
+const ALGORITHM = 'HS256';
+
 /** Generate a JWToken with the received parameters */
 export function createJwt(subject, payload, expiresIn) {
-  return jwt.sign(payload, config.keys.opencollective.jwtSecret, { expiresIn, subject: String(subject) });
+  return jwt.sign(payload, config.keys.opencollective.jwtSecret, {
+    expiresIn,
+    subject: String(subject),
+    algorithm: ALGORITHM,
+  });
 }
 
 /** Verify JWToken */
 export function verifyJwt(token) {
-  return jwt.verify(token, config.keys.opencollective.jwtSecret);
+  return jwt.verify(token, config.keys.opencollective.jwtSecret, {
+    algorithms: [ALGORITHM],
+  });
 }
 
 /**

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -19,7 +19,7 @@ const KID = 'HS256-2019-09-02';
 
 /** Generate a JWToken with the received parameters */
 export function createJwt(subject, payload, expiresIn) {
-  return jwt.sign(payload, config.keys.opencollective.jwtSecret, {
+  return jwt.sign(payload || {}, config.keys.opencollective.jwtSecret, {
     expiresIn,
     subject: String(subject),
     algorithm: ALGORITHM,

--- a/server/middleware/security/authentication.js
+++ b/server/middleware/security/authentication.js
@@ -3,7 +3,7 @@ import config from 'config';
 import jwt from 'jsonwebtoken';
 import passport from 'passport';
 import request from 'request-promise';
-import { get, contains, omitBy, isNil } from 'lodash';
+import { get, omitBy, isNil } from 'lodash';
 import { URLSearchParams } from 'url';
 
 import models from '../../models';
@@ -13,7 +13,7 @@ import { createOrUpdate as createOrUpdateConnectedAccount } from '../../controll
 
 const { User } = models;
 
-const { BadRequest, CustomError, Unauthorized } = errors;
+const { BadRequest, CustomError } = errors;
 
 const { jwtSecret } = config.keys.opencollective;
 
@@ -128,38 +128,6 @@ export function authenticateUser(req, res, next) {
     });
   });
 }
-
-export function authenticateInternalUserByJwt() {
-  return (req, res, next) => {
-    parseJwtNoExpiryCheck(req, res, e => {
-      if (e) {
-        debug('auth')('>>> parseJwtNoExpiryCheck error', e);
-        return next(e);
-      }
-      checkJwtExpiry(req, res, e => {
-        if (e) {
-          debug('auth')('>>> checkJwtExpiry error', e);
-          return next(e);
-        }
-        _authenticateUserByJwt(req, res, e => {
-          if (e) {
-            debug('auth')('>>> _authenticateUserByJwt error', e);
-            return next(e);
-          }
-          _authenticateInternalUserById(req, res, next);
-        });
-      });
-    });
-  };
-}
-
-export const _authenticateInternalUserById = (req, res, next) => {
-  if (req.jwtPayload && contains([1, 2, 4, 5, 6, 7, 8, 30, 40, 212, 772], Number(req.jwtPayload.sub))) {
-    next();
-  } else {
-    throw new Unauthorized();
-  }
-};
 
 export const authenticateService = (req, res, next) => {
   const { service } = req.params;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -3,7 +3,7 @@ import config from 'config';
 import Promise from 'bluebird';
 import slugify from 'limax';
 import debugLib from 'debug';
-import { extend, defaults, intersection } from 'lodash';
+import { defaults, intersection } from 'lodash';
 import { Op } from 'sequelize';
 
 import logger from '../lib/logger';
@@ -242,20 +242,17 @@ export default (Sequelize, DataTypes) => {
     },
   );
 
+  /** Instance Methods */
+
   /**
-   * Instance Methods
+   * Generate a JWT for user.
+   *
+   * @param {object} `payload` - data to attach to the token
+   * @param {Number} `expiration` - expiration period in seconds
    */
   User.prototype.jwt = function(payload, expiration) {
     expiration = expiration || auth.TOKEN_EXPIRATION_LOGIN;
-
-    // We are sending too much data (large jwt) but the app and website
-    // need the id and email. We will refactor that progressively to
-    // have a smaller token.
-    const data = extend({}, payload, {
-      id: this.id,
-      email: this.email,
-    });
-    return auth.createJwt(this.id, data, expiration);
+    return auth.createJwt(this.id, payload, expiration);
   };
 
   User.prototype.generateLoginLink = function(redirect = '/', websiteUrl) {

--- a/test/auth.lib.test.js
+++ b/test/auth.lib.test.js
@@ -31,4 +31,23 @@ describe('authlib', () => {
     const token = auth.createJwt('sub', {}, 5);
     expect(Boolean(auth.verifyJwt(token))).to.be.true;
   });
+
+  it('should prevent changing the algorithm for validate', () => {
+    const payload = { foo: 'bar' };
+    const testKey = `-----BEGIN EC PRIVATE KEY-----
+MHgCAQEEIQCngKdlZNZLnHz1759Ws3tKUfkyTfh+E9o52L5yzjMQ+KAKBggqhkjO
+PQMBB6FEA0IABE6r13quwp3ZFr9SF8k6B0BRiOzAX8UGF1JkV/0KOnyqeTTT9lgW
+quLDCejRhHBkI/i5vZXyk4MqC5q4COJlxKU=
+-----END EC PRIVATE KEY-----`;
+    const maliciousToken = jwt.sign(payload, testKey, {
+      subject: String(payload),
+      header: {
+        alg: 'ES256',
+      },
+    });
+
+    expect(() => {
+      auth.verifyJwt(maliciousToken);
+    }).to.throw('invalid algorithm');
+  });
 });

--- a/test/user.model.test.js
+++ b/test/user.model.test.js
@@ -150,8 +150,6 @@ describe('user.models.test.js', () => {
 
       // And then the decoded token should contain the user data
       expect(Number(decoded.sub)).to.equal(user.id);
-      expect(decoded.id).to.equal(user.id);
-      expect(decoded.email).to.equal('foo@oc.com');
 
       // And then the default expiration of the token should have a
       // short life time


### PR DESCRIPTION
- Enforce `algorithms` in `jwt.verify`. The lib we use is already protected, this adds an additional security to ensure no-one can mess with the algorithm used to decode the tokens.

- Add a `kid` field in JWT headers. This doesn't change anything now, but it will help with migrations strategies if we later want to update the keys or the algorithm used.

- Remove an unused function: `authenticateInternalUserByJwt`

---

New token format (decoded):

![image](https://user-images.githubusercontent.com/1556356/64122914-3f7c8800-cda3-11e9-8621-7c2eb76a50f5.png)
