### PR TITLE
refactor: clearer usage of hostFeePercent platformFeePercent

### DIFF
--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -1,4 +1,5 @@
 import Promise from 'bluebird';
+import { get } from 'lodash';
 
 import logger from '../../lib/logger';
 import models, { sequelize } from '../../models';
@@ -54,7 +55,7 @@ paymentMethodProvider.getBalance = paymentMethod => {
   });
 };
 
-paymentMethodProvider.processOrder = async (order, options = {}) => {
+paymentMethodProvider.processOrder = async order => {
   // Get the host of the fromCollective and collective
   const fromCollectiveHost = await order.fromCollective.getHostCollective();
   const collectiveHost = await order.collective.getHostCollective();
@@ -91,8 +92,8 @@ paymentMethodProvider.processOrder = async (order, options = {}) => {
     throw new Error('Cannot use the opencollective payment method to make a payment on behalf of another collective');
   }
 
-  const hostFeePercent = options.hostFeePercent || 0;
-  const platformFeePercent = options.platformFeePercent || 0;
+  const hostFeePercent = get(order, 'data.hostFeePercent', 0);
+  const platformFeePercent = get(order, 'data.platformFeePercent', 0);
 
   if (!fromCollectiveHost) {
     // If the fromCollective has no Host (ie. when we add fund on behalf of a user/organization),

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import models from '../../models';
 import { TransactionTypes } from '../../constants/transactions';
 import { maxInteger } from '../../constants/math';
@@ -33,7 +33,8 @@ async function processOrder(order) {
     );
   }
 
-  const hostFeeInHostCurrency = -Math.round((order.collective.hostFeePercent / 100) * order.totalAmount);
+  const hostFeePercent = get(order, 'data.hostFeePercent', order.collective.hostFeePercent);
+  const hostFeeInHostCurrency = -Math.round((hostFeePercent / 100) * order.totalAmount);
   const platformFeeInHostCurrency = 0;
   const paymentProcessorFeeInHostCurrency = 0;
 


### PR DESCRIPTION
- From now, store `hostFeePercent` and `platformFeePercent` fees in the Orders table
- Use it as authority when performing transactions