### PR TITLE
BYS: Filter recommended dependencies based on the ones selected by the user

### DIFF
--- a/server/lib/backyourstack/dispatcher.js
+++ b/server/lib/backyourstack/dispatcher.js
@@ -87,6 +87,12 @@ export async function dispatchFunds(order) {
       throw new Error('Unable to fetch dependencies, no attached jsonUrl.');
     }
     depRecommendations = await fetchDependencies(order.data.customData.jsonUrl);
+    // check if the order has selected collectives to receive the funds
+    if (depRecommendations && order.data.customData.selectedCollectives) {
+      const selectedCollectives = order.data.customData.selectedCollectives;
+      // filter recommended dependencies based on selected collectives id
+      depRecommendations = depRecommendations.filter(r => selectedCollectives.indexOf(r.opencollective.id) !== -1);
+    }
   } catch (err) {
     debug('Error fetching dependencies', err);
     console.error(err);


### PR DESCRIPTION
Following up https://github.com/opencollective/backyourstack/pull/244

The user selected collective ids are saved along with `jsonUrl` in `order.data` as `selectedCollectives`. For first and future dispatch, only dependencies with collectives id matching one of `selectedCollectives` will be dispatched. 