### PR TITLE
show paypal email only when expense.payoutMethod is set to 'paypal'

### DIFF
--- a/templates/emails/collective.expense.created.hbs
+++ b/templates/emails/collective.expense.created.hbs
@@ -6,7 +6,7 @@ Subject: New expense on {{collective.name}}: {{{currency expense.amount currency
   <h1>{{{currency expense.amount currency=expense.currency precision=2}}}</h1>
   <div><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></div>
   <div>Submitted by: {{fromCollective.name}}</div>
-  <div>Paypal Email: {{user.paypalEmail}}</div>
+  {{#ifCond expense.payoutMethod '===' 'paypal'}}<div>Paypal Email: {{user.paypalEmail}}</div>{{/ifCond}}
   <p><font color="#999">{{expense.notes}}</font></p>
 
   <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">


### PR DESCRIPTION
This pr solves: https://github.com/opencollective/opencollective/issues/1912