### PR TITLE
Configure ssl when PGSSLMODE=require

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -23,6 +23,11 @@ if (process.env.DEBUG && process.env.DEBUG.match(/psql/)) {
   config.database.options.logging = true;
 }
 
+if (process.env.PGSSLMODE === 'require') {
+  config.database.options.dialectOptions = config.database.options.dialectOptions || {};
+  config.database.options.dialectOptions = { ssl: { rejectUnauthorized: false } };
+}
+
 if (config.database.options.logging) {
   if (process.env.NODE_ENV === 'production') {
     config.database.options.logging = (query, executionTime) => {


### PR DESCRIPTION
In development environment, when using `PGSSLMODE=require` the dialectOptions are currently not properly set. It's taking care of that. (I sometimes connect to staging DB or prod-readonly DB to investigate issues).