### PR TITLE
Invoices: Don't return a default title

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -517,7 +517,7 @@ export const InvoiceType = new GraphQLObjectType({
         description:
           'Title for the invoice. Depending on the type of legal entity, a host should issue an Invoice or a Receipt.',
         resolve(invoice) {
-          return invoice.title || 'Donation Receipt';
+          return invoice.title;
         },
       },
       dateFrom: {


### PR DESCRIPTION
Default invoice title should be handled by the service, not by the API.

See https://github.com/opencollective/opencollective-invoices/pull/184