### PR TITLE
CollectiveInterface: Use parentCollective for event's isApproved

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1026,8 +1026,17 @@ const CollectiveFields = () => {
     isApproved: {
       description: 'Returns whether this collective is approved',
       type: GraphQLBoolean,
-      resolve(collective) {
-        return Boolean(collective.isActive && collective.approvedAt);
+      async resolve(collective, _, req) {
+        if (!collective.HostCollectiveId) {
+          return false;
+        }
+
+        if (collective.type === CollectiveType.EVENT) {
+          const parentCollective = await req.loaders.Collective.byId.load(collective.ParentCollectiveId);
+          return Boolean(parentCollective.isActive && parentCollective.approvedAt);
+        } else {
+          return Boolean(collective.isActive && collective.approvedAt);
+        }
       },
     },
     isDeletable: {

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1029,13 +1029,12 @@ const CollectiveFields = () => {
       async resolve(collective, _, req) {
         if (!collective.HostCollectiveId) {
           return false;
-        }
-
-        if (collective.type === CollectiveType.EVENT) {
-          const parentCollective = await req.loaders.Collective.byId.load(collective.ParentCollectiveId);
-          return Boolean(parentCollective.isActive && parentCollective.approvedAt);
+        } else if (collective.type === types.EVENT) {
+          const ParentCollectiveId = collective.ParentCollectiveId;
+          const parentCollective = ParentCollectiveId && (await req.loaders.Collective.byId.load(ParentCollectiveId));
+          return parentCollective && parentCollective.isApproved();
         } else {
-          return Boolean(collective.isActive && collective.approvedAt);
+          return collective.isApproved();
         }
       },
     },

--- a/server/graphql/v2/object/Collective.js
+++ b/server/graphql/v2/object/Collective.js
@@ -27,7 +27,7 @@ export const Collective = new GraphQLObjectType({
         description: 'Returns whether this collective is approved',
         type: GraphQLBoolean,
         resolve(collective) {
-          return Boolean(collective.HostCollectiveId && collective.isActive && collective.approvedAt);
+          return collective.isApproved();
         },
       },
     };

--- a/server/graphql/v2/object/Collective.js
+++ b/server/graphql/v2/object/Collective.js
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLInt } from 'graphql';
+import { GraphQLObjectType, GraphQLInt, GraphQLBoolean } from 'graphql';
 
 import { Account, AccountFields } from '../interface/Account';
 import { hostResolver } from '../../common/collective';
@@ -22,6 +22,13 @@ export const Collective = new GraphQLObjectType({
         description: 'Get the host collective that is receiving the money on behalf of this collective',
         type: Account,
         resolve: hostResolver,
+      },
+      isApproved: {
+        description: 'Returns whether this collective is approved',
+        type: GraphQLBoolean,
+        resolve(collective) {
+          return Boolean(collective.HostCollectiveId && collective.isActive && collective.approvedAt);
+        },
       },
     };
   },

--- a/server/graphql/v2/object/Event.js
+++ b/server/graphql/v2/object/Event.js
@@ -1,4 +1,4 @@
-import { GraphQLObjectType } from 'graphql';
+import { GraphQLObjectType, GraphQLBoolean } from 'graphql';
 
 import { Account, AccountFields } from '../interface/Account';
 
@@ -10,6 +10,23 @@ export const Event = new GraphQLObjectType({
   fields: () => {
     return {
       ...AccountFields,
+      isApproved: {
+        description: 'Returns whether this collective is approved',
+        type: GraphQLBoolean,
+        async resolve(event, _, req) {
+          if (event.ParentCollectiveId) {
+            return false;
+          }
+
+          const parentCollective = await req.loaders.Collective.byId.load(event.ParentCollectiveId);
+          return Boolean(
+            parentCollective &&
+              parentCollective.HostCollectiveId &&
+              parentCollective.isActive &&
+              parentCollective.approvedAt,
+          );
+        },
+      },
     };
   },
 });

--- a/server/graphql/v2/object/Event.js
+++ b/server/graphql/v2/object/Event.js
@@ -16,15 +16,10 @@ export const Event = new GraphQLObjectType({
         async resolve(event, _, req) {
           if (event.ParentCollectiveId) {
             return false;
+          } else {
+            const parentCollective = await req.loaders.Collective.byId.load(event.ParentCollectiveId);
+            return parentCollective && parentCollective.isApproved();
           }
-
-          const parentCollective = await req.loaders.Collective.byId.load(event.ParentCollectiveId);
-          return Boolean(
-            parentCollective &&
-              parentCollective.HostCollectiveId &&
-              parentCollective.isActive &&
-              parentCollective.approvedAt,
-          );
         },
       },
     };

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -887,6 +887,19 @@ export default function(Sequelize, DataTypes) {
     }
   };
 
+  /**
+   * Checks if the has been approved by a host.
+   * This function will throw if you try to call it with an event, as you should check the
+   * `isApproved` of the `parentCollective` instead.
+   */
+  Collective.prototype.isApproved = function() {
+    if (this.type === types.EVENT) {
+      throw new Error("isApproved must be called on event's parent collective");
+    } else {
+      return Boolean(this.HostCollectiveId && this.isActive && this.approvedAt);
+    }
+  };
+
   // This is quite ugly, and only needed for events.
   // I'd argue that we should store the event slug as `${parentCollectiveSlug}/events/${eventSlug}`
   Collective.prototype.getUrlPath = function() {


### PR DESCRIPTION
That will make it easier to know if it's possible to contribute to an event in the frontend.

This will also set `isApproved` to `false` if no host has been set.