### PR TITLE
GQLV2: Endpoints to process expenses

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -113,7 +113,7 @@ export const canEditExpense = async (req, expense): Promise<boolean> => {
   } else if (!canUseFeature(req.remoteUser, FEATURE.EXPENSES)) {
     return false;
   } else {
-    return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin]);
+    return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin, isCollectiveAdmin]);
   }
 };
 

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1,7 +1,9 @@
-import { expenseStatus, roles } from '../../constants';
+import { expenseStatus, roles, activities } from '../../constants';
 import FEATURE from '../../constants/feature';
 import { canUseFeature } from '../../lib/user-permissions';
 import { ExpenseItem } from '../../models/ExpenseItem';
+import models from '../../models';
+import { Forbidden } from '../errors';
 
 const isOwner = async (req, expense): Promise<boolean> => {
   if (!req.remoteUser) {
@@ -192,4 +194,42 @@ export const canMarkAsUnpaid = async (req, expense): Promise<boolean> => {
   } else {
     return isHostAdmin(req, expense);
   }
+};
+
+// ---- Expense actions ----
+
+export const approveExpense = async (req, expense): Promise<typeof models.Expense> => {
+  if (expense.status === expenseStatus.APPROVED) {
+    return expense;
+  } else if (!(await canApprove(req, expense))) {
+    throw new Forbidden();
+  }
+
+  const updatedExpense = await expense.update({ status: expenseStatus.APPROVED, lastEditedById: req.remoteUser.id });
+  await expense.createActivity(activities.COLLECTIVE_EXPENSE_APPROVED, req.remoteUser);
+  return updatedExpense;
+};
+
+export const unapproveExpense = async (req, expense): Promise<typeof models.Expense> => {
+  if (expense.status === expenseStatus.PENDING) {
+    return expense;
+  } else if (!(await canUnapprove(req, expense))) {
+    throw new Forbidden();
+  }
+
+  const updatedExpense = await expense.update({ status: expenseStatus.PENDING, lastEditedById: req.remoteUser.id });
+  await expense.createActivity(activities.COLLECTIVE_EXPENSE_UNAPPROVED, req.remoteUser);
+  return updatedExpense;
+};
+
+export const rejectExpense = async (req, expense): Promise<typeof models.Expense> => {
+  if (expense.status === expenseStatus.REJECTED) {
+    return expense;
+  } else if (!(await canReject(req, expense))) {
+    throw new Forbidden();
+  }
+
+  const updatedExpense = await expense.update({ status: expenseStatus.REJECTED, lastEditedById: req.remoteUser.id });
+  await expense.createActivity(activities.COLLECTIVE_EXPENSE_APPROVED, req.remoteUser);
+  return updatedExpense;
 };

--- a/server/graphql/v2/enum/ExpenseProcessAction.ts
+++ b/server/graphql/v2/enum/ExpenseProcessAction.ts
@@ -1,0 +1,23 @@
+import { GraphQLEnumType } from 'graphql';
+
+export const ExpenseProcessAction = new GraphQLEnumType({
+  name: 'ExpenseProcessAction',
+  description: 'All supported expense types',
+  values: {
+    APPROVE: {
+      description: 'To mark the expense as approved',
+    },
+    UNAPPROVE: {
+      description: 'To mark the expense as pending after it has been approved',
+    },
+    REJECT: {
+      description: 'To mark the expense as rejected',
+    },
+    MARK_AS_UNPAID: {
+      description: 'To mark the expense as rejected',
+    },
+    PAY: {
+      description: 'To trigger the payment',
+    },
+  },
+});

--- a/server/graphql/v2/enum/index.js
+++ b/server/graphql/v2/enum/index.js
@@ -3,6 +3,7 @@ export { AccountType, AccountTypeToModelMapping } from './AccountType';
 export { ActivityType } from './ActivityType';
 export { Currency, TransferWiseCurrency } from './Currency';
 export { DateTimeField } from './DateTimeField';
+export { ExpenseProcessAction } from './ExpenseProcessAction';
 export { ImageFormat } from './ImageFormat';
 export { MemberRole } from './MemberRole';
 export { OrderDirectionType } from './OrderDirectionType';

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -1,14 +1,24 @@
-import { GraphQLNonNull } from 'graphql';
+import { GraphQLBoolean, GraphQLInputObjectType, GraphQLInt, GraphQLNonNull } from 'graphql';
 import { pick } from 'lodash';
 
 import models from '../../../models';
-import { canDeleteExpense } from '../../common/expenses';
+import { approveExpense, canDeleteExpense, rejectExpense, unapproveExpense } from '../../common/expenses';
 import { NotFound, Unauthorized } from '../../errors';
-import { createExpense as createExpenseLegacy, editExpense as editExpenseLegacy } from '../../v1/mutations/expenses';
+import {
+  createExpense as createExpenseLegacy,
+  editExpense as editExpenseLegacy,
+  markExpenseAsUnpaid as markExpenseAsUnpaidLegacy,
+  payExpense as payExpenseLegacy,
+} from '../../v1/mutations/expenses';
+import { ExpenseProcessAction } from '../enum/ExpenseProcessAction';
 import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { ExpenseCreateInput } from '../input/ExpenseCreateInput';
-import { ExpenseReferenceInput, getDatabaseIdFromExpenseReference } from '../input/ExpenseReferenceInput';
+import {
+  ExpenseReferenceInput,
+  fetchExpenseWithReference,
+  getDatabaseIdFromExpenseReference,
+} from '../input/ExpenseReferenceInput';
 import { ExpenseUpdateInput } from '../input/ExpenseUpdateInput';
 import { Expense } from '../object/Expense';
 
@@ -120,6 +130,63 @@ const expenseMutations = {
       }
 
       return expense.destroy();
+    },
+  },
+  processExpense: {
+    type: new GraphQLNonNull(Expense),
+    description: 'Process the expense with the given action',
+    args: {
+      expense: {
+        type: new GraphQLNonNull(ExpenseReferenceInput),
+        description: 'Reference of the expense to process',
+      },
+      action: {
+        type: new GraphQLNonNull(ExpenseProcessAction),
+        description: 'The action to trigger',
+      },
+      paymentParams: {
+        description: 'If action is related to a payment, this object used for the payment parameters',
+        type: new GraphQLInputObjectType({
+          name: 'ProcessExpensePaymentParams',
+          description: 'Parameters for paying an expense',
+          fields: {
+            paymentProcessorFee: {
+              type: GraphQLInt,
+              description:
+                'The fee charged by payment processor in collective currency, or the fee refunded when used with MARK_AS_UNPAID',
+            },
+            forceManual: {
+              type: GraphQLBoolean,
+              description: 'Bypass automatic integrations (ie. PayPal, Transferwise) to process the expense manually',
+            },
+          },
+        }),
+      },
+    },
+    async resolve(_, args, req): Promise<typeof Expense> {
+      if (!req.remoteUser) {
+        throw new Unauthorized();
+      }
+
+      const expense = await fetchExpenseWithReference(args.expense, { loaders: req.loaders, throwIfMissing: true });
+      switch (args.action) {
+        case 'APPROVE':
+          return approveExpense(req, expense);
+        case 'UNAPPROVE':
+          return unapproveExpense(req, expense);
+        case 'REJECT':
+          return rejectExpense(req, expense);
+        case 'MARK_AS_UNPAID':
+          return markExpenseAsUnpaidLegacy(req, expense.id, args.paymentParams?.paymentProcessorFee);
+        case 'PAY':
+          return payExpenseLegacy(req, {
+            id: expense.id,
+            paymentProcessorFeeInCollectiveCurrency: args.paymentParams?.paymentProcessorFee,
+            forceManual: args.paymentParams?.forceManual,
+          });
+        default:
+          return expense;
+      }
     },
   },
 };

--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -1,8 +1,10 @@
-import { GraphQLBoolean, GraphQLInt, GraphQLObjectType } from 'graphql';
+import { GraphQLBoolean, GraphQLInt, GraphQLNonNull, GraphQLObjectType } from 'graphql';
 import { get } from 'lodash';
 
 import { Account, AccountFields } from '../interface/Account';
 import URL from '../scalar/URL';
+
+import { HostPlan } from './HostPlan';
 
 export const Host = new GraphQLObjectType({
   name: 'Host',
@@ -34,6 +36,12 @@ export const Host = new GraphQLObjectType({
         type: URL,
         resolve(collective) {
           return get(collective, 'settings.tos');
+        },
+      },
+      plan: {
+        type: new GraphQLNonNull(HostPlan),
+        resolve(host) {
+          return host.getPlan();
         },
       },
     };

--- a/server/graphql/v2/object/HostPlan.ts
+++ b/server/graphql/v2/object/HostPlan.ts
@@ -1,0 +1,52 @@
+import { GraphQLBoolean, GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
+
+export const HostPlan = new GraphQLObjectType({
+  name: 'HostPlan',
+  description: 'The name of the current plan and its characteristics.',
+  fields: {
+    name: {
+      type: GraphQLString,
+      description: 'The name of the plan',
+    },
+    hostedCollectives: {
+      type: GraphQLInt,
+      description: 'Number of collectives hosted',
+    },
+    hostedCollectivesLimit: {
+      type: GraphQLInt,
+      description: 'Max number of collectives than can be hosted',
+    },
+    addedFunds: {
+      type: GraphQLInt,
+      description: 'Wether this plan allows to use the added funds feature',
+    },
+    addedFundsLimit: {
+      type: GraphQLInt,
+      description: 'Amount limit for the added funds feature under this plan',
+    },
+    hostDashboard: {
+      type: GraphQLBoolean,
+      description: 'Wether this plan allows to use the host dashboard',
+    },
+    manualPayments: {
+      type: GraphQLBoolean,
+      description: 'Wether this plan allows to use the manual payments feature',
+    },
+    bankTransfers: {
+      type: GraphQLInt,
+      description: 'Wether this plan allows to use the bank transfers feature',
+    },
+    bankTransfersLimit: {
+      type: GraphQLInt,
+      description: 'Amount limit for the bank transfers feature under this plan',
+    },
+    transferwisePayouts: {
+      type: GraphQLInt,
+      description: 'Wether this plan allows to use the transferwise payouts feature',
+    },
+    transferwisePayoutsLimit: {
+      type: GraphQLInt,
+      description: 'Amount limit for the transferwise payouts feature under this plan',
+    },
+  },
+});

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -109,7 +109,7 @@ describe('server/graphql/common/expenses', () => {
       await expense.update({ status: 'REJECTED' });
       expect(await canEditExpense(publicReq, expense)).to.be.false;
       expect(await canEditExpense(randomUserReq, expense)).to.be.false;
-      expect(await canEditExpense(collectiveAdminReq, expense)).to.be.false;
+      expect(await canEditExpense(collectiveAdminReq, expense)).to.be.true;
       expect(await canEditExpense(hostAdminReq, expense)).to.be.true;
       expect(await canEditExpense(expenseOwnerReq, expense)).to.be.true;
       expect(await canEditExpense(limitedHostAdminReq, expense)).to.be.false;


### PR DESCRIPTION
Rather than adding multiple mutations for processing expenses, I chose to add a single `processExpense` endpoint to handle all actions that are meant to change the `status` of an expense.

```ts
processExpense(
  expense: Expense,
  action: APPROVE | UNAPPROVE | REJECT | MARK_AS_UNPAID | PAY,
  paymentParams: ProcessExpensePaymentParams
)
```

The main advantage of doing so is that it simplifies the API usage:

```es6
export const ProcessExpenseButtons = () => {
  const [processExpense] = useMutation(processExpense);
  return (
    <React.Fragment>
      {permissions.canApprove && (
        <StyledButton onClick={() => processExpense({ variables: { action: 'APPROVE' } })}>
          <FormattedMessage id="actions.approve" defaultMessage="Approve" />
        </StyledButton>
      )}
      {permissions.canReject && (
        <StyledButton onClick={() => processExpense({ variables: { action: 'REJECT' } })}>
          <FormattedMessage id="actions.reject" defaultMessage="Reject" />
        </StyledButton>
      )}
    </React.Fragment>
  )
}
```