### PR TITLE
Allow manual payment of expense with paypal method

### DIFF
--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -1,4 +1,4 @@
-import { omit, pick } from 'lodash';
+import { pick } from 'lodash';
 import {
   claimCollective,
   createCollective,
@@ -351,9 +351,10 @@ const mutations = {
       paymentProcessorFeeInCollectiveCurrency: { type: GraphQLInt },
       hostFeeInCollectiveCurrency: { type: GraphQLInt },
       platformFeeInCollectiveCurrency: { type: GraphQLInt },
+      manuallyPayPaypalMethod: { type: GraphQLBoolean },
     },
     resolve(_, args, req) {
-      return payExpense(req.remoteUser, args.id, omit(args, ['id']));
+      return payExpense(req.remoteUser, args);
     },
   },
   markOrderAsPaid: {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -351,7 +351,10 @@ const mutations = {
       paymentProcessorFeeInCollectiveCurrency: { type: GraphQLInt },
       hostFeeInCollectiveCurrency: { type: GraphQLInt },
       platformFeeInCollectiveCurrency: { type: GraphQLInt },
-      manuallyPayPaypalMethod: { type: GraphQLBoolean },
+      forceManual: {
+        type: GraphQLBoolean,
+        description: 'Force expense with paypal method to be paid manually',
+      },
     },
     resolve(_, args, req) {
       return payExpense(req.remoteUser, args);

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -293,6 +293,7 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
   }
 
   const balance = await expense.collective.getBalance();
+  const processorFeeInputed = fees.paymentProcessorFeeInCollectiveCurrency;
 
   if (expense.amount > balance) {
     throw new errors.Unauthorized(
@@ -338,6 +339,9 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
     // then we simply mark the expense as paid
     if (expense.paypalEmail === paymentMethod.name) {
       feesInHostCurrency.paymentProcessorFeeInHostCurrency = 0;
+      await createTransactions(host, expense, feesInHostCurrency);
+    } else if (processorFeeInputed && processorFeeInputed > 0) {
+      // For paypal method mannaully recorded as paid.
       await createTransactions(host, expense, feesInHostCurrency);
     } else {
       await payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, feesInHostCurrency);

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, omit } from 'lodash';
 import errors from '../../../lib/errors';
 import roles from '../../../constants/roles';
 import statuses from '../../../constants/expense_status';
@@ -267,7 +267,10 @@ async function payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, fe
  * @PRE: fees { id, paymentProcessorFeeInCollectiveCurrency, hostFeeInCollectiveCurrency, platformFeeInCollectiveCurrency }
  * Note: some payout methods like PayPal will automatically define `paymentProcessorFeeInCollectiveCurrency`
  */
-export async function payExpense(remoteUser, expenseId, fees = {}) {
+export async function payExpense(remoteUser, args) {
+  const expenseId = args.id;
+  const fees = omit(args, ['id', 'manuallyPayPaypalMethod']);
+
   if (!remoteUser) {
     throw new errors.Unauthorized('You need to be logged in to pay an expense');
   }
@@ -293,7 +296,6 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
   }
 
   const balance = await expense.collective.getBalance();
-  const processorFeeInputed = fees.paymentProcessorFeeInCollectiveCurrency;
 
   if (expense.amount > balance) {
     throw new errors.Unauthorized(
@@ -340,8 +342,7 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
     if (expense.paypalEmail === paymentMethod.name) {
       feesInHostCurrency.paymentProcessorFeeInHostCurrency = 0;
       await createTransactions(host, expense, feesInHostCurrency);
-    } else if (processorFeeInputed && processorFeeInputed > 0) {
-      // For paypal method manually recorded as paid.
+    } else if (args.manuallyPayPaypalMethod) {
       await createTransactions(host, expense, feesInHostCurrency);
     } else {
       await payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, feesInHostCurrency);

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -341,7 +341,7 @@ export async function payExpense(remoteUser, expenseId, fees = {}) {
       feesInHostCurrency.paymentProcessorFeeInHostCurrency = 0;
       await createTransactions(host, expense, feesInHostCurrency);
     } else if (processorFeeInputed && processorFeeInputed > 0) {
-      // For paypal method mannaully recorded as paid.
+      // For paypal method manually recorded as paid.
       await createTransactions(host, expense, feesInHostCurrency);
     } else {
       await payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, feesInHostCurrency);

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -269,7 +269,7 @@ async function payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, fe
  */
 export async function payExpense(remoteUser, args) {
   const expenseId = args.id;
-  const fees = omit(args, ['id', 'manuallyPayPaypalMethod']);
+  const fees = omit(args, ['id', 'forceManual']);
 
   if (!remoteUser) {
     throw new errors.Unauthorized('You need to be logged in to pay an expense');
@@ -342,7 +342,7 @@ export async function payExpense(remoteUser, args) {
     if (expense.paypalEmail === paymentMethod.name) {
       feesInHostCurrency.paymentProcessorFeeInHostCurrency = 0;
       await createTransactions(host, expense, feesInHostCurrency);
-    } else if (args.manuallyPayPaypalMethod) {
+    } else if (args.forceManual) {
       await createTransactions(host, expense, feesInHostCurrency);
     } else {
       await payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, feesInHostCurrency);

--- a/test/graphql.collective.test.js
+++ b/test/graphql.collective.test.js
@@ -80,7 +80,7 @@ describe('graphql.collective.test.js', () => {
         payoutMethod: 'manual',
         collective: { id: apex.id },
       });
-      await expenses.payExpense(hostAdmin, expense.id, 0);
+      await expenses.payExpense(hostAdmin, { id: expense.id });
     }
 
     // When the following query is executed

--- a/test/graphql.expenses.test.js
+++ b/test/graphql.expenses.test.js
@@ -842,7 +842,7 @@ describe('GraphQL Expenses API', () => {
       it('fails if not enough funds on the paypal preapproved key', async () => {
         // And then add funds to the collective
         const initialBalance = 1500;
-        const paymentProcessorFeeInCollectiveCurrency = 0;
+        const paymentProcessorFeeInCollectiveCurrency = 100;
         await addFunds(user, hostCollective, collective, initialBalance);
         // When the expense is paid by the host admin
         const res = await utils.graphqlQuery(

--- a/test/graphql.expenses.test.js
+++ b/test/graphql.expenses.test.js
@@ -842,7 +842,7 @@ describe('GraphQL Expenses API', () => {
       it('fails if not enough funds on the paypal preapproved key', async () => {
         // And then add funds to the collective
         const initialBalance = 1500;
-        const paymentProcessorFeeInCollectiveCurrency = 100;
+        const paymentProcessorFeeInCollectiveCurrency = 0;
         await addFunds(user, hostCollective, collective, initialBalance);
         // When the expense is paid by the host admin
         const res = await utils.graphqlQuery(


### PR DESCRIPTION
As part of https://github.com/opencollective/opencollective/issues/1976 and following up https://github.com/opencollective/opencollective-frontend/pull/2781

This PR uses `paymentProcessorFeeInCollectiveCurrency` provided by the host admin to determine if the paypal  expense should be recorded manually. 