### PR TITLE
PayExpense: Return expense when paying with transferwise

### DIFF
--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -682,7 +682,7 @@ export async function payExpense(req, args) {
       await payExpenseWithTransferwise(host, payoutMethod, expense, feesInHostCurrency, remoteUser);
       await expense.setProcessing(remoteUser.id);
       // Early return, we'll only mark as Paid when the transaction completes.
-      return;
+      return expense;
     }
   } else if (expense.legacyPayoutMethod === 'manual' || expense.legacyPayoutMethod === 'other') {
     // note: we need to check for manual and other for legacy reasons


### PR DESCRIPTION
We forgot to return the expense on this path, and because `processExpense` has a non null return type, it was generating an error message.