### PR TITLE
Remove deprecated fields from GraphQL API

### DIFF
--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -322,11 +322,6 @@ export const OrderInputType = new GraphQLInputObjectType({
     publicMessage: { type: GraphQLString },
     privateMessage: { type: GraphQLString },
     paymentMethod: { type: PaymentMethodInputType },
-    matchingFund: {
-      type: GraphQLString,
-      description: 'The first part of the UUID of the PaymentMethod that can be used to match the donation',
-      deprecationReason: '2019-08-19: Matching funds are not supported anymore',
-    },
     referral: {
       type: CollectiveAttributesInputType,
       description: 'The referral collective',

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -322,11 +322,6 @@ export const OrderInputType = new GraphQLInputObjectType({
     publicMessage: { type: GraphQLString },
     privateMessage: { type: GraphQLString },
     paymentMethod: { type: PaymentMethodInputType },
-    referral: {
-      type: CollectiveAttributesInputType,
-      description: 'The referral collective',
-      deprecationReason: '2019-08-22: Referals are not supported anymore',
-    },
     user: { type: UserInputType },
     fromCollective: { type: CollectiveAttributesInputType },
     collective: { type: new GraphQLNonNull(CollectiveAttributesInputType) },

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -83,19 +83,6 @@ const queries = {
     },
   },
 
-  MatchingFund: {
-    type: PaymentMethodType,
-    description: 'Fetch data about a matching fund from the short version of its UUID (first part)',
-    deprecationReason: '2019-08-19: Matching funds are not supported anymore',
-    args: {
-      uuid: { type: new GraphQLNonNull(GraphQLString) },
-      ForCollectiveId: { type: GraphQLInt },
-    },
-    resolve() {
-      return null;
-    },
-  },
-
   LoggedInUser: {
     type: UserType,
     resolve(_, args, req) {

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1566,14 +1566,6 @@ export const OrderType = new GraphQLObjectType({
           return req.loaders.collective.findById.load(order.CollectiveId);
         },
       },
-      referral: {
-        description: 'Referral user collective',
-        deprecationReason: '2019-08-22: Referals are not supported anymore',
-        type: CollectiveInterfaceType,
-        resolve() {
-          return null;
-        },
-      },
       tier: {
         type: TierType,
         resolve(order) {

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1591,14 +1591,6 @@ export const OrderType = new GraphQLObjectType({
           return order.getPaymentMethodForUser(req.remoteUser);
         },
       },
-      matchingFund: {
-        description: 'Payment method used if this order was matched by a matching fund.',
-        deprecationReason: '2019-08-19: Matching funds are not supported anymore',
-        type: PaymentMethodType,
-        resolve() {
-          return null;
-        },
-      },
       transactions: {
         description: 'transactions for this order ordered by createdAt DESC',
         type: new GraphQLList(TransactionInterfaceType),
@@ -1841,14 +1833,6 @@ export const PaymentMethodType = new GraphQLObjectType({
         type: GraphQLBoolean,
         resolve(paymentMethod) {
           return paymentMethod.primary;
-        },
-      },
-      matching: {
-        type: GraphQLInt,
-        description: 'Matching factor',
-        deprecationReason: '2019-08-19: Matching funds are not supported anymore',
-        resolve() {
-          return 0;
         },
       },
       monthlyLimitPerMember: {


### PR DESCRIPTION
Remove the fields that don't have any dependencies left in other projects.
Note: some of the deprecated fields have already been removed in https://github.com/opencollective/opencollective-api/pull/2948