### PR TITLE
Update order payment method

### DIFF
--- a/server/graphql/v2/input/PaymentMethodCreateInput.js
+++ b/server/graphql/v2/input/PaymentMethodCreateInput.js
@@ -1,0 +1,12 @@
+import { GraphQLInputObjectType, GraphQLString } from 'graphql';
+
+import { PaymentMethodDataInput } from './PaymentMethodDataInput';
+
+export const PaymentMethodCreateInput = new GraphQLInputObjectType({
+  name: 'PaymentMethodCreateInput',
+  fields: () => ({
+    data: { type: PaymentMethodDataInput },
+    name: { type: GraphQLString },
+    token: { type: GraphQLString },
+  }),
+});

--- a/server/graphql/v2/input/PaymentMethodDataInput.js
+++ b/server/graphql/v2/input/PaymentMethodDataInput.js
@@ -1,0 +1,14 @@
+import { GraphQLInputObjectType, GraphQLInt, GraphQLNonNull, GraphQLString } from 'graphql';
+
+export const PaymentMethodDataInput = new GraphQLInputObjectType({
+  name: 'PaymentMethodDataInput',
+  fields: () => ({
+    brand: { type: new GraphQLNonNull(GraphQLString) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    expMonth: { type: new GraphQLNonNull(GraphQLInt) },
+    expYear: { type: new GraphQLNonNull(GraphQLInt) },
+    fullName: { type: GraphQLString },
+    funding: { type: GraphQLString },
+    zip: { type: GraphQLString },
+  }),
+});

--- a/server/graphql/v2/input/PaymentMethodReferenceInput.js
+++ b/server/graphql/v2/input/PaymentMethodReferenceInput.js
@@ -1,0 +1,11 @@
+import { GraphQLInputObjectType, GraphQLInt } from 'graphql';
+
+export const PaymentMethodReferenceInput = new GraphQLInputObjectType({
+  name: 'PaymentMethodReferenceInput',
+  fields: () => ({
+    legacyId: {
+      type: GraphQLInt,
+      description: 'The legacy id assigned to the payment method',
+    },
+  }),
+});

--- a/server/graphql/v2/mutation/PaymentMethodMutations.js
+++ b/server/graphql/v2/mutation/PaymentMethodMutations.js
@@ -1,0 +1,62 @@
+import models from '../../../models';
+import { setupCreditCard } from '../../../paymentProviders/stripe/creditcard';
+import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
+import { PaymentMethodCreateInput } from '../input/PaymentMethodCreateInput';
+import { PaymentMethod } from '../object/PaymentMethod';
+
+const paymentMethodMutations = {
+  addStripeCreditCard: {
+    type: PaymentMethod,
+    description: 'Add a new payment method to be used with an Order',
+    args: {
+      paymentMethod: {
+        type: PaymentMethodCreateInput,
+        description: 'A Payment Method to add to an Account',
+      },
+      account: {
+        type: AccountReferenceInput,
+        description: 'Account to add Payment Method to',
+      },
+    },
+    async resolve(_, args) {
+      const account = await fetchAccountWithReference(args.account);
+      const collective = await models.Collective.findByPk(account.id);
+      if (!collective) {
+        throw Error('This collective does not exist');
+      }
+
+      const { paymentMethod } = args;
+
+      const newPaymentMethodData = {
+        ...paymentMethod,
+        service: 'stripe',
+        type: 'creditcard',
+        CreatedByUserId: account.CreatedByUserId,
+        currency: account.currency,
+        saved: true,
+        CollectiveId: account.id,
+      };
+
+      let pm = await models.PaymentMethod.create(newPaymentMethodData);
+
+      try {
+        pm = await setupCreditCard(pm, {
+          collective,
+          user: account,
+        });
+      } catch (error) {
+        if (!error.stripeResponse) {
+          throw error;
+        }
+
+        pm.stripeError = {
+          message: error.message,
+          response: error.stripeResponse,
+        };
+      }
+      return pm;
+    },
+  },
+};
+
+export default paymentMethodMutations;

--- a/server/graphql/v2/mutation/index.js
+++ b/server/graphql/v2/mutation/index.js
@@ -6,6 +6,7 @@ import conversationMutations from './ConversationMutations';
 import createCollectiveMutations from './CreateCollectiveMutations';
 import expenseMutations from './ExpenseMutations';
 import orderMutations from './OrderMutations';
+import paymentMethodMutations from './PaymentMethodMutations';
 import payoutMethodMutations from './PayoutMethodMutations';
 
 const mutation = {
@@ -18,6 +19,7 @@ const mutation = {
   ...collectiveMutations,
   ...payoutMethodMutations,
   ...orderMutations,
+  ...paymentMethodMutations,
 };
 
 export default mutation;

--- a/server/graphql/v2/object/Order.js
+++ b/server/graphql/v2/object/Order.js
@@ -1,11 +1,12 @@
 import { GraphQLObjectType, GraphQLString } from 'graphql';
-// import { GraphQLInt } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
 
+import models from '../../../models';
 import { OrderFrequency, OrderStatus } from '../enum';
 import { idEncode } from '../identifiers';
 import { Account } from '../interface/Account';
 import { Amount } from '../object/Amount';
+import { PaymentMethod } from '../object/PaymentMethod';
 import { Tier } from '../object/Tier';
 
 export const Order = new GraphQLObjectType({
@@ -102,6 +103,13 @@ export const Order = new GraphQLObjectType({
             CollectiveId: order.CollectiveId,
           });
           return { value, currency: order.currency };
+        },
+      },
+      // needed for recurring contributions work, but we should update to encoded id and write v2 payment method object soon
+      paymentMethod: {
+        type: PaymentMethod,
+        resolve(order) {
+          return models.PaymentMethod.findByPk(order.PaymentMethodId);
         },
       },
     };

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -1,0 +1,31 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
+
+import { idEncode } from '../identifiers';
+
+export const PaymentMethod = new GraphQLObjectType({
+  name: 'PaymentMethod',
+  description: 'PaymentMethod model',
+  fields: () => {
+    return {
+      id: {
+        type: GraphQLString,
+        resolve(paymentMethod) {
+          return idEncode(paymentMethod.id, 'paymentMethod');
+        },
+      },
+      legacyId: {
+        type: GraphQLInt,
+        resolve(paymentMethod) {
+          return paymentMethod.id;
+        },
+      },
+      name: {
+        // last 4 digit of card number for Stripe
+        type: GraphQLString,
+        resolve(paymentMethod) {
+          return paymentMethod.name;
+        },
+      },
+    };
+  },
+});


### PR DESCRIPTION
This PR:

* adds the `paymentMethodReferenceInput` type to GraphQL v2
* creates the `updateOrder` v2 mutation, which for now only updates the payment method, but in later PRs will be expanded to also update the frequency, tier, or amount of the order

Question: with `type: new GraphQLNonNull(PaymentMethodReferenceInput)` I don't want the `paymentMethod` to be non-null, because we might be updating the amount, which would not need the payment method id, for example. However I'm not sure how to initialise the `new PaymentMethodReferenceInput` otherwise? I tried `type: new GraphQLInputObjectType(PaymentMethodReferenceInput)` but that did not work.