### PR TITLE
ExpensePermission: Minor changes

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -179,7 +179,7 @@ export const canUnapprove = async (req, expense): Promise<boolean> => {
   } else if (!canUseFeature(req.remoteUser, FEATURE.EXPENSES)) {
     return false;
   } else {
-    return remoteUserMeetsOneCondition(req, expense, [isCollectiveAdmin, isHostAdmin]);
+    return remoteUserMeetsOneCondition(req, expense, [isCollectiveAdmin, isHostAdmin, isCollectiveAdmin]);
   }
 };
 

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -554,7 +554,7 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         const mutationParams = { expenseId: expense.id, action: 'MARK_AS_UNPAID' };
         const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
         expect(result.errors).to.exist;
-        expect(result.errors[0].message).to.eq('Only expenses with "other" payout method can be marked as unpaid');
+        expect(result.errors[0].message).to.eq("You don't have permission to mark this expense as unpaid");
       });
 
       it('Marks the expense as unpaid', async () => {


### PR DESCRIPTION
- Allow collective admins to unapprove expenses
- Can only mark as paid if OTHER payout method