### PR TITLE
Mocha Config moved from mocha.opts to mocharc.json

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "timeout": 20000,
+  "extension": ["js", "ts"],
+  "require": ["./test/setup-babel.js"],
+  "file": ["./test/setup.js", "./server/env.js"],
+  "recursive": true,
+  "exit": true
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,7 +1,0 @@
---timeout 20000
---extension js,ts
---require ./test/setup-babel.js
---file ./test/setup.js
---file ./server/env.js
---recursive
---exit


### PR DESCRIPTION
Issue: https://github.com/opencollective/opencollective/issues/2787

I have put config into `test/mocharc.json` and updated package.json test script with `--config test/.mocharc.json"` 

I think this is the best and cleanest solution but this also can be added into directly package.json 
or these extensions (**.js .jsonc .yml .json**) can be used.