### PR TITLE
Host Comms:  Handle Email Actions

### DIFF
--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -37,6 +37,8 @@ export default {
   ORDERS_SUSPICIOUS: 'orders.suspicious',
   BACKYOURSTACK_DISPATCH_CONFIRMED: 'backyourstack.dispatch.confirmed',
   ADDED_FUND_TO_ORG: 'added.fund.to.org',
+  ACTIVATED_COLLECTIVE_AS_HOST: 'activated.collective.as.host',
+  DEACTIVATED_COLLECTIVE_AS_HOST: 'deactivated.collective.as.host',
 
   // Not used anymore, leaving for historical reference
   COLLECTIVE_TRANSACTION_PAID: 'collective.transaction.paid', // replaced with COLLECTIVE_EXPENSE_PAID

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -384,20 +384,6 @@ export function editCollective(_, args, req) {
         newCollectiveData.HostCollectiveId !== undefined &&
         newCollectiveData.HostCollectiveId !== collective.HostCollectiveId
       ) {
-        if (newCollectiveData.HostCollectiveId) {
-          const host = await models.Collective.findByPk(newCollectiveData.HostCollectiveId);
-          const hostPlan = await host.getPlan();
-
-          if (hostPlan.hostedCollectivesLimit && hostPlan.hostedCollectivesLimit <= hostPlan.hostedCollectives) {
-            notifyAdminsOfCollective(host.id, {
-              type: 'hostedCollectives.otherPlans.limit.reached',
-              data: { name: host.name },
-            });
-            throw new errors.PlanLimit({
-              message: `This host, ${host.name}, has reached the maximum number of Collectives for their plan on Open Collective. They need to upgrade to a new plan to host your collective.`,
-            });
-          }
-        }
         return collective.changeHost(newCollectiveData.HostCollectiveId, req.remoteUser);
       }
     })
@@ -1067,14 +1053,6 @@ export async function activateCollectiveAsHost(_, args, req) {
     });
   }
 
-  await models.Activity.create({
-    type: activities.ACTIVATED_COLLECTIVE_AS_HOST,
-    CollectiveId: collective.id,
-    data: {
-      collective,
-    },
-  });
-
   return collective.becomeHost();
 }
 
@@ -1097,14 +1075,6 @@ export async function deactivateCollectiveAsHost(_, args, req) {
       message: 'You need to be logged in as an Admin.',
     });
   }
-
-  await models.Activity.create({
-    type: activities.DEACTIVATED_COLLECTIVE_AS_HOST,
-    CollectiveId: collective.id,
-    data: {
-      collective,
-    },
-  });
 
   return collective.deactivateAsHost();
 }

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -120,13 +120,6 @@ async function checkRecaptcha(order, remoteUser, reqIp) {
   return response;
 }
 
-function fundExceededLimit(addedFunds, addedFundsLimit) {
-  if (addedFundsLimit && addedFunds > addedFundsLimit) {
-    return true;
-  }
-  return false;
-}
-
 export async function createOrder(order, loaders, remoteUser, reqIp) {
   debug('Beginning creation of order', order);
   if (!remoteUser) {
@@ -989,7 +982,7 @@ export async function addFundsToCollective(order, remoteUser) {
 
   // Check limits
   let hostPlan = await host.getPlan();
-  if (fundExceededLimit(hostPlan.addedFunds, hostPlan.addedFundsLimit)) {
+  if (hostPlan.addedFundsLimit && hostPlan.addedFunds > hostPlan.addedFundsLimit) {
     throw new errors.PlanLimit({
       message:
         'You’ve reached the free Starter Plan $1,000 limit. To add more funds manually or using bank transfers, you’ll need to upgrade your plan. Payments via credit card (through Stripe) do not count toward the $1,000 limit and you can continue to receive them.',
@@ -1057,7 +1050,7 @@ export async function addFundsToCollective(order, remoteUser) {
 
     // Check if the maximum fund limit has been reached after execution
     hostPlan = await host.getPlan();
-    if (fundExceededLimit(hostPlan.addedFunds, hostPlan.addedFundsLimit)) {
+    if (hostPlan.addedFundsLimit && hostPlan.addedFundsLimit <= hostPlan.addedFunds) {
       notifyAdminsOfCollective(host.id, {
         type: 'hostedCollectives.freePlan.limit.reached',
         data: { name: host.name },

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -120,6 +120,13 @@ async function checkRecaptcha(order, remoteUser, reqIp) {
   return response;
 }
 
+function fundExceededLimit(addedFunds, addedFundsLimit) {
+  if (addedFundsLimit && addedFunds > addedFundsLimit) {
+    return true;
+  }
+  return false;
+}
+
 export async function createOrder(order, loaders, remoteUser, reqIp) {
   debug('Beginning creation of order', order);
   if (!remoteUser) {
@@ -982,7 +989,7 @@ export async function addFundsToCollective(order, remoteUser) {
 
   // Check limits
   let hostPlan = await host.getPlan();
-  if (hostPlan.addedFundsLimit && hostPlan.addedFunds > hostPlan.addedFundsLimit) {
+  if (fundExceededLimit(hostPlan.addedFunds, hostPlan.addedFundsLimit)) {
     throw new errors.PlanLimit({
       message:
         'You’ve reached the free Starter Plan $1,000 limit. To add more funds manually or using bank transfers, you’ll need to upgrade your plan. Payments via credit card (through Stripe) do not count toward the $1,000 limit and you can continue to receive them.',
@@ -1050,7 +1057,7 @@ export async function addFundsToCollective(order, remoteUser) {
 
     // Check if the maximum fund limit has been reached after execution
     hostPlan = await host.getPlan();
-    if (hostPlan.addedFundsLimit && hostPlan.addedFundsLimit <= hostPlan.addedFunds) {
+    if (fundExceededLimit(hostPlan.addedFunds, hostPlan.addedFundsLimit)) {
       notifyAdminsOfCollective(host.id, {
         type: 'hostedCollectives.freePlan.limit.reached',
         data: { name: host.name },

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -995,7 +995,7 @@ export async function addFundsToCollective(order, remoteUser) {
   if (hostPlan.addedFundsLimit && hostPlan.addedFunds > hostPlan.addedFundsLimit) {
     throw new errors.PlanLimit({
       message:
-        'You’ve reached the free Starter Plan $1,000 limit. To add more funds manually or using bank transfers, you’ll need to upgrade your plan. Payments via credit card (through Stripe) do not count toward the $1,000 limit and you can continue to receive them.',
+        'You’ve reached the free Starter Plan $1,000 limit. To add more funds manually or keep using bank transfers, you’ll need to upgrade your plan. Payments via credit card (through Stripe) do not count toward the $1,000 limit and you can continue to receive them.',
     });
   }
 

--- a/server/lib/emailTemplates.js
+++ b/server/lib/emailTemplates.js
@@ -101,6 +101,13 @@ export const templateNames = [
   'user.yearlyreport.text',
   'backyourstack.dispatch.confirmed',
   'added.fund.to.org',
+  'activated.collective.as.host',
+  'deactivated.collective.as.host',
+  'hostedCollectives.freePlan.limit.reached',
+  'hostedCollectives.otherPlans.limit.reached',
+  'hostPlan.renewal.thankyou',
+  'hostplan.first.subscription.confirmation',
+  'hostplan.upgrade.subscription.confirmation',
 ];
 
 const templatesPath = `${__dirname}/../../templates`;

--- a/server/lib/emailTemplates.js
+++ b/server/lib/emailTemplates.js
@@ -105,7 +105,7 @@ export const templateNames = [
   'deactivated.collective.as.host',
   'hostedCollectives.freePlan.limit.reached',
   'hostedCollectives.otherPlans.limit.reached',
-  'hostPlan.renewal.thankyou',
+  'hostplan.renewal.thankyou',
   'hostplan.first.subscription.confirmation',
   'hostplan.upgrade.subscription.confirmation',
 ];

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -379,5 +379,17 @@ async function notifyByEmail(activity) {
       notifyAdminsOfCollective(activity.data.collective.id, activity, {
         template: 'added.fund.to.org',
       });
+      break;
+
+    case activityType.ACTIVATED_COLLECTIVE_AS_HOST:
+      notifyAdminsOfCollective(activity.data.collective.id, activity, {
+        template: 'activated.collective.as.host',
+      });
+      break;
+
+    case activityType.DEACTIVATED_COLLECTIVE_AS_HOST:
+      notifyAdminsOfCollective(activity.data.collective.id, activity, {
+        template: 'deactivated.collective.as.host',
+      });
   }
 }

--- a/server/lib/plans.ts
+++ b/server/lib/plans.ts
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 
 import plans, { PLANS_COLLECTIVE_SLUG } from '../constants/plans';
+import { notifyAdminsOfCollective } from './notifications';
 
 const isSubscribeOrUpgrade = (newPlan: string, oldPlan?: string | null): boolean => {
   return !oldPlan ? true : get(plans, `${newPlan}.level`) > get(plans, `${oldPlan}.level`);
@@ -11,11 +12,32 @@ export async function subscribeOrUpgradePlan(order): Promise<void> {
 
   if (order.tier && order.collective.slug === PLANS_COLLECTIVE_SLUG) {
     const newPlan = get(order, 'tier.slug');
+    const oldPlan = order.fromCollective.plan;
 
     // Update plan only when hiring or upgrading, we don't want to suspend client's
     // features until the end of the billing. Downgrades are dealt in a cronjob.
-    if (newPlan && plans[newPlan] && isSubscribeOrUpgrade(newPlan, order.fromCollective.plan)) {
+    if (newPlan && plans[newPlan] && isSubscribeOrUpgrade(newPlan, oldPlan)) {
       await order.fromCollective.update({ plan: newPlan });
+      const emailData = {
+        name: order.fromCollective.name,
+        plan: get(order, 'tier.name'),
+        hostedCollectivesLimit: get(plans, `${newPlan}.hostedCollectivesLimit`)
+      }
+
+      // First time subscription confirmation
+      if (!oldPlan) {
+        notifyAdminsOfCollective(order.fromCollective.id, {
+          type: 'hostplan.first.subscription.confirmation',
+          data: emailData
+        })
+      } else {
+        // Upgrading subscription confirmation
+        notifyAdminsOfCollective(order.fromCollective.id, {
+          type: 'hostplan.upgrade.subscription.confirmation',
+          data: emailData
+        })
+      }
+
     }
   }
 }

--- a/server/lib/plans.ts
+++ b/server/lib/plans.ts
@@ -52,3 +52,11 @@ export async function validatePlanRequest(order): Promise<void> {
     }
   }
 }
+
+export function isHostPlan (order): boolean {
+  const plan = get(order, 'Tier.slug');
+  if (order.collective.slug === PLANS_COLLECTIVE_SLUG && plan && plans[plan]) {
+    return true;
+  }
+  return false;
+}

--- a/server/lib/subscriptions.js
+++ b/server/lib/subscriptions.js
@@ -347,7 +347,7 @@ export async function sendThankYouEmail(order, transaction) {
 
   if (orderPlan) {
     return emailLib.send(
-      'hostPlan.renewal.thankyou',
+      'hostplan.renewal.thankyou',
       user.email,
       { plan: orderPlan },
       {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -942,6 +942,7 @@ export default function(Sequelize, DataTypes) {
     // TODO unsubscribe from OpenCollective tier plan.
 
     await this.update({ isHostAccount: false });
+
     await models.Activity.create({
       type: activities.DEACTIVATED_COLLECTIVE_AS_HOST,
       CollectiveId: this.id,

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -923,7 +923,7 @@ export default function(Sequelize, DataTypes) {
     await models.Activity.create({
       type: activities.ACTIVATED_COLLECTIVE_AS_HOST,
       CollectiveId: this.id,
-      data: {},
+      data: { collective: this.info },
     });
   };
 
@@ -945,7 +945,7 @@ export default function(Sequelize, DataTypes) {
     await models.Activity.create({
       type: activities.DEACTIVATED_COLLECTIVE_AS_HOST,
       CollectiveId: this.id,
-      data: {},
+      data: { collective: this.info },
     });
   };
 

--- a/templates/emails/activated.collective.as.host.hbs
+++ b/templates/emails/activated.collective.as.host.hbs
@@ -1,0 +1,28 @@
+Subject: Host Activation
+
+{{> header}}
+
+<p>Hi!</p>
+
+<p>I’m Pía, co-founder of Open Collective. Thank you for becoming a Fiscal Host, a company or individual who holds funds on behalf of Collectives. It’s a great way to help your community be sustainable.</p>
+
+<h3>Pricing</h3>
+<p>
+  You on the Starter Plan, which is free. You can receive bank transfers and add funds manually up to $1,000. After that, you’ll be prompted to go on a paid plan based on the number of Collectives you are hosting (<a href="https://opencollective.com/pricing">see plans</a>). Contributions made to your Collectives via credit card (through Stripe) incur a 5% platform fee, and do not count toward the $1,000 limit.
+</p>
+
+<h3>Useful info</h3>
+<ul>
+  <li>How to use <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-dashboard">the host dashboard</a> - your one-stop-shop for all host functionality</li>
+  <li><a href="https://docs.opencollective.com/help/fiscal-hosts/become-a-fiscal-host#things-to-consider-when-becoming-a-host">Some things to consider</a> when becoming a host</li>
+  <li>Our <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-hosts">Host FAQ</a></li>
+  <li>How to <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-fees">set your host fee</a> (what you charge Collectives)</li>
+</ul>
+
+<p>We want to help your community thrive! Please feel free to reply to this email or <a href="http://calendly.com/piamancini/call">schedule a time to chat with me</a>.</p>
+
+<p>Best,</p>
+
+<p>Pía &amp; the Open Collective Team</p>
+
+{{> footer}}

--- a/templates/emails/activated.collective.as.host.hbs
+++ b/templates/emails/activated.collective.as.host.hbs
@@ -4,16 +4,16 @@ Subject: Host Activation
 
 <p>Hi!</p>
 
-<p>I’m Pía, co-founder of Open Collective. Thank you for becoming a Fiscal Host, a company or individual who holds funds on behalf of Collectives. It’s a great way to help your community be sustainable.</p>
+<p>I’m Pía, co-founder of Open Collective. Thank you for becoming a Fiscal Host. A Host is a company or an individual who holds funds on behalf of collectives. It’s a great way to help your community be sustainable.</p>
 
 <h3>Pricing</h3>
 <p>
-  You on the Starter Plan, which is free. You can receive bank transfers and add funds manually up to $1,000. After that, you’ll be prompted to go on a paid plan based on the number of Collectives you are hosting (<a href="https://opencollective.com/pricing">see plans</a>). Contributions made to your Collectives via credit card (through Stripe) incur a 5% platform fee, and do not count toward the $1,000 limit.
+  You are on the Starter Plan, which is free. You can receive bank transfers and add funds manually up to $1,000. After that, you’ll be prompted to go on a paid plan based on the number of Collectives you are hosting (<a href="https://opencollective.com/pricing">see plans</a>). Contributions made to your Collectives via credit card (through Stripe) incur a 5% platform fee, and do not count toward the $1,000 limit.
 </p>
 
 <h3>Useful info</h3>
 <ul>
-  <li>How to use <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-dashboard">the host dashboard</a> - your one-stop-shop for all host functionality</li>
+  <li>How to use <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-dashboard">the host dashboard</a>. Your one-stop-shop for all host functionality</li>
   <li><a href="https://docs.opencollective.com/help/fiscal-hosts/become-a-fiscal-host#things-to-consider-when-becoming-a-host">Some things to consider</a> when becoming a host</li>
   <li>Our <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-hosts">Host FAQ</a></li>
   <li>How to <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-fees">set your host fee</a> (what you charge Collectives)</li>

--- a/templates/emails/deactivated.collective.as.host.hbs
+++ b/templates/emails/deactivated.collective.as.host.hbs
@@ -4,9 +4,9 @@ Subject: Host De-Activation
 
 <p>Hi,</p>
 
-<p>You have successfully deactivated your host. Your profile will no longer be able to receive and add funds for collectives or receive Bank and PayPal payments. Your profile will no longer have a host dashboard either.</p> 
+<p>You have successfully deactivated your host. Your profile is no longer able to receive and add funds for collectives or receive Bank and PayPal payments. Your profile no longer has a host dashboard either.</p>
 
-<p>If you think this was a mistake, please reactivate your host from the settings in your profile or contact <a href="mailto:support@opencollective.com">support@opencollective.com</a></p> 
+<p>If you think this was a mistake, please reactivate your host from the settings in your profile or contact <a href="mailto:support@opencollective.com">support@opencollective.com</a></p>
 
 <p>Thank you!</p>
 

--- a/templates/emails/deactivated.collective.as.host.hbs
+++ b/templates/emails/deactivated.collective.as.host.hbs
@@ -4,7 +4,7 @@ Subject: Host De-Activation
 
 <p>Hi,</p>
 
-<p>You have successfully deactivated your host. Your profile is no longer able to receive and add funds for collectives or receive Bank and PayPal payments. Your profile no longer has a host dashboard either.</p>
+<p>You have successfully deactivated your host. Your profile is no longer able to manage a collective's budget (receive funds and pay for expenses). Your profile no longer has a host dashboard either.</p>
 
 <p>If you think this was a mistake, please reactivate your host from the settings in your profile or contact <a href="mailto:support@opencollective.com">support@opencollective.com</a></p>
 

--- a/templates/emails/deactivated.collective.as.host.hbs
+++ b/templates/emails/deactivated.collective.as.host.hbs
@@ -1,0 +1,13 @@
+Subject: Host De-Activation
+
+{{> header}}
+
+<p>Hi,</p>
+
+<p>You have successfully deactivated your host. Your profile will no longer be able to receive and add funds for collectives or receive Bank and PayPal payments. Your profile will no longer have a host dashboard either.</p> 
+
+<p>If you think this was a mistake, please reactivate your host from the settings in your profile or contact <a href="mailto:support@opencollective.com">support@opencollective.com</a></p> 
+
+<p>Thank you!</p>
+
+{{> footer}}

--- a/templates/emails/hostedCollectives.freePlan.limit.reached.hbs
+++ b/templates/emails/hostedCollectives.freePlan.limit.reached.hbs
@@ -1,0 +1,32 @@
+Subject: Plan reaches Limit
+
+<style>
+  .button {
+    background: linear-gradient(rgb(24, 105, 245) 0%, rgb(22, 89, 225) 100%);
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 14px;
+    color: rgb(255, 255, 255);
+    border-radius: 100px;
+    padding: 5px 14px;
+  }
+</style>
+
+{{> header}}
+
+<p>Hi!</p>
+
+<p>
+  You’ve reached the free Starter Plan $1,000 limit. To add more funds manually or using bank transfers, you’ll need to upgrade your plan. Payments via credit card (through Stripe) do not count toward the $1,000 limit and you can continue to receive them.
+</p>
+
+<img src="{{config.host.website}}/static/images/pricing-table-screenshot.png" alt="Pricing table">
+
+<p>Upgrade your plan now <a class="button" href="https://opencollective.com/pricing">Upgrade</a></p>
+
+<p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+
+<p>Best,</p>
+<p>Pía &amp; the Open Collective Team</p>
+
+{{> footer}}

--- a/templates/emails/hostedCollectives.freePlan.limit.reached.hbs
+++ b/templates/emails/hostedCollectives.freePlan.limit.reached.hbs
@@ -4,11 +4,11 @@ Subject: Plan reaches Limit
   .button {
     background: linear-gradient(rgb(24, 105, 245) 0%, rgb(22, 89, 225) 100%);
     font-weight: 500;
-    font-size: 12px;
-    line-height: 14px;
+    font-size: 16px;
+    line-height: 18px;
     color: rgb(255, 255, 255);
     border-radius: 100px;
-    padding: 5px 14px;
+    padding: 10px 16px;
   }
 </style>
 
@@ -17,12 +17,14 @@ Subject: Plan reaches Limit
 <p>Hi!</p>
 
 <p>
-  You’ve reached the free Starter Plan $1,000 limit. To add more funds manually or using bank transfers, you’ll need to upgrade your plan. Payments via credit card (through Stripe) do not count toward the $1,000 limit and you can continue to receive them.
+  You’ve reached the free Starter Plan $1,000 limit. To add more funds manually or keep using bank transfers, you’ll need to upgrade your plan. Payments via credit card (through Stripe) do not count toward the $1,000 limit and you can continue to receive them.
 </p>
 
-<img src="{{config.host.website}}/static/images/pricing-table-screenshot.png" alt="Pricing table">
+<p>
+  <img src="{{config.host.website}}/static/images/pricing-table-screenshot.png" alt="Pricing table">
+</p>
 
-<p>Upgrade your plan now <a class="button" href="https://opencollective.com/pricing">Upgrade</a></p>
+<p><center><a class="button" href="https://opencollective.com/pricing">Upgrade plan</a></center></p>
 
 <p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
 

--- a/templates/emails/hostedCollectives.otherPlans.limit.reached.hbs
+++ b/templates/emails/hostedCollectives.otherPlans.limit.reached.hbs
@@ -4,11 +4,11 @@ Subject: Plan reaches Limit
   .button {
     background: linear-gradient(rgb(24, 105, 245) 0%, rgb(22, 89, 225) 100%);
     font-weight: 500;
-    font-size: 12px;
-    line-height: 14px;
+    font-size: 16px;
+    line-height: 18px;
     color: rgb(255, 255, 255);
     border-radius: 100px;
-    padding: 5px 14px;
+    padding: 10px 16px;
   }
 </style>
 
@@ -17,12 +17,14 @@ Subject: Plan reaches Limit
 <p>Hello,</p>
 
 <p>
-  Your host, {{name}}, has reached the maximum number of Collectives for your plan on Open Collective. If you want to host more Collectives, please upgrade your plan.
+  We hope you are well! {{name}}, has reached the maximum number of Collectives for your plan on Open Collective. If you want to host more Collectives, please upgrade your plan. Please see below our plan options.
 </p>
 
-<img src="{{config.host.website}}/static/images/pricing-table-screenshot.png" alt="Pricing table">
+<p>
+  <img src="{{config.host.website}}/static/images/pricing-table-screenshot.png" alt="Pricing table">
+</p>
 
-<p>Upgrade your plan now <a class="button" href="https://opencollective.com/pricing">Upgrade</a></p>
+<p><center><a class="button" href="https://opencollective.com/pricing">Upgrade plan</a></center></p>
 
 <p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
 

--- a/templates/emails/hostedCollectives.otherPlans.limit.reached.hbs
+++ b/templates/emails/hostedCollectives.otherPlans.limit.reached.hbs
@@ -17,7 +17,7 @@ Subject: Plan reaches Limit
 <p>Hello,</p>
 
 <p>
-  We hope you are well! {{name}}, has reached the maximum number of Collectives for your plan on Open Collective. If you want to host more Collectives, please upgrade your plan. Please see below our plan options.
+  We hope you are well! {name} has reached the maximum number of collectives on the current plan. If you want to host more Collectives, please upgrade your plan. Please see below our plan options.
 </p>
 
 <p>

--- a/templates/emails/hostedCollectives.otherPlans.limit.reached.hbs
+++ b/templates/emails/hostedCollectives.otherPlans.limit.reached.hbs
@@ -1,0 +1,32 @@
+Subject: Plan reaches Limit
+
+<style>
+  .button {
+    background: linear-gradient(rgb(24, 105, 245) 0%, rgb(22, 89, 225) 100%);
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 14px;
+    color: rgb(255, 255, 255);
+    border-radius: 100px;
+    padding: 5px 14px;
+  }
+</style>
+
+{{> header}}
+
+<p>Hello,</p>
+
+<p>
+  Your host, {{name}}, has reached the maximum number of Collectives for your plan on Open Collective. If you want to host more Collectives, please upgrade your plan.
+</p>
+
+<img src="{{config.host.website}}/static/images/pricing-table-screenshot.png" alt="Pricing table">
+
+<p>Upgrade your plan now <a class="button" href="https://opencollective.com/pricing">Upgrade</a></p>
+
+<p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+
+<p>Best,</p>
+<p>Pía &amp; the Open Collective Team</p>
+
+{{> footer}}

--- a/templates/emails/hostplan.first.subscription.confirmation.hbs
+++ b/templates/emails/hostplan.first.subscription.confirmation.hbs
@@ -1,0 +1,24 @@
+Subject: Plan Subscription Confirmation
+
+{{> header}}
+
+<p>Congratulations! You have successfully subscribed to the {{plan}} on Open Collective for your fiscal host, {{name}}. You can host up to {{hostedCollectivesLimit}} Collectives.</p>
+
+<p>You have access to:</p>
+
+<ul>
+  <li><a href="https://docs.opencollective.com/help/product/product">Collectives</a> - pages to coordinate community and budget for projects, groups, or chapters.</li>
+  <li>Communication tools: <a href="https://docs.opencollective.com/help/collectives/communication">updates</a>, <a href="https://docs.opencollective.com/help/collectives/conversations">conversations</a>, and a <a href="https://docs.opencollective.com/help/collectives/communication#contacting-a-collective">contact form</a>.</li>
+  <li>Show your budget and expenses <a href="https://docs.opencollective.com/help/collectives/budget">transparently</a>.</li>
+  <li><a href="https://docs.opencollective.com/help/fiscal-hosts/create-a-fiscal-host">Fundraise</a> through credit card payments (cost: 5% plus Stripe payment processor fees).</li>
+  <li>Manually <a href="https://docs.opencollective.com/help/fiscal-hosts/add-funds-manually">add funds raised through other channels</a> (e.g. payments you've invoiced, cash, or third party channels like a shop).
+  </li>
+  <li>Enable bank transfer payments[LINK], which automatically provide financial contributors with wire instructions and a reference number for tracking.</li>
+  <li>A <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-dashboard">host dashboard</a> to easily manage budgets and expenses across all your Collectives, including one-click payouts via Paypal.</li>
+</ul>
+
+<p>Let us know if we can help out in any way by emailing <a href="mailto:">support@opencollective.com</a>.</p>
+<p>Best,</p>
+<p>Pía &amp; the Open Collective Team</p>
+
+{{> footer}}

--- a/templates/emails/hostplan.first.subscription.confirmation.hbs
+++ b/templates/emails/hostplan.first.subscription.confirmation.hbs
@@ -2,7 +2,7 @@ Subject: Plan Subscription Confirmation
 
 {{> header}}
 
-<p>Congratulations! You have successfully subscribed to the {{plan}} on Open Collective for your fiscal host, {{name}}. You can host up to {{hostedCollectivesLimit}} Collectives.</p>
+<p>Congratulations! You have successfully subscribed to the {{plan}} on Open Collective for your fiscal host, {{name}}. You can host up to {{hostedCollectivesLimit}} collectives.</p>
 
 <p>You have access to:</p>
 
@@ -13,8 +13,8 @@ Subject: Plan Subscription Confirmation
   <li><a href="https://docs.opencollective.com/help/fiscal-hosts/create-a-fiscal-host">Fundraise</a> through credit card payments (cost: 5% plus Stripe payment processor fees).</li>
   <li>Manually <a href="https://docs.opencollective.com/help/fiscal-hosts/add-funds-manually">add funds raised through other channels</a> (e.g. payments you've invoiced, cash, or third party channels like a shop).
   </li>
-  <li>Enable bank transfer payments[LINK], which automatically provide financial contributors with wire instructions and a reference number for tracking.</li>
-  <li>A <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-dashboard">host dashboard</a> to easily manage budgets and expenses across all your Collectives, including one-click payouts via Paypal.</li>
+  <li>Enable <a href="https://docs.opencollective.com/help/fiscal-hosts/bank-transfers">bank transfer payments</a>, which automatically provide financial contributors with wire instructions and a reference number for tracking.</li>
+  <li>A <a href="https://docs.opencollective.com/help/fiscal-hosts/fiscal-host-dashboard">host dashboard</a> to easily manage budgets and expenses across all your Collectives, including one-click payouts via Paypal and Transferwise.</li>
 </ul>
 
 <p>Let us know if we can help out in any way by emailing <a href="mailto:">support@opencollective.com</a>.</p>

--- a/templates/emails/hostplan.renewal.thankyou.hbs
+++ b/templates/emails/hostplan.renewal.thankyou.hbs
@@ -8,7 +8,7 @@ Subject: Host plan subscription renewal
 
 <p>Thank you for enabling your community to thrive.</p>
 
-L<p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+<p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
 
 <p>Best,</p>
 <p>Pía &amp; the Open Collective Team</p>

--- a/templates/emails/hostplan.renewal.thankyou.hbs
+++ b/templates/emails/hostplan.renewal.thankyou.hbs
@@ -1,0 +1,16 @@
+Subject: Host plan subscription renewal
+
+{{> header}}
+
+<p>Hi!</p>
+
+<p>Your monthly subscription to the {{plan}} has been successfully processed.</p> 
+
+<p>Thank you for enabling your community to thrive.</p>
+
+L<p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+
+<p>Best,</p>
+<p>Pía &amp; the Open Collective Team</p>
+
+{{> footer}}

--- a/templates/emails/hostplan.upgrade.subscription.confirmation.hbs
+++ b/templates/emails/hostplan.upgrade.subscription.confirmation.hbs
@@ -2,7 +2,7 @@ Subject: Plan Upgrade Confirmation
 
 {{> header}}
 
-<p>Congratulations! You have successfully upgraded your host, {{name}}, to the {{plan}} on Open Collective. You can host up to {{hostedCollectivesLimit}}. </p>
+<p>Congratulations! You have successfully upgraded your host, {{name}}, to the {{plan}} on Open Collective. You can host up to {{hostedCollectivesLimit}} collectives.</p>
 
 <p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
 

--- a/templates/emails/hostplan.upgrade.subscription.confirmation.hbs
+++ b/templates/emails/hostplan.upgrade.subscription.confirmation.hbs
@@ -1,0 +1,12 @@
+Subject: Plan Upgrade Confirmation
+
+{{> header}}
+
+<p>Congratulations! You have successfully upgraded your host, {{name}}, to the {{plan}} on Open Collective. You can host up to {{hostedCollectivesLimit}}. </p>
+
+<p>Let us know if we can help out in any way by emailing <a href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+
+<p>Best,</p>
+<p>Pía &amp; the Open Collective Team</p>
+
+{{> footer}}


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2911

- [X] Send email when they activate as host
- [X] email when you deactivate as a host
- [X]  detect when they are reaching an email / over add funds / collective limit
- [X]  monthly email when subscription is renewed
- [X]  first plan subscription confirmation
- [X]  Upgrade plan subscription confirmation
- [X]   Send an email when you add an organization / individual as a host that you own. (Same as the first one 

Updated Error messages

- [X]  Error message when trying to add funds over the limit
- [X] Error message for users trying to apply to a new host
- [X]  Error message for users - Bank Transfer option in Expense Flow