### PR TITLE
webhooks: Add formatted amounts

### DIFF
--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -11,7 +11,7 @@ import activityType from '../constants/activities';
 import models from '../models';
 import debugLib from 'debug';
 import { channels } from '../constants';
-import { sanitizeActivity } from './webhooks';
+import { sanitizeActivity, enrichActivity } from './webhooks';
 
 const debug = debugLib('notification');
 
@@ -72,7 +72,8 @@ function publishToGitter(activity, notifConfig) {
 
 function publishToWebhook(activity, webhookUrl) {
   const sanitizedActivity = sanitizeActivity(activity);
-  return axios.post(webhookUrl, sanitizedActivity);
+  const enrichedActivity = enrichActivity(sanitizedActivity);
+  return axios.post(webhookUrl, enrichedActivity);
 }
 
 function publishToSlack(activity, webhookUrl, options) {

--- a/server/lib/webhooks.js
+++ b/server/lib/webhooks.js
@@ -1,5 +1,6 @@
 import { pick } from 'lodash';
 import { activities } from '../constants';
+import { formatCurrency } from './utils';
 
 /**
  * Filter collective public information, returning a minimal subset for incognito users
@@ -71,4 +72,25 @@ export const sanitizeActivity = activity => {
   }
 
   return cleanActivity;
+};
+
+/**
+ * Adds user-friendly fields to an activity. Mutates activity.
+ */
+export const enrichActivity = activity => {
+  Object.entries(activity).forEach(([key, value]) => {
+    if (value && typeof value === 'object') {
+      enrichActivity(value);
+    } else if (key === 'amount' || key === 'totalAmount') {
+      const amount = activity['amount'] || activity['totalAmount'];
+      const currency = activity['currency'];
+      const interval = activity['interval'];
+      activity.formattedAmount = currency ? formatCurrency(amount, currency, 2) : (amount / 100).toFixed(2);
+      activity.formattedAmountWithInterval = interval
+        ? `${activity.formattedAmount} / ${interval}`
+        : activity.formattedAmount;
+    }
+  });
+
+  return activity;
 };

--- a/test/server/lib/webhooks.test.js
+++ b/test/server/lib/webhooks.test.js
@@ -1,29 +1,70 @@
 import { expect } from 'chai';
-import { sanitizeActivity } from '../../../server/lib/webhooks';
+import { sanitizeActivity, enrichActivity } from '../../../server/lib/webhooks';
 import { activities } from '../../../server/constants';
 
-describe('sanitizeActivity', () => {
-  it('Strips the data for unknown types', () => {
-    const sanitized = sanitizeActivity({ type: 'NOT_A_VALID_TYPE', data: { hello: 'world' } });
-    expect(sanitized.data).to.be.empty;
-  });
-
-  it('COLLECTIVE_TRANSACTION_CREATED', () => {
-    const sanitized = sanitizeActivity({
-      type: activities.COLLECTIVE_MEMBER_CREATED,
-      data: {
-        order: { totalAmount: 4200 },
-        member: {
-          role: 'BACKER',
-          memberCollective: {
-            id: 42,
-          },
-        },
-      },
+describe('test/server/lib/webhooks', () => {
+  describe('sanitizeActivity', () => {
+    it('Strips the data for unknown types', () => {
+      const sanitized = sanitizeActivity({ type: 'NOT_A_VALID_TYPE', data: { hello: 'world' } });
+      expect(sanitized.data).to.be.empty;
     });
 
-    expect(sanitized.data.order.totalAmount).to.eq(4200);
-    expect(sanitized.data.member.memberCollective.id).to.eq(42);
-    expect(sanitized.data.collective).to.not.exist;
+    it('COLLECTIVE_TRANSACTION_CREATED', () => {
+      const sanitized = sanitizeActivity({
+        type: activities.COLLECTIVE_MEMBER_CREATED,
+        data: {
+          order: { totalAmount: 4200 },
+          member: {
+            role: 'BACKER',
+            memberCollective: {
+              id: 42,
+            },
+          },
+        },
+      });
+
+      expect(sanitized.data.order.totalAmount).to.eq(4200);
+      expect(sanitized.data.member.memberCollective.id).to.eq(42);
+      expect(sanitized.data.collective).to.not.exist;
+    });
+  });
+
+  describe('enrichActivity', () => {
+    it('add formattedAmount field', () => {
+      const activity = {
+        type: 'DoesNotReallyMatter',
+        data: {
+          normal: { totalAmount: 4200, currency: 'USD' },
+          withInterval: { amount: 5000, currency: 'EUR', interval: 'month' },
+          withoutCurrency: { amount: 150 },
+        },
+      };
+
+      const enrichedActivity = enrichActivity(activity);
+      expect(enrichedActivity).to.eq(activity); // base object is mutated
+      expect(enrichedActivity).to.deep.eqInAnyOrder({
+        type: 'DoesNotReallyMatter',
+        data: {
+          normal: {
+            totalAmount: 4200,
+            currency: 'USD',
+            formattedAmount: '$42.00',
+            formattedAmountWithInterval: '$42.00',
+          },
+          withInterval: {
+            amount: 5000,
+            currency: 'EUR',
+            interval: 'month',
+            formattedAmount: '€50.00',
+            formattedAmountWithInterval: '€50.00 / month',
+          },
+          withoutCurrency: {
+            amount: 150,
+            formattedAmount: '1.50',
+            formattedAmountWithInterval: '1.50',
+          },
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
Provide the basis to resolve https://github.com/opencollective/opencollective/issues/2117

Recursively adds `formattedAmount` and `formattedAmountWithInterval` values to any activity object or sub-objects that have an `amount` field.

```es6
// In
order: {
  amount: 5000,
  currency: 'EUR',
  interval: 'month'
},

// Out
order: {
  amount: 5000,
  currency: 'EUR',
  interval: 'month',
  formattedAmount: '€50.00',
  formattedAmountWithInterval: '€50.00 / month',
},
```