### PR TITLE
Fix TransferWise "Mark as Paid" logic

### DIFF
--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -114,7 +114,7 @@ export async function createFromPaidExpense(
   } else if (payoutMethodType === PayoutMethodTypes.BANK_ACCOUNT) {
     // Notice this is the FX rate between Host and Collective, the user is not involved here and that's why TransferWise quote rate is irrelevant here.
     hostCurrencyFxRate = await getFxRate(expense.currency, host.currency);
-    paymentProcessorFeeInHostCurrency = Math.round(transactionData.quote.fee * 100);
+    paymentProcessorFeeInHostCurrency = transactionData ? Math.round(transactionData.quote.fee * 100) : 0;
     paymentProcessorFeeInCollectiveCurrency = Math.round((1 / hostCurrencyFxRate) * paymentProcessorFeeInHostCurrency);
     hostFeeInCollectiveCurrency = Math.round((1 / hostCurrencyFxRate) * hostFeeInHostCurrency);
     platformFeeInCollectiveCurrency = Math.round((1 / hostCurrencyFxRate) * platformFeeInHostCurrency);


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/3117

As we can see, there was no "Mark as Paid" logic for Bank Transfers, we were literally processing the transaction when someone clicked "Mark as Paid".

I'm not sure how many people were affected by this since the feature is used as a fallback for when the automated version doesn't work, but we definitely need to reach out to beta testers and let them know.