### PR TITLE
Add longDescription field to Account type v2

### DIFF
--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -53,6 +53,9 @@ const accountFieldsDefinition = () => ({
   description: {
     type: GraphQLString,
   },
+  longDescription: {
+    type: GraphQLString,
+  },
   tags: {
     type: new GraphQLList(GraphQLString),
   },


### PR DESCRIPTION
As said in the title :)

This is specifically for displaying the longDescription on the apply to host info modals.