### PR TITLE
Fix graphql.expenses.test deadlock

### DIFF
--- a/test/graphql.expenses.test.js
+++ b/test/graphql.expenses.test.js
@@ -90,9 +90,13 @@ const addFunds = async (user, hostCollective, collective, amount) => {
 };
 
 describe('GraphQL Expenses API', () => {
-  beforeEach(utils.resetTestDB);
+  beforeEach(async () => {
+    await utils.resetTestDB();
+  });
 
-  beforeEach(utils.resetCaches);
+  beforeEach(async () => {
+    await utils.resetCaches();
+  });
 
   describe('#allExpenses', () => {
     it('fails if collective not found', async () => {


### PR DESCRIPTION
This is a PR to fix : https://github.com/opencollective/opencollective/issues/2623

What was exactly happening that the `#markExpenseAsUnpaid`'s beforeEach `utils.resetTestDB` was still working after it has done. so when`#unapproveExpense`'s  beforeEach `utils.resetTestDB` was called `#markExpenseAsUnpaid`'s beforeEach `utils.resetTestDB` wasn't done yet and that caused the deadlock.

Before : 

![before44](https://user-images.githubusercontent.com/18349358/68673420-5afece80-055c-11ea-94bf-ee803bfb8fd3.png)

After : 

![after44](https://user-images.githubusercontent.com/18349358/68673434-60f4af80-055c-11ea-814d-9726982ba54c.png)

After With Running All Tests : 

![after442](https://user-images.githubusercontent.com/18349358/68673457-6c47db00-055c-11ea-9337-1bfff912114b.png)
