### PR TITLE
Remove Slack badge in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Open Collective API
 
-[![Slack Status](https://slack.opencollective.org/badge.svg)](https://slack.opencollective.org)
 [![Dependency Status](https://david-dm.org/opencollective/opencollective-api.svg)](https://david-dm.org/opencollective/opencollective-api)
 
 ## Foreword


### PR DESCRIPTION
The information in the bottom of the Readme should be enough. I don't like that it's red, feels like an error!