### PR TITLE
Extend existing loaders rather than overwriting

### DIFF
--- a/server/graphql/loaders/comments.ts
+++ b/server/graphql/loaders/comments.ts
@@ -2,24 +2,24 @@ import models, { Op } from '../../models';
 import { createDataLoaderWithOptions, sortResults } from './helpers';
 import DataLoader from 'dataloader';
 
-export default function generateCommentsLoader(_, cache) {
-  return {
-    findAllByAttribute: attribute => {
-      return createDataLoaderWithOptions(
-        (values, attribute) => {
-          return models.Comment.findAll({
-            where: {
-              [attribute]: { [Op.in]: values },
-            },
-            order: [['createdAt', 'DESC']],
-          }).then(results => sortResults(values, results, attribute, []));
-        },
-        cache,
-        attribute,
-        'comments',
-      );
-    },
-    countByExpenseId: new DataLoader(ExpenseIds =>
+export default {
+  findAllByAttribute: (_, cache) => (attribute: string): DataLoader<string | number, object> => {
+    return createDataLoaderWithOptions(
+      (values, attribute) => {
+        return models.Comment.findAll({
+          where: {
+            [attribute]: { [Op.in]: values },
+          },
+          order: [['createdAt', 'DESC']],
+        }).then(results => sortResults(values, results, attribute, []));
+      },
+      cache,
+      attribute,
+      'comments',
+    );
+  },
+  countByExpenseId: (): DataLoader<number, number> =>
+    new DataLoader(ExpenseIds =>
       models.Comment.count({
         attributes: ['ExpenseId'],
         where: { ExpenseId: { [Op.in]: ExpenseIds } },
@@ -28,5 +28,4 @@ export default function generateCommentsLoader(_, cache) {
         .then(results => sortResults(ExpenseIds, results, 'ExpenseId', { count: 0 }))
         .map(result => result.count),
     ),
-  };
-}
+};

--- a/server/graphql/loaders/conversation.ts
+++ b/server/graphql/loaders/conversation.ts
@@ -1,14 +1,9 @@
 import models, { sequelize } from '../../models';
 import DataLoader from 'dataloader';
 
-interface IConversationLoader {
-  followers: DataLoader<number, any>;
-  commentsCount: DataLoader<number, number>;
-}
-
-export default function generateConversationLoaders(): IConversationLoader {
-  return {
-    followers: new DataLoader(async conversationIds => {
+export default {
+  followers: (): DataLoader<number, object> =>
+    new DataLoader(async conversationIds => {
       const subscribedCollectives = await sequelize.query(
         `
         SELECT      c.*, f."ConversationId" AS __conversation_id__
@@ -42,7 +37,8 @@ export default function generateConversationLoaders(): IConversationLoader {
         return groupedCollectives[conversationId] || [];
       });
     }),
-    commentsCount: new DataLoader(async (conversationsIds: number[]) => {
+  commentsCount: (): DataLoader<number, number> =>
+    new DataLoader(async (conversationsIds: number[]) => {
       const counts: Array<{ ConversationId: number; count: number }> = await sequelize.query(
         `
         SELECT "ConversationId", COUNT(id) as count
@@ -69,5 +65,4 @@ export default function generateConversationLoaders(): IConversationLoader {
         }
       });
     }),
-  };
-}
+};

--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -10,8 +10,8 @@ import models, { Op, sequelize } from '../../models';
 import { sortResults, createDataLoaderWithOptions } from './helpers';
 
 // Loaders generators
-import generateCommentsLoader from './comments';
-import generateConversationLoaders from './conversation';
+import commentsLoader from './comments';
+import conversationLoaders from './conversation';
 import { generateExpenseAttachmentsLoader } from './expenses';
 import { generateCollectivePaypalPayoutMethodsLoader, generateCollectivePayoutMethodsLoader } from './payout-method';
 import { generateCanSeeUserPrivateInfoLoader } from './user';
@@ -20,11 +20,22 @@ export const loaders = req => {
   const cache = {};
   const context = createContext(sequelize);
 
-  context.loaders.Comment = generateCommentsLoader(req, cache);
-  context.loaders.Conversation = generateConversationLoaders(req, cache);
+  // Comment
+  context.loaders.Comment.findAllByAttribute = commentsLoader.findAllByAttribute(req, cache);
+  context.loaders.Comment.countByExpenseId = commentsLoader.countByExpenseId(req, cache);
+
+  // Conversation
+  context.loaders.Conversation.followers = conversationLoaders.followers(req, cache);
+  context.loaders.Conversation.commentsCount = conversationLoaders.commentsCount(req, cache);
+
+  // Expense
   context.loaders.ExpenseAttachment.byExpenseId = generateExpenseAttachmentsLoader(req, cache);
+
+  // Payout method
   context.loaders.PayoutMethod.paypalByCollectiveId = generateCollectivePaypalPayoutMethodsLoader(req, cache);
   context.loaders.PayoutMethod.byCollectiveId = generateCollectivePayoutMethodsLoader(req, cache);
+
+  // User
   context.loaders.User.canSeeUserPrivateInfo = generateCanSeeUserPrivateInfoLoader(req, cache);
 
   /** *** Collective *****/


### PR DESCRIPTION
In https://github.com/opencollective/opencollective-api/pull/2989, I didn't understood properly how `dataloader-sequelize` works and as a consequence ended up writing this code:

```es6
context.loaders.Comment = generateCommentsLoader(req, cache);
```

We didn't realize it because we currently don't use the comment loaders generated by  `dataloader-sequelize`, but the library generates loaders on this endpoint, something like:

```es6
context.loaders.Comment = {
  byId: (...) => ...
}
```

I've changed the code to extend these loaders rather than overwriting them.

```es6
context.loaders.Comment.mySpecificLoader = ...
```