### PR TITLE
Properly format backyourstack nextDisptachDate in error message.

### DIFF
--- a/server/graphql/v1/mutations/backyourstack.js
+++ b/server/graphql/v1/mutations/backyourstack.js
@@ -21,7 +21,9 @@ export async function dispatchOrder(orderId) {
 
   if (subscription.data && !needsDispatching(subscription.data.nextDispatchDate)) {
     const nextDispatchDate = moment(subscription.data.nextDispatchDate).format('ll');
-    throw new Error(`Order is not up for dispatching, next dispatching date is ${nextDispatchDate}.`);
+    throw new Error(
+      `Your BackYourStack order is already complete for this month. The next dispatch of funds will be on ${nextDispatchDate}`,
+    );
   }
 
   let dispatchedOrders;

--- a/server/graphql/v1/mutations/backyourstack.js
+++ b/server/graphql/v1/mutations/backyourstack.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import models from '../../../models';
 import { dispatchFunds, getNextDispatchingDate, needsDispatching } from '../../../lib/backyourstack/dispatcher';
 
@@ -19,7 +20,8 @@ export async function dispatchOrder(orderId) {
   }
 
   if (subscription.data && !needsDispatching(subscription.data.nextDispatchDate)) {
-    throw new Error(`Order is not up for dispatching, next dispatching date is ${subscription.data.nextDispatchDate}`);
+    const nextDispatchDate = moment(subscription.data.nextDispatchDate).format('ll');
+    throw new Error(`Order is not up for dispatching, next dispatching date is ${nextDispatchDate}.`);
   }
 
   let dispatchedOrders;


### PR DESCRIPTION
This PR properly formats next dispatch date in error message i.e
 `Order is not up for dispatching, next dispatching date is 2019-11-01T12:14:22.911Z` ---> `Order is not up for dispatching, next dispatching date is Nov 1, 2019`