### PR TITLE
fix: rejectCollective should handle Members deletion

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -982,7 +982,7 @@ export async function rejectCollective(_, args, req) {
     },
   });
 
-  return collective.update({ HostCollectiveId: null });
+  return collective.changeHost(null, req.remoteUser);
 }
 
 export async function activateCollectiveAsHost(_, args, req) {


### PR DESCRIPTION
A few SQL queries that I used to manually check affected entries.

```
SELECT "CollectiveId", COUNT(*) FROM "Members" WHERE "role" = 'HOST' AND "deletedAt" IS NULL GROUP BY "CollectiveId" HAVING COUNT(*) > 1;

SELECT * FROM "Members", "Collectives"
WHERE "Members"."role" = 'HOST' AND "Members"."deletedAt" IS NULL AND "Collectives"."id" = "Members"."CollectiveId"
AND "Members"."MemberCollectiveId" != "Collectives"."HostCollectiveId";

SELECT * FROM "Members", "Collectives"
WHERE "Members"."role" = 'HOST'
AND "Members"."deletedAt" IS NULL
AND "Collectives"."type" = 'COLLECTIVE'
AND "Collectives"."id" = "Members"."CollectiveId"
AND "Collectives"."HostCollectiveId" IS NULL;

UPDATE "Members"
SET "deletedAt" = NOW()
FROM "Collectives"
WHERE "Members"."role" = 'HOST'
AND "Members"."deletedAt" IS NULL
AND "Collectives"."type" = 'COLLECTIVE'
AND "Collectives"."id" = "Members"."CollectiveId"
AND "Collectives"."HostCollectiveId" IS NULL;
```