### PR TITLE
Collective Events: Sort by date DESC per default

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1415,7 +1415,11 @@ const CollectiveFields = () => {
         },
       },
       resolve(collective, args) {
-        const query = { where: { type: 'EVENT', ParentCollectiveId: collective.id } };
+        const query = {
+          where: { type: 'EVENT', ParentCollectiveId: collective.id },
+          order: [['startsAt', 'DESC'], ['endsAt', 'DESC']],
+        };
+
         if (args.limit) query.limit = args.limit;
         if (args.offset) query.offset = args.offset;
         if (!args.includeInactive) query.where.isActive = true;


### PR DESCRIPTION
The modified query is only used in the new collective page, so there's no risk of breaking anything.