### PR TITLE
Update expiring cards dates and add reminder

### DIFF
--- a/cron/disabled/expiring-cards.js
+++ b/cron/disabled/expiring-cards.js
@@ -40,8 +40,7 @@ const fetchExpiringCreditCards = async (month, year) => {
 
 const run = async () => {
   const cards = await fetchExpiringCreditCards(month, year);
-  let reminder;
-  date === 21 ? (reminder = true) : (reminder = false);
+  const reminder = date === 21 ? true : false;
 
   for (const card of cards) {
     try {

--- a/cron/disabled/expiring-cards.js
+++ b/cron/disabled/expiring-cards.js
@@ -5,14 +5,14 @@ import logger from '../../server/lib/logger';
 import models from '../../server/models';
 import * as libPayments from '../../server/lib/payments';
 
-// Only run on the first of the month
+// Run on the 7th and 21st of the month
 const today = new Date();
 const date = today.getDate();
 const month = today.getMonth() + 1;
 const year = today.getFullYear();
 
-if (process.env.NODE_ENV === 'production' && date !== 1 && !process.env.OFFCYCLE) {
-  console.log('NODE_ENV is production and today is not the first of month, script aborted!');
+if (process.env.NODE_ENV === 'production' && (date !== 7 || date !== 21) && !process.env.OFFCYCLE) {
+  console.log('NODE_ENV is production and today is not the 7th or 21st of month, script aborted!');
   process.exit();
 }
 
@@ -40,6 +40,8 @@ const fetchExpiringCreditCards = async (month, year) => {
 
 const run = async () => {
   const cards = await fetchExpiringCreditCards(month, year);
+  let reminder;
+  date === 21 ? (reminder = true) : (reminder = false);
 
   for (const card of cards) {
     try {
@@ -74,10 +76,11 @@ const run = async () => {
           collectiveName,
           slug,
           email,
+          reminder,
         };
 
         logger.info(
-          `Payment method ${data.id} for collective '${data.slug}' is expiring, sending an email to ${data.email}`,
+          `Payment method ${data.id} for collective '${data.slug}' is expiring, sending an email to ${data.email}, reminder = ${reminder}`,
         );
         if (!process.env.DRY_RUN) {
           await libPayments.sendExpiringCreditCardUpdateEmail(data);

--- a/cron/disabled/expiring-cards.js
+++ b/cron/disabled/expiring-cards.js
@@ -11,7 +11,7 @@ const date = today.getDate();
 const month = today.getMonth() + 1;
 const year = today.getFullYear();
 
-if (process.env.NODE_ENV === 'production' && (date !== 7 || date !== 21) && !process.env.OFFCYCLE) {
+if (process.env.NODE_ENV === 'production' && date !== 7 && date !== 21 && !process.env.OFFCYCLE) {
   console.log('NODE_ENV is production and today is not the 7th or 21st of month, script aborted!');
   process.exit();
 }

--- a/templates/emails/payment.creditcard.expiring.hbs
+++ b/templates/emails/payment.creditcard.expiring.hbs
@@ -1,4 +1,8 @@
+{{#if reminder}}
+Subject: Reminder: your {{brand}} ending in {{name}} is about to expire
+{{else}}
 Subject: Your {{brand}} ending in {{name}} is about to expire
+{{/if}}
 
 <style>
   code {
@@ -18,10 +22,19 @@ Subject: Your {{brand}} ending in {{name}} is about to expire
 <p>Hello,</p>
 {{/if}}
 
+
+{{#if reminder}}
+<p>
+  Just a quick reminder: your {{brand}} ending in {{name}} is about to expire. To continue your subscriptions without
+  interruption, you should
+  update this card before the end of the month.
+</p>
+{{else}}
 <p>
   Your {{brand}} ending in {{name}} is about to expire. To continue your subscriptions without interruption, you should
   update this card before the end of the month.
 </p>
+{{/if}}
 
 <p>Add a new credit card <a href="{{updateDetailsLink}}">here</a> to keep your subscriptions going.</p>
 

--- a/templates/emails/payment.creditcard.expiring.hbs
+++ b/templates/emails/payment.creditcard.expiring.hbs
@@ -25,16 +25,15 @@ Subject: Your {{brand}} ending in {{name}} is about to expire
 
 {{#if reminder}}
 <p>
-  Just a quick reminder: your {{brand}} ending in {{name}} is about to expire. To continue your subscriptions without
-  interruption, you should
-  update this card before the end of the month.
+  Just a quick reminder: your {{brand}} ending in {{name}} is about to expire.
 </p>
 {{else}}
 <p>
-  Your {{brand}} ending in {{name}} is about to expire. To continue your subscriptions without interruption, you should
-  update this card before the end of the month.
+  Your {{brand}} ending in {{name}} is about to expire.
 </p>
 {{/if}}
+
+<p>To continue your subscriptions without interruption, you should update this card before the end of the month.</p>
 
 <p>Add a new credit card <a href="{{updateDetailsLink}}">here</a> to keep your subscriptions going.</p>
 


### PR DESCRIPTION
References opencollective/opencollective#2940

Just a small change:

* Change date to 7th/21st for emails
* Adds `reminder` case to code and to email template

Tested locally and once you update your credit card after the first email, it means you won't get the reminder email during the second run, so no extra code is needed.

Let me know if there are any changes needed and if not, I can move it back to the `cron/monthly` folder.
