### PR TITLE
Add a new order status 'EXPIRED'

### DIFF
--- a/server/constants/order_status.js
+++ b/server/constants/order_status.js
@@ -6,6 +6,7 @@
  * pending -> active -> cancelled (subscription)
  * pending -> cancelled
  * pending -> rejected
+ * pending -> expired
  */
 
 export default {
@@ -15,4 +16,5 @@ export default {
   CANCELLED: 'CANCELLED',
   REJECTED: 'REJECTED',
   ERROR: 'ERROR',
+  EXPIRED: 'EXPIRED',
 };

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -21,6 +21,7 @@ import {
   addFundsToCollective,
   completePledge,
   markOrderAsPaid,
+  markPendingOrderAsExpired,
 } from './mutations/orders';
 
 import { createMember, removeMember, editMembership } from './mutations/members';
@@ -317,6 +318,15 @@ const mutations = {
     },
     resolve(_, args, req) {
       return markOrderAsPaid(req.remoteUser, args.id);
+    },
+  },
+  markPendingOrderAsExpired: {
+    type: OrderType,
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+    resolve(_, args, req) {
+      return markPendingOrderAsExpired(req.remoteUser, args.id);
     },
   },
   createExpense: {

--- a/server/graphql/v2/enum/OrderStatus.js
+++ b/server/graphql/v2/enum/OrderStatus.js
@@ -9,5 +9,6 @@ export const OrderStatus = new GraphQLEnumType({
     PENDING: {},
     PAID: {},
     ERROR: {},
+    EXPIRED: {},
   },
 });

--- a/test/graphql.orders.test.js
+++ b/test/graphql.orders.test.js
@@ -121,7 +121,7 @@ describe('graphql.orders.test.js', () => {
   });
 
   describe('mutation', () => {
-    const mutation = `
+    const markOrderAsPaidQuery = `
     mutation markOrderAsPaid($id: Int!) {
       markOrderAsPaid(id: $id) {
         id
@@ -129,15 +129,24 @@ describe('graphql.orders.test.js', () => {
       }
     }
     `;
+
+    const markPendingOrderAsExpiredQuery = `
+      mutation markPendingOrderAsExpired($id: Int!) {
+        markPendingOrderAsExpired(id: $id) {
+          id
+          status
+        }
+      }
+    `;
     it('fails if not authenticated', async () => {
-      const result = await utils.graphqlQuery(mutation, {
+      const result = await utils.graphqlQuery(markOrderAsPaidQuery, {
         id: orders[0].id,
       });
       expect(result.errors[0].message).to.equal('You need to be authenticated to perform this action');
     });
     it('fails if not authenticated as an admin of the host', async () => {
       const result = await utils.graphqlQuery(
-        mutation,
+        markOrderAsPaidQuery,
         {
           id: orders[0].id,
         },
@@ -147,7 +156,7 @@ describe('graphql.orders.test.js', () => {
     });
     it('fails if order not found', async () => {
       const result = await utils.graphqlQuery(
-        mutation,
+        markOrderAsPaidQuery,
         {
           id: 123,
         },
@@ -157,7 +166,7 @@ describe('graphql.orders.test.js', () => {
     });
     it('marks a pending order as paid', async () => {
       const result = await utils.graphqlQuery(
-        mutation,
+        markOrderAsPaidQuery,
         {
           id: orders[0].id,
         },
@@ -185,6 +194,22 @@ describe('graphql.orders.test.js', () => {
       expect(emailSendMessageSpy.callCount).to.equal(3);
       expect(emailSendMessageSpy.thirdCall.args[0]).to.equal(backers[1].email);
       expect(emailSendMessageSpy.thirdCall.args[1]).to.equal('Thank you for your €150 donation to codenplay');
+    });
+
+    it('marks a pending order as expired', async () => {
+      const result = await utils.graphqlQuery(
+        markPendingOrderAsExpiredQuery,
+        {
+          id: orders[1].id,
+        },
+        hostAdmin,
+      );
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      const { markPendingOrderAsExpired } = result.data;
+      expect(markPendingOrderAsExpired.status).to.equal('EXPIRED');
+      const order = await models.Order.findByPk(orders[1].id);
+      expect(order.status).to.equal('EXPIRED');
     });
   });
 });


### PR DESCRIPTION
Following up https://github.com/opencollective/opencollective/issues/2133

This PR add:

-  A new order status, `EXPIRED`
- An  order mutation  `markPendingOrderAsExpired`
-  `markPendingOrderAsExpired` graphql test.