### PR TITLE
Collective: Disable image validation

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -59,7 +59,6 @@ import { capitalize, cleanTags, flattenArray, formatCurrency, getDomain, md5, st
 
 import CustomDataTypes from './DataTypes';
 import { PayoutMethodTypes } from './PayoutMethod';
-import { isValidUploadedImage } from '../lib/images';
 
 const debug = debugLib('models:Collective');
 
@@ -268,11 +267,6 @@ export default function (Sequelize, DataTypes) {
         type: DataTypes.STRING,
         validate: {
           isUrl: true,
-          isValidImage(url) {
-            if (url && !isValidUploadedImage(url)) {
-              throw new Error('The image URL is not valid');
-            }
-          },
         },
         get() {
           const image = this.getDataValue('image');
@@ -287,11 +281,6 @@ export default function (Sequelize, DataTypes) {
         type: DataTypes.STRING,
         validate: {
           isUrl: true,
-          isValidImage(url) {
-            if (url && !isValidUploadedImage(url)) {
-              throw new Error('The background image URL is not valid');
-            }
-          },
         },
         get() {
           return this.getDataValue('backgroundImage');


### PR DESCRIPTION
Fix for https://opencollective.freshdesk.com/a/tickets/6272

Disabling the images validation for now as there are multiple paths that I didn't cover in my initial work. Will create a follow up issue.