### PR TITLE
Enable User collectives to add fund

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -975,7 +975,7 @@ export async function addFundsToCollective(order, remoteUser) {
     user = remoteUser;
   }
 
-  if (order.fromCollective.id) {
+  if (order.fromCollective && order.fromCollective.id) {
     fromCollective = await models.Collective.findByPk(order.fromCollective.id);
     if (!fromCollective) {
       throw new Error(`From collective id ${order.fromCollective.id} not found`);

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -975,13 +975,18 @@ export async function addFundsToCollective(order, remoteUser) {
     user = remoteUser;
   }
 
-  if (order.fromCollective && order.fromCollective.id) {
-    fromCollective = await models.Collective.findByPk(order.fromCollective.id);
-    if (!fromCollective) {
-      throw new Error(`From collective id ${order.fromCollective.id} not found`);
+  if (order.fromCollective) {
+    if (order.fromCollective.id) {
+      fromCollective = await models.Collective.findByPk(order.fromCollective.id);
+      if (!fromCollective) {
+        throw new Error(`From collective id ${order.fromCollective.id} not found`);
+      }
+    } else if (order.fromCollective.name) {
+      fromCollective = await models.Collective.createOrganization(order.fromCollective, user, remoteUser);
     }
   } else {
-    fromCollective = await models.Collective.createOrganization(order.fromCollective, user, remoteUser);
+    // Use the user collective
+    fromCollective = { id: user.CollectiveId };
   }
 
   const orderData = {


### PR DESCRIPTION
Following up @Betree https://github.com/opencollective/opencollective-api/pull/2723#issuecomment-540468599 to fix https://github.com/opencollective/opencollective/issues/2488


This PR enables USER collectives to add fund. Before, it required entering an Organization name to do that. 

Unable to add screen record but here's a screenshot for context.
<img width="1079" alt="Screenshot 2019-10-10 at 10 49 18 AM" src="https://user-images.githubusercontent.com/15707013/66558589-b4ce3c00-eb4b-11e9-8137-272323edf1f8.png">
