### PR TITLE
payExpense: Protect manual payout when no payout method is set

### DIFF
--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -560,7 +560,7 @@ export async function payExpense(remoteUser, args) {
 
   // Pay expense based on chosen payout method
   if (payoutMethodType === PayoutMethodTypes.PAYPAL) {
-    const paypalEmail = payoutMethod.data.email;
+    const paypalEmail = payoutMethod && get(payoutMethod.data, 'email');
     let paypalPaymentMethod = null;
     try {
       paypalPaymentMethod = await host.getPaymentMethod({ service: 'paypal' });


### PR DESCRIPTION
Fix https://opencollective.slack.com/archives/GDTJY7S48/p1582237171005300

Before this PR trying to pay an expense manually would fail if the payout method type was paypal and no paypal email was set for user.