### PR TITLE
DB search enhancements

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -77,6 +77,8 @@ export const searchCollectivesInDB = async (term, offset = 0, limit = 100, types
     to_tsvector('simple', c.name)
     || to_tsvector('simple', c.slug)
     || to_tsvector('simple', COALESCE(c.description, ''))
+    || to_tsvector('simple', COALESCE(c."longDescription", ''))
+    || COALESCE(array_to_tsvector(tags), '')
   `;
 
   // Build dynamic conditions based on arguments

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -88,7 +88,7 @@ export const searchCollectivesInDB = async (term, offset = 0, limit = 100, types
 
   if (term && term.length > 0) {
     term = term.replace(/(_|%|\\)/g, ' ').trim();
-    dynamicConditions += `AND (${tsVector} @@ to_tsquery('simple', :vectorizedTerm) OR name ILIKE '%' || :term || '%' OR slug ILIKE '%' || :term || '%') `;
+    dynamicConditions += `AND (${tsVector} @@ plainto_tsquery('simple', :vectorizedTerm) OR name ILIKE '%' || :term || '%' OR slug ILIKE '%' || :term || '%') `;
   } else {
     term = '';
   }
@@ -103,7 +103,7 @@ export const searchCollectivesInDB = async (term, offset = 0, limit = 100, types
         CASE WHEN (slug = :slugifiedTerm OR name ILIKE :term) THEN
           1
         ELSE
-          ts_rank(${tsVector}, to_tsquery('simple', :vectorizedTerm))
+          ts_rank(${tsVector}, plainto_tsquery('simple', :vectorizedTerm))
         END
       ) AS __rank__
     FROM "Collectives" c

--- a/test/server/lib/search.test.js
+++ b/test/server/lib/search.test.js
@@ -3,7 +3,7 @@ import config from 'config';
 import { CollectiveType } from '../../../server/graphql/v1/CollectiveInterface';
 import { searchCollectivesInDB, searchCollectivesByEmail } from '../../../server/lib/search';
 import { newUser } from '../../stores';
-import { fakeUser } from '../../test-helpers/fake-data';
+import { fakeUser, fakeCollective } from '../../test-helpers/fake-data';
 
 describe('server/lib/search', () => {
   describe('Search in DB', () => {
@@ -20,12 +20,34 @@ describe('server/lib/search', () => {
       expect(results.find(collective => collective.id === userCollective.id)).to.exist;
     });
 
+    it('By long description', async () => {
+      const longDescription = 'Wow thats AVeryUniqueDescription I swear!!!';
+      const collective = await fakeCollective({ longDescription });
+      const [results] = await searchCollectivesInDB('AVeryUniqueDescription');
+      expect(results.find(c => c.id === collective.id)).to.exist;
+    });
+
+    it('By tag', async () => {
+      const tags = ['open source', 'stuff', 'potatoes'];
+      const collective = await fakeCollective({ tags });
+      const [results] = await searchCollectivesInDB('potatoes');
+      expect(results.find(c => c.id === collective.id)).to.exist;
+    });
+
     it("Doesn't return items with the wrong type", async () => {
       const typeFilter = [CollectiveType.ORGANIZATION];
       const { userCollective } = await newUser();
       const [results, count] = await searchCollectivesInDB(userCollective.slug, 0, 10000, typeFilter);
       expect(results.length).to.eq(0);
       expect(count).to.eq(0);
+    });
+
+    it('Does not break if submitting strange input', async () => {
+      const longDescription = 'Wow thats&&}{\'" !%|wow AVeryUniqueDescriptionZZZzzz I swear!!!';
+      const tags = ['\'"{}[]!&|dsa🔥️das'];
+      const collective = await fakeCollective({ longDescription, tags });
+      const [results] = await searchCollectivesInDB('!%|wow🔥️🔥️ AVeryUniqueDescriptionZZZzzz!! &&}{\'"');
+      expect(results.find(c => c.id === collective.id)).to.exist;
     });
 
     describe('By email', async () => {


### PR DESCRIPTION
- Use `plainto_tsquery` to escape input. Before that, queries containing `!` were throwing an error
- Search in collective's `longDescription` and `tags`. @znarf this should make the DB search ready for replacing Algolia. I'll have a try to compare the results once deployed to see if we can make the switch.