### PR TITLE
Return collectives with isActive=FALSE in search

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -108,9 +108,8 @@ export const searchCollectivesInDB = async (term, offset = 0, limit = 100, types
         END
       ) AS __rank__
     FROM "Collectives" c
-    WHERE "deletedAt" IS NULL 
-    AND "deactivatedAt" IS NULL 
-    AND "isActive" = true
+    WHERE "deletedAt" IS NULL
+    AND "deactivatedAt" IS NULL
     AND "isIncognito" = FALSE
     AND type IN (:types) ${dynamicConditions}
     ORDER BY __rank__ DESC


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2712

In the search query we were filtering out collectives with `isActive = FALSE`. But a lot of organizations have this flag set to `FALSE` while being legit.

Because returning inactive collectives is not a huge deal for now, this PR removes the filter. We can always add an optional parameter for it in the future if needed.