### PR TITLE
enhancement(Host): add hostFeePercent to graphql v2 host

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -9,6 +9,12 @@ export const Host = new GraphQLObjectType({
   fields: () => {
     return {
       ...AccountFields,
+      hostFeePercent: {
+        type: GraphQLInt,
+        resolve(collective) {
+          return collective.hostFeePercent;
+        },
+      },
       totalHostedCollectives: {
         type: GraphQLInt,
         resolve(collective) {


### PR DESCRIPTION
The new V2 Host object was missing `hostFeePercent`, which is needed to display on the host cards when you apply to them for fiscal hosting.