### PR TITLE
Remove unnecessary host role check for user collective

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -54,7 +54,7 @@ export async function createCollective(_, args, req) {
     parentCollective = await req.loaders.collective.findById.load(args.collective.ParentCollectiveId);
     if (!parentCollective) {
       return Promise.reject(new Error(`Parent collective with id ${args.collective.ParentCollectiveId} not found`));
-    } else if (!req.remoteUser.hasRole([roles.ADMIN, roles.HOST, roles.MEMBER], parentCollective.id)) {
+    } else if (!req.remoteUser.hasRole([roles.ADMIN, roles.MEMBER], parentCollective.id)) {
       throw new errors.Unauthorized({
         message: `You must be logged in as a member of the ${parentCollective.slug} collective to create an event`,
       });

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -19,10 +19,10 @@ const debug = debugLib('expenses');
  * Only admin of expense.collective or of expense.collective.host can approve/reject expenses
  */
 function canUpdateExpenseStatus(remoteUser, expense) {
-  if (remoteUser.hasRole([roles.HOST, roles.ADMIN], expense.CollectiveId)) {
+  if (remoteUser.hasRole([roles.ADMIN], expense.CollectiveId)) {
     return true;
   }
-  if (remoteUser.hasRole([roles.HOST, roles.ADMIN], expense.collective.HostCollectiveId)) {
+  if (remoteUser.hasRole([roles.ADMIN], expense.collective.HostCollectiveId)) {
     return true;
   }
   return false;

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -282,7 +282,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
         throw new Error(`From collective id ${order.fromCollective.id} not found`);
       }
 
-      const possibleRoles = [roles.ADMIN, roles.HOST];
+      const possibleRoles = [roles.ADMIN];
       if (fromCollective.type === types.ORGANIZATION) {
         possibleRoles.push(roles.MEMBER);
       }


### PR DESCRIPTION
Following up https://github.com/opencollective/opencollective-api/pull/2652#discussion_r331742001

This PR removes unnecessary check for host role, a USER collective cannot be a host but an admin of a host.