### PR TITLE
feat(one-time-login-link): throw exception

### DIFF
--- a/server/middleware/security/authentication.js
+++ b/server/middleware/security/authentication.js
@@ -109,6 +109,7 @@ export const _authenticateUserByJwt = async (req, res, next) => {
         }
       } else if (user.lastLoginAt.getTime() !== req.jwtPayload.lastLoginAt) {
         logger.error('This login link is expired or has already been used');
+        throw new Error('This login link is expired or has already been used');
       } else {
         const now = new Date();
         await user.update({ lastLoginAt: now });


### PR DESCRIPTION
According to the frontend tests https://circleci.com/gh/opencollective/opencollective-frontend/tree/one-time-login-link-strict after the modifications in https://github.com/opencollective/opencollective-api/commit/687d504fdf3515ad9931e99e9945b2cbff0da491  we can now be strict again in the "One Time Login" check.