### PR TITLE
Tier history: TEXT data type for short description

### DIFF
--- a/migrations/20190924204530-longer-tiers-history-description.js
+++ b/migrations/20190924204530-longer-tiers-history-description.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('TierHistories', 'description', {
+      type: Sequelize.STRING(510),
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('TierHistories', 'description', {
+      type: Sequelize.STRING(255),
+    });
+  },
+};

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -67,7 +67,7 @@ export default function(Sequelize, DataTypes) {
         defaultValue: 'TIER',
       },
 
-      description: DataTypes.STRING,
+      description: DataTypes.STRING(510),
 
       longDescription: {
         type: DataTypes.TEXT,


### PR DESCRIPTION
Fix for https://github.com/opencollective/opencollective/issues/2454
Bug introduced in https://github.com/opencollective/opencollective-api/pull/2557

The description max length was doubled in https://github.com/opencollective/opencollective-api/pull/936 but the model was not updated accordingly. When @NotJohs implemented the `TierHistories` table in https://github.com/opencollective/opencollective-api/pull/2557, he used the model as a reference (**which was the right thing to do**, definitely not his fault) and as a consequence all tiers with a description longer than 255 can't be edited anymore because the insert in the history table fails.
