### PR TITLE
Replace all 'donation to' by 'financial contribution to'

### DIFF
--- a/migrations/20191209132522-change-wording-donation-to-financial-contribution.js
+++ b/migrations/20191209132522-change-wording-donation-to-financial-contribution.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * Updates all auto-generated descriptions for orders and transactions to replace
+ * "Donation to" by "Financial contribution to".
+ */
+module.exports = {
+  up: async queryInterface => {
+    // Change all `Donation to ___` -> `Financial contribution to ___`
+    await queryInterface.sequelize.query(`
+      UPDATE  "Orders"
+      SET     description = regexp_replace(description, '^Donation to ', 'Financial contribution to ')
+      WHERE   description LIKE 'Donation to %'
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE  "Transactions"
+      SET     description = regexp_replace(description, '^Donation to ', 'Financial contribution to ')
+      WHERE   description LIKE 'Donation to %'
+    `);
+
+    // Change all `Monthly|Yearly donation to ___` -> `Monthly|Yearly financial contribution to ___`
+    await queryInterface.sequelize.query(`
+      UPDATE  "Orders"
+      SET     description = regexp_replace(description, '^(Monthly|Yearly) donation to ', '\\1 financial contribution to ')
+      WHERE   description LIKE 'Monthly donation to %'
+      OR      description LIKE 'Yearly donation to %'
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE  "Transactions"
+      SET     description = regexp_replace(description, '^(Monthly|Yearly) donation to ', '\\1 financial contribution to ')
+      WHERE   description LIKE 'Monthly donation to %'
+      OR      description LIKE 'Yearly donation to %'
+    `);
+  },
+
+  down: async queryInterface => {
+    // Change all `Financial contribution to ___` -> `Donation to ___`
+    await queryInterface.sequelize.query(`
+      UPDATE  "Orders"
+      SET     description = regexp_replace(description, '^Financial contribution to ', 'Donation to ')
+      WHERE   description LIKE 'Financial contribution to %'
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE  "Transactions"
+      SET     description = regexp_replace(description, '^Financial contribution to ', 'Donation to ')
+      WHERE   description LIKE 'Financial contribution to %'
+    `);
+
+    // Change all `Monthly|Yearly financial contribution to ___` -> `Monthly|Yearly donation to ___`
+    await queryInterface.sequelize.query(`
+      UPDATE  "Orders"
+      SET     description = regexp_replace(description, '^(Monthly|Yearly) financial contribution to ', '\\1 donation to ')
+      WHERE   description LIKE 'Monthly financial contribution to %'
+      OR      description LIKE 'Yearly financial contribution to %'
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE  "Transactions"
+      SET     description = regexp_replace(description, '^(Monthly|Yearly) financial contribution to ', '\\1 donation to ')
+      WHERE   description LIKE 'Monthly financial contribution to %'
+      OR      description LIKE 'Yearly financial contribution to %'
+    `);
+  },
+};

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -412,10 +412,12 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     const tierNameInfo = tier && tier.name ? ` (${tier.name})` : '';
     let defaultDescription;
     if (order.interval) {
-      defaultDescription = `${capitalize(order.interval)}ly donation to ${collective.name}${tierNameInfo}`;
+      defaultDescription = `${capitalize(order.interval)}ly financial contribution to ${
+        collective.name
+      }${tierNameInfo}`;
     } else {
       defaultDescription = `${
-        order.totalAmount === 0 || collective.type === types.EVENT ? 'Registration' : 'Donation'
+        order.totalAmount === 0 || collective.type === types.EVENT ? 'Registration' : 'Financial contribution'
       } to ${collective.name}${tierNameInfo}`;
     }
     debug('defaultDescription', defaultDescription, 'collective.type', collective.type);

--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -228,7 +228,7 @@ export default {
           case TransactionTypes.CREDIT:
             if (userTwitter) {
               tweet = encodeURIComponent(
-                `@${userTwitter} thanks for your ${formatCurrency(currency, recurringAmount)} donation to ${
+                `@${userTwitter} thanks for your ${formatCurrency(currency, recurringAmount)} contribution to ${
                   collectiveTwitter ? `@${collectiveTwitter}` : collectiveName
                 } 👍 ${publicUrl}`,
               );
@@ -262,7 +262,7 @@ export default {
       case activities.SUBSCRIPTION_CONFIRMED:
         if (userTwitter) {
           tweet = encodeURIComponent(
-            `@${userTwitter} thanks for your ${formatCurrency(currency, recurringAmount)} donation to ${
+            `@${userTwitter} thanks for your ${formatCurrency(currency, recurringAmount)} contribution to ${
               collectiveTwitter ? `@${collectiveTwitter}` : collectiveName
             } 👍 ${publicUrl}`,
           );

--- a/server/lib/backyourstack/dispatcher.js
+++ b/server/lib/backyourstack/dispatcher.js
@@ -121,7 +121,7 @@ export async function dispatchFunds(order) {
         FromCollectiveId: order.FromCollectiveId,
         CollectiveId: collective.id,
         quantity: order.quantity,
-        description: `Monthly donation to ${collective.name} through BackYourStack`,
+        description: `Monthly financial contribution to ${collective.name} through BackYourStack`,
         totalAmount,
         currency: order.currency,
         status: status.PENDING,

--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -298,7 +298,10 @@ const generateEmailFromTemplate = (template, recipient, data = {}, options = {})
         : data.collective.name;
       const text = `Hi @${
         data.member.memberCollective.twitterHandle
-      } thanks for your donation to ${collectiveMention} ${config.host.website}${get(data, 'collective.urlPath')} 🎉😊`;
+      } thanks for your financial contribution to ${collectiveMention} ${config.host.website}${get(
+        data,
+        'collective.urlPath',
+      )} 🎉😊`;
       data.tweet = {
         text,
         encoded: encodeURIComponent(text),

--- a/templates/emails/thankyou.brusselstogether.hbs
+++ b/templates/emails/thankyou.brusselstogether.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -17,14 +17,14 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{#if interval}}
   {{#if firstPayment }}
     <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your donation helps us continue our activities.</p>
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.</p>
   {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your donation helps us continue our activities.</p>
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
   {{/if}}
   {{> charge_date_notice }}
 {{else}}
-<p>We would like to thank you for your donation of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
@@ -32,7 +32,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 And don't forget to use the hashtag #BrusselsTogether whenever you share something on social networks about initiatives that are happening that we need to support together.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.chsf.hbs
+++ b/templates/emails/thankyou.chsf.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -19,15 +19,15 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{#if interval}}
   {{#if firstPayment }}
     <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your donation helps us continue our work.</p>
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
       {{> charge_date_notice}}
   {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your donation helps us continue our work.</p>
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our work.</p>
   {{/if}}
 {{else}}
 
-<p>We would like to thank you for your donation of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us continue our work.</p>
 {{/if}}
 
@@ -44,7 +44,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.fearlesscitiesbrussels.hbs
+++ b/templates/emails/thankyou.fearlesscitiesbrussels.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -17,14 +17,14 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{#if interval}}
   {{#if firstPayment }}
     <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your donation helps us continue our activities.</p>
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.</p>
   {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your donation helps us continue our activities.</p>
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
   {{/if}}
   {{> charge_date_notice }}
 {{else}}
-<p>We would like to thank you for your donation of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us make the first Fearless Cities Brussels a reality. Thank you! 🙏</p>
 {{/if}}
 
@@ -36,7 +36,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 Please take a look at the <a href="https://docs.google.com/spreadsheets/d/1x_z1CpyjfRfogYa0iIBpKHiwAMcyWUNi7laXMn2ePWY/edit?usp=sharing">list of things that we still need to do</a> and see if there is anyway you can help. That would be amazing. Among other things, we are still looking for people to help us with child care, video recording, distributing flyers.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.hbs
+++ b/templates/emails/thankyou.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -17,15 +17,15 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{#if interval}}
   {{#if firstPayment }}
     <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your donation helps us continue our work.</p>
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
       {{> charge_date_notice}}
   {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your donation helps us continue our work.</p>
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our work.</p>
   {{/if}}
 {{else}}
 
-<p>We would like to thank you for your donation of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us continue our work.</p>
 {{/if}}
 
@@ -38,7 +38,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.ispcwa.hbs
+++ b/templates/emails/thankyou.ispcwa.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -17,7 +17,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{#if interval}}
 	<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}. Your first payment was received on {{{moment order.createdAt}}}. Your gift will help us continue our activities.</p>
 {{else}}
-	<p>We would like to thank you for your donation of {{{currency order.totalAmount currency=order.currency}}} on {{{moment transaction.createdAt}}}.
+	<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment transaction.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
@@ -27,7 +27,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.kendraio.hbs
+++ b/templates/emails/thankyou.kendraio.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}}/{{interval}} donation to {{group.name}}
+Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}}/{{interval}} contribution to {{group.name}}
 {{else}}
-Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}} donation to {{group.name}}
+Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}} contribution to {{group.name}}
 {{/if}}
 
 {{> header}}
@@ -17,14 +17,14 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
 {{#if interval}}
   {{#if firstPayment }}
     <p>We would like to thank you for your pledge to give {{{currency donation.amount currency=donation.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment donation.createdAt}}}. Your donation helps us continue our activities.</p>
+      Your first payment was received on {{{moment donation.createdAt}}}. Your contribution helps us continue our activities.</p>
       {{> charge_date_notice}}
   {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency donation.amount currency=donation.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your donation helps us continue our activities.</p>
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency donation.amount currency=donation.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
   {{/if}}
 {{else}}
-<p>We would like to thank you for your donation of {{{currency donation.amount currency=donation.currency}}} on {{{moment donation.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency donation.amount currency=donation.currency}}} on {{{moment donation.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
@@ -33,7 +33,7 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.sfartandfilm.hbs
+++ b/templates/emails/thankyou.sfartandfilm.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -20,10 +20,10 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
       Your first payment was received on {{{moment order.createdAt}}}.</p>
     {{> charge_date_notice }}
   {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.</p>
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.</p>
   {{/if}}
 {{else}}
-<p>We would like to thank you for your donation of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.</p>
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.</p>
 {{/if}}
 
 <p>SF Art & Film remains steadfast in its goal of making the arts a vital presence in the lives of young people and your extraordinary generosity is what makes it possible. We hope you’ll continue to introduce people like yourself—people who understand the importance of art education—to our program.</p>
@@ -39,10 +39,10 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   Director
   San Francisco Art & Film for Teenagers
 </p>
-<p>Your donation is tax-deductible to the extent allowed by law. You may save this receipt for your records. San Francisco Art & Film for Teenagers is a qualified non-profit organization with 501-C status, tax ID: 94-3310464.</p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save this receipt for your records. San Francisco Art & Film for Teenagers is a qualified non-profit organization with 501-C status, tax ID: 94-3310464.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 {{> relatedcollectives}}

--- a/templates/emails/thankyou.sustainoss.hbs
+++ b/templates/emails/thankyou.sustainoss.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -17,15 +17,15 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{#if interval}}
   {{#if firstPayment }}
     <p>Thank you so much for being part of the first $ustainOSS Conversation and supporting us with {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your donation helps us make this conversation happen!</p>
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us make this conversation happen!</p>
     {{> charge_date_notice}}
   {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your donation helps us continue our activities.</p>
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
   {{/if}}
 {{else}}
 <p>Thank you so much for being part of the first $ustainOSS Conversation and supporting us with {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
-  If you made a $50 donation for a ticket, we look forward to meeting you! We will be emailing details shortly. You do not have to worry about bringing a ticket but do save this email just in case.</p>
+  If you made a $50 contribution for a ticket, we look forward to meeting you! We will be emailing details shortly. You do not have to worry about bringing a ticket but do save this email just in case.</p>
 {{/if}}
 
 <p>Next steps:
@@ -44,7 +44,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
  </p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.wwcode.hbs
+++ b/templates/emails/thankyou.wwcode.hbs
@@ -1,7 +1,7 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} donation to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
 
 {{> header}}
@@ -19,11 +19,11 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
     <p>I would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
     {{> charge_date_notice }}
   {{else}}
-    <p>I would like to thank you for your continued support. Your latest {{interval}}ly donation of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+    <p>I would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
     Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
   {{/if}}
 {{else}}
-<p>I would like to thank you for your donation of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
+<p>I would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
 {{/if}}
 
 <p>With your support, we are able to extend our program reach. Through this, we are able to provide an avenue into tech, empower women with skills needed for professional advancement, and provide environments where networking and mentorship are valued.</p>
@@ -31,7 +31,7 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 <p>On behalf of the Women Who Code Board of Executives, our leadership team, and our members worldwide, thank you for furthering our mission. We appreciate and value your contribution and continued support of our community.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your donation <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.invoices}}/{{collective.slug}}/transactions/{{transaction.uuid}}/invoice.pdf">here</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -43,6 +43,6 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   EIN: 46 – 4218859
 </p>
 
-<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your records. This email certifies that you have made this donation as a charitable contribution and you are not receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Women Who Code, registered 501(c)3 Nonprofit TAX ID: 46-4218859. </p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your records. This email certifies that you have made this contribution as a charitable contribution and you are not receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Women Who Code, registered 501(c)3 Nonprofit TAX ID: 46-4218859. </p>
 
 {{> footer}}

--- a/test/graphql.mutation.test.js
+++ b/test/graphql.mutation.test.js
@@ -695,7 +695,9 @@ describe('Mutation Tests', () => {
           expect(emailSendMessageSpy.secondCall.args[0]).to.equal('user1@opencollective.com');
           expect(emailSendMessageSpy.secondCall.args[1]).to.equal("Google joined Scouts d'Arlon as backer");
           expect(emailSendMessageSpy.secondCall.args[2]).to.contain('Looking forward!'); // publicMessage
-          expect(emailSendMessageSpy.secondCall.args[2]).to.contain('@google thanks for your donation to @scouts');
+          expect(emailSendMessageSpy.secondCall.args[2]).to.contain(
+            '@google thanks for your financial contribution to @scouts',
+          );
         });
 
         it('as an existing organization', async () => {

--- a/test/graphql.orders.test.js
+++ b/test/graphql.orders.test.js
@@ -197,7 +197,7 @@ describe('graphql.orders.test.js', () => {
       await utils.waitForCondition(() => emailSendMessageSpy.callCount === 1);
       expect(emailSendMessageSpy.callCount).to.equal(1);
       expect(emailSendMessageSpy.firstCall.args[0]).to.equal(backers[1].email);
-      expect(emailSendMessageSpy.firstCall.args[1]).to.match(/Thank you for your €\s?150 donation to codenplay/);
+      expect(emailSendMessageSpy.firstCall.args[1]).to.match(/Thank you for your €\s?150 contribution to codenplay/);
     });
 
     it('marks a pending order as expired', async () => {

--- a/test/lib.activities.test.js
+++ b/test/lib.activities.test.js
@@ -115,7 +115,7 @@ describe('lib.activities.test.js', () => {
     it(`${constants.SUBSCRIPTION_CONFIRMED} with month interval`, () => {
       const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[17], 'slack');
       expect(actual).to.equal(
-        'New subscription confirmed: EUR 12.34/month from <https://twitter.com/xdamman|xdamman> to <https://opencollective.com/yeoman|Yeoman>! [<https://twitter.com/intent/tweet?status=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20donation%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman|Thank that person on Twitter>]',
+        'New subscription confirmed: EUR 12.34/month from <https://twitter.com/xdamman|xdamman> to <https://opencollective.com/yeoman|Yeoman>! [<https://twitter.com/intent/tweet?status=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20contribution%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman|Thank that person on Twitter>]',
       );
     });
 
@@ -144,7 +144,7 @@ describe('lib.activities.test.js', () => {
     it(`${constants.SUBSCRIPTION_CONFIRMED} with month interval for Gitter`, () => {
       const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[17], 'markdown');
       expect(actual).to.equal(
-        'New subscription confirmed: EUR 12.34/month from [xdamman](https://twitter.com/xdamman) to [Yeoman](https://opencollective.com/yeoman)! [[Thank that person on Twitter](https://twitter.com/intent/tweet?status=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20donation%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman)]',
+        'New subscription confirmed: EUR 12.34/month from [xdamman](https://twitter.com/xdamman) to [Yeoman](https://opencollective.com/yeoman)! [[Thank that person on Twitter](https://twitter.com/intent/tweet?status=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20contribution%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman)]',
       );
     });
   });

--- a/test/lib.email.test.js
+++ b/test/lib.email.test.js
@@ -110,7 +110,7 @@ describe('lib/email', () => {
       });
       expect(nm.sendMail.lastCall.args[0].to).to.equal('emailbcc+user1-at-opencollective.com@opencollective.com');
       expect(nm.sendMail.lastCall.args[0].subject).to.contain(
-        `Thank you for your ${amountStr}/month donation to WWCode Austin`,
+        `Thank you for your ${amountStr}/month contribution to WWCode Austin`,
       );
       expect(nm.sendMail.lastCall.args[0].html).to.contain('4218859');
     });
@@ -148,7 +148,7 @@ describe('lib/email', () => {
       expect(nm.sendMail.lastCall.args[0].from).to.equal(from);
       expect(nm.sendMail.lastCall.args[0].to).to.equal('emailbcc+user1-at-opencollective.com@opencollective.com');
       expect(nm.sendMail.lastCall.args[0].subject).to.contain(
-        `Thank you for your ${amountStr}/month donation to #BrusselsTogether`,
+        `Thank you for your ${amountStr}/month contribution to #BrusselsTogether`,
       );
       expect(nm.sendMail.lastCall.args[0].html).to.contain(data.relatedCollectives[0].name);
       expect(nm.sendMail.lastCall.args[0].html).to.contain(


### PR DESCRIPTION
According to https://github.com/opencollective/opencollective/issues/2390#issuecomment-559632867 this PR changes the default description for transactions and orders from `Donation to _____` to `Financial contribution to _____`. A migration handles the conversion of old entries to this new wording.

For consistency, I've also extended the change to update the wording in emails and tweets.