### PR TITLE
refactor: improve how summaries are generated for updates

### DIFF
--- a/migrations/20200423203719-add-summary-to-updates.js
+++ b/migrations/20200423203719-add-summary-to-updates.js
@@ -1,0 +1,42 @@
+'use strict';
+
+import Promise from 'bluebird';
+
+import { generateSummaryForHTML } from '../server/lib/sanitize-html';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Updates', 'summary', { type: Sequelize.STRING });
+    await queryInterface.addColumn('UpdateHistories', 'summary', { type: Sequelize.STRING });
+
+    const updates = await queryInterface.sequelize.query(
+      `
+        SELECT * FROM "Updates"
+        WHERE "summary" IS NULL;
+      `,
+      { type: Sequelize.QueryTypes.SELECT },
+    );
+
+    // Update newly created summary column for existing update entries
+    await Promise.map(updates, updateEntry =>
+      queryInterface.sequelize.query(
+        `
+        UPDATE "Updates" u
+        SET "summary" = :summary
+        WHERE u.id = :id
+      `,
+        {
+          replacements: {
+            id: updateEntry.id,
+            summary: generateSummaryForHTML(updateEntry.html, 240),
+          },
+        },
+      ),
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Updates', 'summary');
+    await queryInterface.removeColumn('UpdateHistories', 'summary');
+  },
+};

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -13,7 +13,6 @@ import {
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { Kind } from 'graphql/language';
-import he from 'he';
 import { get, omit, pick } from 'lodash';
 import moment from 'moment';
 
@@ -1048,21 +1047,7 @@ export const UpdateType = new GraphQLObjectType({
             return null;
           }
 
-          if (update.html.substr(0, 3) === '<p>') {
-            // we only keep the first paragraph
-            return he
-              .decode(update.html)
-              .replace('<p><br /></p>', '')
-              .replace(/<\/p>.*/g, '')
-              .replace('<p>', '');
-          }
-
-          if (update.markdown) {
-            // we only keep the first paragraph (up to 255 chars)
-            return update.markdown.replace(/\n.*/g, '').trunc(255, true);
-          }
-
-          return '';
+          return update.summary || '';
         },
       },
       html: {

--- a/server/models/Update.js
+++ b/server/models/Update.js
@@ -13,6 +13,7 @@ import activities from '../constants/activities';
 import * as errors from '../graphql/errors';
 import { mustHaveRole } from '../lib/auth';
 import logger from '../lib/logger';
+import { generateSummaryForHTML } from '../lib/sanitize-html';
 import { sanitizeObject } from '../lib/utils';
 
 const markdownConverter = new showdown.Converter();
@@ -113,6 +114,10 @@ export default function (Sequelize, DataTypes) {
             ? markdownConverter.makeHtml(this.getDataValue('markdown'))
             : this.getDataValue('html');
         },
+        set(html) {
+          this.setDataValue('html', html);
+          this.setDataValue('summary', generateSummaryForHTML(html, 240));
+        },
       },
 
       image: DataTypes.STRING,
@@ -147,6 +152,10 @@ export default function (Sequelize, DataTypes) {
       makePublicOn: {
         type: DataTypes.DATE,
         defaultValue: null,
+      },
+
+      summary: {
+        type: DataTypes.STRING,
       },
     },
     {


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2547

This PR adds a new `summary` column to `Updates` table and improved how summaries are generated by using `generateSummaryForHTML` helper which is also used to generate summaries for conversations.