### PR TITLE
GQLV2 endpoints for the new expense page

### DIFF
--- a/server/constants/expense_type.js
+++ b/server/constants/expense_type.js
@@ -6,4 +6,5 @@
 export default {
   INVOICE: 'INVOICE',
   RECEIPT: 'RECEIPT',
+  UNCLASSIFIED: 'UNCLASSIFIED',
 };

--- a/server/graphql/common/context-permissions.ts
+++ b/server/graphql/common/context-permissions.ts
@@ -2,61 +2,76 @@
  * Library to store and retrieve permissions in GraphQL's context.
  *
  * This is intended to solve the problem of children's permissions that depends on a parent
- * that may be far away in the hierarchy tree.
+ * that may be far away in the hierarchy tree. Some permissions depend on the context, for example
+ * you're normally not allowed to watch the address of a user. But if you're a host admin
+ * validating an expense that the user has submitted, then you're allowed to see it
+ * **in this context**. The problem is that we have no clue in the User's location resolver
+ * about this context.
+ *
+ * This small helper stores this information in a standardized way within the GraphQl context.
+ * It works as an opt-in for all permissions: everything is forbidden by default and you need
+ * to explicitely set the flag to true with `allowContextPermission` to allow something.
+ *
+ * Permissions are stored inside the `req` as an object that looks like:
+ * {
+ *    // Action type as the key
+ *    SEE_ACCOUNT_LOCATION: {
+ *      // [EntityId (ie. UserId, CollectiveId)]: hasAccess
+ *      45: true
+ *    }
+ * }
  */
 
-import { get, set } from 'lodash';
+import { get, set, has } from 'lodash';
 
 /**
  * Context permissions types to use with `setContextPermission` and `getContextPermission`
  */
 export enum PERMISSION_TYPE {
   SEE_ACCOUNT_LOCATION = 'SEE_ACCOUNT_LOCATION',
+  SEE_EXPENSE_ATTACHMENTS_URL = 'SEE_EXPENSE_ATTACHMENTS_URL',
+  SEE_PAYOUT_METHOD_DATA = 'SEE_PAYOUT_METHOD_DATA',
 }
 
 /**
  * Build a key to get/set a value in permissions.
- *
- * The permission is stored inside the `req` as an object that looks like:
- * {
- *    // Action type as the key
- *    SEE_ACCOUNT_LOCATION: {
- *      // [EntityId (collective id in this case)]: hasAccess
- *      45: true
- *    }
- * }
  */
 const buildKey = (permissionType: PERMISSION_TYPE, entityId: string | number): string => {
   return `permissions.${permissionType}.${entityId}`;
 };
 
-/**
- * Set a permission on GraphQL context that will define the access for the entire query.
+const checkPermissionType = (permissionType): void => {
+  if (!has(PERMISSION_TYPE, permissionType)) {
+    throw new Error(`Unknown permission type ${permissionType}`);
+  }
+};
 
+/**
+ * Allow `permissionType` on `entityId` for the current query.
  *
  * @param req GraphQL context (third param of resolvers)
  * @param permissionType Type of the permission, see PERMISSION_TYPE
  * @param entityId The unique identifier for the item to which the permissions apply
- * @param value Whether this is allowed or not
  */
-export const setContextPermission = (
+export const allowContextPermission = (
   req: object,
   permissionType: PERMISSION_TYPE,
   entityId: string | number,
-  value: boolean,
 ): void => {
-  set(req, buildKey(permissionType, entityId), value);
+  checkPermissionType(permissionType);
+  set(req, buildKey(permissionType, entityId), true);
 };
 
 /**
  * Retrieve a permission previously set with `setPermission`.
  *
- * @returns `true` if allowed, `false` if not allowed or `undefined` if unsure
+ * @returns `true` if allowed, `false` if not allowed
  */
 export const getContextPermission = (
   req: object,
   permissionType: PERMISSION_TYPE,
   entityId: string | number,
-): boolean | undefined => {
-  return get(req, buildKey(permissionType, entityId));
+): boolean => {
+  checkPermissionType(permissionType);
+  return get(req, buildKey(permissionType, entityId), false);
 };

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -369,7 +369,9 @@ export async function deleteExpense(remoteUser, expenseId) {
   }
 
   if (!canDeleteExpense(remoteUser, expense)) {
-    throw new errors.Unauthorized("You don't have permission to delete this expense");
+    throw new errors.Unauthorized(
+      "You don't have permission to delete this expense or it needs to be rejected before being deleted",
+    );
   }
 
   const res = await expense.destroy();

--- a/server/graphql/v2/enum/ExpenseStatus.ts
+++ b/server/graphql/v2/enum/ExpenseStatus.ts
@@ -1,0 +1,11 @@
+import { GraphQLEnumType } from 'graphql';
+import expenseStatus from '../../../constants/expense_status';
+
+const ExpenseStatus = new GraphQLEnumType({
+  name: 'ExpenseStatus',
+  values: Object.values(expenseStatus).reduce((values, key) => {
+    return { ...values, [key]: { value: expenseStatus[key] } };
+  }, {}),
+});
+
+export default ExpenseStatus;

--- a/server/graphql/v2/enum/ExpenseType.ts
+++ b/server/graphql/v2/enum/ExpenseType.ts
@@ -11,5 +11,8 @@ export const ExpenseType = new GraphQLEnumType({
     [expenseType.RECEIPT]: {
       description: 'Receipt: Charge for your time or get paid in advance',
     },
+    [expenseType.UNCLASSIFIED]: {
+      description: 'Unclassified expense',
+    },
   },
 });

--- a/server/graphql/v2/input/CommentCreateInput.js
+++ b/server/graphql/v2/input/CommentCreateInput.js
@@ -1,4 +1,5 @@
 import { GraphQLString, GraphQLInt, GraphQLInputObjectType } from 'graphql';
+import { ExpenseReferenceInput } from './ExpenseReferenceInput';
 
 /**
  * Input type to use as the type for the comment input in createComment mutation.
@@ -6,10 +7,16 @@ import { GraphQLString, GraphQLInt, GraphQLInputObjectType } from 'graphql';
 export const CommentCreateInput = new GraphQLInputObjectType({
   name: 'CommentCreateInput',
   fields: () => ({
-    markdown: { type: GraphQLString },
+    markdown: { type: GraphQLString, deprecationReason: '2020-02-26: Please use html' },
     html: { type: GraphQLString },
-    ExpenseId: { type: GraphQLInt },
-    UpdateId: { type: GraphQLInt },
+    expense: {
+      type: ExpenseReferenceInput,
+      description: 'If your comment is linked to an expense, set it here',
+    },
+    ExpenseId: {
+      type: GraphQLInt,
+      deprecationReason: '2019-02-26: Please use the expense field',
+    },
     ConversationId: { type: GraphQLString },
   }),
 });

--- a/server/graphql/v2/input/ExpenseReferenceInput.ts
+++ b/server/graphql/v2/input/ExpenseReferenceInput.ts
@@ -1,0 +1,32 @@
+import { GraphQLInt, GraphQLString, GraphQLInputObjectType } from 'graphql';
+import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
+
+const ExpenseReferenceInput = new GraphQLInputObjectType({
+  name: 'ExpenseReferenceInput',
+  fields: {
+    id: {
+      type: GraphQLString,
+      description: 'The public id identifying the expense (ie: dgm9bnk8-0437xqry-ejpvzeol-jdayw5re)',
+    },
+    legacyId: {
+      type: GraphQLInt,
+      description: 'The internal id of the expense (ie: 580)',
+    },
+  },
+});
+
+/**
+ * Retrieve an expense from an `ExpenseReferenceInput`
+ */
+const fetchExpenseWithReference = async (input: object, { loaders }): Promise<any> => {
+  if (input['id']) {
+    const id = idDecode(input['id'], IDENTIFIER_TYPES.EXPENSE);
+    return loaders.Expense.byId.load(id);
+  } else if (input['legacyId']) {
+    return loaders.Expense.byId.load(input['legacyId']);
+  } else {
+    return null;
+  }
+};
+
+export { ExpenseReferenceInput, fetchExpenseWithReference };

--- a/server/graphql/v2/object/Comment.js
+++ b/server/graphql/v2/object/Comment.js
@@ -23,13 +23,24 @@ const Comment = new GraphQLObjectType({
         type: GraphQLString,
         resolve: getStripTagsResolver('markdown'),
       },
+      fromAccount: {
+        type: Account,
+        resolve: fromCollectiveResolver,
+      },
+      account: {
+        type: Account,
+        resolve: collectiveResolver,
+      },
+      // Deprecated
       fromCollective: {
         type: Account,
         resolve: fromCollectiveResolver,
+        deprecationReason: '2020-02-25: Please use fromAccount',
       },
       collective: {
         type: Account,
         resolve: collectiveResolver,
+        deprecationReason: '2020-02-25: Please use fromAccount',
       },
     };
   },

--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -1,14 +1,20 @@
-import { GraphQLString, GraphQLObjectType, GraphQLInt } from 'graphql';
+import { GraphQLString, GraphQLObjectType, GraphQLInt, GraphQLNonNull, GraphQLList } from 'graphql';
 import models, { Op } from '../../../models';
 
-import { setContextPermission, PERMISSION_TYPE } from '../../common/context-permissions';
-import { canSeeExpenseInvoiceInfo, canSeeExpensePayeeLocation } from '../../common/expenses';
+import { PERMISSION_TYPE, allowContextPermission } from '../../common/context-permissions';
+import * as ExpensePermissionsLib from '../../common/expenses';
 import { CommentCollection } from '../collection/CommentCollection';
 import { Account } from '../interface/Account';
 import { CollectionArgs } from '../interface/Collection';
 import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';
 
 import { ChronologicalOrderInput } from '../input/ChronologicalOrderInput';
+import PayoutMethod from './PayoutMethod';
+import { ExpenseType } from '../enum/ExpenseType';
+import { Currency } from '../enum';
+import ExpenseAttachment from './ExpenseAttachment';
+import ExpensePermissions from './ExpensePermissions';
+import ExpenseStatus from '../enum/ExpenseStatus';
 
 const Expense = new GraphQLObjectType({
   name: 'Expense',
@@ -16,23 +22,39 @@ const Expense = new GraphQLObjectType({
   fields: () => {
     return {
       id: {
-        type: GraphQLString,
+        type: new GraphQLNonNull(GraphQLString),
         resolve: getIdEncodeResolver(IDENTIFIER_TYPES.EXPENSE),
       },
       legacyId: {
-        type: GraphQLInt,
+        type: new GraphQLNonNull(GraphQLInt),
         description: 'Legacy ID as returned by API V1. Avoid relying on this field as it may be removed in the future.',
         resolve(expense) {
           return expense.id;
         },
       },
+      description: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: 'Title/main description for this expense',
+      },
+      currency: {
+        type: new GraphQLNonNull(Currency),
+        description: 'Currency that should be used for the payout',
+      },
+      type: {
+        type: new GraphQLNonNull(ExpenseType),
+        description: 'Whether this expense is a receipt or an invoice',
+      },
+      status: {
+        type: new GraphQLNonNull(ExpenseStatus),
+        description: 'The state of the expense (pending, approved, paid, rejected...etc)',
+      },
       comments: {
-        type: CommentCollection,
+        type: new GraphQLNonNull(CommentCollection),
         args: {
           ...CollectionArgs,
           orderBy: {
             type: ChronologicalOrderInput,
-            defaultValue: ChronologicalOrderInput.defaultValue,
+            defaultValue: { field: 'createdAt', direction: 'ASC' },
           },
         },
         async resolve(expense, { limit, offset, orderBy }) {
@@ -52,25 +74,86 @@ const Expense = new GraphQLObjectType({
           };
         },
       },
+      account: {
+        type: new GraphQLNonNull(Account),
+        description: 'The account where the expense was submitted',
+        resolve(expense, _, req) {
+          return req.loaders.Collective.byId.load(expense.CollectiveId);
+        },
+      },
       payee: {
-        type: Account,
+        type: new GraphQLNonNull(Account),
         description: 'The account being paid by this expense',
         async resolve(expense, _, req) {
           // Set the permissions for account's fields
-          const canSeeLocation = await canSeeExpensePayeeLocation(req, expense);
-          setContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_LOCATION, expense.FromCollectiveId, canSeeLocation);
+          const canSeeLocation = await ExpensePermissionsLib.canSeeExpensePayeeLocation(req, expense);
+          if (canSeeLocation) {
+            allowContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_LOCATION, expense.FromCollectiveId, true);
+          }
 
           // Return fromCollective
           return req.loaders.Collective.byId.load(expense.FromCollectiveId);
+        },
+      },
+      createdByAccount: {
+        type: Account,
+        description: 'The account who created this expense',
+        async resolve(expense, _, req) {
+          const user = await req.loaders.User.byId.load(expense.UserId);
+          if (user && user.CollectiveId) {
+            const collective = await req.loaders.Collective.byId.load(user.CollectiveId);
+            if (collective && !collective.isIncognito) {
+              return collective;
+            }
+          }
+        },
+      },
+      payoutMethod: {
+        type: PayoutMethod,
+        description: 'The payout method to use for this expense',
+        async resolve(expense, _, req) {
+          if (expense.PayoutMethodId) {
+            if (await ExpensePermissionsLib.canSeeExpensePayoutMethod(expense, req)) {
+              allowContextPermission(req, PERMISSION_TYPE.SEE_PAYOUT_METHOD_DATA, expense.PayoutMethodId);
+            }
+
+            return req.loaders.PayoutMethod.byId.load(expense.PayoutMethodId);
+          }
+        },
+      },
+      attachments: {
+        type: new GraphQLList(ExpenseAttachment),
+        async resolve(expense, _, req) {
+          if (await ExpensePermissionsLib.canSeeExpenseAttachments(req, expense)) {
+            allowContextPermission(req, PERMISSION_TYPE.SEE_EXPENSE_ATTACHMENTS_URL, expense.id);
+          }
+
+          return ExpensePermissionsLib.getExpenseAttachments(expense.id, req);
+        },
+      },
+      privateMessage: {
+        type: GraphQLString,
+        description: 'Additional information about the payment. Only visible to user and admins.',
+        async resolve(expense, _, req) {
+          if (await ExpensePermissionsLib.canSeeExpensePayoutMethod(req, expense)) {
+            return expense.privateMessage;
+          }
         },
       },
       invoiceInfo: {
         type: GraphQLString,
         description: 'Information to display on the invoice. Only visible to user and admins.',
         async resolve(expense, _, req) {
-          if (await canSeeExpenseInvoiceInfo(req, expense)) {
+          if (await ExpensePermissionsLib.canSeeExpenseInvoiceInfo(req, expense)) {
             return expense.invoiceInfo;
           }
+        },
+      },
+      permissions: {
+        type: new GraphQLNonNull(ExpensePermissions),
+        description: 'The permissions given to current logged in user for this expense',
+        async resolve(expense) {
+          return expense; // Individual fields are set by ExpensePermissions's resolvers
         },
       },
     };

--- a/server/graphql/v2/object/ExpenseAttachment.ts
+++ b/server/graphql/v2/object/ExpenseAttachment.ts
@@ -1,0 +1,44 @@
+import { GraphQLString, GraphQLInt, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-iso-date';
+import { getContextPermission, PERMISSION_TYPE } from '../../common/context-permissions';
+
+const ExpenseAttachment = new GraphQLObjectType({
+  name: 'ExpenseAttachment',
+  description: 'Fields for an expense attachment',
+  fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'Unique identifier for this expense attachment',
+    },
+    amount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'Amount of this attachment',
+    },
+    createdAt: {
+      type: new GraphQLNonNull(GraphQLDateTime),
+      description: 'The date on which the attachment was created',
+    },
+    updatedAt: {
+      type: new GraphQLNonNull(GraphQLDateTime),
+      description: 'The date on which the attachment was last updated',
+    },
+    incurredAt: {
+      type: new GraphQLNonNull(GraphQLDateTime),
+      description: 'The date on which the expense took place',
+    },
+    description: {
+      type: GraphQLString,
+      description: 'A description for this attachment. Enforced for new items, but old expenses may not have one.',
+    },
+    url: {
+      type: GraphQLString,
+      resolve(attachment, _, req): string | undefined {
+        if (getContextPermission(req, PERMISSION_TYPE.SEE_EXPENSE_ATTACHMENTS_URL, attachment.ExpenseId)) {
+          return attachment.url;
+        }
+      },
+    },
+  },
+});
+
+export default ExpenseAttachment;

--- a/server/graphql/v2/object/ExpensePermissions.ts
+++ b/server/graphql/v2/object/ExpensePermissions.ts
@@ -1,0 +1,32 @@
+import * as ExpensePermissionsLib from '../../common/expenses';
+import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+
+const ExpensePermissions = new GraphQLObjectType({
+  name: 'ExpensePermissions',
+  description: 'Fields for an expense attachment',
+  fields: {
+    canEdit: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can edit the expense',
+      resolve(expense, _, req): boolean {
+        return ExpensePermissionsLib.canEditExpense(req.remoteUser, expense);
+      },
+    },
+    canDelete: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can edit the expense',
+      resolve(expense, _, req): boolean {
+        return ExpensePermissionsLib.canDeleteExpense(req.remoteUser, expense);
+      },
+    },
+    canSeeInvoiceInfo: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can the the invoice info for this expense',
+      resolve(expense, _, req): Promise<boolean> {
+        return ExpensePermissionsLib.canSeeExpenseInvoiceInfo(req, expense);
+      },
+    },
+  },
+});
+
+export default ExpensePermissions;

--- a/server/graphql/v2/object/PayoutMethod.ts
+++ b/server/graphql/v2/object/PayoutMethod.ts
@@ -2,6 +2,7 @@ import { GraphQLString, GraphQLObjectType, GraphQLNonNull, GraphQLBoolean } from
 import GraphQLJSON from 'graphql-type-json';
 import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';
 import PayoutMethodType from '../enum/PayoutMethodType';
+import { getContextPermission, PERMISSION_TYPE } from '../../common/context-permissions';
 
 const PayoutMethod = new GraphQLObjectType({
   name: 'PayoutMethod',
@@ -10,18 +11,43 @@ const PayoutMethod = new GraphQLObjectType({
     id: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: getIdEncodeResolver(IDENTIFIER_TYPES.PAYOUT_METHOD),
+      description: 'Unique identifier for this payout method',
     },
     type: {
       type: PayoutMethodType,
+      description: 'The type of this payout method (usually the payment provider)',
     },
     name: {
       type: GraphQLString,
+      description: 'A friendly name for users to easily find their payout methods',
+      resolve: (payoutMethod, _, req): string => {
+        // Only collective admins can see the name of a payout method
+        if (req.remoteUser?.isAdmin(payoutMethod.CollectiveId)) {
+          return payoutMethod.isSaved;
+        }
+      },
     },
     isSaved: {
       type: GraphQLBoolean,
+      description: 'Whether this payout method has been saved to be used for future payouts',
+      resolve: (payoutMethod, _, req): boolean => {
+        // Only collective admins can see whether a payout method is saved or not
+        if (req.remoteUser?.isAdmin(payoutMethod.CollectiveId)) {
+          return payoutMethod.isSaved;
+        }
+      },
     },
     data: {
       type: GraphQLJSON,
+      description: 'The actual data for this payout method. Content depends on the type.',
+      resolve: (payoutMethod, _, req): object => {
+        if (
+          req.remoteUser?.isAdmin(payoutMethod.CollectiveId) ||
+          getContextPermission(req, PERMISSION_TYPE.SEE_PAYOUT_METHOD_DATA, payoutMethod.id)
+        ) {
+          return payoutMethod.data;
+        }
+      },
     },
   },
 });

--- a/server/graphql/v2/query/ExpenseQuery.js
+++ b/server/graphql/v2/query/ExpenseQuery.js
@@ -1,20 +1,29 @@
-import { GraphQLNonNull, GraphQLString } from 'graphql';
+import { GraphQLString } from 'graphql';
 
 import { Expense } from '../object/Expense';
-import models from '../../../models';
-import { getDecodedId } from '../identifiers';
+import { ExpenseReferenceInput, fetchExpenseWithReference } from '../input/ExpenseReferenceInput';
 
 const ExpenseQuery = {
   type: Expense,
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: 'Public expense identifier',
+      deprecationReason: '2020-02-28: Please use the `expense` field.',
+    },
+    expense: {
+      type: ExpenseReferenceInput,
+      description: 'Identifiers to retrieve the expense.',
     },
   },
-  async resolve(_, { id }) {
-    const decodedId = getDecodedId(id);
-    return models.Expense.findByPk(decodedId);
+  async resolve(_, args, req) {
+    if (args.expense) {
+      return fetchExpenseWithReference(args.expense, req);
+    } else if (args.id) {
+      return req.loaders.Expense.byId.load(args.id);
+    } else {
+      throw new Error('You must either provide an id or an expense');
+    }
   },
 };
 

--- a/test/server/graphql/common/context-permissions.test.js
+++ b/test/server/graphql/common/context-permissions.test.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { makeRequest } from '../../../utils';
+import {
+  allowContextPermission,
+  getContextPermission,
+  PERMISSION_TYPE,
+} from '../../../../server/graphql/common/context-permissions';
+
+describe('server/graphql/common/context-permissions', () => {
+  let req;
+
+  beforeEach(() => {
+    req = makeRequest();
+  });
+
+  it('returns false by default', () => {
+    expect(getContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_LOCATION, 1)).to.be.false;
+  });
+
+  it('can allow permissions for individual entities', () => {
+    allowContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_LOCATION, 1);
+    expect(getContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_LOCATION, 1)).to.be.true;
+    expect(getContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_LOCATION, 2)).to.be.false;
+  });
+
+  it('raise an error if permission type is unknown', () => {
+    expect(() => allowContextPermission(req, 'nope', 1)).to.throw();
+    expect(() => getContextPermission(req, 'nope', 1)).to.throw();
+  });
+});

--- a/test/server/graphql/v1/expenses.test.js
+++ b/test/server/graphql/v1/expenses.test.js
@@ -1624,7 +1624,7 @@ describe('server/graphql/v1/expenses', () => {
       const result = await utils.graphqlQuery(deleteExpenseQuery, { id: expense.id }, admin);
       expect(result.errors).to.exist;
       // And then the error message should be set accordingly.
-      expect(result.errors[0].message).to.equal('Only rejected expense can be deleted');
+      expect(result.errors[0].message).to.equal("You don't have permission to delete this expense");
     }); /* End of "fails if expense is not rejected" */
 
     it('works if logged in as admin of collective', async () => {

--- a/test/server/graphql/v1/expenses.test.js
+++ b/test/server/graphql/v1/expenses.test.js
@@ -1535,7 +1535,9 @@ describe('server/graphql/v1/expenses', () => {
       // Then there should be an error
       expect(result.errors).to.exist;
       // And then the error message should be set accordingly.
-      expect(result.errors[0].message).to.equal("You don't have permission to delete this expense");
+      expect(result.errors[0].message).to.equal(
+        "You don't have permission to delete this expense or it needs to be rejected before being deleted",
+      );
     }); /* End of "fails if not logged in as author, admin or host" */
 
     it('fails if logged in as backer of collective', async () => {
@@ -1567,7 +1569,9 @@ describe('server/graphql/v1/expenses', () => {
       // Then there should be an error
       expect(result.errors).to.exist;
       // And then the error message should be set accordingly.
-      expect(result.errors[0].message).to.equal("You don't have permission to delete this expense");
+      expect(result.errors[0].message).to.equal(
+        "You don't have permission to delete this expense or it needs to be rejected before being deleted",
+      );
     }); /* End of "fails if logged in as backer of collective" */
 
     it('works if logged in as author', async () => {
@@ -1624,7 +1628,9 @@ describe('server/graphql/v1/expenses', () => {
       const result = await utils.graphqlQuery(deleteExpenseQuery, { id: expense.id }, admin);
       expect(result.errors).to.exist;
       // And then the error message should be set accordingly.
-      expect(result.errors[0].message).to.equal("You don't have permission to delete this expense");
+      expect(result.errors[0].message).to.equal(
+        "You don't have permission to delete this expense or it needs to be rejected before being deleted",
+      );
     }); /* End of "fails if expense is not rejected" */
 
     it('works if logged in as admin of collective', async () => {


### PR DESCRIPTION
## New pattern: fetch permissions from frontend

This PR introduces a pattern that we haven't used before: providing a map of the permissions to the client (see `ExpensePermissions`) as the single source of truth for checking what a user can do with an object. I believe this is something we should tend towards for future developments for the following reasons:
- Permissions is something that will never change from one frontend to another
- Ability to check more complex scenarios without fetching additional data from the frontend
- Only one code to check permissions everywhere = easier to test, less chances of doing it wrong
- Never hide a security issue: if button is hidden, API shouldn't accept the action nether

## Changes in context-permissions

I've updated the documentation for `server/graphql/common/context-permissions.ts` to better explain the what & why.

`setContextPermission` has been renamed to `allowContextPermission` and the value parameter has been removed because setting this field to `false` usually doesn't make sense:

- `getContextPermission` already returns a falsy value by default
- If another parent up the tree set this to true, it makes no sense to remove this permission down the tree
