### PR TITLE
Enhancement: Host admin can un-pay an expense

### DIFF
--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -341,9 +341,10 @@ const mutations = {
     type: ExpenseType,
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
+      processorFeeRefunded: { type: new GraphQLNonNull(GraphQLBoolean) },
     },
     resolve(_, args, req) {
-      return markExpenseAsUnpaid(req.remoteUser, args.id);
+      return markExpenseAsUnpaid(req.remoteUser, args.id, args.processorFeeRefunded);
     },
   },
   editTier: {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -27,7 +27,14 @@ import { createMember, removeMember, editMembership } from './mutations/members'
 import { editTiers, editTier } from './mutations/tiers';
 import { editConnectedAccount } from './mutations/connectedAccounts';
 import { createWebhook, deleteNotification, editWebhooks } from './mutations/notifications';
-import { createExpense, editExpense, updateExpenseStatus, payExpense, deleteExpense } from './mutations/expenses';
+import {
+  createExpense,
+  editExpense,
+  updateExpenseStatus,
+  payExpense,
+  deleteExpense,
+  markExpenseAsUnpaid,
+} from './mutations/expenses';
 import * as paymentMethodsMutation from './mutations/paymentMethods';
 import * as updateMutations from './mutations/updates';
 import * as commentMutations from './mutations/comments';
@@ -328,6 +335,15 @@ const mutations = {
     },
     resolve(_, args, req) {
       return deleteExpense(req.remoteUser, args.id);
+    },
+  },
+  markExpenseAsUnpaid: {
+    type: ExpenseType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+    resolve(_, args, req) {
+      return markExpenseAsUnpaid(req.remoteUser, args.id);
     },
   },
   editTier: {

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -382,7 +382,7 @@ export async function markExpenseAsUnpaid(remoteUser, ExpenseId) {
   }
 
   if (expense.payoutMethod !== 'other') {
-    throw new errors.Unauthorized('Only expense with other payout method can be marked unpaid');
+    throw new errors.Unauthorized('Only expenses with "other" payout method can be marked as unpaid');
   }
 
   const transaction = await models.Transaction.findOne({

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -370,7 +370,7 @@ export async function markExpenseAsUnpaid(remoteUser, ExpenseId) {
   });
 
   if (!expense) {
-    throw new errors.NotFound('No expense transaction found');
+    throw new errors.NotFound('No expense found');
   }
 
   if (!canMarkExpenseUnpaid(remoteUser, expense)) {

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -362,7 +362,7 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
 
 export async function markExpenseAsUnpaid(remoteUser, ExpenseId) {
   if (!remoteUser) {
-    throw new errors.Unauthorized('You need to be logged in to pay an expense');
+    throw new errors.Unauthorized('You need to be logged in to unpay an expense');
   }
 
   const expense = await models.Expense.findByPk(ExpenseId, {

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -374,7 +374,7 @@ export async function markExpenseAsUnpaid(remoteUser, ExpenseId) {
   }
 
   if (!canMarkExpenseUnpaid(remoteUser, expense)) {
-    throw new errors.Unauthorized("You don't have permission to mark this expense unpaid");
+    throw new errors.Unauthorized("You don't have permission to mark this expense as unpaid");
   }
 
   if (expense.status !== statuses.PAID) {

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -378,7 +378,7 @@ export async function markExpenseAsUnpaid(remoteUser, ExpenseId) {
   }
 
   if (expense.status !== statuses.PAID) {
-    throw new errors.Unauthorized('Expense has not been paid');
+    throw new errors.Unauthorized('Expense has not been paid yet');
   }
 
   if (expense.payoutMethod !== 'other') {

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -33,7 +33,7 @@ function canUpdateExpenseStatus(remoteUser, expense) {
  * Only admin of expense.collective.host can mark expenses unpaid
  */
 function canMarkExpenseUnpaid(remoteUser, expense) {
-  if (remoteUser.hasRole([roles.HOST, roles.ADMIN], expense.collective.HostCollectiveId)) {
+  if (remoteUser.hasRole([roles.ADMIN], expense.collective.HostCollectiveId)) {
     return true;
   }
   return false;


### PR DESCRIPTION
This PR follows up https://github.com/opencollective/opencollective/issues/2324 to give admin host ability to mark paid expense with other payout method as unpaid. 

- [x] Complete the `markExpenseAsUnpaid` mutation.
- [x] Add unit test