### PR TITLE
Transactions: add filters to exclude expenses

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1336,6 +1336,11 @@ const CollectiveFields = () => {
         },
         limit: { type: GraphQLInt },
         offset: { type: GraphQLInt },
+        includeExpenseTransactions: {
+          type: GraphQLBoolean,
+          default: true,
+          description: 'If false, only the transactions not linked to an expense (orders/refunds) will be returned',
+        },
       },
       resolve(collective, args) {
         return collective.getTransactions({ ...args, order: [['id', 'DESC']] });

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -382,6 +382,11 @@ const queries = {
       dateTo: { type: GraphQLString },
       /** @deprecated since 2018-11-29: Virtual cards now included by default when necessary */
       includeVirtualCards: { type: GraphQLBoolean },
+      includeExpenseTransactions: {
+        type: GraphQLBoolean,
+        default: true,
+        description: 'If false, only the transactions not linked to an expense (orders/refunds) will be returned',
+      },
       fetchDataFromLedger: { type: GraphQLBoolean }, // flag to go with either api or ledger transactions
       includeHostedCollectivesTransactions: {
         type: GraphQLBoolean,
@@ -403,6 +408,7 @@ const queries = {
         offset: args.offset,
         startDate: args.dateFrom,
         endDate: args.dateTo,
+        includeExpenseTransactions: args.includeExpenseTransactions,
       });
     },
   },

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1947,6 +1947,7 @@ export default function(Sequelize, DataTypes) {
     attributes,
     order = [['createdAt', 'DESC']],
     includeUsedVirtualCardsEmittedByOthers = true,
+    includeExpenseTransactions = true,
   }) {
     // Base query
     const query = { where: this.transactionsWhereQuery(includeUsedVirtualCardsEmittedByOthers) };
@@ -1954,6 +1955,11 @@ export default function(Sequelize, DataTypes) {
     // Select attributes
     if (attributes) {
       query.attributes = attributes;
+    }
+
+    // Hide expenses transactions on demand
+    if (includeExpenseTransactions === false) {
+      query.where.ExpenseId = null;
     }
 
     // Filter on host


### PR DESCRIPTION
With the NCP, we fetch transactions and expenses as two different things because we also want to display pending expenses (that are not yet transactions). This will make it easier.