### PR TITLE
GraphQL v2: apply to an host with a collective

### DIFF
--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -68,7 +68,7 @@ const accountMutations = {
     },
     async resolve(_, args, req): Promise<object> {
       if (!req.remoteUser) {
-        throw new Unauthorized();
+        throw new Unauthorized({ message: 'You need to be logged in' });
       }
 
       const collective = await fetchAccountWithReference(args.collective);
@@ -77,6 +77,9 @@ const accountMutations = {
       }
       if (collective.type !== COLLECTIVE) {
         throw new Error('Account not a Collective');
+      }
+      if (!req.remoteUser.isAdmin(collective.id)) {
+        throw new Unauthorized({ message: 'You need to be an Admin of the Collective' });
       }
 
       const host = await fetchAccountWithReference(args.host);

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -1,11 +1,16 @@
 import { GraphQLNonNull } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { set, cloneDeep } from 'lodash';
+
+import { sequelize } from '../../../models';
+import { Unauthorized, Forbidden, NotFound } from '../../errors';
+import { types as collectiveTypes } from '../../../constants/collectives';
+
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { Account } from '../interface/Account';
 import AccountSettingsKey from '../scalar/AccountSettingsKey';
-import { Unauthorized, Forbidden } from '../../errors';
-import { sequelize } from '../../../models';
+
+const { COLLECTIVE } = collectiveTypes;
 
 const accountMutations = {
   editAccountSetting: {
@@ -45,6 +50,51 @@ const accountMutations = {
         set(settings, args.key, args.value);
         return account.update({ settings }, { transaction });
       });
+    },
+  },
+
+  applyToHost: {
+    type: new GraphQLNonNull(Account),
+    description: 'Apply to an host with a collective',
+    args: {
+      collective: {
+        type: new GraphQLNonNull(AccountReferenceInput),
+        description: 'Account applying to the host.',
+      },
+      host: {
+        type: new GraphQLNonNull(AccountReferenceInput),
+        description: 'Host to apply to.',
+      },
+    },
+    async resolve(_, args, req): Promise<object> {
+      if (!req.remoteUser) {
+        throw new Unauthorized();
+      }
+
+      const collective = await fetchAccountWithReference(args.collective);
+      if (!collective) {
+        throw new NotFound({ message: 'Collective not found' });
+      }
+      if (collective.type !== COLLECTIVE) {
+        throw new Error('Account not a Collective');
+      }
+
+      const host = await fetchAccountWithReference(args.host);
+      if (!host) {
+        throw new NotFound({ message: 'Host not found' });
+      }
+      const isHost = await host.isHost();
+      if (!isHost) {
+        throw new Error('Account is not an host');
+      }
+      const canApply = await host.canApply();
+      if (!canApply) {
+        throw new Error('Host is not open to applications');
+      }
+
+      // No need to check the balance, this is being handled in changeHost
+
+      return collective.changeHost(host.id, req.remoteUser);
     },
   },
 };

--- a/server/graphql/v2/mutation/CollectiveMutations.ts
+++ b/server/graphql/v2/mutation/CollectiveMutations.ts
@@ -1,0 +1,61 @@
+import { GraphQLNonNull } from 'graphql';
+
+import { Unauthorized, NotFound } from '../../errors';
+import { types as collectiveTypes } from '../../../constants/collectives';
+
+import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
+import { Collective } from '../object/Collective';
+
+const { COLLECTIVE } = collectiveTypes;
+
+const collectiveMutations = {
+  applyToHost: {
+    type: new GraphQLNonNull(Collective),
+    description: 'Apply to an host with a collective',
+    args: {
+      collective: {
+        type: new GraphQLNonNull(AccountReferenceInput),
+        description: 'Account applying to the host.',
+      },
+      host: {
+        type: new GraphQLNonNull(AccountReferenceInput),
+        description: 'Host to apply to.',
+      },
+    },
+    async resolve(_, args, req): Promise<object> {
+      if (!req.remoteUser) {
+        throw new Unauthorized({ message: 'You need to be logged in' });
+      }
+
+      const collective = await fetchAccountWithReference(args.collective);
+      if (!collective) {
+        throw new NotFound({ message: 'Collective not found' });
+      }
+      if (collective.type !== COLLECTIVE) {
+        throw new Error('Account not a Collective');
+      }
+      if (!req.remoteUser.isAdmin(collective.id)) {
+        throw new Unauthorized({ message: 'You need to be an Admin of the Collective' });
+      }
+
+      const host = await fetchAccountWithReference(args.host);
+      if (!host) {
+        throw new NotFound({ message: 'Host not found' });
+      }
+      const isHost = await host.isHost();
+      if (!isHost) {
+        throw new Error('Account is not an host');
+      }
+      const canApply = await host.canApply();
+      if (!canApply) {
+        throw new Error('Host is not open to applications');
+      }
+
+      // No need to check the balance, this is being handled in changeHost
+
+      return collective.changeHost(host.id, req.remoteUser);
+    },
+  },
+};
+
+export default collectiveMutations;

--- a/server/graphql/v2/mutation/index.js
+++ b/server/graphql/v2/mutation/index.js
@@ -4,6 +4,7 @@ import conversationMutations from './ConversationMutations';
 import createCollectiveMutations from './CreateCollectiveMutations';
 import expenseMutations from './ExpenseMutations';
 import accountMutations from './AccountMutations';
+import collectiveMutations from './CollectiveMutations';
 
 const mutation = {
   ...commentMutations,
@@ -12,6 +13,7 @@ const mutation = {
   ...createCollectiveMutations,
   ...expenseMutations,
   ...accountMutations,
+  ...collectiveMutations,
 };
 
 export default mutation;


### PR DESCRIPTION
```
mutation applyToHost($collective: AccountReferenceInput!, $host: AccountReferenceInput!) {
  applyToHost(collective: $collective, host: $host) {
    id
    slug
    host {
      id
      slug
    }
  }
}
```

Variables:

```
{
  "collective": {"id": 47474},
  "host": {"id": 3456},
}
```