### PR TITLE
CollectiveInterface: Remove duplicate contextPermissions import

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -45,7 +45,6 @@ import { types } from '../../constants/collectives';
 import models, { Op } from '../../models';
 import roles from '../../constants/roles';
 import { getContributorsForCollective } from '../../lib/contributors';
-import { PERMISSION_TYPE, getContextPermission } from '../common/context-permissions';
 
 export const TypeOfCollectiveType = new GraphQLEnumType({
   name: 'TypeOfCollective',


### PR DESCRIPTION
Broken build after merging #3562 

The reason is that git merge accepted the two lines for `import { PERMISSION_TYPE, getContextPermission } from '../common/context-permissions';` without conflict and babel was not happy with the double import.

The only thing that could have prevented that is to use an ESLint plugin to sort imports.