### PR TITLE
Fix Webhook Timeout

### DIFF
--- a/server/middleware/security/auth.js
+++ b/server/middleware/security/auth.js
@@ -76,7 +76,7 @@ export function authorizeClientApp(req, res, next) {
       method: 'GET',
       regex: /^\/collectives\/[0-9]+\/transactions\/[0-9]+\/callback\?token=.+/,
     }, // PayPal callback
-    { method: 'POST', regex: /^\/webhooks\/(mailgun|stripe)/ },
+    { method: 'POST', regex: /^\/webhooks\/(mailgun|stripe|transferwise)/ },
     {
       method: 'GET',
       regex: /^\/connected-accounts\/(stripe|paypal)\/callback/,


### PR DESCRIPTION
It turns out the Sequelize query was actually timing out because querying JSON values is a bit slow.
This can also be solved by migrating all our JSON columns to JSONB, which can be 1000x faster (literally 🤷‍♂).

JSON query takes up to 61.5s in staging:
![image](https://user-images.githubusercontent.com/2119706/76113841-9584ef00-5fc3-11ea-8f56-686930f55716.png)
