### PR TITLE
Refactor: make express initialization async

### DIFF
--- a/scripts/forestadmin-schema-update.js
+++ b/scripts/forestadmin-schema-update.js
@@ -7,4 +7,8 @@ if (!process.env.FOREST_ENV_SECRET || !process.env.FOREST_AUTH_SECRET) {
   process.exit();
 }
 
-forest.init();
+async function main() {
+  await forest.init();
+}
+
+main();

--- a/server/lib/express.js
+++ b/server/lib/express.js
@@ -22,7 +22,7 @@ import forest from './forest';
 import logger from './logger';
 import { sanitizeForLogs } from './utils';
 
-export default function (app) {
+export default async function (app) {
   app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'].concat(cloudflareIps));
 
   app.use(helmet());
@@ -86,7 +86,7 @@ export default function (app) {
   }
 
   // Forest
-  forest(app);
+  await forest(app);
 
   // Cors.
   app.use(cors());

--- a/server/lib/forest.js
+++ b/server/lib/forest.js
@@ -5,8 +5,8 @@ import { cloneDeep } from 'lodash';
 
 import models, { Op, sequelize } from '../models';
 
-export const init = () =>
-  Liana.init({
+export async function init() {
+  return Liana.init({
     modelsDir: path.resolve(__dirname, '../models'),
     configDir: path.resolve(__dirname, '../forest'),
     envSecret: process.env.FOREST_ENV_SECRET,
@@ -14,13 +14,16 @@ export const init = () =>
     connections: [{ models: getForestModels(), options: sequelize.options }],
     sequelize: sequelize.Sequelize,
   });
+}
 
-export default app => {
+export default async function (app) {
   if (!process.env.FOREST_ENV_SECRET || !process.env.FOREST_AUTH_SECRET) {
     return;
   }
 
-  app.use(init());
+  const forestMiddleware = await init();
+
+  app.use(forestMiddleware);
 
   app.post('/forest/actions/activate-subscription', Liana.ensureAuthenticated, (req, res) => {
     const data = req.body.data;
@@ -292,7 +295,7 @@ export default app => {
       });
     }
   });
-};
+}
 
 function getForestModels() {
   const m = cloneDeep(models);

--- a/test/server/paymentProviders/paypal/payment.test.js
+++ b/test/server/paymentProviders/paypal/payment.test.js
@@ -15,6 +15,12 @@ import * as utils from '../../../utils';
 const application = utils.data('application');
 
 describe('server/paymentProviders/paypal/payment', () => {
+  let expressApp;
+
+  before(async () => {
+    expressApp = await app();
+  });
+
   describe('#paypalUrl', () => {
     let configStub;
 
@@ -111,7 +117,7 @@ describe('server/paymentProviders/paypal/payment', () => {
       }); /* End of "before()" */
 
       it('should call payments/payment endpoint of the PayPal API', async () => {
-        const output = await request(app)
+        const output = await request(expressApp)
           .post(`/services/paypal/create-payment?api_key=${application.api_key}`)
           .send({ amount: '50', currency: 'USD', hostId: host.id })
           .expect(200);

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -8,7 +8,7 @@ import transferwise from '../../../../server/paymentProviders/transferwise';
 import { fakeCollective, fakeConnectedAccount, fakeExpense, fakePayoutMethod } from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
-describe('paymentMethods.transferwise', () => {
+describe('server/paymentProviders/transferwise/index', () => {
   const sandbox = sinon.createSandbox();
   const quote = {
     id: 1234,

--- a/test/server/paymentProviders/transferwise/webhook.test.ts
+++ b/test/server/paymentProviders/transferwise/webhook.test.ts
@@ -21,9 +21,15 @@ import {
 } from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
-describe('paymentMethods/transferwise/webhook.ts', () => {
+describe('server/paymentProviders/transferwise/webhook', () => {
+  let expressApp, api;
+  before(async () => {
+    expressApp = await app();
+    api = request(expressApp) as any;
+  });
+
   const sandbox = sinon.createSandbox();
-  const api = request(app) as any;
+
   /* eslint-disable @typescript-eslint/camelcase */
   const event = {
     data: {

--- a/test/server/routes/connectedAccounts.test.js
+++ b/test/server/routes/connectedAccounts.test.js
@@ -10,20 +10,25 @@ const clientId = config.github.clientID;
 const application = utils.data('application');
 
 describe('server/routes/connectedAccounts', () => {
-  let req, user;
+  let req, user, expressApp;
+
+  before(async () => {
+    expressApp = await app();
+  });
 
   beforeEach(() => utils.resetTestDB());
 
   describe('WHEN calling /connected-accounts/github', () => {
     beforeEach(done => {
-      req = request(app).get('/connected-accounts/github');
+      req = request(expressApp).get('/connected-accounts/github');
       done();
     });
 
     describe('WHEN calling /connected-accounts/github with API key', () => {
       beforeEach(done => {
-        // eslint-disable-next-line camelcase
-        req = request(app).get('/connected-accounts/github?utm_source=mm').send({ api_key: application.api_key });
+        req = request(expressApp)
+          .get('/connected-accounts/github?utm_source=mm')
+          .send({ api_key: application.api_key }); // eslint-disable-line camelcase
         done();
       });
 
@@ -45,7 +50,7 @@ describe('server/routes/connectedAccounts', () => {
 
   describe('WHEN calling /connected-accounts/github/callback', () => {
     beforeEach(done => {
-      req = request(app).get('/connected-accounts/github/callback');
+      req = request(expressApp).get('/connected-accounts/github/callback');
       done();
     });
 
@@ -83,7 +88,7 @@ describe('server/routes/connectedAccounts', () => {
     beforeEach(() => models.User.create(utils.data('user1')).tap(u => (user = u)));
 
     beforeEach(done => {
-      req = request(app).get('/connected-accounts/github/verify');
+      req = request(expressApp).get('/connected-accounts/github/verify');
       done();
     });
 

--- a/test/server/routes/images.test.js
+++ b/test/server/routes/images.test.js
@@ -14,7 +14,11 @@ const application = utils.data('application');
 const userData = utils.data('user1');
 
 describe('server/routes/images', () => {
-  let user;
+  let user, expressApp;
+
+  before(async () => {
+    expressApp = await app();
+  });
 
   before(function () {
     if (!config.aws.s3.key) {
@@ -34,7 +38,7 @@ describe('server/routes/images', () => {
     const originalImage = fs.readFileSync(path.join(__dirname, '../../mocks/images/camera.png'), {
       encoding: 'utf8',
     });
-    request(app)
+    request(expressApp)
       .post(`/images/?api_key=${application.api_key}`)
       .attach('file', 'test/mocks/images/camera.png')
       .set('Authorization', `Bearer ${user.jwt()}`)
@@ -51,7 +55,7 @@ describe('server/routes/images', () => {
   });
 
   it('should throw an error if no file field is sent', done => {
-    request(app)
+    request(expressApp)
       .post(`/images/?api_key=${application.api_key}`)
       .set('Authorization', `Bearer ${user.jwt()}`)
       .expect(400)
@@ -59,7 +63,7 @@ describe('server/routes/images', () => {
   });
 
   it('should upload if the user is not logged in', done => {
-    request(app)
+    request(expressApp)
       .post(`/images/?api_key=${application.api_key}`)
       .attach('file', 'test/mocks/images/camera.png')
       .expect(200)

--- a/test/server/routes/notFound.test.js
+++ b/test/server/routes/notFound.test.js
@@ -8,10 +8,14 @@ const application = utils.data('application');
 
 describe('server/routes/notFound', () => {
   describe('WHEN calling unknown route', () => {
-    let req;
+    let req, expressApp;
+
+    before(async () => {
+      expressApp = await app();
+    });
 
     beforeEach(() => {
-      req = request(app).get(`/blablabla?api_key=${application.api_key}`);
+      req = request(expressApp).get(`/blablabla?api_key=${application.api_key}`);
     });
 
     it('THEN returns 404', () =>

--- a/test/server/routes/status.test.js
+++ b/test/server/routes/status.test.js
@@ -4,9 +4,15 @@ import request from 'supertest';
 import app from '../../../server/index';
 
 describe('server/routes/status', () => {
+  let expressApp;
+
+  before(async () => {
+    expressApp = await app();
+  });
+
   describe('GET /status', () => {
     it('responds with status information', done => {
-      request(app)
+      request(expressApp)
         .get('/status')
         .expect(200)
         .end((e, res) => {

--- a/test/server/routes/users.test.js
+++ b/test/server/routes/users.test.js
@@ -19,7 +19,11 @@ const application = utils.data('application');
  * Tests.
  */
 describe('server/routes/users', () => {
-  let nm;
+  let nm, expressApp;
+
+  before(async () => {
+    expressApp = await app();
+  });
 
   beforeEach(() => utils.resetTestDB());
 
@@ -53,7 +57,7 @@ describe('server/routes/users', () => {
   describe('existence', () => {
     it('returns true', done => {
       models.User.create({ email: 'john@smith.com' }).then(() => {
-        request(app)
+        request(expressApp)
           .get(`/users/exists?email=john@smith.com&api_key=${application.api_key}`)
           .end((e, res) => {
             expect(res.body.exists).to.be.true;
@@ -63,7 +67,7 @@ describe('server/routes/users', () => {
     });
 
     it('returns false', done => {
-      request(app)
+      request(expressApp)
         .get(`/users/exists?email=john2@smith.com&api_key=${application.api_key}`)
         .end((e, res) => {
           expect(res.body.exists).to.be.false;
@@ -79,7 +83,7 @@ describe('server/routes/users', () => {
     const updateTokenUrl = `/users/update-token?api_key=${application.api_key}`;
 
     it('should fail if no token is provided', async () => {
-      const response = await request(app).post(updateTokenUrl);
+      const response = await request(expressApp).post(updateTokenUrl);
       expect(response.statusCode).to.equal(401);
     });
     it('should fail if expired token is provided', async () => {
@@ -88,7 +92,7 @@ describe('server/routes/users', () => {
       const expiredToken = user.jwt({}, -1);
 
       // When the endpoint is hit with an expired token
-      const response = await request(app).post(updateTokenUrl).set('Authorization', `Bearer ${expiredToken}`);
+      const response = await request(expressApp).post(updateTokenUrl).set('Authorization', `Bearer ${expiredToken}`);
 
       // Then the API rejects the request
       expect(response.statusCode).to.equal(401);
@@ -99,7 +103,7 @@ describe('server/routes/users', () => {
       const currentToken = user.jwt();
 
       // When the endpoint is hit with a valid token
-      const response = await request(app).post(updateTokenUrl).set('Authorization', `Bearer ${currentToken}`);
+      const response = await request(expressApp).post(updateTokenUrl).set('Authorization', `Bearer ${currentToken}`);
 
       // Then it responds with success
       expect(response.statusCode).to.equal(200);


### PR DESCRIPTION
Trying to unblock https://github.com/opencollective/opencollective-api/pull/3708

The Forest Middleware is moving to an async signature and that is forcing us to reconsider the way we're initializing `express`.

I'm not 100% happy, let me know if you have ideas to make that better.