### PR TITLE
sanitize-html: Allow figures and captions for images

### DIFF
--- a/server/lib/sanitize-html.ts
+++ b/server/lib/sanitize-html.ts
@@ -48,7 +48,7 @@ export const buildSanitizerOptions = (allowedContent: IAllowedContentType = {}):
 
   // Images
   if (allowedContent.images) {
-    allowedTags.push('img');
+    allowedTags.push('img', 'figure', 'figcaption');
     allowedAttributes['img'] = ['src'];
   }
 


### PR DESCRIPTION
Trix wraps images in `caption`, thus we stripped images when saving.