### PR TITLE
ban-collectives: Add flag in data for banned users

### DIFF
--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -18,8 +18,8 @@ export const randAmount = (min = 100, max = 10000000) => Math.floor(Math.random(
 /**
  * Creates a fake user. All params are optionals.
  */
-export const fakeUser = async () => {
-  return models.User.createUserWithCollective({ email: randEmail(), name: randStr('User Name ') });
+export const fakeUser = async userData => {
+  return models.User.createUserWithCollective({ email: randEmail(), name: randStr('User Name '), ...userData });
 };
 
 /**


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2739 by setting the flag `data.isBanned` to true when banning users and collectives.