### PR TITLE
Host Dashboard Enhancement: Add unapproveExpense method

### DIFF
--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -280,6 +280,15 @@ const mutations = {
       return updateExpenseStatus(req.remoteUser, args.id, statuses.APPROVED);
     },
   },
+  unapproveExpense: {
+    type: ExpenseType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+    resolve(_, args, req) {
+      return updateExpenseStatus(req.remoteUser, args.id, statuses.PENDING);
+    },
+  },
   rejectExpense: {
     type: ExpenseType,
     args: {


### PR DESCRIPTION
Following up https://github.com/opencollective/opencollective/issues/2027

Adds ability for host admin to unapprove `APPROVED` expense, basically updating the status back to `PENDING`

- [x] Add graphql test