### PR TITLE
Add GraphQL API v2 ids to graphql v1 order/transaction

### DIFF
--- a/server/graphql/v1/TransactionInterface.js
+++ b/server/graphql/v1/TransactionInterface.js
@@ -16,6 +16,8 @@ import { CollectiveInterfaceType, UserCollectiveType } from './CollectiveInterfa
 import { SubscriptionType, OrderType, PaymentMethodType, UserType, DateString, ExpenseType } from './types';
 import { canViewExpensePrivateInfo, getExpenseAttachments } from '../common/expenses';
 
+import { idEncode } from '../v2/identifiers';
+
 export const TransactionInterfaceType = new GraphQLInterfaceType({
   name: 'Transaction',
   description: 'Transaction interface',
@@ -32,6 +34,7 @@ export const TransactionInterfaceType = new GraphQLInterfaceType({
   fields: () => {
     return {
       id: { type: GraphQLInt },
+      idV2: { type: GraphQLString },
       uuid: { type: GraphQLString },
       amount: { type: GraphQLInt },
       currency: { type: GraphQLString },
@@ -63,6 +66,12 @@ const TransactionFields = () => {
       type: GraphQLInt,
       resolve(transaction) {
         return transaction.id;
+      },
+    },
+    idV2: {
+      type: GraphQLString,
+      resolve(transaction) {
+        return idEncode(transaction.id, 'transaction');
       },
     },
     refundTransaction: {

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1549,7 +1549,7 @@ export const OrderType = new GraphQLObjectType({
           return order.id;
         },
       },
-      uuid: {
+      idV2: {
         type: GraphQLString,
         resolve(order) {
           return idEncode(order.id, 'order');

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -35,6 +35,8 @@ import { getCollectiveAvatarUrl } from '../../lib/collectivelib';
 import * as commonComment from '../common/comment';
 import { canViewExpensePrivateInfo, getExpenseAttachments } from '../common/expenses';
 
+import { idEncode } from '../v2/identifiers';
+
 /**
  * Take a graphql type and return a wrapper type that adds pagination. The pagination
  * object has limit, offset and total keys to manage pages and stores the result
@@ -1545,6 +1547,12 @@ export const OrderType = new GraphQLObjectType({
         type: GraphQLInt,
         resolve(order) {
           return order.id;
+        },
+      },
+      uuid: {
+        type: GraphQLString,
+        resolve(order) {
+          return idEncode(order.id, 'order');
         },
       },
       quantity: {

--- a/test/server/lib/utils.test.js
+++ b/test/server/lib/utils.test.js
@@ -21,9 +21,7 @@ describe('server/lib/utils', () => {
     expect(res.card.expYear).to.equal(obj.card.expYear);
   });
 
-  it('exports PDF', function(done) {
-    this.timeout(10000);
-
+  it('exports PDF', done => {
     const data = {
       host: {
         name: 'WWCode',


### PR DESCRIPTION
This will be used for forward compatibility with GraphQL API v2.

Required by: https://github.com/opencollective/opencollective-frontend/pull/3466