### PR TITLE
Restrict unsupported TransferWise currencies

### DIFF
--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -15,6 +15,14 @@ export const blackListedCurrencies = [
   /** Incomplete requiredFields API or MVP form support */
   'UYU',
   'KRW',
+  'GHS',
+  'HKD',
+  'ILS',
+  'INR',
+  'JPY',
+  'LKR',
+  'SGD',
+  'VND',
 ];
 
 async function populateProfileId(connectedAccount): Promise<void> {


### PR DESCRIPTION
Due to a lack of support to dynamically generated fields in the BankInformationForm, I'm restricting a few more currencies since they break the frontend.

Related to https://sentry.io/share/issue/041da0ad4137499f8e62164cee8ac318/