### PR TITLE
Inherit hostFeePercent from parent collective

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -466,12 +466,13 @@ export async function approveCollective(remoteUser, CollectiveId) {
     },
   });
 
-  // Approve all events created by this collective under this host
-  collective.getEvents({ where: { HostCollectiveId: host.id } }).then(events => {
+  // Approve all events created by this collective
+  const events = await collective.getEvents();
+  await Promise.all(
     events.map(event => {
       event.update({ isActive: true, approvedAt: new Date() });
-    });
-  });
+    }),
+  );
 
   // Approve the collective and return it
   return collective.update({ isActive: true, approvedAt: new Date() });

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1772,7 +1772,7 @@ export default function (Sequelize, DataTypes) {
     // Prepare events to receive a new host
     const events = await this.getEvents();
     if (events?.length > 0) {
-      await Promise.all(events.map(e => e.update({ HostCollectiveId: null })));
+      await Promise.all(events.map(e => e.changeHost(null)));
     }
 
     if (newHostCollectiveId) {

--- a/test/server/graphql/v1/mutation.test.js
+++ b/test/server/graphql/v1/mutation.test.js
@@ -98,6 +98,7 @@ describe('server/graphql/v1/mutation', () => {
         id
         slug
         currency
+        hostFeePercent
         host {
           id
           currency
@@ -164,8 +165,12 @@ describe('server/graphql/v1/mutation', () => {
         );
       });
 
-      it('creates an event with multiple tiers, uses the currency of parent collective', async () => {
-        await host.collective.update({ currency: 'CAD', settings: { apply: true } });
+      it('creates an event with multiple tiers, uses the currency of parent collective and inherit fees', async () => {
+        await host.collective.update({
+          currency: 'CAD',
+          settings: { apply: true },
+          hostFeePercent: 10,
+        });
         const event = getEventData(collective1);
 
         const result = await utils.graphqlQuery(createCollectiveQuery, { collective: event }, user1);
@@ -173,6 +178,7 @@ describe('server/graphql/v1/mutation', () => {
         const createdEvent = result.data.createCollective;
         expect(createdEvent.slug).to.contain('brusselstogether-meetup');
         expect(createdEvent.tiers.length).to.equal(event.tiers.length);
+        expect(createdEvent.hostFeePercent).to.equal(10);
         expect(createdEvent.isActive).to.be.true;
         event.id = createdEvent.id;
         event.tiers = createdEvent.tiers;


### PR DESCRIPTION
The idea is to inherit the `hostFeePercent` from the parent collective (on Events) only in the creating. If, for some reason, the collective is being moved to a new host, update the `hostFeePercent`.