### PR TITLE
VirtualCards: Fix inverted PaymentMethodId

### DIFF
--- a/migrations/20200213105138-fix-virtualcard-orders-inverted-payment-method.js
+++ b/migrations/20200213105138-fix-virtualcard-orders-inverted-payment-method.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * See https://github.com/opencollective/opencollective/issues/2790
+ * A bug was inverting the "PaymentMethodId" with the "SourcePaymentMethodId" in orders.
+ */
+module.exports = {
+  up: queryInterface => {
+    return queryInterface.sequelize.query(`
+      WITH payment_methods_used_for_gift_cards AS (
+        -- Get all payment methods used for gift cards
+        SELECT      spm.*
+        FROM        "PaymentMethods" pm
+        INNER JOIN  "PaymentMethods" spm ON pm."SourcePaymentMethodId" = spm.id
+        GROUP BY spm.id
+      ), orders_made_directly_with_source_payment_methods AS (
+        -- Get all ordrers made using these payment methods. Not all of these orders are erroneous:
+        -- it's legit to have a payment method used both to generated gift cards and to contribute directly
+        SELECT      o.*
+        FROM        "Orders" o
+        INNER JOIN  payment_methods_used_for_gift_cards pm ON o."PaymentMethodId" = pm.id
+      ), updated_orders AS (
+        -- Get only the orders where payment method was updated at some point by looking at the history
+        SELECT      o.id, o."PaymentMethodId", MAX(oh."PaymentMethodId") AS __other_payment_method_id__
+        FROM        orders_made_directly_with_source_payment_methods o
+        INNER JOIN  "OrderHistories" oh ON o.id = oh.id AND o."PaymentMethodId" != oh."PaymentMethodId"
+        GROUP BY    o.id, o."PaymentMethodId"
+      ), erroneous_orders AS (
+        -- Filter to get only the ones where the payment method was inverted with the source payment method
+        SELECT      o.*, pm2.id AS __virtual_card_id__ FROM updated_orders
+        INNER JOIN  "Orders" o ON o.id = updated_orders.id
+        INNER JOIN  "PaymentMethods" pm1 ON pm1.id = updated_orders."PaymentMethodId"
+        INNER JOIN  "PaymentMethods" pm2 ON pm2.id = updated_orders.__other_payment_method_id__
+        WHERE       pm2."type" = 'virtualcard'
+        AND         pm2."SourcePaymentMethodId" = pm1.id
+      ), fixed_orders AS (
+        -- Fix orders by making sure we use the virtual card id
+        UPDATE ONLY "Orders" o
+        SET         "PaymentMethodId" = erroneous_orders.__virtual_card_id__
+        FROM        erroneous_orders WHERE erroneous_orders.id = o.id
+        RETURNING   *
+      ), fixed_transactions AS (
+        -- Fix transactions by making sure we use the virtual card id
+          UPDATE ONLY   "Transactions" t
+          SET           "PaymentMethodId" = erroneous_orders.__virtual_card_id__
+          FROM          erroneous_orders WHERE erroneous_orders.id = t."OrderId"
+          RETURNING     t.*
+      ) SELECT * FROM fixed_transactions
+    `);
+  },
+
+  down: async () => {
+    // No coming back!
+  },
+};

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -102,15 +102,16 @@ async function processOrder(order) {
   }
   // finding Source Payment method and update order payment method properties
   const sourcePaymentMethod = await models.PaymentMethod.findByPk(paymentMethod.SourcePaymentMethodId);
-  // modifying original order to then process the order of the source payment method
-  order.PaymentMethodId = sourcePaymentMethod.id;
-  order.paymentMethod = sourcePaymentMethod;
+
   // finding the payment provider lib to execute the order
   const sourcePaymentMethodProvider = libpayments.findPaymentMethodProvider(sourcePaymentMethod);
 
-  // gets the Credit transaction generated
   let creditTransaction = null;
   try {
+    // modifying original order to then process the order of the source payment method
+    order.PaymentMethodId = sourcePaymentMethod.id;
+    order.paymentMethod = sourcePaymentMethod;
+    // gets the Credit transaction generated
     creditTransaction = await sourcePaymentMethodProvider.processOrder(order);
   } finally {
     // undo modification of original order after processing the source payment method order


### PR DESCRIPTION
Should fix https://github.com/opencollective/opencollective/issues/2790
Should fix side-effect of https://github.com/opencollective/opencollective/issues/2909

My fix from https://github.com/opencollective/opencollective-api/pull/3354/commits/65bbb86d4c8c2fc25609c9058f2f6582aa09d62b already seemed to resolve the root cause, but I've added a test to confirm it.

Also added a migration to fix all the existing orders and transactions.