### PR TITLE
GraphQL v1: accept slugs as query parameters in allCollectives

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -795,7 +795,7 @@ const queries = {
   allCollectives: {
     type: CollectiveSearchResultsType,
     args: {
-      renderCollectivesFromList: {
+      slugs: {
         type: new GraphQLList(GraphQLString),
         description: 'Fetch collectives with a list of collective slug',
       },
@@ -863,10 +863,8 @@ const queries = {
         include: [],
       };
 
-      if (args.renderCollectivesFromList) {
-        query.where.id = await Promise.all(
-          args.renderCollectivesFromList.map(async id => (typeof id === 'string' ? await fetchCollectiveId(id) : id)),
-        );
+      if (args.slugs) {
+        query.where.slug = { [Op.in]: args.slugs };
       }
 
       if (args.hostCollectiveSlug) {

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -795,6 +795,10 @@ const queries = {
   allCollectives: {
     type: CollectiveSearchResultsType,
     args: {
+      renderCollectivesFromList: {
+        type: new GraphQLList(GraphQLString),
+        description: 'Fetch collectives with a list of collective slug',
+      },
       tags: {
         type: new GraphQLList(GraphQLString),
         description: 'Fetch all collectives that match at least one of the tags',
@@ -858,6 +862,12 @@ const queries = {
         limit: args.limit,
         include: [],
       };
+
+      if (args.renderCollectivesFromList) {
+        query.where.id = await Promise.all(
+          args.renderCollectivesFromList.map(async id => (typeof id === 'string' ? await fetchCollectiveId(id) : id)),
+        );
+      }
 
       if (args.hostCollectiveSlug) {
         args.HostCollectiveId = await fetchCollectiveId(args.hostCollectiveSlug);


### PR DESCRIPTION
… and return collective data.
Re [#2565](https://github.com/opencollective/opencollective/issues/2565)