### PR TITLE
chore: add profile name to report filenames

### DIFF
--- a/cron/monthly/collective-report.js
+++ b/cron/monthly/collective-report.js
@@ -181,7 +181,7 @@ const processCollective = collective => {
 
   let emailData = {};
   const options = {};
-  const csv_filename = `${moment(d).format(dateFormat)}-${collective.slug}-transactions.csv`;
+  const csv_filename = `${collective.slug}-${moment(d).format(dateFormat)}-transactions.csv`;
 
   return Promise.all(promises)
     .then(results => {

--- a/reports/host-report.js
+++ b/reports/host-report.js
@@ -280,7 +280,7 @@ async function HostReport(year, month, hostId) {
       .tap(transactions => {
         const csv = models.Transaction.exportCSV(transactions, collectivesById);
         attachments.push({
-          filename: csv_filename,
+          filename: `${host.slug}-${csv_filename}`,
           content: csv,
         });
       })
@@ -297,7 +297,7 @@ async function HostReport(year, month, hostId) {
       .then(pdf => {
         if (pdf) {
           attachments.push({
-            filename: pdf_filename,
+            filename: `${host.slug}-${pdf_filename}`,
             content: pdf,
           });
           data.expensesPdf = true;


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2882

In this PR, I added the host name to the filenames for the host report. From what I could see, I noticed that the filenames for the collective report already had the collective name so I updated the format of the filename to be `name-date-transactions.csv` as mentioned in the issue. I couldn't find any other report related files.