### PR TITLE
Expense: Allow collective admins to see details

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -64,17 +64,17 @@ export const canSeeExpenseAttachments = async (req, expense): Promise<boolean> =
 
 /** Checks if the user can see expense's payout method */
 export const canSeeExpensePayoutMethod = async (req, expense): Promise<boolean> => {
-  return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin]);
+  return remoteUserMeetsOneCondition(req, expense, [isOwner, isCollectiveAdmin, isHostAdmin]);
 };
 
 /** Checks if the user can see expense's payout method */
 export const canSeeExpenseInvoiceInfo = async (req, expense): Promise<boolean> => {
-  return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin]);
+  return remoteUserMeetsOneCondition(req, expense, [isOwner, isCollectiveAdmin, isHostAdmin]);
 };
 
 /** Checks if the user can see expense's payout method */
 export const canSeeExpensePayeeLocation = async (req, expense): Promise<boolean> => {
-  return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin]);
+  return remoteUserMeetsOneCondition(req, expense, [isOwner, isCollectiveAdmin, isHostAdmin]);
 };
 
 /**

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -66,7 +66,7 @@ describe('server/graphql/common/expenses', () => {
     it('can see only if owner or host admin', async () => {
       expect(await canSeeExpensePayoutMethod(publicReq, expense)).to.be.false;
       expect(await canSeeExpensePayoutMethod(randomUserReq, expense)).to.be.false;
-      expect(await canSeeExpensePayoutMethod(collectiveAdminReq, expense)).to.be.false;
+      expect(await canSeeExpensePayoutMethod(collectiveAdminReq, expense)).to.be.true;
       expect(await canSeeExpensePayoutMethod(hostAdminReq, expense)).to.be.true;
       expect(await canSeeExpensePayoutMethod(expenseOwnerReq, expense)).to.be.true;
       expect(await canSeeExpensePayoutMethod(limitedHostAdminReq, expense)).to.be.false;
@@ -77,7 +77,7 @@ describe('server/graphql/common/expenses', () => {
     it('can see only if owner or host admin', async () => {
       expect(await canSeeExpenseInvoiceInfo(publicReq, expense)).to.be.false;
       expect(await canSeeExpenseInvoiceInfo(randomUserReq, expense)).to.be.false;
-      expect(await canSeeExpenseInvoiceInfo(collectiveAdminReq, expense)).to.be.false;
+      expect(await canSeeExpenseInvoiceInfo(collectiveAdminReq, expense)).to.be.true;
       expect(await canSeeExpenseInvoiceInfo(hostAdminReq, expense)).to.be.true;
       expect(await canSeeExpenseInvoiceInfo(expenseOwnerReq, expense)).to.be.true;
       expect(await canSeeExpenseInvoiceInfo(limitedHostAdminReq, expense)).to.be.false;
@@ -88,7 +88,7 @@ describe('server/graphql/common/expenses', () => {
     it('can see only if owner or host admin', async () => {
       expect(await canSeeExpensePayeeLocation(publicReq, expense)).to.be.false;
       expect(await canSeeExpensePayeeLocation(randomUserReq, expense)).to.be.false;
-      expect(await canSeeExpensePayeeLocation(collectiveAdminReq, expense)).to.be.false;
+      expect(await canSeeExpensePayeeLocation(collectiveAdminReq, expense)).to.be.true;
       expect(await canSeeExpensePayeeLocation(hostAdminReq, expense)).to.be.true;
       expect(await canSeeExpensePayeeLocation(expenseOwnerReq, expense)).to.be.true;
       expect(await canSeeExpensePayeeLocation(limitedHostAdminReq, expense)).to.be.false;

--- a/test/server/graphql/v2/query/ExpenseQuery.test.js
+++ b/test/server/graphql/v2/query/ExpenseQuery.test.js
@@ -18,11 +18,12 @@ const EXPENSE_QUERY = `
 
 describe('server/graphql/v2/query/ExpenseQuery', () => {
   describe('Payout method', () => {
-    it('can only see data if owner or host admin', async () => {
+    it('can only see data if owner, or collective/host admin', async () => {
       // Create data
       const ownerUser = await fakeUser();
       const hostAdminuser = await fakeUser();
       const collectiveAdminUser = await fakeUser();
+      const randomUser = await fakeUser();
       const host = await fakeCollective({ admin: hostAdminuser.collective });
       const collective = await fakeCollective({ admin: collectiveAdminUser.collective, HostCollectiveId: host.id });
       const payoutMethod = await fakePayoutMethod({ type: 'OTHER', data: { content: 'Test content' } });
@@ -38,10 +39,12 @@ describe('server/graphql/v2/query/ExpenseQuery', () => {
       const resultAsOwner = await graphqlQueryV2(EXPENSE_QUERY, queryParams, ownerUser);
       const resultAsCollectiveAdmin = await graphqlQueryV2(EXPENSE_QUERY, queryParams, collectiveAdminUser);
       const resultAsHostAdmin = await graphqlQueryV2(EXPENSE_QUERY, queryParams, hostAdminuser);
+      const resultAsRandomUser = await graphqlQueryV2(EXPENSE_QUERY, queryParams, randomUser);
 
       // Check results
       expect(resultUnauthenticated.data.expense.payoutMethod.data).to.be.null;
-      expect(resultAsCollectiveAdmin.data.expense.payoutMethod.data).to.be.null;
+      expect(resultAsRandomUser.data.expense.payoutMethod.data).to.be.null;
+      expect(resultAsCollectiveAdmin.data.expense.payoutMethod.data).to.deep.equal(payoutMethod.data);
       expect(resultAsOwner.data.expense.payoutMethod.data).to.deep.equal(payoutMethod.data);
       expect(resultAsHostAdmin.data.expense.payoutMethod.data).to.deep.equal(payoutMethod.data);
     });


### PR DESCRIPTION
Rolling back the changes proposed in https://github.com/opencollective/opencollective/issues/2848. 

As reported in https://opencollective.freshdesk.com/a/tickets/6647 (and another ticket I can't find anymore) it seems pretty common to have collective admins to review the expense's payout details for the payees. We already allow them to edit the expenses, so it's strange to not allow them to see the payout information they may have entered themselves.