### PR TITLE
EditCoreContributors: Introduce dedicated mutation

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -417,12 +417,15 @@ export function editCollective(_, args, req) {
     })
     .then(() => collective.update(omit(newCollectiveData, ['HostCollectiveId', 'hostFeePercent']))) // we omit those attributes that have already been updated above
     .then(() => collective.editTiers(args.collective.tiers))
-    .then(() =>
-      collective.editMembers(args.collective.members, {
-        CreatedByUserId: req.remoteUser.id,
-        remoteUserCollectiveId: req.remoteUser.CollectiveId,
-      }),
-    )
+    .then(() => {
+      // @deprecated since 2019-10-21: now using dedicated `editCoreContributors` endpoint
+      if (args.collective.members) {
+        return collective.editMembers(args.collective.members, {
+          CreatedByUserId: req.remoteUser.id,
+          remoteUserCollectiveId: req.remoteUser.CollectiveId,
+        });
+      }
+    })
     .then(() => {
       // Ask cloudflare to refresh the cache for this collective's page
       purgeCacheForPage(`/${collective.slug}`);


### PR DESCRIPTION
- `EditCoreContributors`: Introduce a dedicated mutation

As part of the `Edit members` page revamp, the component will now be responsible for fetching and editing its own data. This endpoint will limit the field of action for the mutation.

Also added the ability to add a member by providing its collective ID, which is required because this is what the collective picker outputs.

- `createUser`: Add param to return instead of throw if user exists

Also added a param to not send the login link. Collective picker will use this endpoint to create users, we don't want to send them login emails because they will receive another email like "You've been added to Collective's core contributors"