### PR TITLE
Rename "collective" payment methods

### DIFF
--- a/migrations/20191211110401-rename-collective-payment-methods.js
+++ b/migrations/20191211110401-rename-collective-payment-methods.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      UPDATE "PaymentMethods" as pm
+      SET "name" = CONCAT(c."name", ' (', INITCAP(LOWER(c."type")), ')')
+      FROM "Collectives" AS c
+      WHERE pm."service" = 'opencollective' AND pm."type" = 'collective'
+      AND pm."CollectiveId" = c."id"
+    `);
+  },
+
+  down: async (queryInterface, DataTypes) => {},
+};

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -642,7 +642,7 @@ export default function(Sequelize, DataTypes) {
               CollectiveId: instance.id,
               service: 'opencollective',
               type: 'collective',
-              name: `${capitalize(instance.name)} ${capitalize(instance.type.toLowerCase())}`,
+              name: `${instance.name} (${capitalize(instance.type.toLowerCase())})`,
               primary: true,
               currency: instance.currency,
             });


### PR DESCRIPTION
Address issue spotted in https://github.com/opencollective/opencollective/issues/2670

- use collective name as is
- add a parenthesis so it's clearer -> "Babel (Collective)" or "Sustain 2020 (Event)"
- refresh all entries with their latest name (would need to do that regularly to keep in sync)

Alternative could be to use a dynamically generated label based on the current `collective.name` instead of the `paymentMethod.name`.