### PR TITLE
Require "ci to pass" for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-codecov:
-  require_ci_to_pass: no
-
 coverage:
   status:
     project:


### PR DESCRIPTION
Should avoid wrong CI failure about missing coverage.