### PR TITLE
chore: Remove direct actions from emails

### DIFF
--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -92,25 +92,6 @@ function publishToSlackPrivateChannel(activity) {
 async function notifySubscribers(users, activity, options = {}) {
   const { data } = activity;
 
-  // Generate Action links
-  switch (activity.type) {
-    case activityType.COLLECTIVE_EXPENSE_CREATED:
-      data.actions = {
-        approve: `${config.host.website}/${data.collective.slug}/expenses/${data.expense.id}/approve`,
-        reject: `${config.host.website}/${data.collective.slug}/expenses/${data.expense.id}/reject`,
-      };
-      break;
-
-    case activityType.COLLECTIVE_CREATED:
-    case activityType.COLLECTIVE_APPLY:
-      if (data.host) {
-        data.actions = {
-          approve: `${config.host.website}/${data.host.slug}/collectives/${data.collective.id}/approve`,
-        };
-      }
-      break;
-  }
-
   if (!users || users.length === 0) {
     debug('notifySubscribers: no user to notify for activity', activity.type);
     return;

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -446,7 +446,6 @@ export const sendReminderPendingOrderEmail = async order => {
     collective: collective.info,
     host: host.info,
     fromCollective: fromCollective.activity,
-    markAsPaidLink: `${config.host.website}/orders/${order.id}/mark-as-paid`,
     viewDetailsLink: `${config.host.website}/${collective.slug}/orders/${order.id}`,
   };
 

--- a/templates/emails/collective.apply.for.host.hbs
+++ b/templates/emails/collective.apply.for.host.hbs
@@ -89,8 +89,11 @@ https://opencollective.com/{{user.collective.slug}}
 
 <br /><br />
 <center>
-  <a href="{{actions.approve}}" class="btn blue">
-    <div>APPROVE</div>
+  <a 
+    class="btn blue"
+    href="{{config.host.website}}/{{host.slug}}/dashboard/pending-applications#application-{{collective.id}}"
+  >
+    <div style="font-size: 15px;">View application</div>
   </a>
 </center>
 

--- a/templates/emails/collective.expense.created.hbs
+++ b/templates/emails/collective.expense.created.hbs
@@ -13,11 +13,11 @@ Subject: New expense on {{collective.name}}: {{{currency expense.amount currency
     <img src="https://res.cloudinary.com/opencollective/image/fetch/w_640,f_jpg/{{expense.attachment}}" width="100%" />
   </a>
   <br />
-  <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">View this expense on the Open Collective website</a>
-
-  <br /><br />
-  <a href="{{actions.approve}}" class="btn blue"><div>APPROVE</div></a>
-  <a href="{{actions.reject}}" class="btn red"><div>REJECT</div></a>
+  <br />
+  <br />
+  <a class="btn blue" href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">
+    <div style="font-size: 15px;">View expense on Open Collective</div>
+  </a>
 
   <br /><br />
 

--- a/templates/emails/order.reminder.pendingFinancialContribution.hbs
+++ b/templates/emails/order.reminder.pendingFinancialContribution.hbs
@@ -20,11 +20,7 @@ currency=order.currency}}} for {{collective.name}}
     currency=order.currency}}} arrived in the bank account of {{host.name}} from {{fromCollective.name}} for {{collective.name}}?
 </p>
 
-<p>Mark as paid:
-  <a href="{{markAsPaidLink}}">{{markAsPaidLink}}</a>.
-</p>
-
-<p>View details:
+<p>You can view the details, mark order as paid or cancel it on:
   <a href="{{viewDetailsLink}}">{{viewDetailsLink}}</a>.
 </p>
 

--- a/test/server/graphql/v1/expenses.test.js
+++ b/test/server/graphql/v1/expenses.test.js
@@ -518,7 +518,7 @@ describe('GraphQL Expenses API', () => {
       expect(emailSendMessageSpy.firstCall.args[1]).to.equal(
         'New expense on Test Collective: $10.00 for Test expense for pizza',
       );
-      expect(emailSendMessageSpy.firstCall.args[2]).to.contain('/test-collective/expenses/1/approve');
+      expect(emailSendMessageSpy.firstCall.args[2]).to.contain('/test-collective/expenses/1');
 
       // XXX: This was just copied over. I don't know what this is
       // actually testing:


### PR DESCRIPTION
This PR replaces the action buttons in emails.

### Expenses

Show a `View expense` button instead of `Approve` and `Reject`. When clicked, users lend on the expense page where they can approve or reject the expense.

![image](https://user-images.githubusercontent.com/1556356/71002371-6efb9a00-20df-11ea-975d-9eb28158b1ab.png)

![image](https://user-images.githubusercontent.com/1556356/71002393-7de24c80-20df-11ea-8b38-f1e86d9eceba.png)

### Host applications

I've added an anchor to the application cards in https://github.com/opencollective/opencollective-frontend/pull/3185, so that the link will scroll directly to the application.

![image](https://user-images.githubusercontent.com/1556356/71003052-c0f0ef80-20e0-11ea-8e38-2920e853dffb.png)

![image](https://user-images.githubusercontent.com/1556356/71007622-9b1b1900-20e7-11ea-95e5-a12e11a7add8.png)


### Orders

![image](https://user-images.githubusercontent.com/1556356/71004568-5c369480-20e2-11ea-9655-ff573eb3fb4a.png)

![image](https://user-images.githubusercontent.com/1556356/71004631-6bb5dd80-20e2-11ea-8982-ae921b94d184.png)

