### PR TITLE
sanitize-html: Allow strikethrough for basic text formatting

### DIFF
--- a/server/lib/sanitize-html.ts
+++ b/server/lib/sanitize-html.ts
@@ -38,7 +38,7 @@ export const buildSanitizerOptions = (allowedContent: IAllowedContentType = {}):
 
   // Multiline text formatting
   if (allowedContent.basicTextFormatting) {
-    allowedTags.push('b', 'i', 'strong', 'em', 'strike');
+    allowedTags.push('b', 'i', 'strong', 'em', 'strike', 'del');
   }
 
   // Basic text formatting


### PR DESCRIPTION
Based on feedback from https://github.com/opencollective/opencollective/issues/2722#issuecomment-565529309