### PR TITLE
Customize expense payee

### DIFF
--- a/server/graphql/v2/interface/IsMemberOf.js
+++ b/server/graphql/v2/interface/IsMemberOf.js
@@ -1,4 +1,5 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList } from 'graphql';
+import { isNil } from 'lodash';
 
 import models, { Op } from '../../../models';
 import { MemberOfCollection } from '../collection/MemberCollection';
@@ -13,6 +14,10 @@ export const IsMemberOfFields = {
       offset: { type: GraphQLInt },
       role: { type: new GraphQLList(MemberRole) },
       accountType: { type: new GraphQLList(AccountType) },
+      isHostAccount: {
+        type: GraphQLBoolean,
+        description: 'Filter on whether the account is a host or not',
+      },
       includeIncognito: {
         type: GraphQLBoolean,
         defaultValue: true,
@@ -34,6 +39,9 @@ export const IsMemberOfFields = {
       }
       if (!args.includeIncognito || !req.remoteUser?.isAdmin(collective.id)) {
         collectiveConditions.isIncognito = false;
+      }
+      if (!isNil(args.isHost)) {
+        collectiveConditions.isHostAccount = args.isHostAccount;
       }
       const result = await models.Member.findAndCountAll({
         where,

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -46,7 +46,7 @@ const expenseMutations = {
         amount: items.reduce((total, item) => total + item.amount, 0),
         PayoutMethod: payoutMethod,
         collective: await fetchAccountWithReference(args.account, req),
-        fromCollective: args.expense.payee,
+        fromCollective: await fetchAccountWithReference(args.expense.payee, { throwIfMissing: true }),
       });
     },
   },
@@ -89,7 +89,7 @@ const expenseMutations = {
           id: attachedFile.id && idDecode(attachedFile.id, IDENTIFIER_TYPES.EXPENSE_ITEM),
           url: attachedFile.url,
         })),
-        fromCollective: null, // TODO payee
+        fromCollective: expense.payee && (await fetchAccountWithReference(expense.payee, { throwIfMissing: true })),
       });
     },
   },

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -957,6 +957,13 @@ export default function (Sequelize, DataTypes) {
   };
 
   /**
+   * Returns true if the collective can be used as a payout profile for an expense
+   */
+  Collective.prototype.canBeUsedAsPayoutProfile = function () {
+    return !this.isIncognito && !this.isHostAccount && [types.USER, types.ORGANIZATION].includes(this.type);
+  };
+
+  /**
    *  Checks if the collective can be contacted.
    */
   Collective.prototype.canContact = async function () {

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -603,6 +603,23 @@ describe('server/models/Collective', () => {
     });
   });
 
+  describe('canBeUsedAsPayoutProfile', () => {
+    const shouldBeUsableAsPayout = account => expect(account.canBeUsedAsPayoutProfile()).to.be.true;
+    const shouldNotBeUsableAsPayout = account => expect(account.canBeUsedAsPayoutProfile()).to.be.false;
+
+    it('is true for users and organizations', async () => {
+      shouldBeUsableAsPayout(await fakeCollective({ type: 'USER' }));
+      shouldBeUsableAsPayout(await fakeCollective({ type: 'ORGANIZATION' }));
+    });
+
+    it('is false for incognito profiles, collectives, events and hosts', async () => {
+      shouldNotBeUsableAsPayout(await fakeCollective({ type: 'USER', isIncognito: true }));
+      shouldNotBeUsableAsPayout(await fakeCollective({ type: 'COLLECTIVE' }));
+      shouldNotBeUsableAsPayout(await fakeCollective({ type: 'EVENT' }));
+      shouldNotBeUsableAsPayout(await fakeCollective({ type: 'ORGANIZATION', isHostAccount: true }));
+    });
+  });
+
   describe('tiers', () => {
     before('adding user as backer', () => collective.addUserWithRole(user2, 'BACKER'));
     before('creating order for backer tier', () =>


### PR DESCRIPTION
Ability to use organization profiles as payees for expenses if they're not hosts.

Also added a filter on `isMemberOf` to filter out hosts on frontend payee select.