### PR TITLE
GQLV2: Add mutation to delete expenses

### DIFF
--- a/server/graphql/v2/input/ExpenseReferenceInput.ts
+++ b/server/graphql/v2/input/ExpenseReferenceInput.ts
@@ -15,18 +15,26 @@ const ExpenseReferenceInput = new GraphQLInputObjectType({
   },
 });
 
-/**
- * Retrieve an expense from an `ExpenseReferenceInput`
- */
-const fetchExpenseWithReference = async (input: object, { loaders }): Promise<any> => {
+const getDatabaseIdFromExpenseReference = (input: object): number => {
   if (input['id']) {
-    const id = idDecode(input['id'], IDENTIFIER_TYPES.EXPENSE);
-    return loaders.Expense.byId.load(id);
+    return idDecode(input['id'], IDENTIFIER_TYPES.EXPENSE);
   } else if (input['legacyId']) {
-    return loaders.Expense.byId.load(input['legacyId']);
+    return input['legacyId'];
   } else {
     return null;
   }
 };
 
-export { ExpenseReferenceInput, fetchExpenseWithReference };
+/**
+ * Retrieve an expense from an `ExpenseReferenceInput`
+ */
+const fetchExpenseWithReference = async (input: object, { loaders }): Promise<any> => {
+  const dbId = getDatabaseIdFromExpenseReference(input);
+  if (dbId) {
+    return loaders.Expense.byId.load(dbId);
+  } else {
+    return null;
+  }
+};
+
+export { ExpenseReferenceInput, fetchExpenseWithReference, getDatabaseIdFromExpenseReference };

--- a/server/graphql/v2/object/Event.js
+++ b/server/graphql/v2/object/Event.js
@@ -2,6 +2,7 @@ import { GraphQLObjectType, GraphQLBoolean, GraphQLInt } from 'graphql';
 
 import { Account, AccountFields } from '../interface/Account';
 import { hostResolver } from '../../common/collective';
+import { Collective } from './Collective';
 
 export const Event = new GraphQLObjectType({
   name: 'Event',
@@ -27,11 +28,22 @@ export const Event = new GraphQLObjectType({
         description: 'Returns whether this collective is approved',
         type: GraphQLBoolean,
         async resolve(event, _, req) {
-          if (event.ParentCollectiveId) {
+          if (!event.ParentCollectiveId) {
             return false;
           } else {
             const parentCollective = await req.loaders.Collective.byId.load(event.ParentCollectiveId);
             return parentCollective && parentCollective.isApproved();
+          }
+        },
+      },
+      parentCollective: {
+        description: 'The collective hosting this event',
+        type: Collective,
+        async resolve(event, _, req) {
+          if (!event.ParentCollectiveId) {
+            return null;
+          } else {
+            return req.loaders.Collective.byId.load(event.ParentCollectiveId);
           }
         },
       },

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -11,6 +11,7 @@ import {
   fakeExpenseAttachment,
 } from '../../../../test-helpers/fake-data';
 import { idEncode, IDENTIFIER_TYPES } from '../../../../../server/graphql/v2/identifiers';
+import { expenseStatus } from '../../../../../server/constants';
 
 const createExpenseMutation = `
 mutation createExpense($expense: ExpenseCreateInput!, $account: AccountReferenceInput!) {
@@ -18,6 +19,14 @@ mutation createExpense($expense: ExpenseCreateInput!, $account: AccountReference
     id
     legacyId
     invoiceInfo
+  }
+}`;
+
+const deleteExpenseMutation = `
+mutation deleteExpense($expense: ExpenseReferenceInput!) {
+  deleteExpense(expense: $expense) {
+    id
+    legacyId
   }
 }`;
 
@@ -187,6 +196,83 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
       const result = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
       expect(result.data.editExpense.privateMessage).to.equal(updatedExpenseData.privateMessage);
       expect(result.data.editExpense.description).to.equal(expense.description);
+    });
+  });
+
+  describe('deleteExpense', () => {
+    const prepareGQLParams = expense => ({ expense: { id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE) } });
+
+    describe('can delete rejected expenses', () => {
+      it('if owner', async () => {
+        const expense = await fakeExpense({ status: expenseStatus.REJECTED });
+        const result = await graphqlQueryV2(deleteExpenseMutation, prepareGQLParams(expense), expense.User);
+
+        expect(result.data.deleteExpense.legacyId).to.eq(expense.id);
+        await expense.reload({ paranoid: false });
+        expect(expense.deletedAt).to.exist;
+      });
+
+      it('if collective admin', async () => {
+        const collectiveAdminUser = await fakeUser();
+        const collective = await fakeCollective({ admin: collectiveAdminUser.collective });
+        const expense = await fakeExpense({ status: expenseStatus.REJECTED, CollectiveId: collective.id });
+        const result = await graphqlQueryV2(deleteExpenseMutation, prepareGQLParams(expense), collectiveAdminUser);
+
+        expect(result.data.deleteExpense.legacyId).to.eq(expense.id);
+        await expense.reload({ paranoid: false });
+        expect(expense.deletedAt).to.exist;
+      });
+
+      it('if host admin', async () => {
+        const hostAdminUser = await fakeUser();
+        const host = await fakeCollective({ admin: hostAdminUser.collective });
+        const collective = await fakeCollective({ HostCollectiveId: host.id });
+        const expense = await fakeExpense({ status: expenseStatus.REJECTED, CollectiveId: collective.id });
+        const result = await graphqlQueryV2(deleteExpenseMutation, prepareGQLParams(expense), hostAdminUser);
+
+        expect(result.data.deleteExpense.legacyId).to.eq(expense.id);
+        await expense.reload({ paranoid: false });
+        expect(expense.deletedAt).to.exist;
+      });
+    });
+
+    describe('cannot delete', () => {
+      it('if backer', async () => {
+        const collectiveBackerUser = await fakeUser();
+        const collective = await fakeCollective();
+        await collective.addUserWithRole(collectiveBackerUser, 'BACKER');
+        const expense = await fakeExpense({ status: expenseStatus.REJECTED, CollectiveId: collective.id });
+        const result = await graphqlQueryV2(deleteExpenseMutation, prepareGQLParams(expense), collectiveBackerUser);
+
+        await expense.reload({ paranoid: false });
+        expect(expense.deletedAt).to.not.exist;
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.eq(
+          "You don't have permission to delete this expense or it needs to be rejected before being deleted",
+        );
+      });
+
+      it('if unauthenticated', async () => {
+        const expense = await fakeExpense({ status: expenseStatus.REJECTED });
+        const result = await graphqlQueryV2(deleteExpenseMutation, prepareGQLParams(expense));
+
+        await expense.reload({ paranoid: false });
+        expect(expense.deletedAt).to.not.exist;
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.eq('You need to be authenticated to perform this action');
+      });
+
+      it('if not rejected', async () => {
+        const expense = await fakeExpense({ status: expenseStatus.APPROVED });
+        const result = await graphqlQueryV2(deleteExpenseMutation, prepareGQLParams(expense), expense.User);
+
+        await expense.reload({ paranoid: false });
+        expect(expense.deletedAt).to.not.exist;
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.eq(
+          "You don't have permission to delete this expense or it needs to be rejected before being deleted",
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Also added `parentCollective` field to `events` because we need the parent slug to redirect to the proper page after the expense is deleted.