### PR TITLE
[feat]: disconnect account api

### DIFF
--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -149,7 +149,9 @@ export const disconnect = async (req, res) => {
       where: { service, CollectiveId },
     });
 
-    await account.delete();
+    if (account) {
+      await account.destroy();
+    }
 
     res.send({
       deleted: true,

--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -131,6 +131,26 @@ export const createOrUpdate = (req, res, next, accessToken, data, emails) => {
   }
 };
 
+export const disconnect = async (req, res) => {
+  const { collectiveId: CollectiveId, service } = req.params;
+  const { remoteUser } = req;
+
+  try {
+    const Account = await ConnectedAccount.findOne({
+      where: { service, CollectiveId },
+    });
+
+    await Account.delete(remoteUser);
+
+    res.send({
+      deleted: true,
+      service,
+    });
+  } catch (err) {
+    res.send(err);
+  }
+};
+
 export const verify = (req, res, next) => {
   const payload = req.jwtPayload;
   const service = req.params.service;

--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -136,11 +136,11 @@ export const disconnect = async (req, res) => {
   const { remoteUser } = req;
 
   try {
-    const Account = await ConnectedAccount.findOne({
+    const account = await ConnectedAccount.findOne({
       where: { service, CollectiveId },
     });
 
-    await Account.delete(remoteUser);
+    await account.delete(remoteUser);
 
     res.send({
       deleted: true,

--- a/server/middleware/security/authentication.js
+++ b/server/middleware/security/authentication.js
@@ -9,7 +9,10 @@ import { URLSearchParams } from 'url';
 import models from '../../models';
 import errors from '../../lib/errors';
 import paymentProviders from '../../paymentProviders';
-import { createOrUpdate as createOrUpdateConnectedAccount } from '../../controllers/connectedAccounts';
+import {
+  createOrUpdate as createOrUpdateConnectedAccount,
+  disconnect as disconnectConnectedAccount,
+} from '../../controllers/connectedAccounts';
 
 const { User } = models;
 
@@ -193,6 +196,10 @@ export const authenticateServiceCallback = (req, res, next) => {
     }
     createOrUpdateConnectedAccount(req, res, next, accessToken, data, emails).catch(next);
   })(req, res, next);
+};
+
+export const authenticateServiceDisconnect = (req, res) => {
+  disconnectConnectedAccount(req, res);
 };
 
 function getOAuthCallbackUrl(req) {

--- a/server/models/ConnectedAccount.js
+++ b/server/models/ConnectedAccount.js
@@ -1,8 +1,5 @@
 import config from 'config';
 
-import { mustBeLoggedInTo } from '../lib/auth';
-
-import * as errors from '../graphql/errors';
 /**
  * Model.
  */
@@ -75,13 +72,7 @@ export default (Sequelize, DataTypes) => {
     });
   };
 
-  ConnectedAccount.prototype.delete = async function(remoteUser) {
-    mustBeLoggedInTo(remoteUser, 'disconnect this connected account');
-    if (remoteUser.id !== this.CreatedByUserId || !remoteUser.isAdmin(this.CollectiveId)) {
-      throw new errors.Unauthorized({
-        message: 'You are either logged out or not authorized to disconnect this account',
-      });
-    }
+  ConnectedAccount.prototype.delete = async function() {
     return this.destroy();
   };
 

--- a/server/models/ConnectedAccount.js
+++ b/server/models/ConnectedAccount.js
@@ -72,9 +72,5 @@ export default (Sequelize, DataTypes) => {
     });
   };
 
-  ConnectedAccount.prototype.delete = async function() {
-    return this.destroy();
-  };
-
   return ConnectedAccount;
 };

--- a/server/models/ConnectedAccount.js
+++ b/server/models/ConnectedAccount.js
@@ -1,5 +1,7 @@
 import config from 'config';
 
+import { mustBeLoggedInTo } from '../lib/auth';
+
 /**
  * Model.
  */
@@ -70,6 +72,16 @@ export default (Sequelize, DataTypes) => {
       foreignKey: 'CollectiveId',
       as: 'collective',
     });
+  };
+
+  ConnectedAccount.prototype.delete = async function(remoteUser) {
+    mustBeLoggedInTo(remoteUser, 'disconnect this connected account');
+    if (remoteUser.id !== this.CreatedByUserId || !remoteUser.isAdmin(this.CollectiveId)) {
+      throw new errors.Unauthorized({
+        message: 'You are either logged out or not authorized to disconnect this account',
+      });
+    }
+    return this.destroy();
   };
 
   return ConnectedAccount;

--- a/server/models/ConnectedAccount.js
+++ b/server/models/ConnectedAccount.js
@@ -2,6 +2,7 @@ import config from 'config';
 
 import { mustBeLoggedInTo } from '../lib/auth';
 
+import * as errors from '../graphql/errors';
 /**
  * Model.
  */

--- a/server/routes.js
+++ b/server/routes.js
@@ -186,6 +186,7 @@ export default app => {
   app.post('/webhooks/stripe', stripeWebhook); // when it gets a new subscription invoice
   app.post('/webhooks/mailgun', email.webhook); // when receiving an email
   app.get('/connected-accounts/:service/callback', aN.authenticateServiceCallback); // oauth callback
+  app.delete('/connected-accounts/:service/disconnect/:collectiveId', aN.authenticateServiceDisconnect);
 
   app.use(sanitizer()); // note: this break /webhooks/mailgun /graphiql
 


### PR DESCRIPTION
Solves **1** and **2** of **Disconnecting** at https://github.com/opencollective/opencollective/issues/1845

which are

- [x] - It's currently impossible to disconnect a Twitter account
- [x] - It's currently impossible to disconnect a GitHub account

#### Includes
- `Disconnect` api endpoint with `DELETE` method
- `delete` method on ConnectedAccount model - which delete the given/attached account

Related with - https://github.com/opencollective/opencollective-frontend/pull/2738