### PR TITLE
Users: Ability for us to block contact feature

### DIFF
--- a/migrations/20191028101813-add-data-to-users.js
+++ b/migrations/20191028101813-add-data-to-users.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Users', 'data', { type: Sequelize.JSON });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Users', 'data');
+  },
+};

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -973,8 +973,8 @@ const CollectiveFields = () => {
     canContact: {
       description: 'Returns whether this collectives can be contacted',
       type: GraphQLBoolean,
-      resolve(collective) {
-        return collective.canContact();
+      resolve(collective, _, req) {
+        return collective.canContact(req.remoteUser);
       },
     },
     isIncognito: {

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -922,6 +922,11 @@ export async function sendMessageToCollective(_, args, req) {
     throw new errors.Unauthorized({
       message: 'You need to be logged in to contact a collective',
     });
+  } else if (get(req.remoteUser.data, 'disableContact', false)) {
+    throw new errors.Unauthorized({
+      message:
+        'You are not authorized to contact Collectives. Please contact support@opencollective.com if you think this is an error.',
+    });
   }
 
   const collective = await models.Collective.findByPk(args.collectiveId);
@@ -931,9 +936,9 @@ export async function sendMessageToCollective(_, args, req) {
     });
   }
 
-  if (!(await collective.canContact())) {
+  if (!(await collective.canContact(req.remoteUser))) {
     throw new errors.Unauthorized({
-      message: `You can't contact this type of collective`,
+      message: `You can't contact this collective`,
     });
   }
 

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -858,10 +858,16 @@ export default function(Sequelize, DataTypes) {
   };
 
   /**
-   *  Checks if the collective can be contacted.
+   *  Checks if the collective can be contacted by `remoteUser`.
    */
-  Collective.prototype.canContact = async function() {
-    return this.isActive && (this.type === types.COLLECTIVE || this.type === types.EVENT || (await this.isHost()));
+  Collective.prototype.canContact = async function(remoteUser) {
+    if (!remoteUser || get(remoteUser.data, 'disableContact', false)) {
+      return false;
+    } else if (!this.isActive) {
+      return false;
+    } else {
+      return [types.COLLECTIVE, types.EVENT].includes(this.type) || (await this.isHost());
+    }
   };
 
   // This is quite ugly, and only needed for events.

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -138,6 +138,11 @@ export default (Sequelize, DataTypes) => {
         defaultValue: false,
         type: DataTypes.BOOLEAN,
       },
+
+      data: {
+        type: DataTypes.JSON,
+        allowNull: true,
+      },
     },
     {
       paranoid: true,


### PR DESCRIPTION
This PR introduces a way for us to easily block someone misusing the contact form.

It introduces a `data` field in `Users`, where we can set a `disableContact` field that will:
- Hide the button from the UI (because `canContact` will be false)
- Throw an error if user tries to call the `sendMessage` endpoint

@znarf let me know what you think of this solution and if having a `data` field for `Users` is welcome or not.