### PR TITLE
Expenses: Don't crash when querying expenses for orgs/collectives

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -707,13 +707,18 @@ const queries = {
       };
 
       if (FromCollectiveId || FromCollectiveSlug) {
-        const { id } = await models.User.findOne({
+        const collectiveUser = await models.User.findOne({
           attributes: ['id'],
           where: {
             CollectiveId: FromCollectiveId || (await fetchCollectiveId(FromCollectiveSlug)),
           },
         });
-        query.where.UserId = id;
+
+        if (!collectiveUser) {
+          return { expenses: [], limit, offset, total: 0 };
+        }
+
+        query.where.UserId = collectiveUser.id;
       }
 
       if (category) query.where.category = { [Op.iLike]: category };


### PR DESCRIPTION
Though we currently don't support adding expenses from organizations and collectives, the endpoint shouldn't crash. This was causing issues on the NCP for organizations because we share the same `Transactions` section than for users, thus the field is queried.