### PR TITLE
Members: Refresh contributors cache after updating public message

### DIFF
--- a/server/graphql/v1/mutations/members.js
+++ b/server/graphql/v1/mutations/members.js
@@ -1,5 +1,6 @@
 import models from '../../../models';
 import errors from '../../../lib/errors';
+import { invalidateContributorsCache } from '../../../lib/contributors';
 
 /** A mutation to edit the public message of all matching members. */
 export async function editPublicMessage(_, { FromCollectiveId, CollectiveId, message }, req) {
@@ -22,5 +23,11 @@ export async function editPublicMessage(_, { FromCollectiveId, CollectiveId, mes
     throw new errors.NotFound('No member found');
   }
 
+  /**
+   * After updating the public message it is necessary to update the cache
+   * used in the collective page. Member's `afterUpdate` hook is not triggered here
+   * because we don't update the model directly (we use Model.update(..., {where})).
+   */
+  invalidateContributorsCache(CollectiveId);
   return updatedMembers;
 }

--- a/test/server/graphql/v1/collective.test.js
+++ b/test/server/graphql/v1/collective.test.js
@@ -977,6 +977,7 @@ describe('server/graphql/v1/collective', () => {
         amount: 20000,
       });
       const message = 'I am happy to support this collective!';
+      cacheDelSpy.resetHistory();
       const res = await utils.graphqlQuery(
         QUERY,
         {
@@ -1030,6 +1031,7 @@ describe('server/graphql/v1/collective', () => {
         },
       );
       expect(quantityUpdated).to.equal(2);
+      cacheDelSpy.resetHistory();
       const res = await utils.graphqlQuery(
         QUERY,
         {


### PR DESCRIPTION
Introduced in opencollective/opencollective-api#3422

We missed it because we don't run E2E CI on forks PRs.