### PR TITLE
Implement retries in stripe payment processing

### DIFF
--- a/server/lib/stripe.js
+++ b/server/lib/stripe.js
@@ -1,7 +1,12 @@
 import config from 'config';
 import Stripe from 'stripe';
 
-export default Stripe(config.stripe.secret);
+const stripe = Stripe(config.stripe.secret);
+
+// Retry a request twice before giving up
+stripe.setMaxNetworkRetries(2);
+
+export default stripe;
 
 export const extractFees = balance => {
   const fees = {

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -113,6 +113,7 @@ const createChargeAndTransactions = async (hostStripeAccount, { order, hostStrip
       customer: hostStripeCustomer.id,
       description: order.description,
       confirm: false,
+      confirmation_method: 'manual',
       metadata: {
         from: `${config.host.website}/${order.fromCollective.slug}`,
         to: `${config.host.website}/${order.collective.slug}`,
@@ -140,14 +141,8 @@ const createChargeAndTransactions = async (hostStripeAccount, { order, hostStrip
     });
   }
 
-  const confirmPayload = { confirmation_method: 'manual' };
-  if (order.interval) {
-    confirmPayload.setup_future_usage = 'off_session';
-  } else if (!order.processedAt && order.data.savePaymentMethod) {
-    confirmPayload.setup_future_usage = 'on_session';
-  }
-  paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, confirmPayload, {
-    stripe_account: hostStripeAccount.username,
+  paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
+    stripeAccount: hostStripeAccount.username,
   });
 
   /* eslint-enable camelcase */

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -103,16 +103,16 @@ const createChargeAndTransactions = async (hostStripeAccount, { order, hostStrip
   // Make sure data is available (breaking in some old tests)
   order.data = order.data || {};
 
-  let paymentIntent;
-  if (!order.data || !order.data.paymentIntent) {
-    /* eslint-disable camelcase */
-    const payload = {
+  /* eslint-disable camelcase */
+
+  let paymentIntent = order.data.paymentIntent;
+  if (!paymentIntent) {
+    const createPayload = {
       amount: order.totalAmount,
       currency: order.currency,
       customer: hostStripeCustomer.id,
       description: order.description,
-      confirm: true,
-      confirmation_method: 'manual',
+      confirm: false,
       metadata: {
         from: `${config.host.website}/${order.fromCollective.slug}`,
         to: `${config.host.website}/${order.collective.slug}`,
@@ -120,31 +120,37 @@ const createChargeAndTransactions = async (hostStripeAccount, { order, hostStrip
     };
     // We don't add a platform fee if the host is the root account
     if (platformFee && hostStripeAccount.username !== config.stripe.accountId) {
-      payload.application_fee_amount = platformFee;
+      createPayload.application_fee_amount = platformFee;
     }
     if (order.interval) {
-      payload.setup_future_usage = 'off_session';
+      createPayload.setup_future_usage = 'off_session';
     } else if (!order.processedAt && order.data.savePaymentMethod) {
-      payload.setup_future_usage = 'on_session';
+      createPayload.setup_future_usage = 'on_session';
     }
     // Add Payment Method ID if it's available
     const paymentMethodId = get(hostStripeCustomer, 'default_source', get(hostStripeCustomer, 'sources.data[0].id'));
     if (paymentMethodId) {
-      payload.payment_method = paymentMethodId;
+      createPayload.payment_method = paymentMethodId;
     } else {
       logger.info('paymentMethod is missing in hostStripeCustomer to pass to Payment Intent.');
       logger.info(JSON.stringify(hostStripeCustomer));
     }
-    /* eslint-enable camelcase */
-
-    paymentIntent = await stripe.paymentIntents.create(payload, {
-      stripeAccount: hostStripeAccount.username,
-    });
-  } else {
-    paymentIntent = await stripe.paymentIntents.confirm(order.data.paymentIntent.id, {
+    paymentIntent = await stripe.paymentIntents.create(createPayload, {
       stripeAccount: hostStripeAccount.username,
     });
   }
+
+  const confirmPayload = { confirmation_method: 'manual' };
+  if (order.interval) {
+    confirmPayload.setup_future_usage = 'off_session';
+  } else if (!order.processedAt && order.data.savePaymentMethod) {
+    confirmPayload.setup_future_usage = 'on_session';
+  }
+  paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, confirmPayload, {
+    stripe_account: hostStripeAccount.username,
+  });
+
+  /* eslint-enable camelcase */
 
   if (paymentIntent.next_action) {
     order.data.paymentIntent = { id: paymentIntent.id, status: paymentIntent.status };

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -127,7 +127,7 @@ describe('server/graphql/v1/createOrder', () => {
         currency: 'eur',
         status: 'succeeded',
       },
-      paymentIntent: {
+      paymentIntentConfirmed: {
         charges: { data: [{ id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm', currency: 'eur', status: 'succeeded' }] },
         status: 'succeeded',
       },

--- a/test/server/graphql/v1/tiers.test.js
+++ b/test/server/graphql/v1/tiers.test.js
@@ -83,7 +83,15 @@ describe('server/graphql/v1/tiers', () => {
     sandbox.stub(stripe.customers, 'retrieve').callsFake(() => Promise.resolve({ id: 'cus_B5s4wkqxtUtNyM' }));
 
     /* eslint-disable camelcase */
-    sandbox.stub(stripe.paymentIntents, 'create').callsFake(data =>
+
+    sandbox.stub(stripe.paymentIntents, 'create').callsFake(() =>
+      Promise.resolve({
+        id: 'pi_1F82vtBYycQg1OMfS2Rctiau',
+        status: 'requires_confirmation',
+      }),
+    );
+
+    sandbox.stub(stripe.paymentIntents, 'confirm').callsFake(data =>
       Promise.resolve({
         charges: {
           data: [
@@ -122,6 +130,7 @@ describe('server/graphql/v1/tiers', () => {
       type: 'charge',
     };
     sandbox.stub(stripe.balanceTransactions, 'retrieve').callsFake(() => Promise.resolve(balanceTransaction));
+
     /* eslint-enable camelcase */
   });
 

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -53,6 +53,12 @@ describe('server/lib/payments', () => {
     sandbox.stub(stripe.tokens, 'create').callsFake(() => Promise.resolve({ id: 'tok_1AzPXGD8MNtzsDcgwaltZuvp' }));
     sandbox.stub(stripe.paymentIntents, 'create').callsFake(() =>
       Promise.resolve({
+        id: 'pi_1F82vtBYycQg1OMfS2Rctiau',
+        status: 'requires_confirmation',
+      }),
+    );
+    sandbox.stub(stripe.paymentIntents, 'confirm').callsFake(() =>
+      Promise.resolve({
         charges: { data: [{ id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' }] },
         status: 'succeeded',
       }),

--- a/test/server/paymentProviders/stripe/creditcard.test.js
+++ b/test/server/paymentProviders/stripe/creditcard.test.js
@@ -65,12 +65,10 @@ describe('server/paymentProviders/stripe/creditcard', () => {
       secondCallToCreateCustomer = nock('https://api.stripe.com:443').post('/v1/customers').reply(200, {});
 
       // Calls performed by createChargeAndTransactions
-      nock('https://api.stripe.com:443')
-        .post('/v1/payment_intents')
-        .reply(200, {
-          id: 'pi_1F82vtBYycQg1OMfS2Rctiau',
-          status: 'requires_confirmation',
-        });
+      nock('https://api.stripe.com:443').post('/v1/payment_intents').reply(200, {
+        id: 'pi_1F82vtBYycQg1OMfS2Rctiau',
+        status: 'requires_confirmation',
+      });
       nock('https://api.stripe.com:443')
         .post('/v1/payment_intents/pi_1F82vtBYycQg1OMfS2Rctiau/confirm')
         .reply(200, {

--- a/test/server/paymentProviders/stripe/creditcard.test.js
+++ b/test/server/paymentProviders/stripe/creditcard.test.js
@@ -68,6 +68,12 @@ describe('server/paymentProviders/stripe/creditcard', () => {
       nock('https://api.stripe.com:443')
         .post('/v1/payment_intents')
         .reply(200, {
+          id: 'pi_1F82vtBYycQg1OMfS2Rctiau',
+          status: 'requires_confirmation',
+        });
+      nock('https://api.stripe.com:443')
+        .post('/v1/payment_intents/pi_1F82vtBYycQg1OMfS2Rctiau/confirm')
+        .reply(200, {
           charges: {
             data: [{ id: 'ch_1B5j91D8MNtzsDcgNMsUgI8L', balance_transaction: 'txn_1B5j92D8MNtzsDcgQzIcmfrn' }],
           },

--- a/test/utils.js
+++ b/test/utils.js
@@ -220,7 +220,8 @@ export function stubStripeCreate(sandbox, overloadDefaults) {
     customer: { id: 'cus_BM7mGwp1Ea8RtL' },
     token: { id: 'tok_1AzPXGD8MNtzsDcgwaltZuvp' },
     charge: { id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' },
-    paymentIntent: { charges: { data: [{ id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' }] }, status: 'succeeded' },
+    paymentIntent: { id: 'pi_1F82vtBYycQg1OMfS2Rctiau', status: 'requires_confirmation' },
+    paymentIntentConfirmed: { charges: { data: [{ id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' }] }, status: 'succeeded' },
     ...overloadDefaults,
   };
   /* Little helper function that returns the stub with a given
@@ -238,6 +239,7 @@ export function stubStripeCreate(sandbox, overloadDefaults) {
 
   sandbox.stub(stripe.customers, 'retrieve').callsFake(factory('customer'));
   sandbox.stub(stripe.paymentIntents, 'create').callsFake(factory('paymentIntent'));
+  sandbox.stub(stripe.paymentIntents, 'confirm').callsFake(factory('paymentIntentConfirmed'));
 }
 
 export function stubStripeBalance(sandbox, amount, currency, applicationFee = 0, stripeFee = 0) {


### PR DESCRIPTION
- Switch to a two steps Stripe payment process `create` -> `confirm`
- Let Stripe library retry these steps if they fails

fix https://github.com/opencollective/opencollective/issues/2584

~~According to E2E tests, this is not ready.~~

> ~~You cannot confirm this PaymentIntent because it's missing a payment method. To confirm the PaymentIntent with cus_GXUt1sPXWkmqEy, specify a payment method attached to this customer along with the customer ID.~~ FIXED

~~Update:  according to E2E tests, 3Dsecure is not working as expected anymore.~~

Seems ready!
