### PR TITLE
Fix deleted events show up in Contributions

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -734,7 +734,7 @@ export async function deleteCollective(_, args, req) {
 
   const eventCollectiveIds = await models.Collective.findAll({
     attributes: ['id'],
-    where: { ParentCollectiveId: collective.id },
+    where: { ParentCollectiveId: collective.id, type: types.EVENT },
   }).then(collectives => collectives.map(({ id }) => id));
 
   return models.Member.findAll({

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -732,8 +732,13 @@ export async function deleteCollective(_, args, req) {
     throw new Error('Can not delete collective with paid expenses.');
   }
 
+  const eventCollectiveIds = await models.Collective.findAll({
+    attributes: ['id'],
+    where: { ParentCollectiveId: collective.id },
+  }).then(collectives => collectives.map(({ id }) => id));
+
   return models.Member.findAll({
-    where: { CollectiveId: collective.id },
+    where: { CollectiveId: [collective.id, ...eventCollectiveIds] },
   })
     .then(members => {
       return map(


### PR DESCRIPTION
When deleting a Collective, all Members from its hosted events should be also deleted so it doesn't show up in a User's memberOf query. 