### PR TITLE
CI: Fix random crash when fetching tarball

### DIFF
--- a/scripts/ci_checkout_frontend.sh
+++ b/scripts/ci_checkout_frontend.sh
@@ -12,7 +12,7 @@ CI_BRANCH=${CI_BRANCH:=master}
 
 TARBALL_URL="https://codeload.github.com/opencollective/opencollective-frontend/tar.gz/"
 echo "> Check ${TARBALL_URL}${CI_BRANCH}"
-if curl -s --head --request GET "${TARBALL_URL}${CI_BRANCH}" | grep "200" > /dev/null
+if curl -s --head --request GET "${TARBALL_URL}${CI_BRANCH}" | head -n 1 | grep "200" > /dev/null
 then
   BRANCH=$CI_BRANCH;
 else


### PR DESCRIPTION
An attempt at solving errors like https://github.com/opencollective/opencollective-frontend/pull/3307/checks?check_run_id=387207818

Full response from curl looks like:

> HTTP/1.1 200 OK
> Access-Control-Allow-Origin: https://render.githubusercontent.com
> Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox
> Strict-Transport-Security: max-age=31536000
> Vary: Authorization,Accept-Encoding
> X-Content-Type-Options: nosniff
> X-Frame-Options: deny
> X-XSS-Protection: 1; mode=block
> ETag: W/"0f71066f61b7a7cb87e59bf5f421130cd48e51131c3a627d075215be6feefe95"
> Content-Type: application/x-gzip

OR

> HTTP/1.1 404 Not Found
> Content-Length: 15
> Access-Control-Allow-Origin: https://render.githubusercontent.com
> Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox
> Strict-Transport-Security: max-age=31536000
> Vary: Authorization,Accept-Encoding
> X-Content-Type-Options: nosniff
> X-Frame-Options: deny
> X-XSS-Protection: 1; mode=block
> Date: Mon, 13 Jan 2020 16:11:18 GMT
> X-Varnish: 1047174460
> Age: 0
> Via: 1.1 varnish-v4
> X-GitHub-Request-Id: C0FC:179A:83E84:14ED7C:5E1C96A6

Previous code could fail to detect a missing branch if the request ID or timecodes somehow included a `200`.