### PR TITLE
Notifications: Simplify new comment notif targets

### DIFF
--- a/test/server/graphql/v1/comments.test.js
+++ b/test/server/graphql/v1/comments.test.js
@@ -121,7 +121,7 @@ describe('server/graphql/v1/comments', () => {
       html: 'first comment & "love"',
       ExpenseId: expense1.id,
     });
-    await utils.waitForCondition(() => sendEmailSpy.callCount === 1);
+    await utils.waitForCondition(() => sendEmailSpy.callCount >= 1);
   }
 
   function populateComments() {


### PR DESCRIPTION
According to https://docs.opencollective.com/help/expenses-and-getting-paid/expense-comments and https://opencollective.slack.com/archives/GFH4N961L/p1588826248022400, this simplifies the targets of the "new comment" email to always send to:
- Collective admins
- Host admins
- Expense submitter