### PR TITLE
Detailed log for stripe payment errors

### DIFF
--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -251,10 +251,17 @@ export default {
       user: order.createdByUser,
     });
 
-    const transactions = await createChargeAndTransactions(hostStripeAccount, {
-      order,
-      hostStripeCustomer,
-    });
+    let transactions;
+    try {
+      transactions = await createChargeAndTransactions(hostStripeAccount, {
+        order,
+        hostStripeCustomer,
+      });
+    } catch (error) {
+      logger.error(`Stripe Payment Error: ${error.message}`);
+      logger.error(error);
+      throw error;
+    }
 
     await order.paymentMethod.update({ confirmedAt: new Date() });
 


### PR DESCRIPTION
In a first step to better handle "An error occurred with our connection to Stripe.", adding detailed log for all stripe payment errors.