### PR TITLE
Improve performances for GQLV2/Expenses

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -21,6 +21,9 @@
       }
     }
   },
+  "graphql": {
+    "apolloEngineAPIKey": "APOLLO_ENGINE_API_KEY"
+  },
   "memcache": {
     "servers": "MEMCACHE_SERVERS",
     "username": "MEMCACHE_USERNAME",

--- a/migrations/20200514141318-add-collective-index-on-activities.js
+++ b/migrations/20200514141318-add-collective-index-on-activities.js
@@ -1,0 +1,34 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Add index on Activity > CollectiveId
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS activities__collective_id ON public."Activities" USING btree ("CollectiveId")
+    `);
+
+    // Create Activity > ExpenseId, add an index and fill column
+    await queryInterface.addColumn('Activities', 'ExpenseId', {
+      type: Sequelize.INTEGER,
+      references: { key: 'id', model: 'Expenses' },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS activities__expense_id ON public."Activities" USING btree ("ExpenseId")
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE "Activities"
+      SET "ExpenseId" = ("data" -> 'expense' ->> 'id')::int
+      WHERE "data" -> 'expense' ->> 'id' IS NOT NULL
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('Activities', 'activities__collective_id');
+    await queryInterface.removeIndex('Activities', 'activities__expense_id');
+    await queryInterface.removeColumn('Activities', 'ExpenseId');
+  },
+};

--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -35,6 +35,9 @@ export const generateExpenseActivitiesLoader = (req): DataLoader<number, object>
         CollectiveId: {
           [Op.in]: collectiveIds,
         },
+        ExpenseId: {
+          [Op.in]: expenseIDs,
+        },
         type: {
           [Op.in]: [
             ACTIVITY.COLLECTIVE_EXPENSE_CREATED,
@@ -48,13 +51,6 @@ export const generateExpenseActivitiesLoader = (req): DataLoader<number, object>
             ACTIVITY.COLLECTIVE_EXPENSE_PROCESSING,
             ACTIVITY.COLLECTIVE_EXPENSE_ERROR,
           ],
-        },
-        data: {
-          expense: {
-            id: {
-              [Op.in]: expenseIDs,
-            },
-          },
         },
       },
     });

--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -208,8 +208,13 @@ const Expense = new GraphQLObjectType({
       },
       requiredLegalDocuments: {
         type: new GraphQLList(LegalDocumentType),
-        description: 'Returns the list of legal documents required from the payee before the expense can be payed',
-        async resolve(expense) {
+        description:
+          'Returns the list of legal documents required from the payee before the expense can be payed. Must be logged in.',
+        async resolve(expense, _, req) {
+          if (!req.remoteUser?.isAdmin(expense.FromCollectiveId)) {
+            return [];
+          }
+
           const incurredYear = moment(expense.incurredAt).year();
           const isW9FormRequired = await isUserTaxFormRequiredBeforePayment({
             year: incurredYear,

--- a/server/models/Activity.js
+++ b/server/models/Activity.js
@@ -8,6 +8,38 @@ export default function (Sequelize, DataTypes) {
 
       data: DataTypes.JSONB,
 
+      CollectiveId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Collectives',
+          key: 'id',
+        },
+      },
+
+      UserId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+      },
+
+      TransactionId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Transactions',
+          key: 'id',
+        },
+      },
+
+      ExpenseId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Expenses',
+          key: 'id',
+        },
+      },
+
       createdAt: {
         type: DataTypes.DATE,
         defaultValue: Sequelize.NOW,

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -266,6 +266,7 @@ export default function (Sequelize, DataTypes) {
       type,
       UserId: user?.id,
       CollectiveId: this.collective.id,
+      ExpenseId: this.id,
       data: {
         host: get(host, 'minimal'),
         collective: { ...this.collective.minimal, isActive: this.collective.isActive },

--- a/server/routes.js
+++ b/server/routes.js
@@ -129,6 +129,9 @@ export default app => {
     schema: graphqlSchemaV2,
     introspection: true,
     playground: isDevelopment,
+    engine: {
+      apiKey: get(config, 'graphql.apolloEngineAPIKey'),
+    },
     // Align with behavior from express-graphql
     context: ({ req }) => {
       return req;


### PR DESCRIPTION
This PR does 3 things:
- Add DB indexes for activities, and an `ExpenseId` column for quick filtering
- Limit requiredLegalDocuments to admin users
- Add support for Apollo Engine: meant to be configured on staging to help analyze the query