### PR TITLE
Tier: Optimizations for availableQuantity

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1214,13 +1214,12 @@ export const TierStatsType = new GraphQLObjectType({
       },
       availableQuantity: {
         type: GraphQLInt,
-        resolve(tier) {
-          return (
-            tier
-              .availableQuantity()
-              // graphql doesn't like infinity value
-              .then(availableQuantity => (availableQuantity === Infinity ? maxInteger : availableQuantity))
-          );
+        resolve(tier, _, req) {
+          if (!tier.maxQuantity) {
+            return maxInteger;
+          } else {
+            return req.loaders.tiers.availableQuantity.load(tier.id);
+          }
         },
       },
     };

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -319,6 +319,10 @@ export default function(Sequelize, DataTypes) {
 
   // TODO: Check for maxQuantityPerUser
   Tier.prototype.availableQuantity = function() {
+    if (!this.maxQuantity) {
+      return Promise.resolve(maxInteger);
+    }
+
     return models.Order.sum('quantity', {
       where: {
         TierId: this.id,


### PR DESCRIPTION
- Use GraphQL loader.
- Never query DB if no `maxQuantity` is set. Will avoid 99% of the DB queries as this field is not set for most of them.

