### PR TITLE
Add new properties to GraphQL API v2

### DIFF
--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -1,4 +1,4 @@
-import { GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
 import GraphQLJSON from 'graphql-type-json';
 import { invert } from 'lodash';
@@ -86,6 +86,10 @@ const accountFieldsDefinition = () => ({
   updatedAt: {
     type: GraphQLDateTime,
     description: 'The time of last update',
+  },
+  isArchived: {
+    type: GraphQLBoolean,
+    description: 'Returns whether this account is archived',
   },
   members: {
     type: MemberCollection,
@@ -313,6 +317,13 @@ export const AccountFields = {
     type: GraphQLDateTime,
     resolve(collective) {
       return collective.updatedAt || collective.createdAt;
+    },
+  },
+  isArchived: {
+    type: GraphQLBoolean,
+    description: 'Returns whether this account is archived',
+    resolve(collective) {
+      return Boolean(collective.deactivatedAt);
     },
   },
   ...HasMembersFields,

--- a/server/graphql/v2/object/Collective.js
+++ b/server/graphql/v2/object/Collective.js
@@ -1,6 +1,8 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-iso-date';
 
 import { hostResolver } from '../../common/collective';
+import { AccountType } from '../enum/AccountType';
 import { Account, AccountFields } from '../interface/Account';
 
 export const Collective = new GraphQLObjectType({
@@ -13,6 +15,7 @@ export const Collective = new GraphQLObjectType({
       ...AccountFields,
       balance: {
         description: 'Amount of money in cents in the currency of the collective currently available to spend',
+        deprecationReason: '2020/04/09 - Should not have been introduced. Use stats.balance.value',
         type: GraphQLInt,
         resolve(collective, _, req) {
           return req.loaders.Collective.balance.load(collective.id);
@@ -23,11 +26,38 @@ export const Collective = new GraphQLObjectType({
         type: Account,
         resolve: hostResolver,
       },
+      approvedAt: {
+        description: 'Return this collective approved date',
+        type: GraphQLDateTime,
+        resolve(collective) {
+          return collective.approvedAt;
+        },
+      },
       isApproved: {
         description: 'Returns whether this collective is approved',
         type: GraphQLBoolean,
         resolve(collective) {
           return collective.isApproved();
+        },
+      },
+      totalFinancialContributors: {
+        description: 'Number of unique financial contributors of the collective.',
+        type: GraphQLInt,
+        args: {
+          accountType: {
+            type: AccountType,
+            description: 'Type of account (COLLECTIVE/EVENT/ORGANIZATION/INDIVIDUAL)',
+          },
+        },
+        async resolve(collective, args, req) {
+          const stats = await req.loaders.Collective.stats.backers.load(collective.id);
+          if (!args.accountType) {
+            return stats.all;
+          } else if (args.accountType === 'INDIVIDUAL') {
+            return stats.USER || 0;
+          } else {
+            return stats[args.accountType] || 0;
+          }
         },
       },
     };

--- a/server/graphql/v2/object/Event.js
+++ b/server/graphql/v2/object/Event.js
@@ -15,6 +15,7 @@ export const Event = new GraphQLObjectType({
       ...AccountFields,
       balance: {
         description: 'Amount of money in cents in the currency of the collective currently available to spend',
+        deprecationReason: '2020/04/09 - Should not have been introduced. Use stats.balance.value',
         type: GraphQLInt,
         resolve(collective, _, req) {
           return req.loaders.Collective.balance.load(collective.id);


### PR DESCRIPTION
Example for totalFinancialContributors:

```
query collective {
  collective(slug: "apex") {
    id
    slug
    totalFinancialContributors
    totalContributingOrganizations: totalFinancialContributors(
      accountType: ORGANIZATION
    )
    totalContributinIndividuals: totalFinancialContributors(
      accountType: INDIVIDUAL
    )
    totalContributingCollectives: totalFinancialContributors(
      accountType: COLLECTIVE
    )
  }
}
```