### PR TITLE
Cleanup debug usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5688,7 +5688,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true,
           "optional": true
@@ -5965,7 +5965,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -6324,7 +6324,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
             "minimist": "^1.2.0"
@@ -15328,7 +15328,7 @@
       "dependencies": {
         "commander": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
           "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
           "requires": {
             "keypress": "0.1.x"
@@ -16020,11 +16020,6 @@
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
-    },
-    "request-as-curl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/request-as-curl/-/request-as-curl-0.1.0.tgz",
-      "integrity": "sha1-8BesWyBg4cT8lndXXDgaCCSdW/c="
     },
     "request-progress": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "pg-format": "1.0.4",
     "prepend-http": "3.0.1",
     "redis": "3.0.2",
-    "request-as-curl": "0.1.0",
     "request-promise": "4.2.5",
     "sanitize-html": "1.21.1",
     "sequelize": "5.21.4",

--- a/server/graphql/loaders/helpers.ts
+++ b/server/graphql/loaders/helpers.ts
@@ -1,8 +1,5 @@
 import { get } from 'lodash';
-import debugLib from 'debug';
 import DataLoader from 'dataloader';
-
-const debug = debugLib('loaders');
 
 /** A default getter that returns item's id */
 const defaultKeyGetter = (item): number | string => item.id;
@@ -84,7 +81,6 @@ export const sortResults = (
   attribute: string = 'id',
   defaultValue: any = undefined,
 ) => {
-  debug('sortResults', attribute, 'number of results:', results.length);
   const resultsById = {};
   results.forEach(r => {
     let key;

--- a/server/lib/backyourstack/dispatcher.js
+++ b/server/lib/backyourstack/dispatcher.js
@@ -10,7 +10,7 @@ import status from '../../constants/order_status';
 import activities from '../../constants/activities';
 import * as paymentsLib from '../payments';
 
-const debug = debugLib('dispatch_prepaid_subscription');
+const debug = debugLib('backyourstack');
 
 export function needsDispatching(nextDispatchDate) {
   const needs = moment(nextDispatchDate).isSameOrBefore();

--- a/server/lib/currency.js
+++ b/server/lib/currency.js
@@ -35,7 +35,7 @@ if (!get(config, 'fixer.accessKey') && !['staging', 'production'].includes(confi
 }
 
 export function getFxRate(fromCurrency, toCurrency, date = 'latest') {
-  debug('>>> getFxRate for ', date, fromCurrency, toCurrency);
+  debug(`getFxRate for ${date} ${fromCurrency} -> ${toCurrency}`);
 
   if (!get(config, 'fixer.accessKey')) {
     if (['staging', 'production'].includes(config.env)) {

--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -15,9 +15,6 @@ import whiteListDomains from './whiteListDomains';
 import { md5 } from './utils';
 
 const debug = debugLib('email');
-const debugData = debugLib('data');
-const debugText = debugLib('text');
-const debugHtml = debugLib('html');
 
 export const getMailer = () => {
   if (config.maildev.client) {
@@ -48,10 +45,6 @@ const render = (template, data) => {
     text = templates[`${template}.text`](data);
   }
   const html = juice(he.decode(templates[template](data)));
-
-  // When in development mode, we log the data used to compile the template
-  // (useful to get login token without sending an email)
-  debugData(`Rendering ${template} with data`, data);
 
   return { text, html };
 };
@@ -188,8 +181,6 @@ const sendMessage = (recipients, subject, html, options = {}) => {
     });
   } else {
     debug('>>> mailer not configured');
-    debugText(options.text);
-    debugHtml(html);
     return Promise.resolve();
   }
 };

--- a/server/lib/express.js
+++ b/server/lib/express.js
@@ -3,7 +3,6 @@ import config from 'config';
 import connectRedis from 'connect-redis';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
-import debug from 'debug';
 import errorHandler from 'errorhandler';
 import helmet from 'helmet';
 import morgan from 'morgan';
@@ -31,23 +30,6 @@ export default function(app) {
   // Loaders are attached to the request to batch DB queries per request
   // It also creates in-memory caching (based on request auth);
   app.use(loadersMiddleware);
-
-  if (process.env.DEBUG && process.env.DEBUG.match(/response/)) {
-    const debugResponse = debug('response');
-    app.use((req, res, next) => {
-      const temp = res.end;
-      res.end = function(str) {
-        try {
-          const obj = JSON.parse(str);
-          debugResponse(JSON.stringify(obj, null, '  '));
-        } catch (e) {
-          debugResponse(str);
-        }
-        temp.apply(this, arguments);
-      };
-      next();
-    });
-  }
 
   // Log requests if enabled (default false)
   if (get(config, 'log.accessLogs')) {

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import config from 'config';
 import Promise from 'bluebird';
+import debugLib from 'debug';
 import { get, remove } from 'lodash';
 
 import activitiesLib from '../lib/activities';
@@ -9,13 +10,12 @@ import twitter from './twitter';
 import emailLib from '../lib/email';
 import activityType from '../constants/activities';
 import models from '../models';
-import debugLib from 'debug';
+
 import { channels } from '../constants';
 import { sanitizeActivity, enrichActivity } from './webhooks';
 import { PayoutMethodTypes } from '../models/PayoutMethod';
 
-const debug = debugLib('notification');
-const debugActivityData = debugLib('activity.data');
+const debug = debugLib('notifications');
 
 export default async (Sequelize, activity) => {
   // publish everything to our private channel
@@ -187,7 +187,6 @@ async function notifyMembersOfCollective(CollectiveId, activity, options) {
 
 async function notifyByEmail(activity) {
   debug('notifyByEmail', activity.type);
-  debugActivityData('activity.data', activity.data);
   switch (activity.type) {
     case activityType.TICKET_CONFIRMED:
       notifyUserId(activity.data.UserId, activity);

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -5,14 +5,11 @@ import { URL } from 'url';
 
 import config from 'config';
 import Promise from 'bluebird';
-import debugLib from 'debug';
 import pdf from 'html-pdf';
 import sanitizeHtml from 'sanitize-html';
 import { get, cloneDeep, isEqual } from 'lodash';
 
 import handlebars from './handlebars';
-
-const debug = debugLib('utils');
 
 export function addParamsToUrl(url, obj) {
   const u = new URL(url);
@@ -210,7 +207,6 @@ export const getTiersStats = (tiers, startDate, endDate) => {
     if (get(tier, 'dataValues.users') && get(tier, 'dataValues.users').length > 0) {
       return true;
     } else {
-      debug('skipping tier', tier.dataValues, 'because it has no users');
       return false;
     }
   });
@@ -221,14 +217,12 @@ export const getTiersStats = (tiers, startDate, endDate) => {
   return Promise.map(tiers, tier => {
     const backers = get(tier, 'dataValues.users');
     let index = 0;
-    debug('> processing tier ', tier.name, 'total backers: ', backers.length, backers);
 
     // We sort backers by total donations DESC
     backers.sort((a, b) => b.totalDonations - a.totalDonations);
 
     return Promise.filter(backers, backer => {
       if (backersIds[backer.id]) {
-        debug('>>> backer ', backer.slug, 'is a duplicate');
         return false;
       }
       backersIds[backer.id] = true;
@@ -249,14 +243,6 @@ export const getTiersStats = (tiers, startDate, endDate) => {
             backer.isLost = true;
             stats.backers.lost++;
           }
-
-          debug('----------- ', backer.slug, '----------');
-          debug('firstDonation', backer.firstDonation && backer.firstDonation.toISOString().substr(0, 10));
-          debug('totalDonations', backer.totalDonations / 100);
-          debug('active last month?', backer.activeLastMonth);
-          debug('active previous month?', backer.activePreviousMonth);
-          debug('is new?', backer.isNew === true);
-          debug('is lost?', backer.isLost === true);
           if (backer.activePreviousMonth) {
             stats.backers.previousMonth++;
           }

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -52,8 +52,7 @@ import plans, { PLANS_COLLECTIVE_SLUG } from '../constants/plans';
 
 import { getFxRate } from '../lib/currency';
 
-const debug = debugLib('collective');
-const debugcollectiveImage = debugLib('collectiveImage');
+const debug = debugLib('models:Collective');
 
 export const defaultTiers = (HostCollectiveId, currency) => {
   const tiers = [];
@@ -840,19 +839,15 @@ export default function(Sequelize, DataTypes) {
 
   // Save image it if it returns 200
   Collective.prototype.checkAndUpdateImage = async function(image) {
-    debugcollectiveImage(`checkAndUpdateImage ${this.slug} ${image}`);
     try {
       const response = await fetch(image);
-      debugcollectiveImage(`checkAndUpdateImage ${this.slug} ${image} response.status: ${response.status}`);
       if (response.status !== 200) {
         throw new Error(`status=${response.status}`);
       }
       const body = await response.text();
-      debugcollectiveImage(`checkAndUpdateImage ${this.slug} ${image} body.length: ${body.length}`);
       if (body.length === 0) {
         throw new Error(`length=0`);
       }
-      debugcollectiveImage(`checkAndUpdateImage ${this.slug} ${image} updating`);
       return this.update({ image });
     } catch (err) {
       logger.info(`collective.checkAndUpdateImage: Unable to fetch ${image} (${err.message})`);

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,18 +1,11 @@
-/*
- * Create a notification to receive certain type of events
- *
- * Notification.create({
- *  UserId, CollectiveId, type = 'collective.transaction.created', channel='email'
- * })
- * Notification.unsubscribe(); // To disable a notification
- */
 import Promise from 'bluebird';
-import _ from 'lodash';
+import { defaults } from 'lodash';
 import debugLib from 'debug';
 import { Op } from 'sequelize';
+
 import channels from '../constants/channels';
 
-const debug = debugLib('notification');
+const debug = debugLib('models:Notification');
 
 export default function(Sequelize, DataTypes) {
   const { models } = Sequelize;
@@ -95,7 +88,7 @@ export default function(Sequelize, DataTypes) {
   };
 
   Notification.createMany = (notifications, defaultValues) => {
-    return Promise.map(notifications, u => Notification.create(_.defaults({}, u, defaultValues))).catch(console.error);
+    return Promise.map(notifications, u => Notification.create(defaults({}, u, defaultValues))).catch(console.error);
   };
 
   /**

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -1,13 +1,13 @@
-import { TransactionTypes } from '../constants/transactions';
 import Promise from 'bluebird';
-import CustomDataTypes from './DataTypes';
 import Temporal from 'sequelize-temporal';
+import debugLib from 'debug';
 import { get } from 'lodash';
 
-import debugLib from 'debug';
-const debug = debugLib('order');
-
+import CustomDataTypes from './DataTypes';
 import status from '../constants/order_status';
+import { TransactionTypes } from '../constants/transactions';
+
+const debug = debugLib('models:Order');
 
 export default function(Sequelize, DataTypes) {
   const { models } = Sequelize;

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -1,5 +1,3 @@
-/** @module models/PaymentMethod */
-
 import debugLib from 'debug';
 import Promise from 'bluebird';
 import { get, intersection } from 'lodash';
@@ -17,7 +15,7 @@ import { isTestToken } from '../lib/stripe';
 
 import { maxInteger } from '../constants/math';
 
-const debug = debugLib('PaymentMethod');
+const debug = debugLib('models:PaymentMethod');
 
 export default function(Sequelize, DataTypes) {
   const { models } = Sequelize;

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -1,6 +1,6 @@
 import Temporal from 'sequelize-temporal';
 import Promise from 'bluebird';
-import _ from 'lodash';
+import { defaults } from 'lodash';
 import debugLib from 'debug';
 import slugify from 'limax';
 import { Op } from 'sequelize';
@@ -10,7 +10,7 @@ import { maxInteger } from '../constants/math';
 import { capitalize, days, formatCurrency, strip_tags } from '../lib/utils';
 import { isSupportedVideoProvider, supportedVideoProviders } from '../lib/validators';
 
-const debug = debugLib('tier');
+const debug = debugLib('models:Tier');
 
 export default function(Sequelize, DataTypes) {
   const { models } = Sequelize;
@@ -370,7 +370,7 @@ export default function(Sequelize, DataTypes) {
    * Class Methods
    */
   Tier.createMany = (tiers, defaultValues = {}) => {
-    return Promise.map(tiers, t => Tier.create(_.defaults({}, t, defaultValues)), { concurrency: 1 });
+    return Promise.map(tiers, t => Tier.create(defaults({}, t, defaultValues)), { concurrency: 1 });
   };
 
   /**

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -1,5 +1,3 @@
-/** @module models/Transaction */
-
 import Promise from 'bluebird';
 import moment from 'moment';
 import uuidv4 from 'uuid/v4';
@@ -12,7 +10,7 @@ import CustomDataTypes from './DataTypes';
 import { toNegative } from '../lib/math';
 import { exportToCSV } from '../lib/utils';
 
-const debug = debugLib('transaction');
+const debug = debugLib('models:Transaction');
 
 /*
  * Transaction model

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -13,7 +13,7 @@ import roles from '../constants/roles';
 import { isValidEmail } from '../lib/utils';
 import emailLib from '../lib/email';
 
-const debug = debugLib('user');
+const debug = debugLib('models:User');
 
 /**
  * Constants.

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,8 +1,6 @@
 import serverStatus from 'express-server-status';
 import GraphHTTP from 'express-graphql';
-import curlify from 'request-as-curl';
 import multer from 'multer';
-import debug from 'debug';
 import config from 'config';
 
 import redis from 'redis';
@@ -29,7 +27,6 @@ import sanitizer from './middleware/sanitizer';
 import * as paypal from './paymentProviders/paypal/payment';
 
 import logger from './lib/logger';
-import { sanitizeForLogs } from './lib/utils';
 
 import graphqlSchemaV1 from './graphql/v1/schema';
 import graphqlSchemaV2 from './graphql/v2/schema';
@@ -93,28 +90,6 @@ export default app => {
       },
     });
     app.use('/graphql', rateLimiter);
-  }
-  if (process.env.DEBUG) {
-    const debugOperation = debug('operation');
-    const debugParams = debug('params');
-    const debugHeaders = debug('headers');
-    const debugCurl = debug('curl');
-
-    app.use('*', (req, res, next) => {
-      const body = sanitizeForLogs(req.body || {});
-      debugOperation(body.operationName, JSON.stringify(body.variables, null));
-      if (body.query) {
-        const query = body.query;
-        debugParams(query);
-        delete body.query;
-      }
-      debugParams('req.query', req.query);
-      debugParams('req.body', JSON.stringify(body, null, '  '));
-      debugParams('req.params', req.params);
-      debugHeaders('req.headers', req.headers);
-      debugCurl('curl', curlify(req, req.body));
-      next();
-    });
   }
 
   /**


### PR DESCRIPTION
Following up on https://github.com/opencollective/opencollective-api/pull/3350 I think it's a good moment to clean a bit our usage of `debug`.

- Removing `debug` in many places we never used
- Removing "sendErrorByEmail" functionality
- Removing `request-as-curl` dependency
- Renaming `debug` namespace to have some consistency, introducing `models:ModelName`