### PR TITLE
createOrder: Fix permission check for unauthorized

### DIFF
--- a/test/server/graphql/v1/mutation.test.js
+++ b/test/server/graphql/v1/mutation.test.js
@@ -508,12 +508,11 @@ describe('Mutation Tests', () => {
             }
           `;
           const order = {
-            user: { email: user1.email },
             collective: { id: 12324 },
             tier: { id: 3 },
             quantity: 1,
           };
-          const result = await utils.graphqlQuery(query, { order });
+          const result = await utils.graphqlQuery(query, { order }, user2);
           expect(result.errors.length).to.equal(1);
           expect(result.errors[0].message).to.equal(`No collective found: ${order.collective.id}`);
         });
@@ -536,12 +535,11 @@ describe('Mutation Tests', () => {
           `;
 
           const order = {
-            user: { email: 'user@email.com' },
             collective: { id: event1.id },
             tier: { id: 1002 },
             quantity: 1,
           };
-          const result = await utils.graphqlQuery(query, { order });
+          const result = await utils.graphqlQuery(query, { order }, user2);
           expect(result.errors.length).to.equal(1);
           expect(result.errors[0].message).to.equal(
             `No tier found with tier id: 1002 for collective slug ${event1.slug}`,
@@ -568,12 +566,11 @@ describe('Mutation Tests', () => {
           `;
 
           const order = {
-            user: { email: 'user@email.com' },
             collective: { id: event1.id },
             tier: { id: 3 },
             quantity: 101,
           };
-          const result = await utils.graphqlQuery(query, { order });
+          const result = await utils.graphqlQuery(query, { order }, user2);
           expect(result.errors[0].message).to.equal(`No more tickets left for ${ticket1.name}`);
         });
       });
@@ -597,12 +594,11 @@ describe('Mutation Tests', () => {
           `;
 
           const order = {
-            user: { email: 'user@email.com' },
             collective: { id: event1.id },
             tier: { id: 4 },
             quantity: 2,
           };
-          const result = await utils.graphqlQuery(query, { order });
+          const result = await utils.graphqlQuery(query, { order }, user2);
           expect(result.errors[0].message).to.equal('This order requires a payment method');
         });
       });
@@ -1055,7 +1051,7 @@ describe('Mutation Tests', () => {
           const result = await utils.graphqlQuery(query, { order }, loggedInUser);
           // result.errors && console.error(result.errors[0]);
           expect(result.errors).to.exist;
-          expect(result.errors[0].message).to.equal('An account already exists for this email address. Please login.');
+          expect(result.errors[0].message).to.equal('You need to be authenticated to perform this action');
         });
 
         it('from a new user', async () => {

--- a/test/server/graphql/v1/paymentMethods.test.js
+++ b/test/server/graphql/v1/paymentMethods.test.js
@@ -169,10 +169,6 @@ describe('graphql.paymentMethods.test.js', () => {
         "You don't have sufficient permissions to create an order on behalf of the open source collective organization",
       );
 
-      order.user = {
-        email: 'admin@neworg.com',
-        name: 'Paul Newman',
-      };
       order.fromCollective = {
         name: 'new org',
         website: 'http://neworg.com',
@@ -237,10 +233,6 @@ describe('graphql.paymentMethods.test.js', () => {
     it('adds funds from the host (USD) to the collective (EUR) on behalf of a new organization', async () => {
       const hostFeePercent = 4;
       order.hostFeePercent = hostFeePercent;
-      order.user = {
-        email: 'admin@neworg.com',
-        name: 'Paul Newman',
-      };
       order.fromCollective = {
         name: 'new org',
         website: 'http://neworg.com',
@@ -270,7 +262,6 @@ describe('graphql.paymentMethods.test.js', () => {
       expect(backerMembership.CreatedByUserId).to.equal(admin.id);
       expect(backerMembership.CollectiveId).to.equal(transaction.CollectiveId);
       expect(orgAdmin.CreatedByUserId).to.equal(admin.id);
-      expect(orgAdmin.name).to.equal(order.user.name);
       expect(transaction.FromCollectiveId).to.equal(org.id);
       expect(transaction.hostFeeInHostCurrency).to.equal(
         -Math.round((hostFeePercent / 100) * order.totalAmount * fxrate),

--- a/test/server/graphql/v1/tiers.test.js
+++ b/test/server/graphql/v1/tiers.test.js
@@ -8,7 +8,7 @@ import stripe from '../../../../server/lib/stripe';
 import models from '../../../../server/models';
 import { VAT_OPTIONS } from '../../../../server/constants/vat';
 
-describe('graphql.tiers.test', () => {
+describe('server/graphql/v1/tiers.test.js', () => {
   let user1, user2, host, collective1, collective2, tier1, tierWithCustomFields, tierProduct, paymentMethod1;
   let sandbox;
 
@@ -245,9 +245,7 @@ describe('graphql.tiers.test', () => {
 
         const result = await utils.graphqlQuery(createOrderQuery, { order });
         expect(result.errors).to.exist;
-        expect(result.errors[0].message).to.equal(
-          'You need to be logged in to be able to use a payment method on file',
-        );
+        expect(result.errors[0].message).to.equal('You need to be authenticated to perform this action');
       });
 
       it('fails to use a payment method on file if not logged in as the owner', async () => {

--- a/test/server/paymentProviders/opencollective/collective.test.js
+++ b/test/server/paymentProviders/opencollective/collective.test.js
@@ -36,7 +36,7 @@ const createOrderQuery = `
   }
 `;
 
-describe('paymentMethods.collective.to.collective.test.js', () => {
+describe('server/paymentProviders/opencollective/collective.test.js', () => {
   before(async () => {
     await utils.resetTestDB();
   });
@@ -237,9 +237,7 @@ describe('paymentMethods.collective.to.collective.test.js', () => {
       // Then there should be Errors for the Result of the query without any user defined as param
       expect(res.errors).to.exist;
       expect(res.errors).to.not.be.empty;
-      expect(res.errors[0].message).to.contain(
-        'need to be logged in to create an order for an existing open collective',
-      );
+      expect(res.errors[0].message).to.contain('You need to be authenticated to perform this action');
 
       // Then there should also be Errors for the Result of the query through user2
       expect(resWithUserParam.errors).to.exist;


### PR DESCRIPTION
The implementation from https://github.com/opencollective/opencollective-api/pull/2667 was not right because the permission check happened too late. As a result it was still possible to create a collective while being unauthenticated - see https://github.com/opencollective/opencollective-api/pull/2667/files#diff-3911cd05c822883980d2e39cbb080898L190

I've also removed the legacy code that was left behind to check if `remoteUser` exists, and the ability to specify a different user in `order.user` that we were not using anyway.