### PR TITLE
Collective Sponsorship

### DIFF
--- a/migrations/20200323163000-collective-platform-fee.js
+++ b/migrations/20200323163000-collective-platform-fee.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const OC_FEE_PERCENT = 5;
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Collectives', 'platformFeePercent', {
+      type: Sequelize.INTEGER,
+      defaultValue: OC_FEE_PERCENT,
+    });
+    await queryInterface.addColumn('CollectiveHistories', 'platformFeePercent', {
+      type: Sequelize.INTEGER,
+      defaultValue: OC_FEE_PERCENT,
+    });
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('Collectives', 'platformFeePercent');
+    await queryInterface.removeColumn('CollectiveHistories', 'platformFeePercent');
+  },
+};

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -51,7 +51,7 @@ import { capitalize, flattenArray, getDomain, formatCurrency, cleanTags, md5, st
 
 import roles, { MemberRoleLabels } from '../constants/roles';
 import activities from '../constants/activities';
-import { HOST_FEE_PERCENT } from '../constants/transactions';
+import { HOST_FEE_PERCENT, OC_FEE_PERCENT } from '../constants/transactions';
 import { types } from '../constants/collectives';
 import expenseStatus from '../constants/expense_status';
 import expenseTypes from '../constants/expense_type';
@@ -235,6 +235,15 @@ export default function(Sequelize, DataTypes) {
       hostFeePercent: {
         type: DataTypes.FLOAT,
         defaultValue: HOST_FEE_PERCENT,
+        validate: {
+          min: 0,
+          max: 100,
+        },
+      },
+
+      platformFeePercent: {
+        type: DataTypes.INTEGER,
+        defaultValue: OC_FEE_PERCENT,
         validate: {
           min: 0,
           max: 100,

--- a/server/paymentProviders/opencollective/prepaid.js
+++ b/server/paymentProviders/opencollective/prepaid.js
@@ -1,7 +1,7 @@
 import models, { Op } from '../../models';
 import * as libpayments from '../../lib/payments';
 import * as currency from '../../lib/currency';
-import { TransactionTypes, OC_FEE_PERCENT } from '../../constants/transactions';
+import { TransactionTypes } from '../../constants/transactions';
 import { get } from 'lodash';
 
 /** Get the balance of a prepaid credit card
@@ -82,7 +82,7 @@ async function processOrder(order) {
     throw new Error("This payment method doesn't have enough funds to complete this order");
   }
 
-  const platformFeePercent = get(order, 'data.platformFeePercent', OC_FEE_PERCENT);
+  const platformFeePercent = get(order, 'data.platformFeePercent', order.collective.platformFeePercent);
   const platformFeeInHostCurrency = libpayments.calcFee(order.totalAmount, platformFeePercent);
 
   const hostFeePercent = get(order, 'data.hostFeePercent', order.collective.hostFeePercent);

--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -128,7 +128,8 @@ export async function createTransaction(order, paymentInfo) {
   const currencyFromPayPal = transaction.amount.currency;
 
   const hostFeeInHostCurrency = libpayments.calcFee(amountFromPayPalInCents, order.collective.hostFeePercent);
-  const platformFeeInHostCurrency = libpayments.calcFee(amountFromPayPalInCents, constants.OC_FEE_PERCENT);
+  const platformFeePercent = get(order, 'data.platformFeePercent', order.collective.platformFeePercent);
+  const platformFeeInHostCurrency = libpayments.calcFee(amountFromPayPalInCents, platformFeePercent);
 
   const payload = {
     CreatedByUserId: order.createdByUser.id,

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -97,7 +97,7 @@ const getOrCreateCustomerOnHostAccount = async (hostStripeAccount, { paymentMeth
  * See: Shared Customers: https://stripe.com/docs/connect/shared-customers
  */
 const createChargeAndTransactions = async (hostStripeAccount, { order, hostStripeCustomer }) => {
-  const platformFeePercent = get(order, 'data.platformFeePercent', constants.OC_FEE_PERCENT);
+  const platformFeePercent = get(order, 'data.platformFeePercent', order.collective.platformFeePercent);
   const platformFee = isNaN(order.platformFee)
     ? parseInt((order.totalAmount * platformFeePercent) / 100, 10)
     : order.platformFee;


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2985.

The idea is adding the flat `sponsored = true` to collective.data for when we want to waive fees and be able to track orders that were sponsored.

**TODO**
- [x] Waive fee from sponsored collectives
- [x] Add resolvers for sponsorship values.