### PR TITLE
Add rejectCollective mutation

### DIFF
--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -8,6 +8,7 @@ export default {
   COLLECTIVE_CREATED_GITHUB: 'collective.created.github',
   COLLECTIVE_APPLY: 'collective.apply',
   COLLECTIVE_APPROVED: 'collective.approved',
+  COLLECTIVE_REJECTED: 'collective.rejected',
   COLLECTIVE_CREATED: 'collective.created',
   COLLECTIVE_COMMENT_CREATED: 'collective.comment.created',
   COLLECTIVE_EXPENSE_CREATED: 'collective.expense.created',

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -11,6 +11,7 @@ import {
   archiveCollective,
   unarchiveCollective,
   sendMessageToCollective,
+  rejectCollective,
 } from './mutations/collectives';
 import {
   createOrder,
@@ -162,6 +163,17 @@ const mutations = {
     },
     resolve(_, args, req) {
       return approveCollective(req.remoteUser, args.id);
+    },
+  },
+  rejectCollective: {
+    type: CollectiveInterfaceType,
+    description: 'Reject a collective',
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+      rejectionReason: { type: GraphQLString },
+    },
+    resolve(_, args, req) {
+      return rejectCollective(_, args, req);
     },
   },
   archiveCollective: {

--- a/server/lib/emailTemplates.js
+++ b/server/lib/emailTemplates.js
@@ -17,6 +17,7 @@ export const templateNames = [
   'collective.apply',
   'collective.apply.for.host',
   'collective.approved',
+  'collective.rejected',
   'collective.comment.created',
   'collective.confirm',
   'collective.created',

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -291,9 +291,14 @@ async function notifyByEmail(activity) {
       break;
 
     case activityType.COLLECTIVE_REJECTED:
-      notifyAdminsOfCollective(activity.data.collective.id, activity, {
-        template: 'collective.rejected',
-      });
+      notifyAdminsOfCollective(
+        activity.data.collective.id,
+        activity,
+        {
+          template: 'collective.rejected',
+        },
+        { replyTo: `hello@${activity.data.host.slug}.opencollective.com` },
+      );
       break;
 
     case activityType.COLLECTIVE_APPLY:

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -290,6 +290,12 @@ async function notifyByEmail(activity) {
       notifyAdminsOfCollective(activity.data.collective.id, activity);
       break;
 
+    case activityType.COLLECTIVE_REJECTED:
+      notifyAdminsOfCollective(activity.data.collective.id, activity, {
+        template: 'collective.rejected',
+      });
+      break;
+
     case activityType.COLLECTIVE_APPLY:
       notifyAdminsOfCollective(activity.data.host.id, activity, {
         template: 'collective.apply.for.host',

--- a/templates/emails/collective.rejected.hbs
+++ b/templates/emails/collective.rejected.hbs
@@ -15,6 +15,5 @@ Subject: Your application to {{host.name}}
   If you would like to apply to another fiscal host, click the "apply" button on their page (if you meet their acceptance criteria). View fiscal hosts <a href="{{config.host.website}}/hosts">here</a>. You may also consider hosting your own Collective (<a href="https://docs.opencollective.com/help/hosts/become-host">more details</a>).
 </p>
 
-<p>If you have questions, please contact <a href="mailto:hello@{{host.slug}}.opencollective.com">hello@{{host.slug}}.opencollective.com</a>.</p>
-
+<p>If you have questions, reply to this email to reach {{host.name}}, or contact <a href="mailto:support@opencollective.com">support@opencollective.com</a> for general inquiries.</p>
 {{> footer}}

--- a/templates/emails/collective.rejected.hbs
+++ b/templates/emails/collective.rejected.hbs
@@ -7,7 +7,7 @@ Subject: Your application to {{host.name}}
 <p>Thank you for applying to host your Collective {{collective.name}} with {{host.name}}. Unfortunately your application has been rejected.</p>
 
 {{#if rejectionReason}}
-  <p>Note from {{host.name}}</p>
+  <p>Note from {{host.name}}:</p>
   <blockquote>{{rejectionReason}}</blockquote>
 {{/if}}
 

--- a/templates/emails/collective.rejected.hbs
+++ b/templates/emails/collective.rejected.hbs
@@ -8,13 +8,13 @@ Subject: Your application to {{host.name}}
 
 {{#if rejectionReason}}
   <p>Note from {{host.name}}:</p>
-  <blockquote>{{rejectionReason}}</blockquote>
+  <blockquote style="color:#6a737d;font-size: 16px;text-align: left;padding: 0.5em 0.75em;margin: 1em 0;border-left: 3px solid #e4e4e4;white-space: pre-line;">{{rejectionReason}}</blockquote>
 {{/if}}
 
 <p>
   If you would like to apply to another fiscal host, click the "apply" button on their page (if you meet their acceptance criteria). View fiscal hosts <a href="{{config.host.website}}/hosts">here</a>. You may also consider hosting your own Collective (<a href="https://docs.opencollective.com/help/hosts/become-host">more details</a>).
 </p>
 
-<p>If you have questions, please contact <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+<p>If you have questions, please contact <a href="mailto:hello@{{host.slug}}.opencollective.com">hello@{{host.slug}}.opencollective.com</a>.</p>
 
 {{> footer}}

--- a/templates/emails/collective.rejected.hbs
+++ b/templates/emails/collective.rejected.hbs
@@ -1,0 +1,20 @@
+Subject: Your application to {{host.name}}
+
+{{> header}}
+
+<h1>Hey {{collective.name}}</h1>
+
+<p>Thank you for applying to host your Collective {{collective.name}} with {{host.name}}. Unfortunately your application has been rejected.</p>
+
+{{#if rejectionReason}}
+  <p>Note from {{host.name}}</p>
+  <blockquote>{{rejectionReason}}</blockquote>
+{{/if}}
+
+<p>
+  If you would like to apply to another fiscal host, click the "apply" button on their page (if you meet their acceptance criteria). View fiscal hosts <a href="{{config.host.website}}/hosts">here</a>. You may also consider hosting your own Collective (<a href="https://docs.opencollective.com/help/hosts/become-host">more details</a>).
+</p>
+
+<p>If you have questions, please contact <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+
+{{> footer}}


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2092

This PR gives host admin ability to reject collective pending applications, a rejection notification email is sent to the collective admins, the host has the ability to provide specific reason why application was rejected as shown below:

#### Rejected with a reason provided:
<img width="702" alt="Screenshot 2019-10-23 at 12 35 56 AM" src="https://user-images.githubusercontent.com/15707013/67343668-dce77300-f52d-11e9-907e-bc508ebff0c5.png">

#### Rejected with no reason provided:

<img width="670" alt="Screenshot 2019-10-23 at 12 42 32 AM" src="https://user-images.githubusercontent.com/15707013/67343727-02747c80-f52e-11e9-9a08-6ce8e8b7b0e8.png">


