### PR TITLE
Collective: ignore remoteUser in canContact

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -980,8 +980,8 @@ const CollectiveFields = () => {
     canContact: {
       description: 'Returns whether this collectives can be contacted',
       type: GraphQLBoolean,
-      resolve(collective, _, req) {
-        return collective.canContact(req.remoteUser);
+      resolve(collective) {
+        return collective.canContact();
       },
     },
     isIncognito: {

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -944,7 +944,7 @@ export async function sendMessageToCollective(_, args, req) {
     });
   }
 
-  if (!(await collective.canContact(req.remoteUser))) {
+  if (get(req.remoteUser.data, 'disableContact', false) || !(await collective.canContact())) {
     throw new errors.Unauthorized({
       message: `You can't contact this collective`,
     });

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -859,12 +859,10 @@ export default function(Sequelize, DataTypes) {
   };
 
   /**
-   *  Checks if the collective can be contacted by `remoteUser`.
+   *  Checks if the collective can be contacted.
    */
-  Collective.prototype.canContact = async function(remoteUser) {
-    if (!remoteUser || get(remoteUser.data, 'disableContact', false)) {
-      return false;
-    } else if (!this.isActive) {
+  Collective.prototype.canContact = async function() {
+    if (!this.isActive) {
       return false;
     } else {
       return [types.COLLECTIVE, types.EVENT].includes(this.type) || (await this.isHost());


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2620 introduced in https://github.com/opencollective/opencollective-api/commit/5356685b1c79f08f0978f9e409ed44f1844de2e8

`Collective.canContact` was accepting a `remoteUser` to check the permissions, but that was a mistake from me:
1. Because it's not the responsibility of the model to check that
2. Because we only care about permissions when sending the message, `Collective.canContact` is a simple flag that's just here to tell if the Collective is contactable. In that regard `isContactable` would have been a better name. It's the responsibility of the frontend to hide the form if user is not authenticated.