### PR TITLE
Expenses: Store the FromCollectiveId of the submitter

### DIFF
--- a/migrations/20200110103056-add-fromCollective-to-expenses.js
+++ b/migrations/20200110103056-add-fromCollective-to-expenses.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Adds a `FromCollectiveId` column to Expenses tables.
+ *
+ * Assuming that all expenses payees have a valid user and collective is safe, as the following
+ * query returns no entry in production:
+ *
+ * ```
+ * SELECT *
+ * FROM "Expenses" e
+ * LEFT JOIN "Users" u ON e."UserId" = u.id
+ * LEFT JOIN "Collectives" c ON u."CollectiveId" = c.id
+ * WHERE u.id IS NULL OR c.id IS NULL
+ * ```
+ *
+ * `ExpenseHistories` does not enforces non-null values for `FromCollectiveId` because
+ * their could be an important cost in migrating the data, and we actually don't care so much if
+ * the old entries in History doesn't have a `FromCollectiveId`.
+ */
+module.exports = {
+  up: async (queryInterface, DataTypes) => {
+    const fromCollectiveFieldSettings = {
+      type: DataTypes.INTEGER,
+      references: { key: 'id', model: 'Collectives' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+      allowNull: true, // We initially allow null for this field while we migrate the data
+    };
+
+    const dbTransaction = await queryInterface.sequelize.transaction();
+    try {
+      // Add column to Expense tables
+      await queryInterface.addColumn('ExpenseHistories', 'FromCollectiveId', fromCollectiveFieldSettings, {
+        transaction: dbTransaction,
+      });
+
+      await queryInterface.addColumn('Expenses', 'FromCollectiveId', fromCollectiveFieldSettings, {
+        transaction: dbTransaction,
+      });
+
+      // Migrate the data for Expenses
+      await queryInterface.sequelize.query(
+        `
+          UPDATE ONLY "Expenses"
+          SET         "FromCollectiveId" = "Users"."CollectiveId"
+          FROM        "Users"
+          WHERE       "Expenses"."UserId" = "Users".id
+        `,
+        { transaction: dbTransaction },
+      );
+
+      // Enforce column on Expenses table
+      await queryInterface.sequelize.query(
+        `
+          ALTER TABLE "Expenses" ALTER COLUMN "FromCollectiveId" SET NOT NULL;
+        `,
+        { transaction: dbTransaction },
+      );
+
+      // Run the transaction
+      dbTransaction.commit();
+    } catch (e) {
+      console.error('Transaction failed:', e);
+      await dbTransaction.rollback();
+      throw e;
+    }
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('Expenses', 'FromCollectiveId');
+    await queryInterface.removeColumn('ExpenseHistories', 'FromCollectiveId');
+  },
+};

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -45,11 +45,13 @@ function canMarkExpenseUnpaid(remoteUser, expense) {
 function canEditExpense(remoteUser, expense) {
   if (expense.status === statuses.PAID) {
     return false;
-  }
-  if (remoteUser.id === expense.UserId) {
+  } else if (remoteUser.id === expense.UserId) {
     return true;
+  } else if (remoteUser.isAdmin(expense.FromCollectiveId)) {
+    return true;
+  } else {
+    return canUpdateExpenseStatus(remoteUser, expense);
   }
-  return canUpdateExpenseStatus(remoteUser, expense);
 }
 
 export async function updateExpenseStatus(remoteUser, expenseId, status) {
@@ -135,6 +137,7 @@ export async function createExpense(remoteUser, expenseData) {
     ...expenseData,
     status: statuses.PENDING,
     CollectiveId: collective.id,
+    FromCollectiveId: remoteUser.CollectiveId,
     lastEditedById: expenseData.UserId,
     incurredAt: expenseData.incurredAt || new Date(),
   });

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -788,15 +788,8 @@ export const ExpenseType = new GraphQLObjectType({
       },
       fromCollective: {
         type: CollectiveInterfaceType,
-        resolve(expense) {
-          return expense.getUser().then(u => {
-            if (!u) {
-              return console.error(
-                `Cannot fetch the UserId ${expense.UserId} referenced in ExpenseId ${expense.id} -- has the user been deleted?`,
-              );
-            }
-            return models.Collective.findByPk(u.CollectiveId);
-          });
+        resolve(expense, _, req) {
+          return req.loaders.Collective.byId.load(expense.FromCollectiveId);
         },
       },
       comments: {

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -29,6 +29,14 @@ export default function(Sequelize, DataTypes) {
         allowNull: false,
       },
 
+      FromCollectiveId: {
+        type: DataTypes.INTEGER,
+        references: { key: 'id', model: 'Collectives' },
+        onDelete: 'SET NULL', // Collective deletion will fail if it has expenses
+        onUpdate: 'CASCADE',
+        allowNull: false,
+      },
+
       CollectiveId: {
         type: DataTypes.INTEGER,
         references: {

--- a/test/server/graphql/v1/comments.test.js
+++ b/test/server/graphql/v1/comments.test.js
@@ -60,6 +60,7 @@ describe('server/graphql/v1/comments', () => {
       CollectiveId: collective1.id,
       lastEditedById: user1.id,
       UserId: user1.id,
+      FromCollectiveId: user1.CollectiveId,
       description: 'Plane ticket',
       incurredAt: new Date(),
       amount: 100000,

--- a/test/server/lib/tax-forms.test.js
+++ b/test/server/lib/tax-forms.test.js
@@ -35,7 +35,7 @@ const callbackUrl = 'https://opencollective/api/taxForm/callback';
 const workflowId = 'scuttlebutt';
 const year = moment().year();
 
-describe('lib.taxForms', () => {
+describe('server/lib/tax-forms', () => {
   // globals to be set in the before hooks.
   // need:
   // - some users who are over the threshold for this year _and_ last year
@@ -50,12 +50,13 @@ describe('lib.taxForms', () => {
     year: moment().year(),
   };
 
-  function ExpenseOverThreshold({ incurredAt, UserId, CollectiveId, amount, type }) {
+  function ExpenseOverThreshold({ incurredAt, UserId, CollectiveId, amount, type, FromCollectiveId }) {
     return {
       description: 'pizza',
       amount: amount || US_TAX_FORM_THRESHOLD + 100e2,
       currency: 'USD',
       UserId,
+      FromCollectiveId,
       lastEditedById: UserId,
       incurredAt,
       createdAt: incurredAt,
@@ -155,6 +156,7 @@ describe('lib.taxForms', () => {
     await Expense.create(
       ExpenseOverThreshold({
         UserId: users[0].id,
+        FromCollectiveId: users[0].CollectiveId,
         CollectiveId: organisationCollectives[0].id,
         incurredAt: moment(),
       }),
@@ -163,6 +165,7 @@ describe('lib.taxForms', () => {
     await Expense.create(
       ExpenseOverThreshold({
         UserId: users[2].id,
+        FromCollectiveId: users[2].CollectiveId,
         CollectiveId: organisationCollectives[0].id,
         incurredAt: moment(),
         type: RECEIPT,
@@ -172,6 +175,7 @@ describe('lib.taxForms', () => {
     await Expense.create(
       ExpenseOverThreshold({
         UserId: users[1].id,
+        FromCollectiveId: users[1].CollectiveId,
         CollectiveId: organisationCollectives[0].id,
         incurredAt: moment(),
       }),
@@ -180,6 +184,7 @@ describe('lib.taxForms', () => {
     await Expense.create(
       ExpenseOverThreshold({
         UserId: users[1].id,
+        FromCollectiveId: users[1].CollectiveId,
         CollectiveId: organisationCollectives[0].id,
         incurredAt: moment(),
         amount: US_TAX_FORM_THRESHOLD - 200e2,
@@ -189,6 +194,7 @@ describe('lib.taxForms', () => {
     await Expense.create(
       ExpenseOverThreshold({
         UserId: users[0].id,
+        FromCollectiveId: users[0].CollectiveId,
         CollectiveId: organisationCollectives[1].id,
         incurredAt: moment(),
       }),
@@ -197,6 +203,7 @@ describe('lib.taxForms', () => {
     await Expense.create(
       ExpenseOverThreshold({
         UserId: users[0].id,
+        FromCollectiveId: users[0].CollectiveId,
         CollectiveId: organisationCollectives[0].id,
         incurredAt: moment().set('year', 2016),
       }),
@@ -206,6 +213,7 @@ describe('lib.taxForms', () => {
     await Expense.create(
       ExpenseOverThreshold({
         UserId: users[3].id,
+        FromCollectiveId: users[3].CollectiveId,
         CollectiveId: organisationCollectives[0].id,
         incurredAt: moment(),
       }),

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -7,7 +7,7 @@ import { roles } from '../../../server/constants';
 
 const { Transaction, Collective, User } = models;
 
-describe('Collective model', () => {
+describe('server/models/Collective', () => {
   let collective = {},
     opensourceCollective,
     user1,
@@ -135,6 +135,7 @@ describe('Collective model', () => {
           amount: 1000,
           currency: 'USD',
           UserId: user1.id,
+          FromCollectiveId: user1.CollectiveId,
           lastEditedById: user1.id,
           incurredAt: transactions[0].createdAt,
           createdAt: transactions[0].createdAt,
@@ -147,6 +148,7 @@ describe('Collective model', () => {
           amount: 15000,
           currency: 'USD',
           UserId: user1.id,
+          FromCollectiveId: user1.CollectiveId,
           lastEditedById: user1.id,
           incurredAt: transactions[1].createdAt,
           createdAt: transactions[1].createdAt,
@@ -159,6 +161,7 @@ describe('Collective model', () => {
           amount: 60100,
           currency: 'USD',
           UserId: user2.id,
+          FromCollectiveId: user2.CollectiveId,
           lastEditedById: user2.id,
           incurredAt: transactions[1].createdAt,
           createdAt: transactions[1].createdAt,

--- a/test/server/models/Notification.test.js
+++ b/test/server/models/Notification.test.js
@@ -9,7 +9,7 @@ import emailLib from '../../../server/lib/email';
 
 const { User, Collective, Notification, Tier, Order } = models;
 
-describe('notification.model.test.js', () => {
+describe('server/models/Notification', () => {
   let host, collective, hostAdmin, sandbox, emailSendMessageSpy;
 
   beforeEach(() => utils.resetTestDB());
@@ -102,6 +102,7 @@ describe('notification.model.test.js', () => {
         incurredAt: new Date(),
         description: 'pizza',
         UserId: user.id,
+        FromCollectiveId: user.CollectiveId,
         CollectiveId: collective.id,
         amount: 10000,
         currency: 'USD',

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -93,14 +93,19 @@ export const fakeUpdate = async updateData => {
 /**
  * Creates a fake update. All params are optionals.
  */
-export const fakeExpense = async updateData => {
-  let CollectiveId = get(updateData, 'CollectiveId') || get(updateData, 'collective.id');
-  let UserId = get(updateData, 'UserId') || get(updateData, 'user.id');
+export const fakeExpense = async expenseData => {
+  let CollectiveId = get(expenseData, 'CollectiveId') || get(expenseData, 'collective.id');
+  let UserId = get(expenseData, 'UserId') || get(expenseData, 'user.id');
+  let FromCollectiveId = get(expenseData, 'FromCollectiveId') || get(expenseData, 'fromCollective.id');
   if (!CollectiveId) {
     CollectiveId = (await fakeCollective()).id;
   }
   if (!UserId) {
     UserId = (await fakeUser()).id;
+  }
+
+  if (!FromCollectiveId) {
+    FromCollectiveId = (await models.User.findByPk(UserId)).CollectiveId;
   }
 
   return models.Update.create({
@@ -110,7 +115,8 @@ export const fakeExpense = async updateData => {
     category: 'Engineering',
     description: randStr('Test expense '),
     payoutMethod: 'other',
-    ...updateData,
+    ...expenseData,
+    FromCollectiveId,
     CollectiveId,
     UserId,
   });


### PR DESCRIPTION
Provide the database basis for https://github.com/opencollective/opencollective/issues/2266

- Migrate all the existing expenses to store the `FromCollectiveId`
- For all new exenses, store user's collective in `FromCollectiveId` in expenses
- In GraphQL Expense > `fromCollective`, use the new field rather than fetching the user