### PR TITLE
Host report: adapt for latest expense flow changes

### DIFF
--- a/reports/host-report.js
+++ b/reports/host-report.js
@@ -267,7 +267,25 @@ async function HostReport(year, month, hostId) {
       })
       .then(() =>
         getTransactions(Object.keys(collectivesById), startDate, endDate, {
-          include: [{ model: models.Expense }, { model: models.User, as: 'createdByUser' }],
+          include: [
+            {
+              model: models.Expense,
+              include: [
+                'fromCollective',
+                {
+                  model: models.ExpenseAttachment,
+                  as: 'attachments',
+                  where: {
+                    url: { [Op.not]: null },
+                  },
+                },
+              ],
+            },
+            {
+              model: models.User,
+              as: 'createdByUser',
+            },
+          ],
         }),
       )
       .tap(transactions => {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -207,7 +207,7 @@ export function setupModels(client) {
     foreignKey: 'FromCollectiveId',
     as: 'fromCollective',
   });
-  m.Expense.hasMany(m.ExpenseAttachment);
+  m.Expense.hasMany(m.ExpenseAttachment, { as: 'attachments' });
   m.Expense.hasMany(m.Transaction);
   m.Transaction.belongsTo(m.Expense);
   m.Transaction.belongsTo(m.Order);

--- a/templates/pdf/expenses.hbs
+++ b/templates/pdf/expenses.hbs
@@ -162,7 +162,7 @@ td.tdpadding {
             <td>-{{{currency paymentProcessorFeeInHostCurrency currency=@root.host.currency precision=2}}}</td>
           </tr>
           <tr><th nowrap>Net amount in {{@root.host.currency}}</th><td></td><td>{{{currency netAmountInHostCurrency currency=@root.host.currency precision=2}}}{{#if note}}*{{/if}}</td></tr>
-          <tr><th nowrap>Payout method</th><td></td><td nowrap>{{Expense.payoutMethod}}</td></tr>
+          <tr><th nowrap>Payout method</th><td></td><td nowrap>{{Expense.legacyPayoutMethod}}</td></tr>
           <tr><th>Recipient</th><td></td><td nowrap><a href="https://opencollective.com/{{Expense.fromCollective.slug}}">{{Expense.fromCollective.name}}</a></td></tr>
         </table>
         <table class="expenseTitleDescription">

--- a/templates/pdf/expenses.hbs
+++ b/templates/pdf/expenses.hbs
@@ -90,6 +90,11 @@ td.tdpadding {
   color: #333;
   font-size: 9pt;
 }
+
+.no-attachmentsblack {
+  color: #4e4e4e;
+  font-style: italic;
+}
 </style>
 
 <div id="document">
@@ -176,7 +181,13 @@ td.tdpadding {
         </table>
       </div>
 
-      <div class="preview" style="z-index:0; background-size: contain; background-image: url('https://res.cloudinary.com/opencollective/image/fetch/w_640,f_jpg/{{Expense.attachment}}')"></div>
+      {{#each Expense.attachments}}
+        <div class="preview" style="z-index:0; background-size: contain; background-image: url('https://res.cloudinary.com/opencollective/image/fetch/w_640,f_jpg/{{this.url}}')"></div>
+      {{else}}
+        <div class="no-attachments">
+          There's no file attached to this expense.
+        </div>
+      {{/each}}
 
       <div class="footer">{{@root.host.name}} - {{@root.month}} {{@root.year}} expense receipts - expense {{page}}/{{@root.stats.numberPaidExpenses}} - <a href="https://opencollective.com/{{collective.slug}}/expenses/{{Expense.id}}">opencollective.com/{{collective.slug}}/expenses/{{Expense.id}}</a></div>
 

--- a/templates/pdf/expenses.hbs
+++ b/templates/pdf/expenses.hbs
@@ -163,7 +163,7 @@ td.tdpadding {
           </tr>
           <tr><th nowrap>Net amount in {{@root.host.currency}}</th><td></td><td>{{{currency netAmountInHostCurrency currency=@root.host.currency precision=2}}}{{#if note}}*{{/if}}</td></tr>
           <tr><th nowrap>Payout method</th><td></td><td nowrap>{{Expense.payoutMethod}}</td></tr>
-          <tr><th>Recipient</th><td></td><td nowrap>{{createdByUser.firstName}} {{createdByUser.lastName}} &lt;{{createdByUser.email}}&gt;</td></tr>
+          <tr><th>Recipient</th><td></td><td nowrap><a href="https://opencollective.com/{{Expense.fromCollective.slug}}">{{Expense.fromCollective.name}}</a></td></tr>
         </table>
         <table class="expenseTitleDescription">
           <tr>


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2943
Missing data introduced in https://github.com/opencollective/opencollective-api/pull/3190 and https://github.com/opencollective/opencollective-api/pull/3172

I wasn't aware of the host report feature details until recently and missed that in the scope when I introduced the expense flow changes. I'm taking a note to give a special attention to it for the next iterations (ie https://github.com/opencollective/opencollective/issues/2944).