### PR TITLE
CI: Merge lint and prettier jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,17 +43,6 @@ jobs:
       - run: npm ci --ignore-scripts
       - <<: *persist_cache
       - run: npm run lint
-
-  prettier:
-    docker:
-      - image: circleci/node:11.8.0
-    environment:
-      NODE_ENV: circleci
-    steps:
-      - checkout
-      - <<: *restore_cache
-      - run: npm ci --ignore-scripts
-      - <<: *persist_cache
       - run: npm run prettier:check
 
   typescript:
@@ -92,8 +81,6 @@ workflows:
   main:
     jobs:
       - lint:
-          <<: *test_filters
-      - prettier:
           <<: *test_filters
       - typescript:
           <<: *test_filters


### PR DESCRIPTION
To match the Frontend's config and limit the number of parallel jobs, this merges lint + prettier.