### PR TITLE
Collective: Add arg to return null instead of an error if not found

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -48,17 +48,22 @@ const queries = {
     args: {
       slug: { type: GraphQLString },
       id: { type: GraphQLInt },
+      throwIfMissing: {
+        type: GraphQLBoolean,
+        defaultValue: true,
+        description: 'If false, will return null instead of an error if collective is not found',
+      },
     },
     resolve(_, args) {
       let collective;
       if (args.slug) {
-        collective = models.Collective.findBySlug(args.slug.toLowerCase());
+        collective = models.Collective.findBySlug(args.slug.toLowerCase(), null, args.throwIfMissing);
       } else if (args.id) {
         collective = models.Collective.findByPk(args.id);
       } else {
         return new Error('Please provide a slug or an id');
       }
-      if (!collective) {
+      if (!collective && args.throwIfMissing) {
         throw new errors.NotFound('Collective not found');
       }
       return collective;

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2296,7 +2296,7 @@ export default function(Sequelize, DataTypes) {
       .then(slugList => slugSuggestionHelper(suggestions[0], slugList, 0));
   };
 
-  Collective.findBySlug = (slug, options = {}) => {
+  Collective.findBySlug = (slug, options = {}, throwIfMissing = true) => {
     if (!slug || slug.length < 1) {
       return Promise.resolve(null);
     }
@@ -2304,7 +2304,7 @@ export default function(Sequelize, DataTypes) {
       where: { slug: slug.toLowerCase() },
       ...options,
     }).then(collective => {
-      if (!collective) {
+      if (!collective && throwIfMissing) {
         throw new Error(`No collective found with slug ${slug}`);
       }
       return collective;


### PR DESCRIPTION
Conceptually, it's wrong to throw here because the return type is not `GraphQLNonNull`, so a not found collective should always return null rather than an error. That was preventing a clean fix for https://github.com/opencollective/opencollective/issues/1369.

However, because we do check the error message in a lot of services (images, invoices...etc) the option to not throw is an opt-in parameter.