### PR TITLE
Remove "smart" set Twitter as website if website is null behaviour

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -420,12 +420,7 @@ export default function (Sequelize, DataTypes) {
         type: DataTypes.STRING,
         get() {
           const website = this.getDataValue('website');
-          if (website) {
-            return prependHttp(website);
-          }
-          return this.getDataValue('twitterHandle')
-            ? `https://twitter.com/${this.getDataValue('twitterHandle')}`
-            : null;
+          return website ? prependHttp(website) : null;
         },
         set(url) {
           if (url) {


### PR DESCRIPTION
When creating/editing a collective, if the website is null, we add the full Twitter URL as the 'website'. This isn't ideal behaviour - if a user leaves the field blank on purpose, it should be left blank.