### PR TITLE
Enforce simple-import-sort

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
     "camelcase": "error",
     // simple-import-sort
     "simple-import-sort/sort": [
-      "warn",
+      "error",
       {
         "groups": [
           // Side effect imports.

--- a/server/models/ExpenseItem.ts
+++ b/server/models/ExpenseItem.ts
@@ -2,8 +2,8 @@ import { pick } from 'lodash';
 import { Model, Transaction } from 'sequelize';
 
 import { diffDBEntries } from '../lib/data';
-import restoreSequelizeAttributesOnClass from '../lib/restore-sequelize-attributes-on-class';
 import { isValidUploadedImage } from '../lib/images';
+import restoreSequelizeAttributesOnClass from '../lib/restore-sequelize-attributes-on-class';
 
 /**
  * Sequelize model to represent an ExpenseItem, linked to the `ExpenseItems` table.


### PR DESCRIPTION
It's a distraction if people forget to run `npm run lint:fix`, so we should enforce it in CI.

Our experience is that eslint is not that great in pre-commit hooks, so we're not doing it there.