### PR TITLE
fix(paypal): reduce verbosity in error sent to UI

### DIFF
--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -88,11 +88,13 @@ export async function createFromPaidExpense(
 
       case 'ERROR':
         throw new errors.ServerError(
-          `Error while paying the expense with PayPal: "${executePaymentResponse.payErrorList[0].error.message}"`,
+          `Error while paying the expense with PayPal: "${executePaymentResponse.payErrorList[0].error.message}". Please contact support@opencollective.com`,
         );
 
       default:
-        throw new errors.ServerError(`Error while paying the expense with PayPal`);
+        throw new errors.ServerError(
+          `Error while paying the expense with PayPal. Please contact support@opencollective.com`,
+        );
     }
 
     const senderFees = createPaymentResponse.defaultFundingPlan.senderFees;

--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -86,12 +86,13 @@ export async function createFromPaidExpense(
           `Please approve this payment manually on ${createPaymentResponse.paymentApprovalUrl}`,
         );
 
-      default:
+      case 'ERROR':
         throw new errors.ServerError(
-          `controllers.expenses.pay: Unknown error while trying to create transaction for expense ${
-            expense.id
-          }. The full response was: ${JSON.stringify(executePaymentResponse)}`,
+          `Error while paying the expense with PayPal: "${executePaymentResponse.payErrorList[0].error.message}"`,
         );
+
+      default:
+        throw new errors.ServerError(`Error while paying the expense with PayPal`);
     }
 
     const senderFees = createPaymentResponse.defaultFundingPlan.senderFees;


### PR DESCRIPTION
I created the ERROR case in order to be certain that the message to be sent exists.

related to https://github.com/opencollective/opencollective/issues/2639