### PR TITLE
Fix empty webhookUrl

### DIFF
--- a/migrations/20200420165656-clean-invalid-webhooks.js
+++ b/migrations/20200420165656-clean-invalid-webhooks.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  up: queryInterface => {
+    return queryInterface.sequelize.query(`
+      DELETE FROM "Notifications"
+      WHERE "channel" = 'webhook'
+      AND "webhookUrl" IS NULL;
+    `);
+  },
+
+  down: () => {},
+};

--- a/server/graphql/v1/mutations/notifications.js
+++ b/server/graphql/v1/mutations/notifications.js
@@ -47,14 +47,12 @@ export async function editWebhooks(args, remoteUser) {
   // Create
   if (toCreate.length > 0) {
     promises.push(
-      models.Notification.bulkCreate(
-        toCreate.map(notification => {
-          return {
-            ...pick(notification, allowedFields),
-            CollectiveId: args.collectiveId,
-            UserId: remoteUser.id,
-            channel: channels.WEBHOOK,
-          };
+      toCreate.map(notification =>
+        models.Notification.create({
+          ...pick(notification, allowedFields),
+          CollectiveId: args.collectiveId,
+          UserId: remoteUser.id,
+          channel: channels.WEBHOOK,
         }),
       ),
     );

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,9 +1,10 @@
 import Promise from 'bluebird';
 import debugLib from 'debug';
-import { defaults } from 'lodash';
+import { defaults, isNil } from 'lodash';
 import { Op } from 'sequelize';
 
 import channels from '../constants/channels';
+import { ValidationFailed } from '../graphql/errors';
 
 const debug = debugLib('models:Notification');
 
@@ -78,6 +79,14 @@ export default function (Sequelize, DataTypes) {
           type: 'unique',
         },
       ],
+      hooks: {
+        beforeCreate(instance) {
+          console.log(instance);
+          if (instance.channel === channels.WEBHOOK && isNil(instance.webhookUrl)) {
+            throw new ValidationFailed('Webhook URL can not be undefined');
+          }
+        },
+      },
     },
   );
 

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -81,7 +81,6 @@ export default function (Sequelize, DataTypes) {
       ],
       hooks: {
         beforeCreate(instance) {
-          console.log(instance);
           if (instance.channel === channels.WEBHOOK && isNil(instance.webhookUrl)) {
             throw new ValidationFailed('Webhook URL can not be undefined');
           }


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3071

The `bulkCreate` method would skip hooks, so I mapped normal create methods.