### PR TITLE
BackYourStack: Improve first dispatch performance

### DIFF
--- a/server/graphql/v1/mutations/backyourstack.js
+++ b/server/graphql/v1/mutations/backyourstack.js
@@ -1,4 +1,6 @@
 import moment from 'moment';
+import { omit } from 'lodash';
+
 import models from '../../../models';
 import { dispatchFunds, getNextDispatchingDate, needsDispatching } from '../../../lib/backyourstack/dispatcher';
 
@@ -39,8 +41,10 @@ export async function dispatchOrder(orderId) {
     subscription.data = {
       nextDispatchDate: getNextDispatchingDate(subscription.interval, currentDispatchDate),
     };
-
+    // Remove firstDispatchRecommendations in custom data after the first dispatch is over
+    order.data = omit(order.data, ['customData.firstDispatchRecommendations']);
     await subscription.save();
+    await order.save();
   }
 
   return dispatchedOrders;


### PR DESCRIPTION
This PR follows up https://github.com/opencollective/backyourstack/pull/248

Checks for `firstDispatchRecommendations` in custom data, use it instead of fetching for recommendations on backyourstack again. At the end of dispatch, remove `firstDispatchRecommendations` from order customData.
