### PR TITLE
Extend expenses permission library

### DIFF
--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -328,7 +328,7 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
-      return updateExpenseStatus(req.remoteUser, args.id, statuses.APPROVED);
+      return updateExpenseStatus(req, args.id, statuses.APPROVED);
     },
   },
   unapproveExpense: {
@@ -337,7 +337,7 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
-      return updateExpenseStatus(req.remoteUser, args.id, statuses.PENDING);
+      return updateExpenseStatus(req, args.id, statuses.PENDING);
     },
   },
   rejectExpense: {
@@ -346,7 +346,7 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
-      return updateExpenseStatus(req.remoteUser, args.id, statuses.REJECTED);
+      return updateExpenseStatus(req, args.id, statuses.REJECTED);
     },
   },
   payExpense: {
@@ -362,7 +362,7 @@ const mutations = {
       },
     },
     resolve(_, args, req) {
-      return payExpense(req.remoteUser, args);
+      return payExpense(req, args);
     },
   },
   markOrderAsPaid: {
@@ -398,7 +398,7 @@ const mutations = {
       expense: { type: new GraphQLNonNull(ExpenseInputType) },
     },
     resolve(_, args, req) {
-      return editExpense(req.remoteUser, args.expense);
+      return editExpense(req, args.expense);
     },
   },
   deleteExpense: {
@@ -407,7 +407,7 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
-      return deleteExpense(req.remoteUser, args.id);
+      return deleteExpense(req, args.id);
     },
   },
   markExpenseAsUnpaid: {
@@ -417,7 +417,7 @@ const mutations = {
       processorFeeRefunded: { type: new GraphQLNonNull(GraphQLBoolean) },
     },
     resolve(_, args, req) {
-      return markExpenseAsUnpaid(req.remoteUser, args.id, args.processorFeeRefunded);
+      return markExpenseAsUnpaid(req, args.id, args.processorFeeRefunded);
     },
   },
   editTier: {

--- a/server/graphql/v2/object/ExpensePermissions.ts
+++ b/server/graphql/v2/object/ExpensePermissions.ts
@@ -1,6 +1,6 @@
 import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType } from 'graphql';
 
-import * as ExpensePermissionsLib from '../../common/expenses';
+import * as ExpenseLib from '../../common/expenses';
 
 const ExpensePermissions = new GraphQLObjectType({
   name: 'ExpensePermissions',
@@ -10,29 +10,56 @@ const ExpensePermissions = new GraphQLObjectType({
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'Whether the current user can edit the expense',
       async resolve(expense, _, req): Promise<boolean> {
-        if (!expense.collective) {
-          expense.collective = await req.loaders.Collective.byId.load(expense.CollectiveId);
-        }
-
-        return ExpensePermissionsLib.canEditExpense(req.remoteUser, expense);
+        return ExpenseLib.canEditExpense(req, expense);
       },
     },
     canDelete: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'Whether the current user can edit the expense',
-      async resolve(expense, _, req): Promise<boolean> {
-        if (!expense.collective) {
-          expense.collective = await req.loaders.Collective.byId.load(expense.CollectiveId);
-        }
-
-        return ExpensePermissionsLib.canDeleteExpense(req.remoteUser, expense);
+      resolve(expense, _, req): Promise<boolean> {
+        return ExpenseLib.canDeleteExpense(req, expense);
       },
     },
     canSeeInvoiceInfo: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'Whether the current user can the the invoice info for this expense',
       resolve(expense, _, req): Promise<boolean> {
-        return ExpensePermissionsLib.canSeeExpenseInvoiceInfo(req, expense);
+        return ExpenseLib.canSeeExpenseInvoiceInfo(req, expense);
+      },
+    },
+    canPay: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can trigger the payment for this expense',
+      async resolve(expense, _, req): Promise<boolean> {
+        return ExpenseLib.canPayExpense(req, expense);
+      },
+    },
+    canApprove: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can approve this expense',
+      async resolve(expense, _, req): Promise<boolean> {
+        return ExpenseLib.canApprove(req, expense);
+      },
+    },
+    canUnapprove: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can unapprove this expense',
+      async resolve(expense, _, req): Promise<boolean> {
+        return ExpenseLib.canUnapprove(req, expense);
+      },
+    },
+    canReject: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can reject this expense',
+      async resolve(expense, _, req): Promise<boolean> {
+        return ExpenseLib.canReject(req, expense);
+      },
+    },
+    canMarkAsUnpaid: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can mark this expense as unpaid',
+      async resolve(expense, _, req): Promise<boolean> {
+        return ExpenseLib.canMarkAsUnpaid(req, expense);
       },
     },
   },

--- a/server/lib/user-permissions.ts
+++ b/server/lib/user-permissions.ts
@@ -8,7 +8,7 @@ import FEATURE from '../constants/feature';
  * Returns true if the given user can use the passed feature. Will always return false
  * if user is not set.
  */
-export const canUseFeature = (user: User, feature: FEATURE) => {
+export const canUseFeature = (user: User, feature: FEATURE): boolean => {
   // Must be provided
   if (!user) {
     return false;

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -1,22 +1,30 @@
 import { expect } from 'chai';
 
 import {
+  canApprove,
+  canDeleteExpense,
+  canEditExpense,
+  canMarkAsUnpaid,
+  canPayExpense,
+  canReject,
   canSeeExpenseAttachments,
   canSeeExpenseInvoiceInfo,
   canSeeExpensePayeeLocation,
   canSeeExpensePayoutMethod,
+  canUnapprove,
 } from '../../../../server/graphql/common/expenses';
 import { fakeCollective, fakeExpense, fakeUser } from '../../../test-helpers/fake-data';
 import { makeRequest } from '../../../utils';
 
 describe('server/graphql/common/expenses', () => {
-  let expense, collective, collectiveAdmin, hostAdmin, expenseOwner, randomUser;
-  let publicReq, randomUserReq, collectiveAdminReq, hostAdminReq, expenseOwnerReq;
+  let expense, collective, collectiveAdmin, hostAdmin, limitedHostAdmin, expenseOwner, randomUser;
+  let publicReq, randomUserReq, collectiveAdminReq, hostAdminReq, limitedHostAdminReq, expenseOwnerReq;
 
   before(async () => {
     randomUser = await fakeUser();
     collectiveAdmin = await fakeUser();
     hostAdmin = await fakeUser();
+    limitedHostAdmin = await fakeUser();
     expenseOwner = await fakeUser();
     collective = await fakeCollective();
     expense = await fakeExpense({ CollectiveId: collective.id, FromCollectiveId: expenseOwner.CollectiveId });
@@ -25,11 +33,15 @@ describe('server/graphql/common/expenses', () => {
 
     await collectiveAdmin.populateRoles();
     await hostAdmin.populateRoles();
+    await limitedHostAdmin.populateRoles();
+
+    await limitedHostAdmin.update({ data: { features: { ALL: false } } });
 
     publicReq = makeRequest();
     randomUserReq = makeRequest(randomUser);
     collectiveAdminReq = makeRequest(collectiveAdmin);
     hostAdminReq = makeRequest(hostAdmin);
+    limitedHostAdminReq = makeRequest(limitedHostAdmin);
     expenseOwnerReq = makeRequest(expenseOwner);
   });
 
@@ -40,6 +52,7 @@ describe('server/graphql/common/expenses', () => {
       expect(await canSeeExpenseAttachments(collectiveAdminReq, expense)).to.be.true;
       expect(await canSeeExpenseAttachments(hostAdminReq, expense)).to.be.true;
       expect(await canSeeExpenseAttachments(expenseOwnerReq, expense)).to.be.true;
+      expect(await canSeeExpenseAttachments(limitedHostAdminReq, expense)).to.be.false;
     });
   });
 
@@ -50,6 +63,7 @@ describe('server/graphql/common/expenses', () => {
       expect(await canSeeExpensePayoutMethod(collectiveAdminReq, expense)).to.be.false;
       expect(await canSeeExpensePayoutMethod(hostAdminReq, expense)).to.be.true;
       expect(await canSeeExpensePayoutMethod(expenseOwnerReq, expense)).to.be.true;
+      expect(await canSeeExpensePayoutMethod(limitedHostAdminReq, expense)).to.be.false;
     });
   });
 
@@ -60,6 +74,7 @@ describe('server/graphql/common/expenses', () => {
       expect(await canSeeExpenseInvoiceInfo(collectiveAdminReq, expense)).to.be.false;
       expect(await canSeeExpenseInvoiceInfo(hostAdminReq, expense)).to.be.true;
       expect(await canSeeExpenseInvoiceInfo(expenseOwnerReq, expense)).to.be.true;
+      expect(await canSeeExpenseInvoiceInfo(limitedHostAdminReq, expense)).to.be.false;
     });
   });
 
@@ -70,6 +85,196 @@ describe('server/graphql/common/expenses', () => {
       expect(await canSeeExpensePayeeLocation(collectiveAdminReq, expense)).to.be.false;
       expect(await canSeeExpensePayeeLocation(hostAdminReq, expense)).to.be.true;
       expect(await canSeeExpensePayeeLocation(expenseOwnerReq, expense)).to.be.true;
+      expect(await canSeeExpensePayeeLocation(limitedHostAdminReq, expense)).to.be.false;
+    });
+  });
+
+  describe('canEditExpense', () => {
+    it('only if not processing or paid', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canEditExpense(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'APPROVED' });
+      expect(await canEditExpense(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'ERROR' });
+      expect(await canEditExpense(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'REJECTED' });
+      expect(await canEditExpense(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'PROCESSING' });
+      expect(await canEditExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PAID' });
+      expect(await canEditExpense(hostAdminReq, expense)).to.be.false;
+    });
+
+    it('only if owner or host admin', async () => {
+      await expense.update({ status: 'REJECTED' });
+      expect(await canEditExpense(publicReq, expense)).to.be.false;
+      expect(await canEditExpense(randomUserReq, expense)).to.be.false;
+      expect(await canEditExpense(collectiveAdminReq, expense)).to.be.false;
+      expect(await canEditExpense(hostAdminReq, expense)).to.be.true;
+      expect(await canEditExpense(expenseOwnerReq, expense)).to.be.true;
+      expect(await canEditExpense(limitedHostAdminReq, expense)).to.be.false;
+    });
+  });
+
+  describe('canDeleteExpense', () => {
+    it('only if rejected', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canDeleteExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'APPROVED' });
+      expect(await canDeleteExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PROCESSING' });
+      expect(await canDeleteExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'ERROR' });
+      expect(await canDeleteExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PAID' });
+      expect(await canDeleteExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'REJECTED' });
+      expect(await canDeleteExpense(hostAdminReq, expense)).to.be.true;
+    });
+
+    it('only if owner, collective admin or host admin', async () => {
+      await expense.update({ status: 'REJECTED' });
+      expect(await canDeleteExpense(publicReq, expense)).to.be.false;
+      expect(await canDeleteExpense(randomUserReq, expense)).to.be.false;
+      expect(await canDeleteExpense(collectiveAdminReq, expense)).to.be.true;
+      expect(await canDeleteExpense(hostAdminReq, expense)).to.be.true;
+      expect(await canDeleteExpense(expenseOwnerReq, expense)).to.be.true;
+      expect(await canDeleteExpense(limitedHostAdminReq, expense)).to.be.false;
+    });
+  });
+
+  describe('canPayExpense', () => {
+    it('only if approved or error', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canPayExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'APPROVED' });
+      expect(await canPayExpense(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'PROCESSING' });
+      expect(await canPayExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'ERROR' });
+      expect(await canPayExpense(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'PAID' });
+      expect(await canPayExpense(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'REJECTED' });
+      expect(await canPayExpense(hostAdminReq, expense)).to.be.false;
+    });
+
+    it('only if host admin', async () => {
+      await expense.update({ status: 'APPROVED' });
+      expect(await canPayExpense(publicReq, expense)).to.be.false;
+      expect(await canPayExpense(randomUserReq, expense)).to.be.false;
+      expect(await canPayExpense(collectiveAdminReq, expense)).to.be.false;
+      expect(await canPayExpense(hostAdminReq, expense)).to.be.true;
+      expect(await canPayExpense(expenseOwnerReq, expense)).to.be.false;
+      expect(await canPayExpense(limitedHostAdminReq, expense)).to.be.false;
+    });
+  });
+
+  describe('canApprove', () => {
+    it('only if pending or rejected', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canApprove(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'APPROVED' });
+      expect(await canApprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PROCESSING' });
+      expect(await canApprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'ERROR' });
+      expect(await canApprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PAID' });
+      expect(await canApprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'REJECTED' });
+      expect(await canApprove(hostAdminReq, expense)).to.be.true;
+    });
+
+    it('only if host admin or collective admin', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canApprove(publicReq, expense)).to.be.false;
+      expect(await canApprove(randomUserReq, expense)).to.be.false;
+      expect(await canApprove(collectiveAdminReq, expense)).to.be.true;
+      expect(await canApprove(hostAdminReq, expense)).to.be.true;
+      expect(await canApprove(expenseOwnerReq, expense)).to.be.false;
+      expect(await canApprove(limitedHostAdminReq, expense)).to.be.false;
+    });
+  });
+
+  describe('canReject', () => {
+    it('only if pending', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canReject(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'APPROVED' });
+      expect(await canReject(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PROCESSING' });
+      expect(await canReject(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'ERROR' });
+      expect(await canReject(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PAID' });
+      expect(await canReject(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'REJECTED' });
+      expect(await canReject(hostAdminReq, expense)).to.be.false;
+    });
+
+    it('only if host admin or collective admin', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canReject(publicReq, expense)).to.be.false;
+      expect(await canReject(randomUserReq, expense)).to.be.false;
+      expect(await canReject(collectiveAdminReq, expense)).to.be.true;
+      expect(await canReject(hostAdminReq, expense)).to.be.true;
+      expect(await canReject(expenseOwnerReq, expense)).to.be.false;
+      expect(await canReject(limitedHostAdminReq, expense)).to.be.false;
+    });
+  });
+
+  describe('canUnapprove', () => {
+    it('only if approved', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'APPROVED' });
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'PROCESSING' });
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'ERROR' });
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PAID' });
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'REJECTED' });
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
+    });
+
+    it('only if host admin or collective admin', async () => {
+      await expense.update({ status: 'APPROVED' });
+      expect(await canUnapprove(publicReq, expense)).to.be.false;
+      expect(await canUnapprove(randomUserReq, expense)).to.be.false;
+      expect(await canUnapprove(collectiveAdminReq, expense)).to.be.true;
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.true;
+      expect(await canUnapprove(expenseOwnerReq, expense)).to.be.false;
+      expect(await canUnapprove(limitedHostAdminReq, expense)).to.be.false;
+    });
+  });
+
+  describe('canMarkAsUnpaid', () => {
+    it('only if paid', async () => {
+      await expense.update({ status: 'PENDING' });
+      expect(await canMarkAsUnpaid(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'APPROVED' });
+      expect(await canMarkAsUnpaid(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PROCESSING' });
+      expect(await canMarkAsUnpaid(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'ERROR' });
+      expect(await canMarkAsUnpaid(hostAdminReq, expense)).to.be.false;
+      await expense.update({ status: 'PAID' });
+      expect(await canMarkAsUnpaid(hostAdminReq, expense)).to.be.true;
+      await expense.update({ status: 'REJECTED' });
+      expect(await canMarkAsUnpaid(hostAdminReq, expense)).to.be.false;
+    });
+
+    it('only if host admin', async () => {
+      await expense.update({ status: 'PAID' });
+      expect(await canMarkAsUnpaid(publicReq, expense)).to.be.false;
+      expect(await canMarkAsUnpaid(randomUserReq, expense)).to.be.false;
+      expect(await canMarkAsUnpaid(collectiveAdminReq, expense)).to.be.false;
+      expect(await canMarkAsUnpaid(hostAdminReq, expense)).to.be.true;
+      expect(await canMarkAsUnpaid(expenseOwnerReq, expense)).to.be.false;
+      expect(await canMarkAsUnpaid(limitedHostAdminReq, expense)).to.be.false;
     });
   });
 });

--- a/test/server/graphql/v1/collective.test.js
+++ b/test/server/graphql/v1/collective.test.js
@@ -81,7 +81,7 @@ describe('server/graphql/v1/collective', () => {
         items: [{ amount: 100 * (i + 1), url: store.randUrl() }],
         collective: { id: apex.id },
       });
-      await expenses.payExpense(hostAdmin, { id: expense.id });
+      await expenses.payExpense(utils.makeRequest(hostAdmin), { id: expense.id });
     }
 
     // When the following query is executed


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/2936

Add new fields related to processing expenses to `ExpensePermissions` in GQLV2:
- `canApprove`
- `canDeleteExpense`
- `canEditExpense`
- `canMarkAsUnpaid`
- `canPayExpense`
- `canReject`
- `canUnapprove`

The frontend so retrieves a single object that tells you what the permissions are, and which buttons you should display:
```es6
{
  canApprove: false,
  canDelete: false,
  canEdit: true,
  canMarkAsUnpaid: false,
  canPay: true,
  canReject: false,
  canSeeInvoiceInfo: true,
  canUnapprove: true
}
```

Also did a bit of refactoring without going too far to try to use the same helpers between GQLV1 & V2. All these new helpers have matching unit tests.