### PR TITLE
Feat/add docker files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:12.13.0
+
+# Install postgres client
+RUN apt-get update && apt-get install -y postgresql-client \
+  # Clean apt-get cache
+  && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /usr/src/app
+
+EXPOSE 3060 1080 1025
+
+# Copy the setup script
+COPY scripts/setup.sh /usr/local/bin/
+
+# Enable excution permission for the setup script
+RUN chmod +x /usr/local/bin/setup.sh
+
+# Use setup script as entrypoint
+ENTRYPOINT ["setup.sh"]
+
+# Default commad 'start'. Can by overriden from docker cli.
+CMD [ "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ RUN chmod +x /usr/local/bin/setup.sh
 # Use setup script as entrypoint
 ENTRYPOINT ["setup.sh"]
 
-# Default commad 'start'. Can by overriden from docker cli.
+# Default command 'start'. Can by overridden from Docker cli.
 CMD [ "start" ]

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -21,6 +21,9 @@
       }
     }
   },
+  "maintenancedb": {
+    "url": "PG_MAINTENANCE_URL"
+  },
   "memcache": {
     "servers": "MEMCACHE_SERVERS",
     "username": "MEMCACHE_USERNAME",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.7'
+
+services:
+  opencollective_api:
+    build:
+      context: . # Build the api image from the Dockerfile
+    command: ${OPENCOLLECTIVE_DOCKER_INIT_CMD:-start} # Use this env var to send pre-defined and custom commands
+    ports:
+      - '3060:3060' # App port
+      - '1080:1080' # Mail gui port
+      - '1025:1025'
+      - '9229:9229' # Debug port
+    volumes:
+      - .:/usr/src/app # Mount the app in the container
+    depends_on:
+      - opencollective_db # Add dependency on the db service
+    environment:
+      - PGHOST=opencollective_db # The db host is the name of the service
+      - PGUSER=postgres
+      - PG_URL=postgres://opencollective@opencollective_db:5432/opencollective_dvl
+      - PG_MAINTENANCE_URL=postgres://opencollective_db:5432/postgres
+
+  opencollective_db:
+    image: mdillon/postgis:9.6
+    volumes:
+      - opencollective-db-data:/var/lib/postgresql/data # Persist data between mounts
+    ports:
+      - '5432:5432' # Export PG port to the host allowing to access the db with a pg client
+    environment:
+      - POSTGRES_USER=postgres # Default user
+
+volumes:
+  opencollective-db-data:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@ installNodeModules() {
   npm install
 }
 
-waitForPostgresToByReady() {
+waitForPostgresToBeReady() {
   # Code by https://starkandwayne.com/blog/how-to-know-when-your-postgres-service-is-ready/
   until pg_isready
   do
@@ -19,7 +19,7 @@ waitForPostgresToByReady() {
 
 seedDB() {
   echo "Seeding database"
-  waitForPostgresToByReady
+  waitForPostgresToBeReady
   npm run postinstall
 }
 
@@ -34,7 +34,7 @@ doesDatabaseExists() {
 
 setupTestingDB() {
   echo "Setting up testing db"
-  waitForPostgresToByReady
+  waitForPostgresToBeReady
   if ! doesDatabaseExists "opencollective_test"; then
     npm run db:setup
     createdb opencollective_test || true
@@ -68,7 +68,7 @@ case $1 in
     echo "Starting in e2e mode"
     setupEnvironmentIfNodeModulesDoesNotExists
     if ! $setupScriptRan; then
-      waitForPostgresToByReady
+      waitForPostgresToBeReady
       npm run db:restore && npm run db:migrate
     fi
     npm run build

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,7 @@ installNodeModules() {
   echo "Installing node modules"
   npm install
 }
+
 waitForPostgresToByReady() {
   # Code by https://starkandwayne.com/blog/how-to-know-when-your-postgres-service-is-ready/
   until pg_isready
@@ -15,11 +16,13 @@ waitForPostgresToByReady() {
     sleep 2;
   done
 }
+
 seedDB() {
   echo "Seeding database"
   waitForPostgresToByReady
   npm run postinstall
 }
+
 doesDatabaseExists() {
   # Code by https://stackoverflow.com/a/16783253/5801753
   if psql -lqt | cut -d \| -f 1 | grep -qw $1; then
@@ -28,6 +31,7 @@ doesDatabaseExists() {
     return 1
   fi
 }
+
 setupTestingDB() {
   echo "Setting up testing db"
   waitForPostgresToByReady
@@ -39,6 +43,7 @@ setupTestingDB() {
     psql -d opencollective_test -c 'ALTER USER opencollective WITH SUPERUSER;' || true
   fi
 }
+
 setupEnvironmentIfNodeModulesDoesNotExists() {
   if [ ! -d node_modules ]; then
     setupScriptRan=true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+setupScriptRan=false
+
+installNodeModules() {
+  echo "Installing node modules"
+  npm install
+}
+waitForPostgresToByReady() {
+  # Code by https://starkandwayne.com/blog/how-to-know-when-your-postgres-service-is-ready/
+  until pg_isready
+  do
+    echo "Waiting for postgres"
+    sleep 2;
+  done
+}
+seedDB() {
+  echo "Seeding database"
+  waitForPostgresToByReady
+  npm run postinstall
+}
+doesDatabaseExists() {
+  # Code by https://stackoverflow.com/a/16783253/5801753
+  if psql -lqt | cut -d \| -f 1 | grep -qw $1; then
+    return 0
+  else
+    return 1
+  fi
+}
+setupTestingDB() {
+  echo "Setting up testing db"
+  waitForPostgresToByReady
+  if ! doesDatabaseExists "opencollective_test"; then
+    npm run db:setup
+    createdb opencollective_test || true
+    psql -d opencollective_test -c 'GRANT ALL PRIVILEGES ON DATABASE opencollective_test TO opencollective' || true
+    psql -d opencollective_test -c 'CREATE EXTENSION postgis' || true
+    psql -d opencollective_test -c 'ALTER USER opencollective WITH SUPERUSER;' || true
+  fi
+}
+setupEnvironmentIfNodeModulesDoesNotExists() {
+  if [ ! -d node_modules ]; then
+    setupScriptRan=true
+    installNodeModules
+    seedDB
+  fi
+}
+
+case $1 in
+  'start')
+    echo "Starting in default mode"
+    setupEnvironmentIfNodeModulesDoesNotExists
+    npm run build
+    exec npm run start
+    ;;
+  'dev')
+    echo "Starting in dev mode"
+    setupEnvironmentIfNodeModulesDoesNotExists
+    exec npm run dev
+    ;;
+  'e2e')
+    echo "Starting in e2e mode"
+    setupEnvironmentIfNodeModulesDoesNotExists
+    if ! $setupScriptRan; then
+      waitForPostgresToByReady
+      npm run db:restore && npm run db:migrate
+    fi
+    npm run build
+    TZ=UTC NODE_ENV=e2e E2E_TEST=1 exec npm run start
+    ;;
+  'test')
+    echo "Starting in test mode"
+    setupEnvironmentIfNodeModulesDoesNotExists
+    setupTestingDB
+    exec npm run test
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac


### PR DESCRIPTION
To try this branch you need to install [Docker and Docker Compose](https://docs.docker.com/v17.09/engine/installation/).

# Commands

Before running any of the predefined commands for the first time or every time you want to reinstall the node modules and run the db migrations, remove the `node_modules` folder (`rm -rf node_modules`).

#### `docker-compose up`

Setup the api and runs `npm start`. 

#### `OPENCOLLECTIVE_DOCKER_INIT_CMD=dev docker-compose up` 

Setup the api in a way that restart the server when files change.

#### `OPENCOLLECTIVE_DOCKER_INIT_CMD=e2e docker-compose up`

Setup the api in e2e mode.

#### `OPENCOLLECTIVE_DOCKER_INIT_CMD=test docker-compose up`

Setup the api and runs the unit/integration tests. After the tests are done running you need to stop the app manually with `ctrl+c`.

The db is restored and migrated every time you run this command.

#### `OPENCOLLECTIVE_DOCKER_INIT_CMD="<`npm run ...` command>" docker-compose up`

Start the db and run the custom `npm run ...` command.

Only the predefined commands will install node modules and run migrations on your behalf. Before using a custom command make sure the environment is in the state you want.