### PR TITLE
Fix/requesting expense comments when empty

### DIFF
--- a/server/graphql/loaders.js
+++ b/server/graphql/loaders.js
@@ -258,7 +258,7 @@ export const loaders = req => {
           where: { ExpenseId: { [Op.in]: ExpenseIds } },
           group: ['ExpenseId'],
         })
-          .then(results => sortResults(ExpenseIds, results, 'ExpenseId'))
+          .then(results => sortResults(ExpenseIds, results, 'ExpenseId', { count: 0 }))
           .map(result => result.count),
       ),
     },

--- a/test/graphql.collective.test.js
+++ b/test/graphql.collective.test.js
@@ -9,11 +9,6 @@ import * as expenses from '../server/graphql/v1/mutations/expenses';
 import * as utils from './utils';
 import * as store from './stores';
 
-function expectNotErrorsFromResult(res) {
-  res.errors && console.error(res.errors);
-  expect(res.errors).to.not.exist;
-}
-
 describe('graphql.collective.test.js', () => {
   beforeEach(async () => {
     await utils.resetTestDB();
@@ -913,7 +908,7 @@ describe('graphql.collective.test.js', () => {
         },
         pubnubAdmin,
       );
-      expectNotErrorsFromResult(res);
+      utils.expectNoErrorsFromResult(res);
       // Check only two members where returned by the mutation
       expect(res.data.editPublicMessage.length).to.equal(2);
       // Find all members modified by the mutation in the database.
@@ -966,7 +961,7 @@ describe('graphql.collective.test.js', () => {
         },
         pubnubAdmin,
       );
-      expectNotErrorsFromResult(res);
+      utils.expectNoErrorsFromResult(res);
       // Check only two members where returned by the mutation
       expect(res.data.editPublicMessage.length).to.equal(2);
       // Find all members modified by the mutation in the database.


### PR DESCRIPTION
This PR solves a bug found while working on issue [#2590](https://github.com/opencollective/opencollective/issues/2590).

When requesting expense comments from `Expense->comments` field, if there are not comments the api v1 breaks.