### PR TITLE
BackYourStack: Update dispatch process to Async

### DIFF
--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -32,6 +32,7 @@ export default {
   WEBHOOK_PAYPAL_RECEIVED: 'webhook.paypal.received',
   COLLECTIVE_MONTHLY: 'collective.monthly',
   ORDERS_SUSPICIOUS: 'orders.suspicious',
+  BACKYOURSTACK_DISPATCH_CONFIRMED: 'backyourstack.dispatch.confirmed',
 
   // Not used anymore, leaving for historical reference
   COLLECTIVE_TRANSACTION_PAID: 'collective.transaction.paid', // replaced with COLLECTIVE_EXPENSE_PAID

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -901,7 +901,12 @@ const mutations = {
     },
   },
   backyourstackDispatchOrder: {
-    type: new GraphQLList(OrderType),
+    type: new GraphQLObjectType({
+      name: 'BackYourStackResult',
+      fields: {
+        dispatching: { type: GraphQLBoolean },
+      },
+    }),
     args: {
       id: {
         type: new GraphQLNonNull(GraphQLInt),

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -902,7 +902,7 @@ const mutations = {
   },
   backyourstackDispatchOrder: {
     type: new GraphQLObjectType({
-      name: 'BackYourStackResult',
+      name: 'BackYourStackDispatchState',
       fields: {
         dispatching: { type: GraphQLBoolean },
       },

--- a/server/graphql/v1/mutations/backyourstack.js
+++ b/server/graphql/v1/mutations/backyourstack.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import models from '../../../models';
-import { backgroundDispatch, needsDispatching } from '../../../lib/backyourstack/dispatcher';
+import { dispatch, needsDispatching } from '../../../lib/backyourstack/dispatcher';
 
 import status from '../../../constants/order_status';
 
@@ -25,7 +25,7 @@ export async function dispatchOrder(orderId) {
       `Your BackYourStack order is already complete for this month. The next dispatch of funds will be on ${nextDispatchDate}`,
     );
   }
-  // Funds are dispatched asynchronously
-  backgroundDispatch(order, subscription);
+  // Funds are dispatched asynchronously, we're not waiting here on purpose
+  dispatch(order, subscription);
   return { dispatching: true };
 }

--- a/server/lib/backyourstack/dispatcher.js
+++ b/server/lib/backyourstack/dispatcher.js
@@ -7,6 +7,7 @@ import { pick } from 'lodash';
 
 import models from '../../models';
 import status from '../../constants/order_status';
+import activities from '../../constants/activities';
 import * as paymentsLib from '../payments';
 
 export function getNextDispatchingDate(interval, currentDispatchDate) {
@@ -147,4 +148,36 @@ export async function dispatchFunds(order) {
     },
     { concurrency: 3 },
   );
+}
+
+export function backgroundDispatch(order, subscription) {
+  dispatchFunds(order)
+    .then(async dispatchedOrders => {
+      // update subscription next dispatch date
+      if (dispatchedOrders) {
+        const currentDispatchDate = (subscription.data && subscription.data.nextDispatchDate) || new Date();
+        subscription.data = {
+          nextDispatchDate: getNextDispatchingDate(subscription.interval, currentDispatchDate),
+        };
+        await subscription.save();
+      }
+      return dispatchedOrders;
+    })
+    .then(async dispatchedOrders => {
+      const collective = await models.Collective.findByPk(order.FromCollectiveId);
+      // send confirmation email to collective admins
+      models.Activity.create({
+        type: activities.BACKYOURSTACK_DISPATCH_CONFIRMED,
+        UserId: order.CreatedByUserId,
+        CollectiveId: collective.id,
+        data: {
+          orders: dispatchedOrders,
+          collective: collective.info,
+        },
+      });
+    })
+    .catch(err => {
+      console.log('>>>> Background dispatch failed');
+      console.error(err);
+    });
 }

--- a/server/lib/emailTemplates.js
+++ b/server/lib/emailTemplates.js
@@ -92,6 +92,7 @@ export const templateNames = [
   'user.new.token.text',
   'user.yearlyreport',
   'user.yearlyreport.text',
+  'backyourstack.dispatch.confirmed',
 ];
 
 const templatesPath = `${__dirname}/../../templates`;

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -328,10 +328,10 @@ async function notifyByEmail(activity) {
       break;
 
     case activityType.BACKYOURSTACK_DISPATCH_CONFIRMED:
-      activity.data.orders.map(async order => {
+      for (const order of activity.data.orders) {
         order.collective = await models.Collective.findByPk(order.CollectiveId);
-        return order;
-      });
+      }
+
       notifyAdminsOfCollective(activity.data.collective.id, activity, {
         template: 'backyourstack.dispatch.confirmed',
       });

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -326,5 +326,14 @@ async function notifyByEmail(activity) {
         template: 'collective.created.opensource',
       });
       break;
+
+    case activityType.BACKYOURSTACK_DISPATCH_CONFIRMED:
+      activity.data.orders.map(async order => {
+        order.collective = await models.Collective.findByPk(order.CollectiveId);
+        return order;
+      });
+      notifyAdminsOfCollective(activity.data.collective.id, activity, {
+        template: 'backyourstack.dispatch.confirmed',
+      });
   }
 }

--- a/templates/emails/backyourstack.dispatch.confirmed.hbs
+++ b/templates/emails/backyourstack.dispatch.confirmed.hbs
@@ -4,7 +4,11 @@ Subject: Backyourstack dispatch confirmation.
 
 <div>
    <h1>Woot woot! 🎉</h1>
-    <h3>Your first payment was successfully dispatched.</h3>
+    {{#if recurringDispatch}}
+      <h3>Your first payment was successfully dispatched.</h3>
+    {{else}}
+      <h3>Your payment was successfully dispatched.</h3>
+    {{/if}}
     <div>
         <p>
           You&apos;re contributing to the following Collectives:

--- a/templates/emails/backyourstack.dispatch.confirmed.hbs
+++ b/templates/emails/backyourstack.dispatch.confirmed.hbs
@@ -1,0 +1,41 @@
+Subject: Backyourstack dispatch confirmation.
+
+{{> header}}
+
+<div>
+   <h1>Woot woot! 🎉</h1>
+    <h3>Your first payment was successfully dispatched.</h3>
+    <div>
+        <p>
+          You&apos;re contributing to the following Collectives:
+        </p>
+        <table>
+          <tr>
+            <th style="border-bottom: 1px solid #dcdee0;padding: 0.5em;white-space: nowrap;text-transform: uppercase;font-weight: bold;font-size: 10px;">Collective</th>
+            <th style="border-bottom: 1px solid #dcdee0;padding: 0.5em;white-space: nowrap;text-transform: uppercase;font-weight: bold;font-size: 10px;">Amount</th>
+          </tr>
+          {{#each orders}}
+             <tr>
+               <td style="border-bottom: 1px solid #dcdee0;padding: 0.5em;white-space: nowrap;font-size: 14px;">
+                  <a
+                    style="color: #76777a;"
+                    href="{{config.host.website}}/{{collective.slug}}"
+                  >
+                    {{collective.name}}
+                  </a>
+                <td style="border-bottom: 1px solid #dcdee0;padding: 0.5em;white-space: nowrap;font-size: 14px;">{{{currency totalAmount currency=currency}}}</td>
+             </tr>
+          {{/each}}
+        </table>
+        <p>
+          That&apos;s it! You will be charged for the first time
+          today, then on the 1st of each month from now on. The funds
+          will be automatically distributed to your dependencies.
+        </p>
+        <h3>
+          Thank you for Backing Your Stack!
+        </h3>
+      </div>
+    </div>
+
+{{> footer}}

--- a/test/graphql.createOrder.backyourstack.test.js
+++ b/test/graphql.createOrder.backyourstack.test.js
@@ -68,12 +68,7 @@ const createOrderQuery = `
 const backyourstackDispatchOrder = `
   mutation backyourstackDispatchOrder($id: Int!) {
     backyourstackDispatchOrder(id: $id) {
-      id
-      totalAmount
-      collective {
-        name
-        slug
-      }
+      dispatching
     }
   }
   `;
@@ -194,7 +189,6 @@ describe('createOrder', () => {
   it('it dispatch the donation accross dependencies', async () => {
     // When the order is created
     const res = await utils.graphqlQuery(backyourstackDispatchOrder, { id: orderCreated.id }, xdamman);
-
     // There should be no errors
     res.errors && console.error(res.errors);
     expect(res.errors).to.not.exist;


### PR DESCRIPTION
Following up https://github.com/opencollective/backyourstack/issues/247#issuecomment-546838595

This PR updates the dispatch process from previous synchronous method, the collective admin will be notified about dispatch confirmation through an email as shown below:

<img width="608" alt="Screenshot 2019-10-29 at 7 16 00 PM" src="https://user-images.githubusercontent.com/15707013/67796568-8e335f00-fa80-11e9-91f1-fd4a30587ce5.png">

<img width="653" alt="Screenshot 2019-10-29 at 7 16 18 PM" src="https://user-images.githubusercontent.com/15707013/67796598-98555d80-fa80-11e9-8ee6-56799c42f0d0.png">
