### PR TITLE
Search: Add partial search for slugs

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -91,7 +91,7 @@ export const searchCollectivesInDB = async (term, offset = 0, limit = 100, types
 
   if (term && term.length > 0) {
     term = term.replace(/(_|%|\\)/g, ' ');
-    dynamicConditions += `AND (${tsVector} @@ to_tsquery('simple', :term) OR name ILIKE '%' || :term || '%') `;
+    dynamicConditions += `AND (${tsVector} @@ to_tsquery('simple', :term) OR name ILIKE '%' || :term || '%') OR slug ILIKE '%' || :term || '%') `;
   }
 
   // Build the query


### PR DESCRIPTION
When users search for `xda`, they expect to see `xdamman` in the results list even if the `name` field is `Xavier`.