### PR TITLE
Remove async dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "apollo-errors": "1.9.0",
     "apollo-server-express": "2.9.16",
     "argparse": "1.0.10",
-    "async": "3.1.0",
     "aws-sdk": "2.609.0",
     "axios": "0.19.2",
     "babel-plugin-add-module-exports": "1.0.2",

--- a/test/server/routes/paypal.preapproval.test.js
+++ b/test/server/routes/paypal.preapproval.test.js
@@ -1,5 +1,4 @@
 import Promise from 'bluebird';
-import async from 'async';
 import request from 'supertest';
 import sinon from 'sinon';
 import { expect } from 'chai';
@@ -23,36 +22,10 @@ describe('server/routes/paypal.preapproval', () => {
     paypalAdaptive.preapproval.restore();
   });
 
-  beforeEach(done => {
-    async.auto(
-      {
-        resetDB: cb => {
-          utils.resetTestDB().asCallback(cb);
-        },
-        createUserA: [
-          'resetDB',
-          (_, cb) => {
-            models.User.createUserWithCollective(utils.data('user1'))
-              .then(user => cb(null, user))
-              .catch(cb);
-          },
-        ],
-        createUserB: [
-          'createUserA',
-          (_, cb) => {
-            models.User.createUserWithCollective(utils.data('user2'))
-              .then(user => cb(null, user))
-              .catch(cb);
-          },
-        ],
-      },
-      (e, results) => {
-        expect(e).to.not.exist;
-        user = results.createUserA;
-        user2 = results.createUserB;
-        done();
-      },
-    );
+  beforeEach(async () => {
+    await utils.resetTestDB();
+    user = await models.User.createUserWithCollective(utils.data('user1'));
+    user2 = await models.User.createUserWithCollective(utils.data('user2'));
   });
 
   /**


### PR DESCRIPTION
I'm not sure why this why introduced (maybe `chai-as-promised` was not available at the time?) but it seems overly complex (30 lines before, 3 lines after) and we only used it in two tests.