### PR TITLE
Change how pledge historical information is stored

### DIFF
--- a/cron/daily/60-clean-orders.js
+++ b/cron/daily/60-clean-orders.js
@@ -18,10 +18,18 @@ Promise.all([
   AND "Collectives"."id" = "Orders"."CollectiveId"
   AND "Collectives"."isPledged" = FALSE
   AND "Collectives"."HostCollectiveId" IS NOT NULL
-  AND "Orders"."createdAt" <  (NOW() - interval '2 month')`,
+  AND "Orders"."createdAt" <  (NOW() - interval '2 month')
+  AND (
+    -- Either the collective is not a previously pledged collective
+    ("Collectives"."data" ->> 'hasBeenPledged')::boolean IS NOT TRUE
+    -- Or the order was created before the activation (which means it was a pledge)
+    OR "Orders"."createdAt" < "Collectives"."approvedAt"
+  )`,
   ),
 
   // Mark all PENDING errors that are not Manual Payments or Pledge as ERROR after 1 day
+  // No need to check for Orders made to previously pledged collectives here because pledged orders
+  // always have a null `PaymentMethodId`.
   sequelize.query(
     `UPDATE "Orders"
   SET "status" = 'ERROR', "updatedAt" = NOW()

--- a/migrations/20191006165340-add-pledge-info-in-collective-data.js
+++ b/migrations/20191006165340-add-pledge-info-in-collective-data.js
@@ -1,0 +1,26 @@
+'use strict';
+
+import models from '../server/models';
+
+module.exports = {
+  up: queryInterface => {
+    // We don't want to keep the `isPledged` flag anymore when the collective is claimed.
+    // For already active collectives, this information is moved to `data.hasBeenPledged`
+    // so that we don't loose it.
+    return queryInterface.sequelize.query(`
+      UPDATE 
+        "Collectives"
+      SET     
+        "isPledged" = FALSE, 
+        data = (
+          CASE WHEN data IS NULL 
+          THEN '{"hasBeenPledged": true}'::jsonb
+          ELSE data::jsonb || '{"hasBeenPledged": true}'::jsonb
+        END)
+      WHERE 
+        "isPledged" IS TRUE AND "isActive" IS TRUE
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -555,6 +555,7 @@ export async function claimCollective(_, args, req) {
   collective = await collective.update({
     CreatedByUserId: req.remoteUser.id,
     LastEditedByUserId: req.remoteUser.id,
+    isPledged: false,
   });
 
   // add opensource collective as host

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -182,7 +182,11 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     } else if (order.collective.githubHandle) {
       collective = await models.Collective.findOne({ where: { githubHandle: order.collective.githubHandle } });
       if (!collective) {
-        collective = await models.Collective.create({ ...order.collective, isPledged: true });
+        collective = await models.Collective.create({
+          ...order.collective,
+          isPledged: true,
+          data: { hasBeenPledged: true },
+        });
       }
     }
 

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import { v4 as uuid } from 'uuid';
 import debugLib from 'debug';
 import Promise from 'bluebird';
-import { omit, get, isNil } from 'lodash';
+import { omit, get, isNil, pick } from 'lodash';
 import config from 'config';
 import * as LibTaxes from '@opencollective/taxes';
 
@@ -182,8 +182,10 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     } else if (order.collective.githubHandle) {
       collective = await models.Collective.findOne({ where: { githubHandle: order.collective.githubHandle } });
       if (!collective) {
+        const allowed = ['slug', 'name', 'company', 'description', 'website', 'twitterHandle', 'githubHandle', 'tags'];
         collective = await models.Collective.create({
-          ...order.collective,
+          ...pick(order.collective, allowed),
+          type: types.COLLECTIVE,
           isPledged: true,
           data: { hasBeenPledged: true },
         });


### PR DESCRIPTION
With https://github.com/opencollective/opencollective-frontend/pull/2760 we now rely on `isPledged` to know if the collective is **currently** pledged. With the current system, there's a risk that we show the pledge page if a collective that has been pledged in the past is archived (because we check `isPledged && !isActive`).

This PR:
- Sets the `isPledged` flag to false when claiming the collective
- Sets a new flag instead: `data.hasBeenPledged` so that we keep this information
- Limits the number of allowed fields when creating a collective for a pledge (because the creator of the collective is not an admin in this case, we want to be more restrictive)
