### PR TITLE
feat(one-use-login-link): Changes login links to single use

### DIFF
--- a/.forestadmin-schema.json
+++ b/.forestadmin-schema.json
@@ -5288,7 +5288,7 @@
           "validations": []
         },
         {
-          "field": "lastLogin",
+          "field": "lastLoginAt",
           "type": "Date",
           "defaultValue": null,
           "enums": null,

--- a/.forestadmin-schema.json
+++ b/.forestadmin-schema.json
@@ -5288,6 +5288,21 @@
           "validations": []
         },
         {
+          "field": "lastLogin",
+          "type": "Date",
+          "defaultValue": null,
+          "enums": null,
+          "integration": null,
+          "isFilterable": true,
+          "isReadOnly": false,
+          "isRequired": false,
+          "isSortable": true,
+          "isVirtual": false,
+          "reference": null,
+          "inverseOf": null,
+          "validations": []
+        },
+        {
           "field": "transactions",
           "type": ["Number"],
           "defaultValue": null,

--- a/migrations/05-user-model.js
+++ b/migrations/05-user-model.js
@@ -60,9 +60,6 @@ module.exports = {
         defaultValue: DataTypes.NOW,
       },
       seenAt: DataTypes.DATE,
-      lastLogin: {
-        type: DataTypes.DATE,
-      },
       deletedAt: {
         type: DataTypes.DATE,
       },

--- a/migrations/05-user-model.js
+++ b/migrations/05-user-model.js
@@ -60,6 +60,9 @@ module.exports = {
         defaultValue: DataTypes.NOW,
       },
       seenAt: DataTypes.DATE,
+      lastLogin: {
+        type: DataTypes.DATE,
+      },
       deletedAt: {
         type: DataTypes.DATE,
       },

--- a/migrations/20191007173134-add-lastlogin-column-to-users.js
+++ b/migrations/20191007173134-add-lastlogin-column-to-users.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   up: function(queryInterface, DataTypes) {
-    return queryInterface.addColumn('Users', 'lastLogin', {
+    return queryInterface.addColumn('Users', 'lastLoginAt', {
       type: DataTypes.DATE,
     });
   },
 
   down: function(queryInterface) {
-    return queryInterface.removeColumn('Users', 'lastLogin');
+    return queryInterface.removeColumn('Users', 'lastLoginAt');
   },
 };

--- a/migrations/20191007173134-add-lastlogin-column-to-users.js
+++ b/migrations/20191007173134-add-lastlogin-column-to-users.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  up: function(queryInterface, DataTypes) {
+    return queryInterface.addColumn('Users', 'lastLogin', {
+      type: DataTypes.DATE,
+    });
+  },
+
+  down: function(queryInterface) {
+    return queryInterface.removeColumn('Users', 'lastLogin');
+  },
+};

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -40,8 +40,8 @@ export const signin = (req, res, next) => {
     .then(u => u || models.User.createUserWithCollective(user))
     .then(u => {
       const now = new Date();
-      const lastLogin = u.lastLogin || now;
-      loginLink = u.generateLoginLink(redirect || '/', websiteUrl, lastLogin);
+      const lastLoginAt = u.lastLoginAt || now;
+      loginLink = u.generateLoginLink(redirect || '/', websiteUrl, lastLoginAt);
       if (config.env === 'development') {
         logger.info(`Login Link: ${loginLink}`);
       }

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -30,6 +30,8 @@ export const exists = async (req, res) => {
 
 /**
  * Login or create a new user
+ * If creating a user, we set the last login attempt to when user is created
+ * If logging in, we get the last login from the db
  */
 export const signin = (req, res, next) => {
   const { user, redirect, websiteUrl } = req.body;
@@ -37,7 +39,9 @@ export const signin = (req, res, next) => {
   return models.User.findOne({ where: { email: user.email.toLowerCase() } })
     .then(u => u || models.User.createUserWithCollective(user))
     .then(u => {
-      loginLink = u.generateLoginLink(redirect || '/', websiteUrl);
+      const now = new Date();
+      const lastLogin = u.lastLogin || now;
+      loginLink = u.generateLoginLink(redirect || '/', websiteUrl, lastLogin);
       if (config.env === 'development') {
         logger.info(`Login Link: ${loginLink}`);
       }

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -216,7 +216,7 @@ const mutations = {
         }
 
         const user = await models.User.createUserWithCollective(args.user, transaction);
-        const loginLink = user.generateLoginLink(args.redirect, args.websiteUrl);
+        const loginLink = user.generateLoginLink(args.redirect, args.websiteUrl, 'firstLogin');
 
         if (!args.organization) {
           emailLib.send('user.new.token', user.email, { loginLink }, { sendEvenIfNotProduction: true });

--- a/server/middleware/security/authentication.js
+++ b/server/middleware/security/authentication.js
@@ -84,23 +84,32 @@ export const checkJwtExpiry = (req, res, next) => {
 export const _authenticateUserByJwt = (req, res, next) => {
   if (!req.jwtPayload) return next();
   const userid = Number(req.jwtPayload.sub);
-  const lastLogin = req.jwtPayload.last;
+  const lastLoginAt = req.jwtPayload.lastLoginAt;
   User.findByPk(userid)
     .then(user => {
       if (!user) throw errors.Unauthorized(`User id ${userid} not found`);
-      if (req.jwtPayload.last) {
-        if (req.jwtPayload.last === 'firstLogin' && !user.lastLogin) {
-          const now = new Date();
-          user.update({ lastLogin: now });
-        } else {
-          const jwtDate = new Date(lastLogin);
-          const dbLogin = user.lastLogin;
-          if (jwtDate.getTime() !== dbLogin.getTime()) {
+      /**
+       * Functionality for one-time login links. It checks if the JWT has
+       * lastLoginAt in the payload, which it only has during the first
+       * auth.
+       */
+      if (req.jwtPayload.lastLoginAt) {
+        /**
+         * If the user has just signed up, the JWT has a payload of 'firstLogin'
+         * and lastLoginAt is null in the db; so we allow them in only if both
+         * conditions are met. For normal logins, we check that the lastLoginAt
+         * in the JWT matches the lastLoginAt in the db. If so, we allow the user
+         * to log in, and update the lastLoginAt.
+         */
+        if (req.jwtPayload.lastLoginAt !== 'firstLogin' || user.lastLoginAt) {
+          const lastLoginInJwt = new Date(lastLoginAt);
+          const lastLoginInDb = user.lastLoginAt;
+          if (lastLoginInJwt.getTime() !== lastLoginInDb.getTime()) {
             throw errors.Unauthorized('Invalid login link - multiple uses');
           }
-          const now = new Date();
-          user.update({ lastLogin: now });
         }
+        const now = new Date();
+        user.update({ lastLoginAt: now });
       }
       user.update({ seenAt: new Date() });
       req.remoteUser = user;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -133,7 +133,7 @@ export default (Sequelize, DataTypes) => {
 
       seenAt: DataTypes.DATE,
 
-      lastLogin: {
+      lastLoginAt: {
         type: DataTypes.DATE,
       },
 
@@ -260,8 +260,8 @@ export default (Sequelize, DataTypes) => {
     return auth.createJwt(this.id, payload, expiration);
   };
 
-  User.prototype.generateLoginLink = function(redirect = '/', websiteUrl, lastLogin) {
-    const token = this.jwt({ scope: 'login', last: lastLogin });
+  User.prototype.generateLoginLink = function(redirect = '/', websiteUrl, lastLoginAt) {
+    const token = this.jwt({ scope: 'login', lastLoginAt: lastLoginAt });
     // if a different websiteUrl is passed
     // we don't accept that in production to avoid fishing related issues
     if (websiteUrl && config.env !== 'production') {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -133,6 +133,10 @@ export default (Sequelize, DataTypes) => {
 
       seenAt: DataTypes.DATE,
 
+      lastLogin: {
+        type: DataTypes.DATE,
+      },
+
       newsletterOptIn: {
         allowNull: false,
         defaultValue: false,
@@ -256,8 +260,8 @@ export default (Sequelize, DataTypes) => {
     return auth.createJwt(this.id, payload, expiration);
   };
 
-  User.prototype.generateLoginLink = function(redirect = '/', websiteUrl) {
-    const token = this.jwt({ scope: 'login' });
+  User.prototype.generateLoginLink = function(redirect = '/', websiteUrl, lastLogin) {
+    const token = this.jwt({ scope: 'login', last: lastLogin });
     // if a different websiteUrl is passed
     // we don't accept that in production to avoid fishing related issues
     if (websiteUrl && config.env !== 'production') {


### PR DESCRIPTION
Addresses opencollective/opencollective#2192

![single-use-login](https://user-images.githubusercontent.com/37520401/66394435-08664b80-e9cd-11e9-94ee-5a8d18fd4a88.gif)

This creates single-use login links by adding a field to the first JWT token that is processed when a user signs in.

Hopefully I've updated all the relevant database and GraphQL bits, but let me know if I've missed anything.

Feedback and questions welcome 👍 