### PR TITLE
MemberInvitation: Exclude invitations from/to deleted collectives

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -1298,7 +1298,14 @@ const queries = {
       if (args.MemberCollectiveId) {
         where.MemberCollectiveId = args.MemberCollectiveId;
       }
-      return models.MemberInvitation.findAll({ where });
+
+      return models.MemberInvitation.findAll({
+        where,
+        include: [
+          { association: 'collective', required: true, attributes: [] },
+          { association: 'memberCollective', required: true, attributes: [] },
+        ],
+      });
     },
   },
 


### PR DESCRIPTION
Now generates the following SQL:

```sql
SELECT "MemberInvitation"."id",
       "MemberInvitation"."CreatedByUserId",
       "MemberInvitation"."MemberCollectiveId",
       "MemberInvitation"."CollectiveId",
       "MemberInvitation"."TierId",
       "MemberInvitation"."role",
       "MemberInvitation"."description",
       "MemberInvitation"."createdAt",
       "MemberInvitation"."updatedAt",
       "MemberInvitation"."deletedAt",
       "MemberInvitation"."since"
FROM "MemberInvitations" AS "MemberInvitation"
INNER JOIN "Collectives" AS "collective" ON "MemberInvitation"."CollectiveId" = "collective"."id"
AND ("collective"."deletedAt" IS NULL)
INNER JOIN "Collectives" AS "memberCollective" ON "MemberInvitation"."MemberCollectiveId" = "memberCollective"."id"
AND ("memberCollective"."deletedAt" IS NULL)
WHERE ("MemberInvitation"."deletedAt" IS NULL
       AND "MemberInvitation"."CollectiveId" = 10884);
```