### PR TITLE
Fix GitHub flow timeout

### DIFF
--- a/server/controllers/connectedAccounts.js
+++ b/server/controllers/connectedAccounts.js
@@ -197,9 +197,13 @@ const getGithubAccount = async req => {
   return githubAccount;
 };
 
+// Use a 1 minutes timeout as the default 25 seconds can leads to failing requests.
+const GITHUB_REPOS_FETCH_TIMEOUT = 1 * 60 * 1000;
+
 export const fetchAllRepositories = async (req, res, next) => {
   const githubAccount = await getGithubAccount(req);
   try {
+    req.setTimeout(GITHUB_REPOS_FETCH_TIMEOUT);
     let repos = await github.getAllUserPublicRepos(githubAccount.token);
     if (repos.length !== 0) {
       repos = repos.filter(repo => {

--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -64,6 +64,9 @@ export function getData(res) {
   return res.data;
 }
 
+/**
+ * Get all the public repos for which user is admin
+ */
 export async function getAllUserPublicRepos(accessToken) {
   const cacheKey = `user_repos_all_${accessToken}`;
   const fromCache = await cache.get(cacheKey);
@@ -82,7 +85,7 @@ export async function getAllUserPublicRepos(accessToken) {
     // https://octokit.github.io/rest.js/#api-Repos-list
     // https://developer.github.com/v3/repos/#list-your-repositories
     fetchRepos = await octokit.repos.list(parameters).then(getData);
-    repos = [...repos, ...fetchRepos];
+    repos = [...repos, ...fetchRepos.filter(r => r.permissions.admin)];
     parameters.page++;
   } while (fetchRepos.length === parameters.per_page && parameters.page < maxNbPages);
 

--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -77,13 +77,18 @@ export async function getAllUserPublicRepos(accessToken) {
 
   let repos = [];
   let fetchRepos;
+  const maxNbPages = 15; // More than that would probably timeout the request
   do {
     // https://octokit.github.io/rest.js/#api-Repos-list
     // https://developer.github.com/v3/repos/#list-your-repositories
     fetchRepos = await octokit.repos.list(parameters).then(getData);
     repos = [...repos, ...fetchRepos];
     parameters.page++;
-  } while (fetchRepos.length === parameters.per_page);
+  } while (fetchRepos.length === parameters.per_page && parameters.page < maxNbPages);
+
+  if (parameters.page === maxNbPages) {
+    logger.error(`Aborted: Too many repos to fetch for user with token ${accessToken}`);
+  }
 
   repos = repos.map(compactRepo);
 


### PR DESCRIPTION
An attempt at solving https://opencollective.freshdesk.com/a/tickets/2381 with the following changes:
- Increase timeout from 25s to 1min for fetching public repos
- Limit max number of fetched pages
- Only return repos user id admin of

---

Context: In https://opencollective.freshdesk.com/a/tickets/2381, user has access the hundreds of repos with read-only permissions. This is making the API timeout and if returned to frontend we would show tons of unrelated repositories.