### PR TITLE
Improve allHosts query

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -974,6 +974,10 @@ const queries = {
         defaultValue: 0,
         type: GraphQLInt,
       },
+      onlyOpenHosts: {
+        type: GraphQLBoolean,
+        defaultValue: true,
+      },
     },
     async resolve(_, args) {
       const { collectives, total } = await rawQueries.getPublicHostsByTotalCollectives(args);


### PR DESCRIPTION
- Added a param to optionally retrieve collectives not open to applications
- Fixed the query to retrieve collectives not open to applications
  Because it was just checking that `apply IS NOT NULL`, query also returned collectives with apply = false.
- Fixed total
- Fixed sorting