### PR TITLE
Add createConnectedAccount mutation to GraphQL V2

### DIFF
--- a/server/constants/connected_account.ts
+++ b/server/constants/connected_account.ts
@@ -1,0 +1,10 @@
+export enum Service {
+  PAYPAL = 'paypal',
+  STRIPE = 'stripe',
+  GITHUB = 'github',
+  TWITTER = 'twitter',
+  MEETUP = 'meetup',
+  TRANSFERWISE = 'transferwise',
+}
+
+export const supportedServices = Object.values(Service);

--- a/server/graphql/v2/enum/ConnectedAccountService.ts
+++ b/server/graphql/v2/enum/ConnectedAccountService.ts
@@ -1,0 +1,8 @@
+import { GraphQLEnumType } from 'graphql';
+import { Service } from '../../../constants/connected_account';
+
+export const ConnectedAccountService = new GraphQLEnumType({
+  name: 'ConnectedAccountService',
+  description: 'All supported services a user can connect with',
+  values: Object.values(Service).reduce((values, key) => ({ ...values, [key]: { value: key } }), {}),
+});

--- a/server/graphql/v2/identifiers.js
+++ b/server/graphql/v2/identifiers.js
@@ -16,6 +16,7 @@ export const IDENTIFIER_TYPES = {
   CONVERSATION: 'conversation',
   PAYOUT_METHOD: 'payout-method',
   EXPENSE: 'expense',
+  CONNECTED_ACCOUNT: 'connected-account',
 };
 
 const getDefaultInstance = type => {

--- a/server/graphql/v2/input/ConnectedAccountCreateInput.ts
+++ b/server/graphql/v2/input/ConnectedAccountCreateInput.ts
@@ -1,0 +1,22 @@
+import { GraphQLString, GraphQLInputObjectType } from 'graphql';
+import GraphQLJSON from 'graphql-type-json';
+import { ConnectedAccountService } from '../enum/ConnectedAccountService';
+
+/**
+ * An input for ConnectedAccount that can be used for either editing or creating.
+ */
+const ConnectedAccountCreateInput = new GraphQLInputObjectType({
+  name: 'ConnectedAccountCreateInput',
+  fields: {
+    clientId: { type: GraphQLString },
+    data: { type: GraphQLJSON },
+    id: { type: GraphQLString },
+    refreshToken: { type: GraphQLString },
+    settings: { type: GraphQLJSON },
+    token: { type: GraphQLString },
+    service: { type: ConnectedAccountService },
+    username: { type: GraphQLString },
+  },
+});
+
+export { ConnectedAccountCreateInput };

--- a/server/graphql/v2/input/ConnectedAccountCreateInput.ts
+++ b/server/graphql/v2/input/ConnectedAccountCreateInput.ts
@@ -8,14 +8,34 @@ import { ConnectedAccountService } from '../enum/ConnectedAccountService';
 const ConnectedAccountCreateInput = new GraphQLInputObjectType({
   name: 'ConnectedAccountCreateInput',
   fields: {
-    clientId: { type: GraphQLString },
-    data: { type: GraphQLJSON },
-    id: { type: GraphQLString },
-    refreshToken: { type: GraphQLString },
-    settings: { type: GraphQLJSON },
-    token: { type: GraphQLString },
-    service: { type: ConnectedAccountService },
-    username: { type: GraphQLString },
+    clientId: {
+      type: GraphQLString,
+      description: 'Optional Client ID for the token or secret',
+    },
+    data: {
+      type: GraphQLJSON,
+      description: 'Private data related to the connected account',
+    },
+    refreshToken: {
+      type: GraphQLString,
+      description: 'Refresh token for the connected account',
+    },
+    settings: {
+      type: GraphQLJSON,
+      description: 'Public data related to the connected account',
+    },
+    token: {
+      type: GraphQLString,
+      description: 'Secret token used to call service',
+    },
+    service: {
+      type: ConnectedAccountService,
+      description: 'Service which the connected account belongs to',
+    },
+    username: {
+      type: GraphQLString,
+      description: 'Optional username for the connected account',
+    },
   },
 });
 

--- a/server/graphql/v2/input/ConnectedAccountReferenceInput.ts
+++ b/server/graphql/v2/input/ConnectedAccountReferenceInput.ts
@@ -16,12 +16,14 @@ export const ConnectedAccountReferenceInput = new GraphQLInputObjectType({
     legacyId: {
       type: GraphQLInt,
       description: 'The internal id of the account (ie: 580)',
-      deprecationReason: '2020-01-01: should only be used during the transition to GraphQL API v2.',
     },
   },
 });
 
-export const fetchConnectedAccountWithReference = async (input, { throwIfMissing } = {}) => {
+export const fetchConnectedAccountWithReference = async (
+  input,
+  { throwIfMissing } = { throwIfMissing: false },
+): Promise<any> => {
   let connectedAccount;
   if (input.id) {
     const id = idDecode(input.id, IDENTIFIER_TYPES.CONNECTED_ACCOUNT);

--- a/server/graphql/v2/input/ConnectedAccountReferenceInput.ts
+++ b/server/graphql/v2/input/ConnectedAccountReferenceInput.ts
@@ -1,0 +1,38 @@
+import { GraphQLString, GraphQLInt, GraphQLInputObjectType } from 'graphql';
+import models from '../../../models';
+import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
+import { NotFound } from '../../errors';
+
+/**
+ * An input for referencing ConnectedAccounts.
+ */
+export const ConnectedAccountReferenceInput = new GraphQLInputObjectType({
+  name: 'ConnectedAccountReferenceInput',
+  fields: {
+    id: {
+      type: GraphQLString,
+      description: 'The public id identifying the connected account (ie: dgm9bnk8-0437xqry-ejpvzeol-jdayw5re)',
+    },
+    legacyId: {
+      type: GraphQLInt,
+      description: 'The internal id of the account (ie: 580)',
+      deprecationReason: '2020-01-01: should only be used during the transition to GraphQL API v2.',
+    },
+  },
+});
+
+export const fetchConnectedAccountWithReference = async (input, { throwIfMissing } = {}) => {
+  let connectedAccount;
+  if (input.id) {
+    const id = idDecode(input.id, IDENTIFIER_TYPES.CONNECTED_ACCOUNT);
+    connectedAccount = await models.ConnectedAccount.findByPk(id);
+  } else if (input.legacyId) {
+    connectedAccount = await models.ConnectedAccount.findByPk(input.legacyId);
+  } else {
+    throw new Error('Please provide an id or a legacyId');
+  }
+  if (!connectedAccount && throwIfMissing) {
+    throw new NotFound({ message: 'ConnectedAccount Not Found' });
+  }
+  return connectedAccount;
+};

--- a/server/graphql/v2/mutation/ConnectedAccountMutations.ts
+++ b/server/graphql/v2/mutation/ConnectedAccountMutations.ts
@@ -5,7 +5,9 @@ import { ConnectedAccount } from '../object/ConnectedAccount';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { ConnectedAccountCreateInput } from '../input/ConnectedAccountCreateInput';
 import models from '../../../models';
+import * as transferwise from '../../../lib/transferwise';
 import * as errors from '../../errors';
+import { Service } from '../../../constants/connected_account';
 import {
   ConnectedAccountReferenceInput,
   fetchConnectedAccountWithReference,
@@ -27,13 +29,31 @@ const connectedAccountMutations = {
     },
     async resolve(_, args, req): Promise<object> {
       if (!req.remoteUser) {
-        throw new errors.Unauthorized('You need to be logged in to create a connected account');
+        throw new errors.Unauthorized({ message: 'You need to be logged in to create a connected account' });
       }
 
       const collective = await fetchAccountWithReference(args.account, { loaders: req.loaders, throwIfMissing: true });
       if (!req.remoteUser.isAdmin(collective.id)) {
-        throw new errors.Unauthorized("You don't have permission to edit this collective");
+        throw new errors.Unauthorized({ message: "You don't have permission to edit this collective" });
       }
+
+      if (args.connectedAccount.service === Service.TRANSFERWISE) {
+        if (!args.connectedAccount.token) {
+          throw new errors.ValidationFailed({ message: 'A token is required for TransferWise accounts' });
+        }
+        const sameTokenCount = await models.ConnectedAccount.count({
+          where: { service: Service.TRANSFERWISE, token: args.connectedAccount.token },
+        });
+        if (sameTokenCount > 0) {
+          throw new errors.ValidationFailed({ message: 'This token is already being used' });
+        }
+        try {
+          await transferwise.getProfiles(args.connectedAccount.token);
+        } catch (e) {
+          throw new errors.ValidationFailed({ message: 'The token is not a valid TransferWise token' });
+        }
+      }
+
       const connectedAccount = await models.ConnectedAccount.create({
         ...pick(args.connectedAccount, [
           'clientId',

--- a/server/graphql/v2/mutation/ConnectedAccountMutations.ts
+++ b/server/graphql/v2/mutation/ConnectedAccountMutations.ts
@@ -27,7 +27,7 @@ const connectedAccountMutations = {
     },
     async resolve(_, args, req): Promise<object> {
       if (!req.remoteUser) {
-        throw new errors.Unauthorized('You need to be logged in to edit a connected account');
+        throw new errors.Unauthorized('You need to be logged in to create a connected account');
       }
 
       const collective = await fetchAccountWithReference(args.account, { loaders: req.loaders, throwIfMissing: true });
@@ -62,10 +62,12 @@ const connectedAccountMutations = {
     },
     async resolve(_, args, req): Promise<object> {
       if (!req.remoteUser) {
-        throw new errors.Unauthorized('You need to be logged in to edit a connected account');
+        throw new errors.Unauthorized('You need to be logged in to delete a connected account');
       }
 
-      const connectedAccount = await fetchConnectedAccountWithReference(args.connectedAccount);
+      const connectedAccount = await fetchConnectedAccountWithReference(args.connectedAccount, {
+        throwIfMissing: true,
+      });
       if (!req.remoteUser.isAdmin(connectedAccount.CollectiveId)) {
         throw new errors.Unauthorized("You don't have permission to edit this collective");
       }

--- a/server/graphql/v2/mutation/ConnectedAccountMutations.ts
+++ b/server/graphql/v2/mutation/ConnectedAccountMutations.ts
@@ -1,0 +1,52 @@
+import { pick } from 'lodash';
+import { GraphQLNonNull } from 'graphql';
+
+import { ConnectedAccount } from '../object/ConnectedAccount';
+import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
+import { ConnectedAccountCreateInput } from '../input/ConnectedAccountCreateInput';
+import models from '../../../models';
+import * as errors from '../../errors';
+
+const connectedAccountMutations = {
+  createConnectedAccount: {
+    type: ConnectedAccount,
+    description: 'Submit an expense to a collective',
+    args: {
+      connectedAccount: {
+        type: new GraphQLNonNull(ConnectedAccountCreateInput),
+        description: 'Expense data',
+      },
+      account: {
+        type: new GraphQLNonNull(AccountReferenceInput),
+        description: 'Account where the expense will be created',
+      },
+    },
+    async resolve(_, args, req): Promise<object> {
+      if (!req.remoteUser) {
+        throw new errors.Unauthorized('You need to be logged in to edit a connected account');
+      }
+
+      const collective = await fetchAccountWithReference(args.account, { loaders: req.loaders, throwIfMissing: true });
+      if (!req.remoteUser.isAdmin(collective.id)) {
+        throw new errors.Unauthorized("You don't have permission to edit this collective");
+      }
+      const connectedAccount = await models.ConnectedAccount.create({
+        ...pick(args.connectedAccount, [
+          'clientId',
+          'data',
+          'refreshToken',
+          'settings',
+          'token',
+          'service',
+          'username',
+        ]),
+        CollectiveId: collective.id,
+        CreatedByUserId: req.remoteUser.id,
+      });
+
+      return connectedAccount;
+    },
+  },
+};
+
+export default connectedAccountMutations;

--- a/server/graphql/v2/mutation/ConnectedAccountMutations.ts
+++ b/server/graphql/v2/mutation/ConnectedAccountMutations.ts
@@ -10,15 +10,15 @@ import * as errors from '../../errors';
 const connectedAccountMutations = {
   createConnectedAccount: {
     type: ConnectedAccount,
-    description: 'Submit an expense to a collective',
+    description: 'Connect external account to Open Collective Account',
     args: {
       connectedAccount: {
         type: new GraphQLNonNull(ConnectedAccountCreateInput),
-        description: 'Expense data',
+        description: 'Connected Account data',
       },
       account: {
         type: new GraphQLNonNull(AccountReferenceInput),
-        description: 'Account where the expense will be created',
+        description: 'Account where the external account will be connected',
       },
     },
     async resolve(_, args, req): Promise<object> {

--- a/server/graphql/v2/mutation/index.js
+++ b/server/graphql/v2/mutation/index.js
@@ -1,10 +1,12 @@
 import commentMutations from './CommentMutations';
+import connectedAccountMutations from './ConnectedAccountMutations';
 import conversationMutations from './ConversationMutations';
 import createCollectiveMutations from './CreateCollectiveMutations';
 import expenseMutations from './ExpenseMutations';
 
 const mutation = {
   ...commentMutations,
+  ...connectedAccountMutations,
   ...conversationMutations,
   ...createCollectiveMutations,
   ...expenseMutations,

--- a/server/graphql/v2/object/ConnectedAccount.ts
+++ b/server/graphql/v2/object/ConnectedAccount.ts
@@ -1,0 +1,25 @@
+import { GraphQLString, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-iso-date';
+import GraphQLJSON from 'graphql-type-json';
+import { ConnectedAccountService } from '../enum/ConnectedAccountService';
+
+export const ConnectedAccount = new GraphQLObjectType({
+  name: 'ConnectedAccount',
+  description: 'Fields for an connected account',
+  fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'Unique identifier for this connected account',
+    },
+    createdAt: {
+      type: new GraphQLNonNull(GraphQLDateTime),
+      description: 'The date on which the attachment was created',
+    },
+    updatedAt: {
+      type: new GraphQLNonNull(GraphQLDateTime),
+      description: 'The date on which the attachment was last updated',
+    },
+    settings: { type: GraphQLJSON },
+    service: { type: new GraphQLNonNull(ConnectedAccountService) },
+  },
+});

--- a/server/graphql/v2/object/ConnectedAccount.ts
+++ b/server/graphql/v2/object/ConnectedAccount.ts
@@ -5,7 +5,7 @@ import { ConnectedAccountService } from '../enum/ConnectedAccountService';
 
 export const ConnectedAccount = new GraphQLObjectType({
   name: 'ConnectedAccount',
-  description: 'Fields for an connected account',
+  description: 'Fields for a connected account',
   fields: {
     id: {
       type: new GraphQLNonNull(GraphQLString),

--- a/server/graphql/v2/object/ConnectedAccount.ts
+++ b/server/graphql/v2/object/ConnectedAccount.ts
@@ -13,11 +13,11 @@ export const ConnectedAccount = new GraphQLObjectType({
     },
     createdAt: {
       type: new GraphQLNonNull(GraphQLDateTime),
-      description: 'The date on which the attachment was created',
+      description: 'The date on which the ConnectedAccount was created',
     },
     updatedAt: {
       type: new GraphQLNonNull(GraphQLDateTime),
-      description: 'The date on which the attachment was last updated',
+      description: 'The date on which the ConnectedAccount was last updated',
     },
     settings: { type: GraphQLJSON },
     service: { type: new GraphQLNonNull(ConnectedAccountService) },

--- a/server/models/ConnectedAccount.js
+++ b/server/models/ConnectedAccount.js
@@ -1,11 +1,9 @@
 import config from 'config';
-
+import { supportedServices } from '../constants/connected_account';
 /**
  * Model.
  */
 export default (Sequelize, DataTypes) => {
-  const supportedServices = ['paypal', 'stripe', 'github', 'twitter', 'meetup', 'transferwise'];
-
   const ConnectedAccount = Sequelize.define(
     'ConnectedAccount',
     {

--- a/test/server/graphql/v2/mutation/ConnectedAccountMutations.test.ts
+++ b/test/server/graphql/v2/mutation/ConnectedAccountMutations.test.ts
@@ -1,9 +1,20 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
+
 import { graphqlQueryV2 } from '../../../../utils';
 import { fakeCollective, fakeUser, fakeConnectedAccount } from '../../../../test-helpers/fake-data';
+import * as transferwise from '../../../../../server/lib/transferwise';
+import * as utils from '../../../../utils';
 import models from '../../../../../server/models';
 
 describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
+  const sandbox = sinon.createSandbox();
+  beforeEach(() => {
+    sandbox.restore();
+    sandbox.stub(transferwise, 'getProfiles').resolves();
+  });
+  beforeEach(utils.resetTestDB);
+
   describe('createConnectedAccount', () => {
     const createConnectedAccountMutation = `
       mutation createConnectedAccount($connectedAccount: ConnectedAccountCreateInput!, $account: AccountReferenceInput!) {
@@ -14,14 +25,15 @@ describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
         }
       }
     `;
-
     let user, collective;
     beforeEach(async () => {
       user = await fakeUser();
-      collective = await fakeCollective({ admin: user.collective });
+      collective = await fakeCollective({
+        admin: user.collective,
+      });
     });
 
-    it('creates the connected account with the linked attachments', async () => {
+    it('should create a new connected account', async () => {
       const connectedAccount = {
         refreshToken: 'fakeRefreshToken',
         settings: { a: true },
@@ -33,7 +45,10 @@ describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
 
       const result = await graphqlQueryV2(
         createConnectedAccountMutation,
-        { connectedAccount, account: { legacyId: collective.id } },
+        {
+          connectedAccount,
+          account: { legacyId: collective.id },
+        },
         user,
       );
 
@@ -44,6 +59,57 @@ describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
 
       const createdConnectedAccount = await models.ConnectedAccount.findByPk(result.data.createConnectedAccount.id);
       expect(createdConnectedAccount.toJSON()).to.deep.include(connectedAccount);
+    });
+
+    it('should fail if token already exists', async () => {
+      const connectedAccount = {
+        token: 'fakeToken',
+        service: 'transferwise',
+      };
+
+      await graphqlQueryV2(
+        createConnectedAccountMutation,
+        {
+          connectedAccount,
+          account: { legacyId: collective.id },
+        },
+        user,
+      );
+
+      const result = await graphqlQueryV2(
+        createConnectedAccountMutation,
+        {
+          connectedAccount,
+          account: { legacyId: collective.id },
+        },
+        user,
+      );
+
+      expect(result.errors).to.exist;
+      expect(result.errors[0].originalError.name).to.equal('ValidationFailed');
+      expect(result.errors[0].message).to.include('This token is already being used');
+    });
+
+    it('should fail if token is not valid', async () => {
+      const connectedAccount = {
+        token: 'fakeToken',
+        service: 'transferwise',
+      };
+
+      (transferwise.getProfiles as sinon.stub).rejects();
+
+      const result = await graphqlQueryV2(
+        createConnectedAccountMutation,
+        {
+          connectedAccount,
+          account: { legacyId: collective.id },
+        },
+        user,
+      );
+
+      expect(result.errors).to.exist;
+      expect(result.errors[0].originalError.name).to.equal('ValidationFailed');
+      expect(result.errors[0].message).to.include('The token is not a valid TransferWise token');
     });
   });
 
@@ -59,14 +125,20 @@ describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
     let user, collective, connectedAccount;
     beforeEach(async () => {
       user = await fakeUser();
-      collective = await fakeCollective({ admin: user.collective });
+      collective = await fakeCollective({
+        admin: user.collective,
+      });
       connectedAccount = await fakeConnectedAccount({ CollectiveId: collective.id });
     });
 
     it('should force delete the connected account', async () => {
       const result = await graphqlQueryV2(
         deleteConnectedAccountMutation,
-        { connectedAccount: { legacyId: connectedAccount.id } },
+        {
+          connectedAccount: {
+            legacyId: connectedAccount.id,
+          },
+        },
         user,
       );
 

--- a/test/server/graphql/v2/mutation/ConnectedAccountMutations.test.ts
+++ b/test/server/graphql/v2/mutation/ConnectedAccountMutations.test.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { graphqlQueryV2 } from '../../../../utils';
+import { fakeCollective, fakeUser } from '../../../../test-helpers/fake-data';
+import models from '../../../../../server/models';
+
+const createConnectedAccountMutation = `
+mutation createConnectedAccount($connectedAccount: ConnectedAccountCreateInput!, $account: AccountReferenceInput!) {
+  createConnectedAccount(connectedAccount: $connectedAccount, account: $account) {
+    id
+    settings
+    service
+  }
+}`;
+
+describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
+  describe('createConnectedAccount', () => {
+    let user, collective;
+    beforeEach(async () => {
+      user = await fakeUser();
+      collective = await fakeCollective({ admin: user.collective });
+    });
+
+    it('creates the connected account with the linked attachments', async () => {
+      const connectedAccount = {
+        refreshToken: 'fakeRefreshToken',
+        settings: { a: true },
+        token: 'fakeToken',
+        service: 'transferwise',
+        username: 'kewitz',
+        data: { secret: true },
+      };
+
+      const result = await graphqlQueryV2(
+        createConnectedAccountMutation,
+        { connectedAccount, account: { legacyId: collective.id } },
+        user,
+      );
+
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(result.data).to.exist;
+      expect(result.data.createConnectedAccount).to.exist;
+
+      const createdConnectedAccount = await models.ConnectedAccount.findByPk(result.data.createConnectedAccount.id);
+      expect(createdConnectedAccount.toJSON()).to.deep.include(connectedAccount);
+    });
+  });
+});

--- a/test/server/graphql/v2/mutation/ConnectedAccountMutations.test.ts
+++ b/test/server/graphql/v2/mutation/ConnectedAccountMutations.test.ts
@@ -1,19 +1,20 @@
 import { expect } from 'chai';
 import { graphqlQueryV2 } from '../../../../utils';
-import { fakeCollective, fakeUser } from '../../../../test-helpers/fake-data';
+import { fakeCollective, fakeUser, fakeConnectedAccount } from '../../../../test-helpers/fake-data';
 import models from '../../../../../server/models';
-
-const createConnectedAccountMutation = `
-mutation createConnectedAccount($connectedAccount: ConnectedAccountCreateInput!, $account: AccountReferenceInput!) {
-  createConnectedAccount(connectedAccount: $connectedAccount, account: $account) {
-    id
-    settings
-    service
-  }
-}`;
 
 describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
   describe('createConnectedAccount', () => {
+    const createConnectedAccountMutation = `
+      mutation createConnectedAccount($connectedAccount: ConnectedAccountCreateInput!, $account: AccountReferenceInput!) {
+        createConnectedAccount(connectedAccount: $connectedAccount, account: $account) {
+          id
+          settings
+          service
+        }
+      }
+    `;
+
     let user, collective;
     beforeEach(async () => {
       user = await fakeUser();
@@ -43,6 +44,38 @@ describe('server/graphql/v2/mutation/ConnectedAccountMutations', () => {
 
       const createdConnectedAccount = await models.ConnectedAccount.findByPk(result.data.createConnectedAccount.id);
       expect(createdConnectedAccount.toJSON()).to.deep.include(connectedAccount);
+    });
+  });
+
+  describe('deleteConnectedAccount', () => {
+    const deleteConnectedAccountMutation = `
+      mutation deleteConnectedAccount($connectedAccount: ConnectedAccountReferenceInput!) {
+        deleteConnectedAccount(connectedAccount: $connectedAccount) {
+          id
+        }
+      }
+    `;
+
+    let user, collective, connectedAccount;
+    beforeEach(async () => {
+      user = await fakeUser();
+      collective = await fakeCollective({ admin: user.collective });
+      connectedAccount = await fakeConnectedAccount({ CollectiveId: collective.id });
+    });
+
+    it('should force delete the connected account', async () => {
+      const result = await graphqlQueryV2(
+        deleteConnectedAccountMutation,
+        { connectedAccount: { legacyId: connectedAccount.id } },
+        user,
+      );
+
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(result.data).to.exist;
+
+      const createdConnectedAccount = await models.ConnectedAccount.findByPk(connectedAccount.id, { paranoid: false });
+      expect(createdConnectedAccount).to.be.null;
     });
   });
 });

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -97,6 +97,18 @@ export const fakeCollective = async (collectiveData = {}) => {
       // Ignore if host is already linked
     }
   }
+  if (collectiveData.admin) {
+    try {
+      await models.Member.create({
+        CollectiveId: collective.id,
+        MemberCollectiveId: collectiveData.admin.id,
+        role: roles.ADMIN,
+        CreatedByUserId: collectiveData.admin.CreatedByUserId,
+      });
+    } catch {
+      // Ignore if host is already linked
+    }
+  }
 
   return collective;
 };


### PR DESCRIPTION
Resovles opencollective/opencollective#2972

This will be used to connect the TransferWise account through the collective settings.

Missing:
- [ ] Token encryption
- [x] Validate token with TransferWise
- [x] Prevent duplicated TransferWise tokens