### PR TITLE
feat(graphql/v2/object): expose required v2 fields

### DIFF
--- a/server/graphql/v2/object/AccountStats.js
+++ b/server/graphql/v2/object/AccountStats.js
@@ -1,5 +1,5 @@
 import { GraphQLInt, GraphQLObjectType } from 'graphql';
-import { get, has } from 'lodash';
+import { get, has, isEmpty } from 'lodash';
 
 import queries from '../../../lib/queries';
 import { idEncode } from '../identifiers';
@@ -78,6 +78,17 @@ export const AccountStats = new GraphQLObjectType({
             value: await collective.getYearlyIncome(),
             currency: collective.currency,
           };
+        },
+      },
+      totalFinancialContributors: {
+        description: 'Total members with role as Backer',
+        type: GraphQLInt,
+        async resolve(collective) {
+          const totalFinancialContributors = await collective.getTopBackers();
+          if (isEmpty(totalFinancialContributors)) {
+            return 0;
+          }
+          return totalFinancialContributors.length;
         },
       },
     };

--- a/server/graphql/v2/object/Collective.js
+++ b/server/graphql/v2/object/Collective.js
@@ -1,4 +1,5 @@
-import { GraphQLBoolean, GraphQLInt, GraphQLObjectType } from 'graphql';
+import { GraphQLObjectType, GraphQLInt, GraphQLBoolean } from 'graphql';
+import { GraphQLDateTime } from 'graphql-iso-date';
 
 import { hostResolver } from '../../common/collective';
 import { Account, AccountFields } from '../interface/Account';
@@ -28,6 +29,20 @@ export const Collective = new GraphQLObjectType({
         type: GraphQLBoolean,
         resolve(collective) {
           return collective.isApproved();
+        },
+      },
+      isArchived: {
+        description: 'Returns whether this collective is archived',
+        type: GraphQLBoolean,
+        resolve(collective) {
+          return Boolean(collective.deactivatedAt && !collective.isActive);
+        },
+      },
+      approvedAt: {
+        description: 'Return this collective approved date',
+        type: GraphQLDateTime,
+        resolve(collective) {
+          return collective.approvedAt;
         },
       },
     };


### PR DESCRIPTION
Expose fields required for `REST API`
- AccountStats: `totalFinancialContributors`
- Collective: `isArchived `,`approvedAt `

re [#2808](https://github.com/opencollective/opencollective/issues/2808)