### PR TITLE
EditMembers: Skip invitation when users add themselves

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -142,7 +142,12 @@ export async function createCollective(_, args, req) {
       }
     });
   } else if (collectiveData.members) {
-    collective.editMembers(collectiveData.members, { CreatedByUserId: req.remoteUser.id });
+    promises.push(
+      collective.editMembers(collectiveData.members, {
+        CreatedByUserId: req.remoteUser.id,
+        remoteUserCollectiveId: req.remoteUser.CollectiveId,
+      }),
+    );
   } else {
     promises.push(collective.addUserWithRole(req.remoteUser, roles.ADMIN, { CreatedByUserId: req.remoteUser.id }));
   }


### PR DESCRIPTION
In a recent change for the collective picker, we manually push the user creating an organization among the members to make sure they'll be an admin of it. 

Before this PR we were sending these users an invitation rather than adding them directly.