### PR TITLE
NewExpenseEmail: Add items info

### DIFF
--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -256,6 +256,7 @@ export default function (Sequelize, DataTypes) {
     }
     const host = await this.collective.getHostCollective(); // may be null
     const payoutMethod = await this.getPayoutMethod();
+    const items = this.items || (await this.getItems());
     const transaction =
       this.status === status.PAID &&
       (await models.Transaction.findOne({
@@ -273,6 +274,13 @@ export default function (Sequelize, DataTypes) {
         expense: this.info,
         transaction: transaction.info,
         payoutMethod: payoutMethod && pick(payoutMethod.dataValues, ['id', 'type', 'data']),
+        items: items.map(item => ({
+          id: item.id,
+          incurredAt: item.incurredAt,
+          description: item.description,
+          amount: item.amount,
+          url: item.url,
+        })),
       },
     });
   };

--- a/templates/emails/collective.expense.created.hbs
+++ b/templates/emails/collective.expense.created.hbs
@@ -5,7 +5,7 @@ Subject: New expense on {{collective.name}}: {{{currency expense.amount currency
 <center>
   <h1>{{{currency expense.amount currency=expense.currency precision=2}}}</h1>
   <div><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></div>
-  <div>Submitted by: {{fromCollective.name}}</div>
+  <div>Payee: <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></div>
   {{#if payoutMethod}}
     {{#ifCond payoutMethod.type '===' 'PAYPAL'}}
       <div>Paypal Email: {{payoutMethod.data.email}}</div>
@@ -14,9 +14,33 @@ Subject: New expense on {{collective.name}}: {{{currency expense.amount currency
   
   <p><font color="#999">{{expense.notes}}</font></p>
 
-  <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">
-    <img src="https://res.cloudinary.com/opencollective/image/fetch/w_640,f_jpg/{{expense.attachment}}" width="100%" />
-  </a>
+  <h3 style="margin: 24px;">Expense items</h3>
+
+  <div>
+    {{#each items}}
+      <div style="display: flex; padding: 12px 0; margin: 0 24px; justify-content: space-between; align-items: center; border-bottom: 1px dotted rgb(196, 199, 204);">
+        <div style="display: flex;">
+          {{#if this.url}}
+            <div style="margin-right: 16px;">
+              <div style="border: 1px solid #dcdee0; width: 48px; height: 48px; padding: 4px;">
+                <a href="{{this.url}}">
+                  <div class="preview" style="width: 100%; height: 100%; z-index:0; background-size: contain; background-image: url('https://res.cloudinary.com/opencollective/image/fetch/w_640,f_jpg/{{this.url}}')"></div>
+                </a>
+              </div>
+            </div>
+          {{/if}}
+          <div style="display: flex; flex-direction: column; text-align: left; justify-content: center;">
+            <span style="margin-bottom: 4px;">{{this.description}}</span>
+            <span style="color: #9D9FA3;">{{moment this.incurredAt}}</span>
+          </div>
+        </div>
+        <p>
+          {{{currency this.amount currency=../expense.currency precision=2}}}
+        </p>
+      </div>
+    {{/each}}
+  </div>
+
   <br />
   <br />
   <br />


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2850 and adds items info on the "New expense create" email.

![image](https://user-images.githubusercontent.com/1556356/81289409-aa830a80-9066-11ea-8935-063b986e31cd.png)
