### PR TITLE
Comment: Don't strip tags in resolver

### DIFF
--- a/server/graphql/v2/object/Comment.js
+++ b/server/graphql/v2/object/Comment.js
@@ -18,7 +18,6 @@ const Comment = new GraphQLObjectType({
       },
       html: {
         type: GraphQLString,
-        resolve: getStripTagsResolver('html'),
       },
       markdown: {
         type: GraphQLString,


### PR DESCRIPTION
Tags are stripped in the model when saving.