### PR TITLE
refactor: remove inTheContextOfCollectiveId field

### DIFF
--- a/server/graphql/common/context-permissions.ts
+++ b/server/graphql/common/context-permissions.ts
@@ -22,7 +22,7 @@
  * }
  */
 
-import { get, set, has } from 'lodash';
+import { get, set, has, isNil } from 'lodash';
 
 /**
  * Context permissions types to use with `setContextPermission` and `getContextPermission`
@@ -31,6 +31,7 @@ export enum PERMISSION_TYPE {
   SEE_ACCOUNT_LOCATION = 'SEE_ACCOUNT_LOCATION',
   SEE_EXPENSE_ATTACHMENTS_URL = 'SEE_EXPENSE_ATTACHMENTS_URL',
   SEE_PAYOUT_METHOD_DATA = 'SEE_PAYOUT_METHOD_DATA',
+  SEE_INCOGNITO_ACCOUNT_DETAILS = 'SEE_INCOGNITO_ACCOUNT_DETAILS',
 }
 
 /**
@@ -59,7 +60,9 @@ export const allowContextPermission = (
   entityId: string | number,
 ): void => {
   checkPermissionType(permissionType);
-  set(req, buildKey(permissionType, entityId), true);
+  if (!isNil(entityId)) {
+    set(req, buildKey(permissionType, entityId), true);
+  }
 };
 
 /**

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -44,6 +44,7 @@ import { types } from '../../constants/collectives';
 import models, { Op } from '../../models';
 import roles from '../../constants/roles';
 import { getContributorsForCollective } from '../../lib/contributors';
+import { PERMISSION_TYPE, getContextPermission } from '../common/context-permissions';
 
 export const TypeOfCollectiveType = new GraphQLEnumType({
   name: 'TypeOfCollective',
@@ -815,7 +816,7 @@ const CollectiveFields = () => {
       resolve(collective, args, req) {
         if (
           collective.isIncognito &&
-          (!req.remoteUser || !req.remoteUser.isAdmin(collective.inTheContextOfCollectiveId))
+          !getContextPermission(req, PERMISSION_TYPE.SEE_INCOGNITO_ACCOUNT_DETAILS, collective.id)
         ) {
           return {};
         }

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -443,12 +443,6 @@ export default function (Sequelize, DataTypes) {
         },
       },
 
-      inTheContextOfCollectiveId: {
-        type: new DataTypes.VIRTUAL(DataTypes.STRING),
-        description:
-          'Variable to keep track of the Parent Collective Id when traversing the graph of collective relationships. This is needed to know if the current logged in user can access the createdByUser of the collective.',
-      },
-
       tags: {
         type: DataTypes.ARRAY(DataTypes.STRING),
         set(tags) {


### PR DESCRIPTION
For the incognito feature we decided to store an info about which collective was the "context" for a query as a virtual field (`inTheContextOfCollectiveId`). We didn't block this decision because the feature needed to be released fast, yet it is problematic: there's no reason for the collective model to know about Graphql's context and anyone anywhere can change this value with whatever they want. It could quickly lead to unsafe behavior if we continue using it in the future.

This PR uses the new `context-permissions` lib to revamp the feature.