### PR TITLE
allHosts: Add param to filter on number of collectives hosted

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -978,9 +978,13 @@ const queries = {
         type: GraphQLBoolean,
         defaultValue: true,
       },
+      minNbCollectivesHosted: {
+        type: new GraphQLNonNull(GraphQLInt),
+        defaultValue: 0,
+      },
     },
     async resolve(_, args) {
-      const { collectives, total } = await rawQueries.getPublicHostsByTotalCollectives(args);
+      const { collectives, total } = await rawQueries.getHosts(args);
       return {
         total,
         collectives,


### PR DESCRIPTION
Also renamed the function to `getHosts` because we can also fetch private hosts with it.