### PR TITLE
CI: adjust codecov thresold to 0.1

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1


### PR DESCRIPTION
We don't want CI to fail too easily because of changes in coverage.

This should be later adjusted according to sample values collected.