### PR TITLE
Complete pledge enhancements

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -629,7 +629,9 @@ export async function completePledge(remoteUser, order) {
   }
 
   if (paymentRequired) {
+    existingOrder.totalAmount = order.totalAmount;
     existingOrder.interval = order.interval;
+    existingOrder.currency = order.currency;
     if (get(order, 'paymentMethod.type') === 'manual') {
       existingOrder.paymentMethod = order.paymentMethod;
     } else {


### PR DESCRIPTION
- Better permissions check (improve error message)
- Don't try to complete pledge if order is not `PENDING`
- Allow users to update amount
- Allow users to update currency (pledge collective currency can be set to something different than the default `USD` after the collective has been claimed)