### PR TITLE
GQL/Members: Filter incognito profiles

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -196,10 +196,27 @@ export const UserType = new GraphQLObjectType({
       },
       memberOf: {
         type: new GraphQLList(MemberType),
-        resolve(user) {
+        includeIncognito: {
+          type: GraphQLBoolean,
+          defaultValue: true,
+          description:
+            'Wether incognito profiles should be included in the result. Only works if requesting user is an admin of the account.',
+        },
+        resolve(user, args, req) {
+          const collectiveConditions = {};
+          if (!args.includeIncognito || !req.remoteUser?.isAdmin(user.CollectiveId)) {
+            collectiveConditions.isIncognito = false;
+          }
           return models.Member.findAll({
             where: { MemberCollectiveId: user.CollectiveId },
-            include: [{ model: models.Collective, as: 'collective', required: true }],
+            include: [
+              {
+                model: models.Collective,
+                as: 'collective',
+                required: true,
+                where: collectiveConditions,
+              },
+            ],
           });
         },
       },

--- a/server/graphql/v2/interface/IsMemberOf.js
+++ b/server/graphql/v2/interface/IsMemberOf.js
@@ -1,4 +1,4 @@
-import { GraphQLInt, GraphQLList } from 'graphql';
+import { GraphQLInt, GraphQLList, GraphQLBoolean } from 'graphql';
 
 import { MemberOfCollection } from '../collection/MemberCollection';
 import { AccountType, AccountTypeToModelMapping } from '../enum/AccountType';
@@ -14,8 +14,14 @@ export const IsMemberOfFields = {
       offset: { type: GraphQLInt },
       role: { type: new GraphQLList(MemberRole) },
       accountType: { type: new GraphQLList(AccountType) },
+      includeIncognito: {
+        type: GraphQLBoolean,
+        defaultValue: true,
+        description:
+          'Wether incognito profiles should be included in the result. Only works if requesting user is an admin of the account.',
+      },
     },
-    async resolve(collective, args) {
+    async resolve(collective, args, req) {
       const where = { MemberCollectiveId: collective.id };
 
       if (args.role && args.role.length > 0) {
@@ -26,6 +32,9 @@ export const IsMemberOfFields = {
         collectiveConditions.type = {
           [Op.in]: args.accountType.map(value => AccountTypeToModelMapping[value]),
         };
+      }
+      if (!args.includeIncognito || !req.remoteUser?.isAdmin(collective.id)) {
+        collectiveConditions.isIncognito = false;
       }
       const result = await models.Member.findAndCountAll({
         where,

--- a/test/server/graphql/v2/query/AccountQuery.test.js
+++ b/test/server/graphql/v2/query/AccountQuery.test.js
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { graphqlQueryV2 } from '../../../../utils';
+import { fakeCollective, fakeUser } from '../../../../test-helpers/fake-data';
+import { roles } from '../../../../../server/constants';
+
+const ACCOUNT_QUERY = `
+  query account($slug: String!) {
+    account(slug: $slug) {
+      id
+      memberOf {
+        totalCount
+        nodes {
+          id
+          account {
+            id
+            slug
+          }
+        }
+      }
+    }
+  }
+`;
+
+describe('server/graphql/v2/query/AccountQuery', () => {
+  describe('memberOf', () => {
+    describe('incognito profiles', () => {
+      it('are returned if user is an admin', async () => {
+        const user = await fakeUser();
+        const incognitoProfile = await fakeCollective({ type: 'USER', isIncognito: true, CreatedByUserId: user.id });
+        await incognitoProfile.addUserWithRole(user, roles.ADMIN);
+        const result = await graphqlQueryV2(ACCOUNT_QUERY, { slug: user.collective.slug }, user);
+
+        expect(result.data.account.memberOf.nodes[0].account.slug).to.eq(incognitoProfile.slug);
+      });
+
+      it('are not returned if user is not an admin', async () => {
+        const user = await fakeUser();
+        const otherUser = await fakeUser();
+        const incognitoProfile = await fakeCollective({ type: 'USER', isIncognito: true, CreatedByUserId: user.id });
+        await incognitoProfile.addUserWithRole(user, roles.ADMIN);
+        const resultUnauthenticated = await graphqlQueryV2(ACCOUNT_QUERY, { slug: user.collective.slug });
+        const resultAsAnotherUser = await graphqlQueryV2(ACCOUNT_QUERY, { slug: user.collective.slug }, otherUser);
+
+        expect(resultUnauthenticated.data.account.memberOf.totalCount).to.eq(0);
+        expect(resultAsAnotherUser.data.account.memberOf.totalCount).to.eq(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
For the expense payee profiles we need to filter out the incognito profiles.