### PR TITLE
Multiple expense's attachments

### DIFF
--- a/migrations/20200113141339-create-expense-attachments.js
+++ b/migrations/20200113141339-create-expense-attachments.js
@@ -1,0 +1,103 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, DataTypes) => {
+    const dbTransaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.createTable(
+        'ExpenseAttachments',
+        {
+          id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+          amount: { type: DataTypes.INTEGER, allowNull: false },
+          url: { type: DataTypes.STRING, allowNull: false },
+          description: { type: DataTypes.STRING, allowNull: true },
+          createdAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW, allowNull: false },
+          updatedAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW, allowNull: false },
+          deletedAt: { type: DataTypes.DATE },
+          incurredAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW, allowNull: false },
+          ExpenseId: {
+            type: DataTypes.INTEGER,
+            references: { model: 'Expenses', key: 'id' },
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+            allowNull: false,
+          },
+          CreatedByUserId: {
+            type: DataTypes.INTEGER,
+            references: { key: 'id', model: 'Users' },
+            onDelete: 'SET NULL',
+            onUpdate: 'CASCADE',
+            allowNull: true,
+          },
+        },
+        { transaction: dbTransaction },
+      );
+
+      await queryInterface.sequelize.query(
+        `
+        INSERT INTO "ExpenseAttachments" (
+          "amount",
+          "url",
+          "createdAt",
+          "updatedAt",
+          "deletedAt",
+          "incurredAt",
+          "ExpenseId",
+          "CreatedByUserId"
+        ) SELECT 
+          e."amount",
+          e."attachment",
+          e."createdAt",
+          e."updatedAt",
+          e."deletedAt",
+          e."incurredAt",
+          e."id",
+          e."UserId"
+        FROM 
+          "Expenses" e
+        WHERE 
+          attachment IS NOT NULL
+      `,
+        { transaction: dbTransaction },
+      );
+
+      await queryInterface.removeColumn('Expenses', 'attachment', { transaction: dbTransaction });
+      dbTransaction.commit();
+    } catch (e) {
+      console.error('Transaction failed:', e);
+      await dbTransaction.rollback();
+      throw e;
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const dbTransaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.addColumn(
+        'Expenses',
+        'attachment',
+        { type: Sequelize.STRING },
+        { transaction: dbTransaction },
+      );
+
+      await queryInterface.sequelize.query(
+        `
+        UPDATE ONLY "Expenses" e
+        SET attachment = a.url
+        FROM "ExpenseAttachments" a
+        WHERE e.id = a."ExpenseId"
+      `,
+        { transaction: dbTransaction },
+      );
+
+      await queryInterface.dropTable('ExpenseAttachments', { transaction: dbTransaction });
+
+      dbTransaction.commit();
+    } catch (e) {
+      console.error('Transaction failed:', e);
+      await dbTransaction.rollback();
+      throw e;
+    }
+  },
+};

--- a/scripts/check_ledger_health.js
+++ b/scripts/check_ledger_health.js
@@ -334,7 +334,7 @@ const checkTransactions = () => {
                 GROUP BY "ExpenseId"
                 HAVING COUNT(*) != 2
       )
-      SELECT ie."ExpenseId", ie."numberOfTransactions", c.slug as collective, e.category, e.amount, e.currency, e.description, e."payoutMethod", u.email as "user email", u."paypalEmail", e.attachment, e."incurredAt", e."createdAt", e."updatedAt" FROM "invalidExpenses" ie LEFT JOIN "Expenses" e ON ie."ExpenseId" = e.id LEFT JOIN "Users" u ON u.id=e."UserId" LEFT JOIN "Collectives" c ON c.id=e."CollectiveId" WHERE e.id IN (select "ExpenseId" FROM "invalidExpenses" WHERE valid is false)
+      SELECT ie."ExpenseId", ie."numberOfTransactions", c.slug as collective, e.category, e.amount, e.currency, e.description, e."payoutMethod", u.email as "user email", u."paypalEmail", e."incurredAt", e."createdAt", e."updatedAt" FROM "invalidExpenses" ie LEFT JOIN "Expenses" e ON ie."ExpenseId" = e.id LEFT JOIN "Users" u ON u.id=e."UserId" LEFT JOIN "Collectives" c ON c.id=e."CollectiveId" WHERE e.id IN (select "ExpenseId" FROM "invalidExpenses" WHERE valid is false)
     `,
           { type: sequelize.QueryTypes.SELECT },
         ),

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1,0 +1,23 @@
+import { ExpenseAttachment } from '../../models/ExpenseAttachment';
+
+/**
+ * Returns true if user is allowed to see the private infos for an expense.
+ * Based on loaders, so it's safe to use this function in lists.
+ */
+export const canViewExpensePrivateInfo = async (expense, req): Promise<boolean> => {
+  if (!req.remoteUser) {
+    return false;
+  } else if (req.remoteUser.isAdmin(expense.CollectiveId) || req.remoteUser.id === expense.UserId) {
+    return true;
+  } else {
+    const collective = await req.loaders.Collective.byId.load(expense.CollectiveId);
+    return req.remoteUser.isAdmin(collective.HostCollectiveId) || req.remoteUser.isAdmin(collective.ParentCollectiveId);
+  }
+};
+
+/**
+ * Returns the list of attachments for this expense.
+ */
+export const getExpenseAttachments = async (expenseId, req): Promise<ExpenseAttachment[]> => {
+  return req.loaders.ExpenseAttachment.byExpenseId.load(expenseId);
+};

--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -1,0 +1,17 @@
+import DataLoader from 'dataloader';
+import models, { Op } from '../../models';
+import { ExpenseAttachment } from '../../models/ExpenseAttachment';
+import { sortResultsArray } from './helpers';
+
+/**
+ * Loader for expense's attachments.
+ */
+export const generateExpenseAttachmentsLoader = (): DataLoader<number, ExpenseAttachment[]> => {
+  return new DataLoader(async (expenseIds: number[]) => {
+    const attachments = await models.ExpenseAttachment.findAll({
+      where: { ExpenseId: { [Op.in]: expenseIds } },
+    });
+
+    return sortResultsArray(expenseIds, attachments, attachment => attachment.ExpenseId);
+  });
+};

--- a/server/graphql/loaders/helpers.ts
+++ b/server/graphql/loaders/helpers.ts
@@ -4,6 +4,9 @@ import DataLoader from 'dataloader';
 
 const debug = debugLib('loaders');
 
+/** A default getter that returns item's id */
+const defaultKeyGetter = (item): number | string => item.id;
+
 /**
  * A newer implementation of `sortResults`.
  *
@@ -11,26 +14,55 @@ const debug = debugLib('loaders');
  *
  * @param keys: the keys to use as a reference for sorting (usually a list of ids)
  * @param results: the results as a list of entities
- * @param attribute: the attribute to use to get the key
+ * @param getKeyFromResult: a function to get the id to match keys
  * @param defaultValue: a default value used when there's no result in `results`
  */
-export const sortResultsSimple = (
-  keys: readonly any[],
-  results: readonly any[],
-  attribute: string = 'id',
-  defaultValue: any = undefined,
-) => {
-  // Group items by ids
+export function sortResultsSimple<ResultType>(
+  keys: readonly (string | number)[],
+  results: readonly ResultType[],
+  getKeyFromResult = defaultKeyGetter,
+  defaultValue: ResultType = undefined,
+): ResultType[] {
   const resultsById = {};
   results.forEach(item => {
-    const id = item[attribute];
+    const id = getKeyFromResult(item);
     if (id) {
       resultsById[id] = item;
     }
   });
 
   return keys.map(id => resultsById[id] || defaultValue);
-};
+}
+
+/**
+ * Similar to `sortResultsSimple`, but stack items in arrays to allow storing multiple
+ * results for each key.
+ *
+ * @param keys: the keys to use as a reference for sorting (usually a list of ids)
+ * @param results: the results as a list of entities
+ * @param getKeyFromResult: a function to get the id to match keys
+ * @param defaultValue: a default value used when there's no result in `results`
+ */
+export function sortResultsArray<ResultType>(
+  keys: readonly (string | number)[],
+  results: readonly ResultType[],
+  getKeyFromResult = defaultKeyGetter,
+  defaultValue = [],
+): ResultType[][] {
+  const resultsById = {};
+  results.forEach(item => {
+    const id = getKeyFromResult(item);
+    if (id) {
+      if (resultsById[id]) {
+        resultsById[id].push(item);
+      } else {
+        resultsById[id] = [item];
+      }
+    }
+  });
+
+  return keys.map(id => resultsById[id] || defaultValue);
+}
 
 /**
  * @deprecated Prefer to use `simpleSortResults`.

--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -12,6 +12,7 @@ import { sortResults, createDataLoaderWithOptions } from './helpers';
 // Loaders generators
 import generateCommentsLoader from './comments';
 import generateConversationLoaders from './conversation';
+import { generateExpenseAttachmentsLoader } from './expenses';
 
 export const loaders = req => {
   const cache = {};
@@ -19,6 +20,7 @@ export const loaders = req => {
 
   context.loaders.Comment = generateCommentsLoader(req, cache);
   context.loaders.Conversation = generateConversationLoaders(req, cache);
+  context.loaders.ExpenseAttachment.byExpenseId = generateExpenseAttachmentsLoader(req, cache);
 
   /** *** Collective *****/
 

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -437,6 +437,18 @@ export const UpdateAttributesInputType = new GraphQLInputObjectType({
   }),
 });
 
+export const ExpenseAttachmentInputType = new GraphQLInputObjectType({
+  name: 'ExpenseAttachmentInputType',
+  description: 'Fields for creating or editing an expense attachment',
+  fields: {
+    id: { type: GraphQLInt },
+    url: { type: new GraphQLNonNull(DateString) },
+    amount: { type: new GraphQLNonNull(GraphQLInt) },
+    incurredAt: { type: DateString },
+    description: { type: GraphQLString },
+  },
+});
+
 export const ExpenseInputType = new GraphQLInputObjectType({
   name: 'ExpenseInputType',
   description: 'Input type for ExpenseType',
@@ -444,7 +456,10 @@ export const ExpenseInputType = new GraphQLInputObjectType({
     return {
       id: { type: GraphQLInt },
       amount: { type: GraphQLInt },
-      currency: { type: GraphQLString },
+      currency: {
+        type: GraphQLString,
+        deprecationReason: '2020-01-16: Expense currency is based on collective currency',
+      },
       createdAt: { type: DateString },
       incurredAt: { type: DateString },
       description: { type: GraphQLString },
@@ -456,7 +471,11 @@ export const ExpenseInputType = new GraphQLInputObjectType({
         description: 'Can be: paypal, other. Also deprecated: donation, manual',
       },
       privateMessage: { type: GraphQLString },
-      attachment: { type: GraphQLString },
+      attachment: {
+        type: GraphQLString,
+        deprecationReason: '2020-01-13 - Expenses now support multiple attachments. Please use attachments instead.',
+      },
+      attachments: { type: new GraphQLList(ExpenseAttachmentInputType) },
       user: { type: UserInputType },
       collective: { type: CollectiveAttributesInputType },
     };

--- a/server/lib/restore-sequelize-attributes-on-class.ts
+++ b/server/lib/restore-sequelize-attributes-on-class.ts
@@ -1,0 +1,21 @@
+import { Model } from 'sequelize';
+
+/**
+ * Because of https://github.com/sequelize/sequelize/issues/10579, the classes transpiled
+ * by Babel are resetting the sequelize properties getters & setters. This helper fixes these properties
+ * by re-defining them. Based on https://github.com/RobinBuschmann/sequelize-typescript/issues/612#issuecomment-491890977.
+ *
+ * Must be called from the constructor.
+ */
+export default function restoreSequelizeAttributesOnClass(newTarget, self: Model): void {
+  Object.keys(newTarget.rawAttributes).forEach((propertyKey: keyof Model) => {
+    Object.defineProperty(self, propertyKey, {
+      get() {
+        return self.getDataValue(propertyKey);
+      },
+      set(value) {
+        self.setDataValue(propertyKey, value);
+      },
+    });
+  });
+}

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -75,7 +75,6 @@ export default function(Sequelize, DataTypes) {
       },
 
       privateMessage: DataTypes.STRING,
-      attachment: DataTypes.STRING,
       category: DataTypes.STRING,
       vat: DataTypes.INTEGER,
 
@@ -141,7 +140,6 @@ export default function(Sequelize, DataTypes) {
             currency: this.currency,
             amount: this.amount,
             description: this.description,
-            attachment: this.attachment,
             category: this.category,
             payoutMethod: this.payoutMethod,
             vat: this.vat,
@@ -179,6 +177,9 @@ export default function(Sequelize, DataTypes) {
             case status.APPROVED:
               return expense.createActivity(activities.COLLECTIVE_EXPENSE_APPROVED);
           }
+        },
+        afterDestroy(expense) {
+          return models.ExpenseAttachment.destroy({ where: { ExpenseId: expense.id } });
         },
       },
     },

--- a/server/models/ExpenseAttachment.ts
+++ b/server/models/ExpenseAttachment.ts
@@ -1,0 +1,140 @@
+import { Model, Transaction } from 'sequelize';
+import { pick } from 'lodash';
+import restoreSequelizeAttributesOnClass from '../lib/restore-sequelize-attributes-on-class';
+import { diffDBEntries } from '../lib/data';
+
+/**
+ * Sequelize model to represent an ExpenseAttachment, linked to the `ExpenseAttachments` table.
+ */
+export class ExpenseAttachment extends Model<ExpenseAttachment> {
+  public readonly id!: number;
+  public ExpenseId!: number;
+  public CreatedByUserId!: number;
+  public amount!: number;
+  public url!: string;
+  public createdAt!: Date;
+  public updatedAt!: Date;
+  public deletedAt: Date;
+  public incurredAt!: Date;
+  public description: string;
+
+  private static editableFields = ['amount', 'url', 'description', 'incurredAt'];
+
+  constructor(...args) {
+    super(...args);
+    restoreSequelizeAttributesOnClass(new.target, this);
+  }
+
+  /**
+   * Based on `diffDBEntries`, diff two attachments list to know which ones where
+   * added, removed or added.
+   * @returns [newEntries, removedEntries, updatedEntries]
+   */
+  static diffDBEntries = (baseAttachments, attachmentsData): [object[], ExpenseAttachment[], object[]] => {
+    return diffDBEntries(baseAttachments, attachmentsData, ExpenseAttachment.editableFields);
+  };
+
+  /**
+   * Create an attachment from user-submitted data.
+   * @param attachmentData: The (potentially unsafe) user data. Fields will be whitelisted.
+   * @param user: User creating this attachment
+   * @param expense: The linked expense
+   */
+  static async createFromData(
+    attachmentData: object,
+    user,
+    expense,
+    dbTransaction: Transaction | null,
+  ): Promise<ExpenseAttachment> {
+    const cleanData = ExpenseAttachment.cleanData(attachmentData);
+    return ExpenseAttachment.create(
+      { ...cleanData, ExpenseId: expense.id, CreatedByUserId: user.id },
+      { transaction: dbTransaction },
+    );
+  }
+
+  /**
+   * Updates an attachment from user-submitted data.
+   * @param attachmentData: The (potentially unsafe) user data. Fields will be whitelisted.
+   */
+  static async updateFromData(attachmentData: object, dbTransaction: Transaction | null): Promise<ExpenseAttachment> {
+    const id = attachmentData['id'];
+    const cleanData = ExpenseAttachment.cleanData(attachmentData);
+    return ExpenseAttachment.update(cleanData, { where: { id }, transaction: dbTransaction });
+  }
+
+  /** Filters out all the fields that cannot be edited by user */
+  private static cleanData(data: object): object {
+    return pick(data, ExpenseAttachment.editableFields);
+  }
+}
+
+export default (sequelize, DataTypes): typeof ExpenseAttachment => {
+  // Link the model to database fields
+  ExpenseAttachment.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      amount: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        validate: {
+          min: 1,
+        },
+      },
+      url: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          isUrl: true,
+        },
+      },
+      description: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+      },
+      incurredAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+      ExpenseId: {
+        type: DataTypes.INTEGER,
+        references: { model: 'Expenses', key: 'id' },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false,
+      },
+      CreatedByUserId: {
+        type: DataTypes.INTEGER,
+        references: { key: 'id', model: 'Users' },
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+        allowNull: false,
+      },
+    },
+    {
+      sequelize,
+      paranoid: true,
+      tableName: 'ExpenseAttachments',
+    },
+  );
+
+  return ExpenseAttachment;
+};

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -79,6 +79,7 @@ export function setupModels(client) {
     'Conversation',
     'ConversationFollower',
     'Expense',
+    'ExpenseAttachment',
     'LegalDocument',
     'Member',
     'MemberInvitation',
@@ -199,8 +200,12 @@ export function setupModels(client) {
     foreignKey: 'CollectiveId',
     as: 'collective',
   });
+  m.Expense.hasMany(m.ExpenseAttachment);
   m.Transaction.belongsTo(m.Expense);
   m.Transaction.belongsTo(m.Order);
+
+  // Expense attachments
+  m.ExpenseAttachment.belongsTo(m.Expense);
 
   // Order.
   m.Order.belongsTo(m.User, {

--- a/test/server/graphql/v1/collective.test.js
+++ b/test/server/graphql/v1/collective.test.js
@@ -79,6 +79,7 @@ describe('server/graphql/v1/collective', () => {
         description: 'test',
         currency,
         payoutMethod: 'manual',
+        attachments: [{ amount: 100 * (i + 1), url: store.randUrl() }],
         collective: { id: apex.id },
       });
       await expenses.payExpense(hostAdmin, { id: expense.id });
@@ -295,6 +296,7 @@ describe('server/graphql/v1/collective', () => {
       currency: 'EUR',
       payoutMethod: 'manual',
       collective: { id: cid },
+      attachments: [{ url: store.randUrl(), amount }],
     });
 
     // And given that we add some expenses to brussels together:

--- a/test/server/graphql/v1/expenses.test.js
+++ b/test/server/graphql/v1/expenses.test.js
@@ -8,6 +8,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 
 /* Test utilities */
+import { pick } from 'lodash';
 import * as utils from '../../../utils';
 import * as store from '../../../stores';
 
@@ -17,6 +18,8 @@ import emailLib from '../../../../server/lib/email';
 import { getFxRate } from '../../../../server/lib/currency';
 
 import paypalAdaptive from '../../../../server/paymentProviders/paypal/adaptiveGateway';
+import { fakeExpense, fakeUser, fakeExpenseAttachment, fakeCollective, randStr } from '../../../test-helpers/fake-data';
+import { roles } from '../../../../server/constants';
 
 /* Queries used throughout these tests */
 const allExpensesQuery = `
@@ -27,7 +30,10 @@ const allExpensesQuery = `
       amount
       category
       user { id email paypalEmail collective { id slug } }
-      collective { id slug } } }`;
+      collective { id slug } 
+      attachment
+    } 
+  }`;
 
 const expensesQuery = `
   query expenses($CollectiveId: Int, $CollectiveSlug: String, $category: String, $FromCollectiveId: Int, $FromCollectiveSlug: String, $status: ExpenseStatus, $offset: Int, $limit: Int, $orderBy: OrderByType) {
@@ -44,12 +50,61 @@ const expensesQuery = `
   }
 `;
 
+const expenseQuery = `
+  query expense($id: Int!) {
+    Expense(id: $id) {
+      id
+      description
+      amount
+      category
+      user { id email paypalEmail collective { id slug } }
+      collective { id slug }
+      attachment
+      attachments {
+        id
+        amount
+        description
+        url
+      }
+    }
+  }
+`;
+
 const createExpenseQuery = `
   mutation createExpense($expense: ExpenseInputType!) {
     createExpense(expense: $expense) {
       id
       status
-      user { id name collective { id name slug } } } }`;
+      user { id name collective { id name slug } }
+      amount
+      attachment
+      attachments {
+        id
+        url
+        amount
+        description
+        incurredAt
+      } 
+    } 
+  }`;
+
+const editExpenseMutation = `
+  mutation editExpense($expense: ExpenseInputType!) {
+    editExpense(expense: $expense) {
+      id
+      status
+      user { id name collective { id name slug } }
+      amount
+      attachment
+      attachments {
+        id
+        url
+        amount
+        description
+        incurredAt
+      } 
+    } 
+  }`;
 
 const approveExpenseQuery = `
   mutation approveExpense($id: Int!) {
@@ -135,26 +190,31 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 2000 }],
         amount: 2000,
         description: 'Beer',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 3000 }],
         amount: 3000,
         description: 'Banner',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 4000 }],
         amount: 4000,
         description: 'Stickers',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 5000 }],
         amount: 5000,
         description: 'T-shirts',
         ...data,
@@ -194,11 +254,13 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 2000 }],
         amount: 2000,
         description: 'Beer',
         ...data,
@@ -207,11 +269,13 @@ describe('server/graphql/v1/expenses', () => {
       // two expenses
       data.collective = { id: anotherCollective.id };
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 3000 }],
         amount: 3000,
         description: 'Banner',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 4000 }],
         amount: 4000,
         description: 'Stickers',
         ...data,
@@ -220,6 +284,7 @@ describe('server/graphql/v1/expenses', () => {
       // one expense
       data.collective = { id: inactiveCollective.id };
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 3500 }],
         amount: 3500,
         description: 'Banner inactive',
         ...data,
@@ -256,12 +321,14 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         category: 'legal',
         description: 'Pizza',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 2000 }],
         amount: 2000,
         category: 'treat',
         description: 'Beer',
@@ -271,12 +338,14 @@ describe('server/graphql/v1/expenses', () => {
       // two expenses but just one categorized as `legal`.
       data.collective = { id: anotherCollective.id };
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 3000 }],
         amount: 3000,
         category: 'legal',
         description: 'Banner',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 4000 }],
         amount: 4000,
         category: 'stuff',
         description: 'Stickers',
@@ -313,12 +382,14 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       await store.createExpense(xdamman, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         category: 'legal',
         description: 'Pizza',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 2000 }],
         amount: 2000,
         category: 'treat',
         description: 'Beer',
@@ -328,12 +399,14 @@ describe('server/graphql/v1/expenses', () => {
       // two expenses but just one filed by our user
       data.collective = { id: anotherCollective.id };
       await store.createExpense(xdamman, {
+        attachments: [{ url: store.randUrl(), amount: 3000 }],
         amount: 3000,
         category: 'legal',
         description: 'Banner',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 4000 }],
         amount: 4000,
         category: 'stuff',
         description: 'Stickers',
@@ -387,26 +460,31 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 2000 }],
         amount: 2000,
         description: 'Beer',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 3000 }],
         amount: 3000,
         description: 'Banner',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 4000 }],
         amount: 4000,
         description: 'Stickers',
         ...data,
       });
       await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 5000 }],
         amount: 5000,
         description: 'T-shirts',
         ...data,
@@ -428,6 +506,55 @@ describe('server/graphql/v1/expenses', () => {
       // collective
       expect(expenses.map(e => e.description)).to.deep.equal(['T-shirts', 'Stickers', 'Banner', 'Beer', 'Pizza']);
     }); /* End of "gets the latest expenses from one collective" */
+  });
+
+  describe('#expense', () => {
+    it('hides attachment if not allowed to see', async () => {
+      const host = await fakeCollective({ type: 'ORGANIZATION' });
+      const collective = await fakeCollective({ host });
+      const expense = await fakeExpense({ collective, attachments: [] });
+      const attachment = await fakeExpenseAttachment({ expense });
+      const collectiveAdmin = await fakeUser();
+      await collective.addUserWithRole(collectiveAdmin, roles.ADMIN);
+      const hostAdmin = await fakeUser();
+      await host.addUserWithRole(hostAdmin, roles.ADMIN);
+
+      // Fetch as unauthenticated (should not have URL)
+      let result = await utils.graphqlQuery(expenseQuery, { id: expense.id });
+      expect(result.data.Expense.attachment).to.be.null;
+      result.data.Expense.attachments.forEach(attachmentFromAPI => {
+        expect(attachmentFromAPI.url).to.be.null;
+      });
+
+      // Fetch as another user (should not have URL)
+      const randomUser = await fakeUser();
+      result = await utils.graphqlQuery(expenseQuery, { id: expense.id }, randomUser);
+      expect(result.data.Expense.attachment).to.be.null;
+      result.data.Expense.attachments.forEach(attachmentFromAPI => {
+        expect(attachmentFromAPI.url).to.be.null;
+      });
+
+      // Fetch as expense's creator (should have URL)
+      result = await utils.graphqlQuery(expenseQuery, { id: expense.id }, expense.User);
+      expect(result.data.Expense.attachment).to.eq(attachment.url);
+      result.data.Expense.attachments.forEach(attachmentFromAPI => {
+        expect(attachmentFromAPI.url).to.eq(attachment.url);
+      });
+
+      // Fetch as collective admin (should have URL)
+      result = await utils.graphqlQuery(expenseQuery, { id: expense.id }, collectiveAdmin);
+      expect(result.data.Expense.attachment).to.eq(attachment.url);
+      result.data.Expense.attachments.forEach(attachmentFromAPI => {
+        expect(attachmentFromAPI.url).to.eq(attachment.url);
+      });
+
+      // Fetch as host admin (should have URL)
+      result = await utils.graphqlQuery(expenseQuery, { id: expense.id }, hostAdmin);
+      expect(result.data.Expense.attachment).to.eq(attachment.url);
+      result.data.Expense.attachments.forEach(attachmentFromAPI => {
+        expect(attachmentFromAPI.url).to.eq(attachment.url);
+      });
+    });
   });
 
   describe('#createExpense', () => {
@@ -499,6 +626,8 @@ describe('server/graphql/v1/expenses', () => {
       expect(result.data.createExpense.status).to.equal('PENDING');
       // And then the expense's creator should be our user
       expect(result.data.createExpense.user.id).to.equal(user.id);
+      expect(result.data.createExpense.attachment).to.equal(data.attachment);
+      expect(result.data.createExpense.attachments[0].url).to.equal(data.attachment);
 
       // And then the user should become a member of the project
       const membership = await models.Member.findOne({
@@ -526,6 +655,71 @@ describe('server/graphql/v1/expenses', () => {
       const res = await utils.graphqlQuery(createExpenseQuery, { expense: data }, user);
       expect(res.errors).to.not.exist;
     }); /* End of "creates a new expense logged in and send email to collective admin for approval" */
+
+    it('creates an expense using the new "attachments" field', async () => {
+      const user = await fakeUser();
+      const collective = await fakeCollective();
+      const expenseData = {
+        amount: 500,
+        description: 'Bought some potatoes',
+        type: 'RECEIPT',
+        category: 'food',
+        collective: { id: collective.id },
+        attachments: [
+          {
+            amount: 250,
+            description: 'Burger',
+            url: store.randUrl(),
+            incurredAt: new Date('2000-01-01T00:00:00'),
+          },
+          {
+            amount: 250,
+            description: 'French Fries',
+            url: store.randUrl(),
+            incurredAt: new Date('2000-01-03T00:00:00'),
+          },
+        ],
+      };
+
+      const result = await utils.graphqlQuery(createExpenseQuery, { expense: expenseData }, user);
+      const attachments = result.data.createExpense.attachments;
+      expect(result.data.createExpense.amount).to.equal(expenseData.amount);
+      attachments.forEach(attachment => {
+        const baseData = expenseData.attachments.find(a => a.description === attachment.description);
+        expect(baseData.url).to.equal(attachment.url);
+        expect(baseData.amount).to.equal(attachment.amount);
+      });
+    });
+
+    it("fails if attachments amount don't match expense", async () => {
+      const user = await fakeUser();
+      const collective = await fakeCollective();
+      const expenseData = {
+        amount: 500,
+        description: 'Bought some potatoes',
+        type: 'RECEIPT',
+        category: 'food',
+        collective: { id: collective.id },
+        attachments: [
+          {
+            amount: 250,
+            description: 'Burger',
+            url: store.randUrl(),
+          },
+          {
+            amount: 400,
+            description: 'French Fries',
+            url: store.randUrl(),
+          },
+        ],
+      };
+
+      const result = await utils.graphqlQuery(createExpenseQuery, { expense: expenseData }, user);
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(
+        "The sum of all attachments must be equal to the total expense's amount. Expense's total is 500, but the total of attachments was 650.",
+      );
+    });
   }); /* End of "#createExpense" */
 
   describe('#approveExpense', () => {
@@ -548,6 +742,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -581,6 +776,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -632,6 +828,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -687,6 +884,7 @@ describe('server/graphql/v1/expenses', () => {
       // And given the above collective has one expense (in PENDING
       // state)
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         currency: 'USD',
@@ -715,6 +913,7 @@ describe('server/graphql/v1/expenses', () => {
       // And given the above collective has one expense (in PENDING
       // state)
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         currency: 'USD',
@@ -750,6 +949,7 @@ describe('server/graphql/v1/expenses', () => {
       // And given the above collective has one expense (in PENDING
       // state)
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         currency: 'USD',
@@ -789,6 +989,7 @@ describe('server/graphql/v1/expenses', () => {
       // And given the above collective has one expense (in PENDING
       // state)
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         currency: 'USD',
@@ -851,6 +1052,7 @@ describe('server/graphql/v1/expenses', () => {
         // And given the above collective has one expense (in PENDING
         // state)
         expense = await store.createExpense(user, {
+          attachments: [{ url: store.randUrl(), amount: 1000 }],
           amount: 1000,
           description: 'Pizza',
           currency: 'EUR',
@@ -907,6 +1109,7 @@ describe('server/graphql/v1/expenses', () => {
         // And given the above collective has one expense (in PENDING
         // state)
         expense = await store.createExpense(user, {
+          attachments: [{ url: store.randUrl(), amount: 1000 }],
           amount: 1000,
           description: 'Pizza',
           currency: 'EUR',
@@ -1026,7 +1229,133 @@ describe('server/graphql/v1/expenses', () => {
   }); /* End of #payExpense */
 
   describe('#editExpense', () => {
-    // not implemented
+    it('goes back to pending if editing critical fields', async () => {
+      // Amount
+      let expense = await fakeExpense({ status: 'APPROVED', amount: 1000 });
+      let newExpenseData = { expense: { id: expense.id, amount: 100 } };
+      let result = await utils.graphqlQuery(editExpenseMutation, newExpenseData, expense.User);
+      expect(result.data.editExpense.status).to.equal('PENDING');
+
+      // Payout
+      expense = await fakeExpense({ status: 'APPROVED', payoutMethod: 'other' });
+      newExpenseData = { id: expense.id, payoutMethod: 'paypal' };
+      result = await utils.graphqlQuery(editExpenseMutation, { expense: newExpenseData }, expense.User);
+      expect(result.data.editExpense.status).to.equal('PENDING');
+
+      // Attachment(s)
+      expense = await fakeExpense({ status: 'APPROVED' });
+      newExpenseData = { id: expense.id, attachment: store.randUrl() };
+      result = await utils.graphqlQuery(editExpenseMutation, { expense: newExpenseData }, expense.User);
+      expect(result.data.editExpense.status).to.equal('PENDING');
+
+      // Description => should not change status
+      expense = await fakeExpense({ status: 'APPROVED' });
+      newExpenseData = { id: expense.id, description: randStr() };
+      result = await utils.graphqlQuery(editExpenseMutation, { expense: newExpenseData }, expense.User);
+      expect(result.data.editExpense.status).to.equal('APPROVED');
+    });
+
+    it('updates an expense using the new "attachments" field', async () => {
+      const expense = await fakeExpense({ amount: 1000 });
+      const expenseUpdateData = {
+        id: expense.id,
+        attachments: [
+          {
+            amount: 800,
+            description: 'Burger',
+            url: store.randUrl(),
+          },
+          {
+            amount: 200,
+            description: 'French Fries',
+            url: store.randUrl(),
+          },
+        ],
+      };
+
+      const result = await utils.graphqlQuery(editExpenseMutation, { expense: expenseUpdateData }, expense.User);
+      const attachmentsFromAPI = result.data.editExpense.attachments;
+      expect(result.data.editExpense.amount).to.equal(1000);
+      expect(attachmentsFromAPI.length).to.equal(2);
+      expenseUpdateData.attachments.forEach(attachment => {
+        const attachmentFromApi = attachmentsFromAPI.find(a => a.description === attachment.description);
+        expect(attachmentFromApi).to.exist;
+        expect(attachmentFromApi.url).to.equal(attachment.url);
+        expect(attachmentFromApi.amount).to.equal(attachment.amount);
+      });
+    });
+
+    it("fails if attachments amount doesn't match expense", async () => {
+      const expense = await fakeExpense({ amount: 1000 });
+      const expenseUpdateData = {
+        id: expense.id,
+        attachments: [
+          { amount: 800, url: store.randUrl() },
+          { amount: 300, url: store.randUrl() },
+        ],
+      };
+
+      const result = await utils.graphqlQuery(editExpenseMutation, { expense: expenseUpdateData }, expense.User);
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(
+        "The sum of all attachments must be equal to the total expense's amount. Expense's total is 1000, but the total of attachments was 1100.",
+      );
+    });
+
+    it('updates the attachments', async () => {
+      const expense = await fakeExpense({ amount: 10000, attachments: [] });
+      const attachments = await Promise.all([
+        fakeExpenseAttachment({ ExpenseId: expense.id, amount: 2000 }),
+        fakeExpenseAttachment({ ExpenseId: expense.id, amount: 3000 }),
+        fakeExpenseAttachment({ ExpenseId: expense.id, amount: 5000 }),
+      ]);
+
+      const updatedExpenseData = {
+        id: expense.id,
+        attachments: [
+          pick(attachments[0], ['id', 'url', 'amount']), // Don't change the first one (value=2000)
+          { ...pick(attachments[1], ['id', 'url']), amount: 7000 }, // Update amount for the second one
+          { amount: 1000, url: store.randUrl() }, // Remove the third one and create another instead
+        ],
+      };
+
+      const result = await utils.graphqlQuery(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
+      const returnedAttachments = result.data.editExpense.attachments;
+      const sumAttachments = returnedAttachments.reduce((total, attachment) => total + attachment.amount, 0);
+      expect(sumAttachments).to.equal(10000);
+      expect(returnedAttachments.find(a => a.id === attachments[0].id)).to.exist;
+      expect(returnedAttachments.find(a => a.id === attachments[1].id)).to.exist;
+      expect(returnedAttachments.find(a => a.id === attachments[2].id)).to.not.exist;
+      expect(returnedAttachments.find(a => a.id === attachments[1].id).amount).to.equal(7000);
+    });
+
+    it('Updates the attachments and the expense amount at the same time', async () => {
+      const expense = await fakeExpense({ amount: 10000, attachments: [] });
+      const attachments = await Promise.all([
+        fakeExpenseAttachment({ ExpenseId: expense.id, amount: 2000 }),
+        fakeExpenseAttachment({ ExpenseId: expense.id, amount: 3000 }),
+        fakeExpenseAttachment({ ExpenseId: expense.id, amount: 5000 }),
+      ]);
+
+      const updatedExpenseData = {
+        id: expense.id,
+        amount: 15000,
+        attachments: [
+          pick(attachments[0], ['id', 'url', 'amount']), // Don't change the first one (value=2000)
+          { ...pick(attachments[1], ['id', 'url']), amount: 7000 }, // Update amount for the second one
+          { amount: 6000, url: store.randUrl() }, // Remove the third one and create another instead
+        ],
+      };
+
+      const result = await utils.graphqlQuery(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
+      const returnedAttachments = result.data.editExpense.attachments;
+      const sumAttachments = returnedAttachments.reduce((total, attachment) => total + attachment.amount, 0);
+      expect(sumAttachments).to.equal(15000);
+      expect(returnedAttachments.find(a => a.id === attachments[0].id)).to.exist;
+      expect(returnedAttachments.find(a => a.id === attachments[1].id)).to.exist;
+      expect(returnedAttachments.find(a => a.id === attachments[2].id)).to.not.exist;
+      expect(returnedAttachments.find(a => a.id === attachments[1].id).amount).to.equal(7000);
+    });
   }); /* End of "#editExpense" */
 
   describe('#deleteExpense', () => {
@@ -1040,6 +1369,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -1064,6 +1394,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(hostAdmin, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -1091,6 +1422,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -1122,6 +1454,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -1153,6 +1486,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -1181,6 +1515,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -1209,6 +1544,7 @@ describe('server/graphql/v1/expenses', () => {
         collective: { id: collective.id },
       };
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         amount: 1000,
         description: 'Pizza',
         ...data,
@@ -1242,6 +1578,7 @@ describe('server/graphql/v1/expenses', () => {
       // state)
       const expenseAmount = 1500;
       const expense = await store.createExpense(user, {
+        attachments: [{ url: store.randUrl(), amount: expenseAmount }],
         amount: expenseAmount,
         description: 'Pizza',
         currency: 'USD',
@@ -1311,6 +1648,7 @@ describe('server/graphql/v1/expenses', () => {
       const expense = await store.createExpense(user, {
         amount: 1000,
         description: 'Pizza',
+        attachments: [{ url: store.randUrl(), amount: 1000 }],
         ...data,
       });
       // approve the expense

--- a/test/server/models/Expense.test.js
+++ b/test/server/models/Expense.test.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import { fakeExpense } from '../../test-helpers/fake-data';
+
+describe('test/server/models/Expense', () => {
+  describe('Delete', () => {
+    it('Deleting an expense deletes its attachments', async () => {
+      const expense = await fakeExpense();
+      await expense.destroy();
+      for (const attachment of expense.attachments) {
+        await attachment.reload({ paranoid: false });
+        expect(attachment.deletedAt).to.not.be.null;
+      }
+    });
+  });
+});

--- a/test/server/models/ExpenseAttachment.test.js
+++ b/test/server/models/ExpenseAttachment.test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { fakeExpense, fakeUser } from '../../test-helpers/fake-data';
+import models from '../../../server/models';
+import { randUrl } from '../../stores';
+
+describe('test/server/models/ExpenseAttachments', () => {
+  describe('createFromData', () => {
+    it('Filters out the bad fields', async () => {
+      const expense = await fakeExpense();
+      const user = await fakeUser();
+      const data = {
+        url: randUrl(),
+        amount: 1500,
+        incurredAt: new Date('2000-01-01T00:00:00'),
+        deletedAt: new Date('2000-01-01T00:00:00'),
+      };
+
+      const attachment = await models.ExpenseAttachment.createFromData(data, user, expense);
+      expect(attachment.url).to.equal(data.url);
+      expect(attachment.amount).to.equal(data.amount);
+      expect(attachment.incurredAt.getTime()).to.equal(data.incurredAt.getTime());
+      expect(attachment.deletedAt).to.be.null;
+    });
+  });
+});

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -13,8 +13,26 @@ import { types as CollectiveType } from '../../server/constants/collectives';
 import { randEmail, randUrl } from '../stores';
 
 export const randStr = (prefix = '') => `${prefix}${uuid().split('-')[0]}`;
-export const randAmount = (min = 100, max = 10000000) => Math.floor(Math.random() * max) + min;
+export const randNumber = (min = 0, max = 10000000) => Math.floor(Math.random() * max) + min;
+export const randAmount = (min = 100, max = 10000000) => randNumber(min, max);
 export const multiple = (fn, n, args) => Promise.all([...Array(n).keys()].map(() => fn(args)));
+
+/** Generate an array containing between min and max item, filled with generateFunc */
+export const randArray = (generateFunc, min = 1, max = 1) => {
+  const arrayLength = randNumber(min, max);
+  return [...Array(arrayLength)].map((_, idx) => generateFunc(idx, arrayLength));
+};
+
+/** A small helper to get a value from the data or generate a default one */
+const getIdFromData = async (data, keys, defaultGenerator, idKey = 'id') => {
+  const existingKey = keys.find(key => typeof get(data, key) !== 'undefined');
+  if (existingKey) {
+    return get(data, existingKey);
+  }
+
+  const newEntity = await defaultGenerator();
+  return newEntity.get(idKey);
+};
 
 /**
  * Creates a fake user. All params are optionals.
@@ -39,6 +57,17 @@ export const fakeUser = async userData => {
   return user;
 };
 
+/** Create a fake host */
+export const fakeHost = async hostData => {
+  return fakeCollective({
+    type: CollectiveType.ORGANIZATION,
+    name: randStr('Test Host '),
+    slug: randStr('host-'),
+    HostCollectiveId: null,
+    ...hostData,
+  });
+};
+
 /**
  * Creates a fake update. All params are optionals.
  */
@@ -57,6 +86,7 @@ export const fakeCollective = async collectiveData => {
     tags: [randStr(), randStr()],
     isActive: true,
     ...collectiveData,
+    HostCollectiveId: await getIdFromData(collectiveData, ['HostCollectiveId', 'host.id'], fakeHost),
   });
 };
 
@@ -75,7 +105,11 @@ export const fakeEvent = async collectiveData => {
     slug: randStr('event-'),
     ...collectiveData,
     type: 'EVENT',
-    ParentCollectiveId,
+    ParentCollectiveId: await getIdFromData(
+      collectiveData,
+      ['ParentCollectiveId', 'parentCollective.id'],
+      fakeCollective,
+    ),
   });
 };
 
@@ -107,36 +141,54 @@ export const fakeUpdate = async updateData => {
   });
 };
 
+export const fakeExpenseAttachment = async attachmentData => {
+  return models.ExpenseAttachment.create(
+    {
+      amount: randAmount(),
+      url: `${randUrl()}.pdf`,
+      description: randStr(),
+      ...attachmentData,
+      ExpenseId: await getIdFromData(attachmentData, ['ExpenseId', 'expense.id'], fakeExpense),
+      CreatedByUserId: await getIdFromData(attachmentData, ['CreatedByUserId', 'createdByUser.id'], fakeUser),
+    },
+    {
+      include: [models.Expense],
+    },
+  );
+};
+
 /**
  * Creates a fake update. All params are optionals.
  */
 export const fakeExpense = async expenseData => {
-  let CollectiveId = get(expenseData, 'CollectiveId') || get(expenseData, 'collective.id');
-  let UserId = get(expenseData, 'UserId') || get(expenseData, 'user.id');
-  let FromCollectiveId = get(expenseData, 'FromCollectiveId') || get(expenseData, 'fromCollective.id');
-  if (!CollectiveId) {
-    CollectiveId = (await fakeCollective()).id;
-  }
-  if (!UserId) {
-    UserId = (await fakeUser()).id;
-  }
-
-  if (!FromCollectiveId) {
-    FromCollectiveId = (await models.User.findByPk(UserId)).CollectiveId;
-  }
-
-  return models.Update.create({
+  const expense = await models.Expense.create({
     amount: randAmount(),
-    attachement: `${randUrl()}/attachment.pdf`,
     currency: 'USD',
     category: 'Engineering',
     description: randStr('Test expense '),
     payoutMethod: 'other',
+    incurredAt: new Date(),
     ...expenseData,
-    FromCollectiveId,
-    CollectiveId,
-    UserId,
+    FromCollectiveId: await getIdFromData(expenseData, ['FromCollectiveId', 'fromCollective.id'], fakeCollective),
+    CollectiveId: await getIdFromData(expenseData, ['CollectiveId', 'collective.id'], fakeCollective),
+    UserId: await getIdFromData(expenseData, ['UserId', 'user.id'], fakeUser),
+    lastEditedById: await getIdFromData(expenseData, ['lastEditedById', 'lastEditedBy.id'], fakeUser),
   });
+
+  if (!expenseData || typeof expenseData.attachments === 'undefined') {
+    // Helper to generate an attachment. Ensures that attachments match expense amount
+    const generateAttachment = (idx, nbItems) => {
+      const baseAmount = Math.floor(expense.amount / nbItems);
+      const remainder = expense.amount % nbItems;
+      const realAmount = idx !== nbItems - 1 ? baseAmount : baseAmount + remainder;
+      return fakeExpenseAttachment({ ExpenseId: expense.id, amount: realAmount });
+    };
+
+    expense.attachments = await Promise.all(randArray(generateAttachment, 1, 5));
+  }
+
+  expense.User = await models.User.findByPk(expense.UserId);
+  return expense;
 };
 
 /**


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2803

This PR ended up being way larger than I initially thought it would be.

It fully preserves the compatibility with the existing behaviors:
- submitting an expense with the `attachment` field will just store one
- the old `expense.attachment` field returns the first attachment

Yet the new fields should provide full control for the frontend implementation.

Only thing left to do: apply these changes to API v2 (that we will consume for the expense flow). That will be done in a separate PR.