### PR TITLE
Fix `extended` parameter in urlencoded parser

### DIFF
--- a/server/lib/express.js
+++ b/server/lib/express.js
@@ -50,7 +50,7 @@ export default function (app) {
       },
     }),
   );
-  app.use(express.urlencoded({ limit: '50mb' }));
+  app.use(express.urlencoded({ limit: '50mb', extended: true }));
 
   // Slow requests if enabled (default false)
   if (get(config, 'log.slowRequest')) {


### PR DESCRIPTION
 `extended` is the default but we should not rely on it (currently generating a warning).