### PR TITLE
Add refund method for manual payment

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -89,8 +89,16 @@ export async function processOrder(order, options) {
  *  associated to the refund transaction as who performed the refund.
  */
 export async function refundTransaction(transaction, user) {
-  const paymentMethod = findPaymentMethodProvider(transaction.PaymentMethod);
-  return await paymentMethod.refundTransaction(transaction, user);
+  // If no payment method was used, it means that we're using a manual payment method
+  const paymentMethodProvider = transaction.PaymentMethod
+    ? findPaymentMethodProvider(transaction.PaymentMethod)
+    : paymentProviders.opencollective.types.manual;
+
+  if (!paymentMethodProvider.refundTransaction) {
+    throw new Error('This payment method provider does not support refunds');
+  }
+
+  return await paymentMethodProvider.refundTransaction(transaction, user);
 }
 
 /** Calculates how much an amount's fee is worth.

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -2,6 +2,7 @@ import { pick } from 'lodash';
 import models from '../../models';
 import { TransactionTypes } from '../../constants/transactions';
 import { maxInteger } from '../../constants/math';
+import { createRefundTransaction, associateTransactionRefundId } from '../../lib/payments';
 
 /**
  * Manual Payment method
@@ -57,6 +58,16 @@ async function processOrder(order) {
   return creditTransaction;
 }
 
+/**
+ * Refund a given transaction by creating the opposing transaction.
+ * There's nothing more to do because it's up to the host/collective to see how
+ * they want to actually refund the money.
+ */
+const refundTransaction = async (transaction, user) => {
+  const refundTransaction = await createRefundTransaction(transaction, 0, null, user);
+  return associateTransactionRefundId(transaction, refundTransaction);
+};
+
 /* Expected API of a Payment Method Type */
 export default {
   features: {
@@ -65,4 +76,5 @@ export default {
   },
   getBalance,
   processOrder,
+  refundTransaction,
 };

--- a/test/paymentMethods.manual.test.js
+++ b/test/paymentMethods.manual.test.js
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+
+import models from '../server/models';
+import ManualPaymentMethod from '../server/paymentProviders/opencollective/manual';
+import * as store from './stores';
+
+describe('Manual Payment Method', () => {
+  const hostFeePercent = 5;
+
+  let user, host, collective;
+
+  /** Create a test PENDING order from `user` to `collective` */
+  const createOrder = async (amount = 5000) => {
+    const order = await models.Order.create({
+      CreatedByUserId: user.id,
+      FromCollectiveId: user.CollectiveId,
+      CollectiveId: collective.id,
+      totalAmount: amount,
+      currency: 'USD',
+      status: 'PENDING',
+    });
+
+    // Bind some required properties
+    order.collective = collective;
+    order.fromCollective = user.collective;
+    order.createByUser = user;
+    return order;
+  };
+
+  // ---- Setup host, collective and user
+
+  before('Create Host (USD)', async () => {
+    host = await models.Collective.create({ name: 'Host 1', currency: 'USD', isActive: true, hostFeePercent });
+  });
+
+  before('Create collective', async () => {
+    collective = await models.Collective.create({
+      name: 'collective1',
+      currency: 'USD',
+      HostCollectiveId: host.id,
+      isActive: true,
+      hostFeePercent,
+    });
+  });
+
+  before('Create User', async () => {
+    user = await models.User.createUserWithCollective({ email: store.randEmail(), name: 'User 1' });
+  });
+
+  // ---- Test features ----
+
+  describe('Features', () => {
+    it("Doesn't support recurring", () => expect(ManualPaymentMethod.features.recurring).to.be.false);
+    it("Doesn't charge automatically", () => expect(ManualPaymentMethod.features.waitToCharge).to.be.true);
+  });
+
+  // ---- Test processOrder ----
+
+  describe('processOrder', () => {
+    it('Returns the CREDIT transaction', async () => {
+      const amount = 5000;
+      const order = await createOrder(amount);
+      const transaction = await ManualPaymentMethod.processOrder(order);
+
+      expect(transaction.type).to.equal('CREDIT');
+      expect(transaction.currency).to.equal('USD');
+      expect(transaction.hostCurrency).to.equal('USD');
+      expect(transaction.OrderId).to.equal(order.id);
+      expect(transaction.amount).to.equal(amount);
+      expect(transaction.amountInHostCurrency).to.equal(amount);
+      expect(transaction.hostFeeInHostCurrency).to.equal(-250);
+      expect(transaction.platformFeeInHostCurrency).to.equal(0); // We take no fee on manual transactions
+      expect(transaction.netAmountInCollectiveCurrency).to.equal(4750);
+      expect(transaction.HostCollectiveId).to.equal(host.id);
+      expect(transaction.CreatedByUserId).to.equal(user.id);
+      expect(transaction.FromCollectiveId).to.equal(user.collective.id);
+      expect(transaction.CollectiveId).to.equal(collective.id);
+      expect(transaction.PaymentMethodId).to.be.null;
+    });
+
+    it('Is not fooled by floating issues', async () => {
+      // (hostFeePercent = 5 / 100) * 28 = 1.4000000000000001
+      const amount = 28;
+      const order = await createOrder(amount);
+      const transaction = await ManualPaymentMethod.processOrder(order);
+      expect(transaction.amountInHostCurrency).to.equal(amount);
+      expect(transaction.hostFeeInHostCurrency).to.equal(-1);
+    });
+  });
+});


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/1936

- Implemented refund for manual PM
- Added unit tests for manual PM (including for `processOrder`)
- Added a clearer error message if a payment method provider does not support refunds. 