### PR TITLE
EditCollective: Prevent editing tiers if not event or collective

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1884,6 +1884,10 @@ export default function (Sequelize, DataTypes) {
 
   // edit the tiers of this collective (create/update/remove)
   Collective.prototype.editTiers = function (tiers) {
+    if (this.type !== types.COLLECTIVE && this.type !== types.EVENT) {
+      return [];
+    }
+
     if (!tiers) {
       return this.getTiers();
     }


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3014

I'm not sure where this was introduced. The real solution to avoid that in the future would be https://github.com/opencollective/opencollective/issues/1451.