### PR TITLE
Add Information About Installing Postgres Client Tools on Linux

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -35,12 +35,20 @@ export PGHOST=localhost
 export PGUSER=postgres
 ```
 
-You'll also need to have Postgres client tools like `psql`, `dropdb`, `createuser` locally available to run our scripts. In macOS you can install those using Homebrew with:
+You'll also need to have Postgres client tools like `psql`, `dropdb`, `createuser` locally available to run our scripts.
+
+#### MacOS
+
+In macOS you can install those using Homebrew with:
 
 ```
 brew install libpq
 echo 'export PATH="/usr/local/opt/libpq/bin:$PATH"' >> ~/.bash_profile
 ```
+
+#### Linux
+
+##### Debian Based Distributions
 
 For Ubuntu 16.04 and above you can execute the following to install Postgres client tools:
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -42,6 +42,12 @@ brew install libpq
 echo 'export PATH="/usr/local/opt/libpq/bin:$PATH"' >> ~/.bash_profile
 ```
 
+For Ubuntu 16.04 and above you can execute the following to install Postgres client tools:
+
+```
+sudo apt-get install postgresql-client
+```
+
 ## Setup
 
 #### Development

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -35,20 +35,12 @@ export PGHOST=localhost
 export PGUSER=postgres
 ```
 
-You'll also need to have Postgres client tools like `psql`, `dropdb`, `createuser` locally available to run our scripts.
-
-#### MacOS
-
-In macOS you can install those using Homebrew with:
+You'll also need to have Postgres client tools like `psql`, `dropdb`, `createuser` locally available to run our scripts. In macOS you can install those using Homebrew with:
 
 ```
 brew install libpq
 echo 'export PATH="/usr/local/opt/libpq/bin:$PATH"' >> ~/.bash_profile
 ```
-
-#### Linux
-
-##### Debian Based Distributions
 
 For Ubuntu 16.04 and above you can execute the following to install Postgres client tools:
 


### PR DESCRIPTION
This adds information to postgres.md about installing Postgres client tools on Ubuntu. We currently only have information about Postgres client tool installation on Mac. :smile: 