### PR TITLE
Conversations: Add missing data for email

### DIFF
--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -231,6 +231,9 @@ async function notifyByEmail(activity) {
       activity.data.collective = await models.Collective.findByPk(activity.data.conversation.CollectiveId);
       activity.data.fromCollective = await models.Collective.findByPk(activity.data.conversation.FromCollectiveId);
       activity.data.rootComment = await models.Comment.findByPk(activity.data.conversation.RootCommentId);
+      activity.data.collective = activity.data.collective?.info;
+      activity.data.fromCollective = activity.data.fromCollective?.info;
+      activity.data.rootComment = activity.data.rootComment?.info;
       notifyAdminsOfCollective(activity.data.conversation.CollectiveId, activity, { exclude: [activity.UserId] });
       break;
     case activityType.COLLECTIVE_COMMENT_CREATED:


### PR DESCRIPTION
Resolve https://opencollective.freshdesk.com/a/tickets/6376
Follow up on https://github.com/opencollective/opencollective-api/pull/3693

Add missing data for the "New conversation" email. I tried to see if other emails were impacted in this file, but the rest seems ok.

![image](https://user-images.githubusercontent.com/1556356/81078611-be0b6580-8eee-11ea-9730-9022cd928513.png)
