### PR TITLE
Add support for requiredLegalDocuments on GQLV2 > Expense

### DIFF
--- a/server/graphql/v2/enum/LegalDocumentType.ts
+++ b/server/graphql/v2/enum/LegalDocumentType.ts
@@ -4,10 +4,10 @@ import { LEGAL_DOCUMENT_TYPE } from '../../../models/LegalDocument';
 
 export const LegalDocumentType = new GraphQLEnumType({
   name: 'LegalDocumentType',
-  description: 'US tax form (W9)',
+  description: 'Type for a required legal document',
   values: {
     [LEGAL_DOCUMENT_TYPE.US_TAX_FORM]: {
-      description: 'Invoice: Get paid back for a purchase already made.',
+      description: 'US tax form (W9)',
     },
   },
 });

--- a/server/graphql/v2/enum/LegalDocumentType.ts
+++ b/server/graphql/v2/enum/LegalDocumentType.ts
@@ -1,0 +1,13 @@
+import { GraphQLEnumType } from 'graphql';
+
+import { LEGAL_DOCUMENT_TYPE } from '../../../models/LegalDocument';
+
+export const LegalDocumentType = new GraphQLEnumType({
+  name: 'LegalDocumentType',
+  description: 'US tax form (W9)',
+  values: {
+    [LEGAL_DOCUMENT_TYPE.US_TAX_FORM]: {
+      description: 'Invoice: Get paid back for a purchase already made.',
+    },
+  },
+});

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2773,10 +2773,10 @@ export default function (Sequelize, DataTypes) {
   };
 
   Collective.prototype.doesUserHaveTotalExpensesOverThreshold = async function ({ threshold, year, UserId }) {
-    const { PENDING, APPROVED, PAID } = expenseStatus;
+    const { PENDING, APPROVED, PAID, PROCESSING } = expenseStatus;
     const since = moment({ year });
     const until = moment({ year }).add(1, 'y');
-    const status = [PENDING, APPROVED, PAID];
+    const status = [PENDING, APPROVED, PAID, PROCESSING];
     const excludedTypes = [expenseTypes.RECEIPT];
 
     const expenses = await this.getExpensesForHost(status, since, until, UserId, excludedTypes);
@@ -2787,10 +2787,10 @@ export default function (Sequelize, DataTypes) {
   };
 
   Collective.prototype.getUsersWhoHaveTotalExpensesOverThreshold = async function ({ threshold, year }) {
-    const { PENDING, APPROVED, PAID } = expenseStatus;
+    const { PENDING, APPROVED, PAID, PROCESSING } = expenseStatus;
     const since = moment({ year });
     const until = moment({ year }).add(1, 'y');
-    const status = [PENDING, APPROVED, PAID];
+    const status = [PENDING, APPROVED, PAID, PROCESSING];
     const excludedTypes = [expenseTypes.RECEIPT];
     const expenses = await this.getExpensesForHost(status, since, until, null, excludedTypes);
 

--- a/server/models/LegalDocument.js
+++ b/server/models/LegalDocument.js
@@ -1,10 +1,12 @@
+export const LEGAL_DOCUMENT_TYPE = {
+  US_TAX_FORM: 'US_TAX_FORM',
+};
+
 export default function (Sequelize, DataTypes) {
   const NOT_REQUESTED = 'NOT_REQUESTED';
   const REQUESTED = 'REQUESTED';
   const RECEIVED = 'RECEIVED';
   const ERROR = 'ERROR';
-
-  const US_TAX_FORM = 'US_TAX_FORM';
 
   const LegalDocument = Sequelize.define(
     'LegalDocument',
@@ -25,9 +27,9 @@ export default function (Sequelize, DataTypes) {
       },
       documentType: {
         type: DataTypes.ENUM,
-        values: [US_TAX_FORM],
+        values: [LEGAL_DOCUMENT_TYPE.US_TAX_FORM],
         allowNull: false,
-        defaultValue: US_TAX_FORM,
+        defaultValue: LEGAL_DOCUMENT_TYPE.US_TAX_FORM,
         unique: 'yearTypeCollective',
       },
       documentLink: {


### PR DESCRIPTION
The endpoint is a bit different from what we have in V1, it returns a list of required documents (`requiredLegalDocuments` rather than `userTaxFormRequiredBeforePayment`) to preserve the generic aspect that we have in the DB and that could allow to easily add new legal document types in the future.

In the frontend the check is then done like that:
```es6
const needsTaxForm = expense.requiredLegalDocuments.includes('US_TAX_FORM');
```

Also included the expenses currently processing when computing the total submitted expenses sum.