### PR TITLE
isValidUploadedImage: Use a regex to allow different URL patterns

### DIFF
--- a/server/lib/images.ts
+++ b/server/lib/images.ts
@@ -8,6 +8,7 @@ export const isValidUploadedImage = (url: string): boolean => {
   if (config.env !== 'production') {
     return true;
   } else {
-    return url.startsWith(`https://${config.aws.s3.bucket}.s3-us-west-1.amazonaws.com/`);
+    const regex = new RegExp(`^https://${config.aws.s3.bucket}\\.s3[.-]us-west-1.amazonaws.com/`);
+    return regex.test(url);
   }
 };

--- a/test/server/lib/images.test.js
+++ b/test/server/lib/images.test.js
@@ -26,11 +26,16 @@ describe('server/lib/images', () => {
 
       it('returns true for valid images based on S3 bucket', () => {
         expect(isValidUploadedImage('https://valid-bucket.s3-us-west-1.amazonaws.com/image.jpg')).to.be.true;
+        expect(isValidUploadedImage('https://valid-bucket.s3.us-west-1.amazonaws.com/image.jpg')).to.be.true;
       });
 
       it('returns false for invalid images', () => {
         expect(isValidUploadedImage('test')).to.be.false;
         expect(isValidUploadedImage('https://malicious-bucket.s3-us-west-1.amazonaws.com/image.jpg')).to.be.false;
+        expect(isValidUploadedImage('https://valid-bucket.not-realy.s3.us-west-1.amazonaws.com/image.jpg')).to.be.false;
+        expect(isValidUploadedImage('https://valid-bucket.s3.us-west-1.amazonaws.com.fake.com/img.jpg')).to.be.false;
+        expect(isValidUploadedImage('https://valid-bucket.s3xus-west-1.amazonaws.com/image.jpg')).to.be.false;
+        expect(isValidUploadedImage('https://valid-bucketxs3.us-west-1.amazonaws.com/image.jpg')).to.be.false;
       });
     });
   });


### PR DESCRIPTION
The images we get with images from AWS on production can slightly change, some are using a dot and others are using a dash (both are valid and can be used indifferently). I suppose they changed their API at some point?

I've updated `isValidUploadedImage` with a regex that covers both cases:

> https://valid-bucket.s3.us-west-1.amazonaws.com/image.jpg
> https://valid-bucket.s3-us-west-1.amazonaws.com/image.jpg
> _________________^