### PR TITLE
CI: Matching branch functionality can only work on pushes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,14 +1,6 @@
 name: E2E
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+on: [push]
 
 env:
   CI: true


### PR DESCRIPTION
On pull_request events, it's trying to match with PR branches and it's not what we want.

ie: downloading https://codeload.github.com/opencollective/opencollective-frontend/tar.gz/refs/pull/3177/merge