### PR TITLE
ExpenseAttachment: Make url nullable

### DIFF
--- a/migrations/20200210175821-make-expense-attachment-url-nullable.js
+++ b/migrations/20200210175821-make-expense-attachment-url-nullable.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('ExpenseAttachments', 'url', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('ExpenseAttachments', 'url', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+  },
+};

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -442,7 +442,7 @@ export const ExpenseAttachmentInputType = new GraphQLInputObjectType({
   description: 'Fields for creating or editing an expense attachment',
   fields: {
     id: { type: GraphQLInt },
-    url: { type: new GraphQLNonNull(DateString) },
+    url: { type: GraphQLString },
     amount: { type: new GraphQLNonNull(GraphQLInt) },
     incurredAt: { type: DateString },
     description: { type: GraphQLString },

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -1,6 +1,7 @@
 import { get, omit, pick, flatten } from 'lodash';
 import errors from '../../../lib/errors';
 import roles from '../../../constants/roles';
+import expenseType from '../../../constants/expense_type';
 import statuses from '../../../constants/expense_status';
 import activities from '../../../constants/activities';
 import models, { sequelize } from '../../../models';
@@ -113,6 +114,16 @@ const checkExpenseAttachments = (expenseData, attachments) => {
     throw new ValidationFailed({
       message: `The sum of all attachments must be equal to the total expense's amount. Expense's total is ${expenseData.amount}, but the total of attachments was ${sumAttachments}.`,
     });
+  }
+
+  // If expense is a receipt (not an invoice) then files must be attached
+  if (expenseData.type === expenseType.RECEIPT) {
+    const hasMissingFiles = attachments.some(a => !a.url);
+    if (hasMissingFiles) {
+      throw new ValidationFailed({
+        message: 'Some attachments are missing a file',
+      });
+    }
   }
 };
 

--- a/server/models/ExpenseAttachment.ts
+++ b/server/models/ExpenseAttachment.ts
@@ -87,7 +87,7 @@ export default (sequelize, DataTypes): typeof ExpenseAttachment => {
       },
       url: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
         validate: {
           isUrl: true,
         },


### PR DESCRIPTION
In the new expense flow, when the expense type is `INVOICE`, we still have this notion of attachments except they don't have a file linked. All the other fields are there: amount, date, description...

So the way I went with this was to make `url` nullable, and only check its presence if the expense type is `RECEIPT`.

![image](https://user-images.githubusercontent.com/1556356/74179857-90d84f80-4c3e-11ea-8f32-d2784cbcc2cc.png)
