### PR TITLE
fix(user-report): only query ACTIVE and PAID orders

### DIFF
--- a/cron/monthly/user-report.js
+++ b/cron/monthly/user-report.js
@@ -196,10 +196,7 @@ const processBacker = async FromCollectiveId => {
         SubscriptionId: { [Op.ne]: null },
       },
       status: {
-        [Op.and]: {
-          [Op.ne]: ORDER_STATUS.ERROR,
-          [Op.ne]: ORDER_STATUS.CANCELLED,
-        },
+        [Op.in]: [ORDER_STATUS.PAID, ORDER_STATUS.ACTIVE],
       },
       deletedAt: null,
     },


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2692

Warning: that code doesn't look solid but rewrite is not on the table today