### PR TITLE
Add Support for Expense Tag Suggestions

### DIFF
--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -164,6 +164,13 @@ const accountFieldsDefinition = () => ({
       limit: { type: GraphQLInt, defaultValue: 30 },
     },
   },
+  expensesTags: {
+    type: new GraphQLList(TagStats),
+    description: 'Returns expense tags for collective sorted by popularity',
+    args: {
+      limit: { type: GraphQLInt, defaultValue: 30 },
+    },
+  },
   transferwise: {
     type: TransferWise,
     async resolve(collective) {
@@ -368,6 +375,16 @@ export const AccountFields = {
     },
     async resolve(collective, _, { limit }) {
       return models.Conversation.getMostPopularTagsForCollective(collective.id, limit);
+    },
+  },
+  expensesTags: {
+    type: new GraphQLList(TagStats),
+    description: 'Returns expense tags for collective sorted by popularity',
+    args: {
+      limit: { type: GraphQLInt, defaultValue: 30 },
+    },
+    async resolve(collective, _, { limit }) {
+      return models.Expense.getMostPopularExpenseTagsForCollective(collective.id, limit);
     },
   },
   payoutMethods: {

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -374,6 +374,23 @@ export default function (Sequelize, DataTypes) {
     return legacyPayoutMethod === 'paypal' ? PayoutMethodTypes.PAYPAL : PayoutMethodTypes.OTHER;
   };
 
+  Expense.getMostPopularExpenseTagsForCollective = async function (collectiveId, limit = 100) {
+    return Sequelize.query(
+      `
+      SELECT UNNEST(tags) AS id, UNNEST(tags) AS tag, COUNT(id)
+      FROM "Expenses"
+      WHERE "CollectiveId" = $collectiveId
+      GROUP BY UNNEST(tags)
+      ORDER BY count DESC
+      LIMIT $limit
+    `,
+      {
+        type: Sequelize.QueryTypes.SELECT,
+        bind: { collectiveId, limit },
+      },
+    );
+  };
+
   Temporal(Expense, Sequelize);
 
   return Expense;


### PR DESCRIPTION
This adds support for expense tag suggestions for the api layer.

Related to https://github.com/opencollective/opencollective/issues/3088