### PR TITLE
v2: Let users who are admin of a Collective host this Collective

### DIFF
--- a/server/graphql/v2/mutation/CollectiveMutations.ts
+++ b/server/graphql/v2/mutation/CollectiveMutations.ts
@@ -1,7 +1,7 @@
 import { GraphQLNonNull } from 'graphql';
 
 import { types as collectiveTypes } from '../../../constants/collectives';
-import { NotFound,Unauthorized } from '../../errors';
+import { NotFound, Unauthorized } from '../../errors';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { Collective } from '../object/Collective';
 
@@ -41,16 +41,8 @@ const collectiveMutations = {
       if (!host) {
         throw new NotFound('Host not found');
       }
-      const isHost = await host.isHost();
-      if (!isHost) {
-        throw new Error('Account is not an host');
-      }
-      const canApply = await host.canApply();
-      if (!canApply) {
-        throw new Error('Host is not open to applications');
-      }
 
-      // No need to check the balance, this is being handled in changeHost
+      // No need to check the balance, this is being handled in changeHost, along with most other checks
 
       return collective.changeHost(host.id, req.remoteUser);
     },


### PR DESCRIPTION
I hope I am understanding this correctly.

* The v2 `applyToHost` was checking a single item - `canApply` - to see whether a Collective could apply to a Host.
* for a User who wants to fiscally host a Collective themselves, `isHostAccount` will automatically be `true` but they do not automatically have the `canApply` setting set to true in their settings.
* In the v1 `changeHost` which changes or adds a host to a Collective, it checks whether the potential Host is a Host account via the first method (`isHostAccount`) and then `addHost` within it goes on to check whether a user is the admin of the applying Collective before automatically approving that they can also be the Host

This PR for now adds a line in the v2 `applyToHost` mutation to check in the case of `canApply` being false, whether the host is a `USER`, and then allows `changeHost` and `addHost` to do the work of checking whether they're an admin of the Collective and therefore can host it.