### PR TITLE
fix(export:csv): using e.tags instead of e.category

### DIFF
--- a/scripts/monthly_data_exports.js
+++ b/scripts/monthly_data_exports.js
@@ -71,7 +71,7 @@ const queries = [
     query: `
     SELECT
     t."createdAt", c.slug as "collective slug", t.type as "transaction type", t.amount::float / 100,
-    t.currency, fc.slug as "from slug", fc.type as "from type", t.description, e.category as "expense category",
+    t.currency, fc.slug as "from slug", fc.type as "from type", t.description, e.tags as "expense tags",
     h.slug as "host slug", t."hostCurrency", t."hostCurrencyFxRate",
     pm.service as "payment processor", pm.type as "payment method type",
     t."paymentProcessorFeeInHostCurrency"::float / 100 as "paymentProcessorFeeInHostCurrency",


### PR DESCRIPTION
Export of open collective on drive.opencollective.com was not up to date.
It has to be run manually by someone who has access to the database (read).

This is the command to run:

```PG_DATABASE=opencollective_prod_snapshot npm run export:csv```

It was broken because the schema for the `Expenses` table has changed.
This is fixing it.

Related to https://github.com/opencollective/opencollective/issues/3004 (but financial data still needs to be updated)