### PR TITLE
PayPal Payout workers

### DIFF
--- a/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.js
+++ b/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.js
@@ -7,7 +7,7 @@ import { groupBy, values } from 'lodash';
 import status from '../../server/constants/expense_status';
 import models from '../../server/models';
 import { PayoutMethodTypes } from '../../server/models/PayoutMethod';
-import { payExpensesBatch } from '../../server/paymentProviders/paypal/payouts';
+import * as paypal from '../../server/paymentProviders/paypal/payouts';
 
 export async function run() {
   const expenses = await models.Expense.findAll({
@@ -19,9 +19,9 @@ export async function run() {
       { model: models.PayoutMethod, as: 'PayoutMethod', where: { type: PayoutMethodTypes.PAYPAL } },
     ],
   });
-  const batches = values(groupBy(expenses, 'CollectiveId'));
+  const batches = values(groupBy(expenses, 'collective.HostCollectiveId'));
   for (const batch of batches) {
-    await payExpensesBatch(batch).catch(console.error);
+    await paypal.payExpensesBatch(batch).catch(console.error);
   }
 }
 

--- a/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.js
+++ b/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.js
@@ -5,6 +5,7 @@ import '../../server/env';
 import { groupBy, values } from 'lodash';
 
 import status from '../../server/constants/expense_status';
+import logger from '../../server/lib/logger';
 import models from '../../server/models';
 import { PayoutMethodTypes } from '../../server/models/PayoutMethod';
 import * as paypal from '../../server/paymentProviders/paypal/payouts';
@@ -20,9 +21,12 @@ export async function run() {
     ],
   });
   const batches = values(groupBy(expenses, 'collective.HostCollectiveId'));
+  logger.info(`Processing ${expenses.length} expense(s) scheduled for payment using PayPal Payouts...`);
   for (const batch of batches) {
+    logger.info(`Paying host ${batch[0]?.collective?.HostCollectiveId} batch with ${batch.length} expense(s)...`);
     await paypal.payExpensesBatch(batch).catch(console.error);
   }
+  logger.info('Done!');
 }
 
 if (require.main === module) {

--- a/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.js
+++ b/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import '../../server/env';
+
+import { groupBy, values } from 'lodash';
+
+import status from '../../server/constants/expense_status';
+import models from '../../server/models';
+import { PayoutMethodTypes } from '../../server/models/PayoutMethod';
+import { payExpensesBatch } from '../../server/paymentProviders/paypal/payouts';
+
+export async function run() {
+  const expenses = await models.Expense.findAll({
+    where: {
+      status: status.SCHEDULED_FOR_PAYMENT,
+    },
+    include: [
+      { model: models.Collective, as: 'collective' },
+      { model: models.PayoutMethod, as: 'PayoutMethod', where: { type: PayoutMethodTypes.PAYPAL } },
+    ],
+  });
+  const batches = values(groupBy(expenses, 'CollectiveId'));
+  for (const batch of batches) {
+    await payExpensesBatch(batch).catch(console.error);
+  }
+}
+
+if (require.main === module) {
+  run()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch(e => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/cron/hourly/11-check-pending-paypal-expenses.js
+++ b/cron/hourly/11-check-pending-paypal-expenses.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import '../../server/env';
+
+import { groupBy, values } from 'lodash';
+import moment from 'moment';
+import { Op } from 'sequelize';
+
+import status from '../../server/constants/expense_status';
+import models from '../../server/models';
+import { PayoutMethodTypes } from '../../server/models/PayoutMethod';
+import { checkBatchStatus } from '../../server/paymentProviders/paypal/payouts';
+
+export async function run() {
+  const expenses = await models.Expense.findAll({
+    where: {
+      [Op.or]: [
+        { status: status.PROCESSING },
+        {
+          updatedAt: {
+            [Op.gte]: moment().subtract(15, 'days').toDate(),
+          },
+        },
+      ],
+      'data.payout_batch_id': { [Op.not]: null },
+    },
+    include: [
+      { model: models.Collective, as: 'collective' },
+      { model: models.PayoutMethod, as: 'PayoutMethod', where: { type: PayoutMethodTypes.PAYPAL } },
+    ],
+  });
+  const batches = values(groupBy(expenses, 'data.payout_batch_id'));
+  for (const batch of batches) {
+    await checkBatchStatus(batch).catch(console.error);
+  }
+}
+
+if (require.main === module) {
+  run()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch(e => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/cron/hourly/11-check-pending-paypal-expenses.js
+++ b/cron/hourly/11-check-pending-paypal-expenses.js
@@ -7,6 +7,7 @@ import moment from 'moment';
 import { Op } from 'sequelize';
 
 import status from '../../server/constants/expense_status';
+import logger from '../../server/lib/logger';
 import models from '../../server/models';
 import { PayoutMethodTypes } from '../../server/models/PayoutMethod';
 import { checkBatchStatus } from '../../server/paymentProviders/paypal/payouts';
@@ -30,9 +31,12 @@ export async function run() {
     ],
   });
   const batches = values(groupBy(expenses, 'data.payout_batch_id'));
+  logger.info(`Checking the status of ${expenses.length} transaction(s) paid using PayPal Payouts...`);
   for (const batch of batches) {
+    logger.info(`Checking host ${batch[0]?.collective?.HostCollectiveId} batch with ${batch.length} expense(s)...`);
     await checkBatchStatus(batch).catch(console.error);
   }
+  logger.info('Done!');
 }
 
 if (require.main === module) {

--- a/migrations/20200528091200-add-data-to-expenses.js
+++ b/migrations/20200528091200-add-data-to-expenses.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Expenses', 'data', { type: Sequelize.JSONB });
+    await queryInterface.addColumn('ExpenseHistories', 'data', { type: Sequelize.JSONB });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Expenses', 'data');
+    await queryInterface.removeColumn('ExpenseHistories', 'data');
+  },
+};

--- a/server/lib/paypal.ts
+++ b/server/lib/paypal.ts
@@ -1,20 +1,65 @@
-import paypalPayoutsSDK from '@paypal/payouts-sdk';
+import paypal from '@paypal/payouts-sdk';
+
+import { PayoutBatchDetails, PayoutRequestBody, PayoutRequestResult } from '../types/paypal';
+
+const parseError = e => {
+  try {
+    return JSON.parse(e.message).message;
+  } catch (_) {
+    return e.message;
+  }
+};
 
 interface ConnectedAccount {
   token: string;
   clientId: string;
 }
 
-const getPayPalClient = ({ token, clientId }: ConnectedAccount) => {
+const getPayPalClient = ({ token, clientId }: ConnectedAccount): ReturnType<typeof paypal.core.PayPalHttpClient> => {
   const environment =
     process.env.NODE_ENV === 'production'
-      ? new paypalPayoutsSDK.core.LiveEnvironment(clientId, token)
-      : new paypalPayoutsSDK.core.SandboxEnvironment(clientId, token);
+      ? new paypal.core.LiveEnvironment(clientId, token)
+      : new paypal.core.SandboxEnvironment(clientId, token);
 
-  return new paypalPayoutsSDK.core.PayPalHttpClient(environment);
+  return new paypal.core.PayPalHttpClient(environment);
+};
+
+const executeRequest = async (
+  connectedAccount: ConnectedAccount,
+  request: PayoutRequestBody | Record<string, any>,
+): Promise<any> => {
+  try {
+    const client = getPayPalClient(connectedAccount);
+    const response = await client.execute(request);
+    return response.result;
+  } catch (e) {
+    throw new Error(parseError(e));
+  }
+};
+
+export const executePayouts = async (
+  connectedAccount: ConnectedAccount,
+  requestBody: PayoutRequestBody,
+): Promise<PayoutRequestResult> => {
+  const request = new paypal.payouts.PayoutsPostRequest();
+  request.requestBody(requestBody);
+  return executeRequest(connectedAccount, request);
+};
+
+export const getBatchInfo = async (
+  connectedAccount: ConnectedAccount,
+  batchId: string,
+): Promise<PayoutBatchDetails> => {
+  const request = new paypal.payouts.PayoutsGetRequest(batchId);
+  request.page(1);
+  request.pageSize(100);
+  request.totalRequired(true);
+  return executeRequest(connectedAccount, request);
 };
 
 export const validateConnectedAccount = async ({ token, clientId }: ConnectedAccount): Promise<void> => {
-  const paypal = getPayPalClient({ token, clientId });
-  await paypal.fetchAccessToken();
+  const client = getPayPalClient({ token, clientId });
+  await client.fetchAccessToken();
 };
+
+export { paypal };

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -2,12 +2,12 @@ import Promise from 'bluebird';
 import config from 'config';
 import { get, pick } from 'lodash';
 
-import models, { Op, sequelize } from '../models';
-
 import { memoize } from './cache';
 import { convertToCurrency } from './currency';
+import sequelize, { Op } from './sequelize';
 
 const twoHoursInSeconds = 2 * 60 * 60;
+const models = sequelize.models;
 
 /*
  * Hacky way to do currency conversion
@@ -914,6 +914,41 @@ const getCollectivesWithMinBackersQuery = async ({
   return { total, collectives };
 };
 
+const getBalances = async (collectiveIds, until = new Date()) =>
+  sequelize.query(
+    `
+        WITH "blockedFunds" AS (
+          SELECT
+            e."CollectiveId", COALESCE(sum(e.amount), 0) as sum
+          FROM
+            "Expenses" e
+          WHERE
+            e."CollectiveId" IN (:ids)
+            AND e."createdAt" < :until
+            AND (
+              e.status = 'SCHEDULED_FOR_PAYMENT'
+              OR (
+                e.status = 'PROCESSING' AND e.data ->> 'payout_batch_id' IS NOT NULL
+              )
+          )
+          GROUP BY
+            e."CollectiveId"
+        )
+        SELECT
+          t."CollectiveId",
+          COALESCE(sum(t."netAmountInCollectiveCurrency") - COALESCE(max(bf.sum), 0), 0) AS "balance"
+        FROM
+          "Transactions" t
+        LEFT JOIN "blockedFunds" bf ON t."CollectiveId" = bf."CollectiveId"
+        WHERE
+          t."CollectiveId" IN (:ids)
+          AND t."createdAt" < :until
+        GROUP BY
+          t."CollectiveId";
+      `,
+    { type: sequelize.QueryTypes.SELECT, replacements: { ids: collectiveIds, until } },
+  );
+
 const serializeCollectivesResult = JSON.stringify;
 
 const unserializeCollectivesResult = string => {
@@ -938,6 +973,7 @@ const getCollectivesWithMinBackers = memoize(getCollectivesWithMinBackersQuery, 
 
 const queries = {
   getHosts,
+  getBalances,
   getCollectivesOrderedByMonthlySpending,
   getCollectivesOrderedByMonthlySpendingQuery,
   getTotalDonationsByCollectiveType,

--- a/server/lib/sequelize.js
+++ b/server/lib/sequelize.js
@@ -1,0 +1,66 @@
+import config from 'config';
+import debugLib from 'debug';
+import pg from 'pg';
+import Sequelize from 'sequelize';
+
+import { getDBConf } from '../lib/db';
+import logger from '../lib/logger';
+
+// this is needed to prevent sequelize from converting integers to strings, when model definition isn't clear
+// like in case of the key totalOrders and raw query (like User.getTopBackers())
+pg.defaults.parseInt8 = true;
+
+const dbConfig = getDBConf('database');
+const debug = debugLib('psql');
+
+/**
+ * Database connection.
+ */
+logger.info(`Connecting to postgres://${dbConfig.host}/${dbConfig.database}`);
+
+// If we launch the process with DEBUG=psql, we log the postgres queries
+if (process.env.DEBUG && process.env.DEBUG.match(/psql/)) {
+  config.database.options.logging = true;
+}
+
+if (process.env.PGSSLMODE === 'require') {
+  config.database.options.dialectOptions = config.database.options.dialectOptions || {};
+  config.database.options.dialectOptions = { ssl: { rejectUnauthorized: false } };
+}
+
+if (config.database.options.logging) {
+  if (process.env.NODE_ENV === 'production') {
+    config.database.options.logging = (query, executionTime) => {
+      if (executionTime > 50) {
+        debug(query.replace(/(\n|\t| +)/g, ' ').slice(0, 100), '|', executionTime, 'ms');
+      }
+    };
+  } else {
+    config.database.options.logging = (query, executionTime) => {
+      debug(
+        '\n-------------------- <query> --------------------\n',
+        query,
+        `\n-------------------- </query executionTime="${executionTime}"> --------------------\n`,
+      );
+    };
+  }
+}
+
+if (config.database.options.pool) {
+  if (config.database.options.pool.min) {
+    config.database.options.pool.min = parseInt(config.database.options.pool.min, 10);
+  }
+  if (config.database.options.pool.max) {
+    config.database.options.pool.max = parseInt(config.database.options.pool.max, 10);
+  }
+}
+
+const sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, {
+  host: dbConfig.host,
+  port: dbConfig.port,
+  dialect: dbConfig.dialect,
+  ...config.database.options,
+});
+
+export { Op } from 'sequelize';
+export default sequelize;

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2136,41 +2136,7 @@ export default function (Sequelize, DataTypes) {
 
   Collective.prototype.getBalance = async function (until) {
     until = until || new Date();
-    const result = await this.sequelize.query(
-      `
-        WITH "blockedFunds" AS (
-          SELECT
-            e."CollectiveId", COALESCE(sum(e.amount), 0) as sum
-          FROM
-            "Expenses" e
-          WHERE
-            e."CollectiveId" = :id
-            AND e."createdAt" < :until
-            AND (
-              e.status = 'SCHEDULED_FOR_PAYMENT'
-              OR (
-                e.status = 'PROCESSING' AND e.data ->> 'payout_batch_id' IS NOT NULL
-              )
-            )
-          GROUP BY
-            e."CollectiveId"
-        )
-
-        SELECT
-          t."CollectiveId",
-          COALESCE(sum(t."netAmountInCollectiveCurrency") - COALESCE(max(bf.sum), 0), 0) AS "balance"
-        FROM
-          "Transactions" t
-        LEFT JOIN "blockedFunds" bf ON t."CollectiveId" = bf."CollectiveId"
-        WHERE
-          t."CollectiveId" = :id
-          AND t."createdAt" < :until
-        GROUP BY
-          t."CollectiveId";
-      `,
-      { type: this.sequelize.QueryTypes.SELECT, replacements: { id: this.id, until } },
-    );
-
+    const result = await queries.getBalances([this.id], until);
     return get(result, '[0].balance') || 0;
   };
 

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -66,6 +66,8 @@ export default function (Sequelize, DataTypes) {
         },
       },
 
+      data: DataTypes.JSONB,
+
       CollectiveId: {
         type: DataTypes.INTEGER,
         references: {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,70 +1,6 @@
-import config from 'config';
-import debugLib from 'debug';
-import pg from 'pg';
 import Sequelize from 'sequelize';
 
-import { getDBConf } from '../lib/db';
-import logger from '../lib/logger';
-
-// this is needed to prevent sequelize from converting integers to strings, when model definition isn't clear
-// like in case of the key totalOrders and raw query (like User.getTopBackers())
-pg.defaults.parseInt8 = true;
-
-const dbConfig = getDBConf('database');
-const debug = debugLib('psql');
-
-/**
- * Database connection.
- */
-logger.info(`Connecting to postgres://${dbConfig.host}/${dbConfig.database}`);
-
-// If we launch the process with DEBUG=psql, we log the postgres queries
-if (process.env.DEBUG && process.env.DEBUG.match(/psql/)) {
-  config.database.options.logging = true;
-}
-
-if (process.env.PGSSLMODE === 'require') {
-  config.database.options.dialectOptions = config.database.options.dialectOptions || {};
-  config.database.options.dialectOptions = { ssl: { rejectUnauthorized: false } };
-}
-
-if (config.database.options.logging) {
-  if (process.env.NODE_ENV === 'production') {
-    config.database.options.logging = (query, executionTime) => {
-      if (executionTime > 50) {
-        debug(query.replace(/(\n|\t| +)/g, ' ').slice(0, 100), '|', executionTime, 'ms');
-      }
-    };
-  } else {
-    config.database.options.logging = (query, executionTime) => {
-      debug(
-        '\n-------------------- <query> --------------------\n',
-        query,
-        `\n-------------------- </query executionTime="${executionTime}"> --------------------\n`,
-      );
-    };
-  }
-}
-
-if (config.database.options.pool) {
-  if (config.database.options.pool.min) {
-    config.database.options.pool.min = parseInt(config.database.options.pool.min, 10);
-  }
-  if (config.database.options.pool.max) {
-    config.database.options.pool.max = parseInt(config.database.options.pool.max, 10);
-  }
-}
-
-export const sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, {
-  host: dbConfig.host,
-  port: dbConfig.port,
-  dialect: dbConfig.dialect,
-  ...config.database.options,
-});
-
-const models = setupModels(sequelize);
-
-export default models;
+import sequelize from '../lib/sequelize';
 
 /**
  * Separate function to be able to use in scripts
@@ -271,4 +207,8 @@ export function setupModels(client) {
   return m;
 }
 
-export const Op = Sequelize.Op;
+const Op = Sequelize.Op;
+const models = setupModels(sequelize);
+
+export { sequelize, Op };
+export default models;

--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 import activities from '../../constants/activities';
 import status from '../../constants/expense_status';
+import logger from '../../lib/logger';
 import * as paypal from '../../lib/paypal';
 import { createFromPaidExpense as createTransactionFromPaidExpense } from '../../lib/transactions';
 
@@ -109,12 +110,12 @@ export const checkBatchStatus = async (batch: any[]): Promise<any[]> => {
         case 'UNCLAIMED': // Link sent to a non-paypal user, waiting for being claimed.
         case 'PENDING':
         default:
-          console.warn(`Expense is still being processed, nothing to do but wait.`);
+          logger.debug(`Expense ${expense.id} is still being processed, nothing to do but wait.`);
           break;
       }
       return expense;
     } catch (e) {
-      console.error(e);
+      logger.error(e);
     }
   };
 

--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -6,6 +6,7 @@ import moment from 'moment';
 import activities from '../../constants/activities';
 import status from '../../constants/expense_status';
 import * as paypal from '../../lib/paypal';
+import { createFromPaidExpense as createTransactionFromPaidExpense } from '../../lib/transactions';
 
 export const payExpensesBatch = async (expenses: any[]): Promise<any[]> => {
   const [firstExpense] = expenses;
@@ -53,4 +54,72 @@ export const payExpensesBatch = async (expenses: any[]): Promise<any[]> => {
     await e.createActivity(activities.COLLECTIVE_EXPENSE_PROCESSING);
   });
   return Promise.all(updateExpenses);
+};
+
+export const checkBatchStatus = async (batch: any[]): Promise<any[]> => {
+  const [firstExpense] = batch;
+  const host = await firstExpense.collective.getHostCollective();
+  if (!host) {
+    throw new Error(`Could not find the host embursing the expense.`);
+  }
+
+  const [connectedAccount] = await host.getConnectedAccounts({
+    where: { service: 'paypal', deletedAt: null },
+  });
+  if (!connectedAccount) {
+    throw new Error(`Host is not connected to PayPal Payouts.`);
+  }
+
+  const batchId = firstExpense.data.payout_batch_id;
+  const batchInfo = await paypal.getBatchInfo(connectedAccount, batchId);
+  const checkExpense = async (expense: any): Promise<any> => {
+    try {
+      const item = batchInfo.items.find(i => i.payout_item.sender_item_id === expense.id.toString());
+      if (!item) {
+        throw new Error('Could not find expense in payouts batch');
+      }
+
+      const paymentProcessorFeeInHostCurrency = round(toNumber(item.payout_item_fee?.value) * 100);
+      switch (item.transaction_status) {
+        case 'SUCCESS':
+          await createTransactionFromPaidExpense(
+            host,
+            null,
+            expense,
+            null,
+            expense.UserId,
+            paymentProcessorFeeInHostCurrency,
+            0,
+            0,
+            item,
+          );
+          await expense.setPaid(expense.lastEditedById);
+          await expense.createActivity(activities.COLLECTIVE_EXPENSE_PAID);
+          break;
+        case 'FAILED':
+        case 'BLOCKED':
+        case 'REFUNDED':
+        case 'RETURNED':
+        case 'REVERSED':
+          await expense.setError(expense.lastEditedById);
+          await expense.createActivity(activities.COLLECTIVE_EXPENSE_ERROR);
+          break;
+        // Ignore cases
+        case 'ONHOLD':
+        case 'UNCLAIMED': // Link sent to a non-paypal user, waiting for being claimed.
+        case 'PENDING':
+        default:
+          console.warn(`Expense is still being processed, nothing to do but wait.`);
+          break;
+      }
+      return expense;
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  for (const expense of batch) {
+    await checkExpense(expense);
+  }
+  return batch;
 };

--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/camelcase, camelcase */
+
+import { isNil, round, toNumber } from 'lodash';
+import moment from 'moment';
+
+import activities from '../../constants/activities';
+import status from '../../constants/expense_status';
+import * as paypal from '../../lib/paypal';
+
+export const payExpensesBatch = async (expenses: any[]): Promise<any[]> => {
+  const [firstExpense] = expenses;
+  const isSameHost = expenses.every(e => !isNil(e.CollectiveId) && e.CollectiveId === firstExpense.CollectiveId);
+  if (!isSameHost) {
+    throw new Error('All expenses in the batch should belong to the same Collective.');
+  }
+
+  const host = await firstExpense.collective.getHostCollective();
+  if (!host) {
+    throw new Error(`Could not find the host embursing the expense.`);
+  }
+
+  const [connectedAccount] = await host.getConnectedAccounts({
+    where: { service: 'paypal', deletedAt: null },
+  });
+  if (!connectedAccount) {
+    throw new Error(`Host is not connected to PayPal Payouts.`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const getExpenseItem = expense => ({
+    note: `Expense #${expense.id}: ${expense.description}`,
+    amount: {
+      currency: expense.currency,
+      value: round(expense.amount / 100, 2),
+    },
+    receiver: expense.PayoutMethod.data.email,
+    sender_item_id: expense.id,
+  });
+
+  const requestBody = {
+    sender_batch_header: {
+      recipient_type: 'EMAIL',
+      email_message: 'Good news, your expense was paid!',
+      sender_batch_id: `${firstExpense.collective.slug}-${moment().format('DDMMYYYY-HHmm')}`,
+      email_subject: `Expense Payout for ${firstExpense.collective.name}`,
+    },
+    items: expenses.map(getExpenseItem),
+  };
+
+  const response = await paypal.executePayouts(connectedAccount, requestBody);
+  const updateExpenses = expenses.map(async e => {
+    await e.update({ data: response.batch_header, status: status.PROCESSING });
+    await e.createActivity(activities.COLLECTIVE_EXPENSE_PROCESSING);
+  });
+  return Promise.all(updateExpenses);
+};

--- a/server/types/paypal.ts
+++ b/server/types/paypal.ts
@@ -1,0 +1,81 @@
+/* eslint-disable camelcase */
+
+export type PayoutRequestBody = {
+  sender_batch_header: {
+    recipient_type: string;
+    email_message: string;
+    sender_batch_id: string;
+    email_subject: string;
+  };
+  items: {
+    note: string;
+    receiver: string;
+    sender_item_id: string;
+    amount: {
+      currency: string;
+      value: string;
+    };
+  }[];
+};
+
+export type PayoutRequestResult = {
+  batch_header: {
+    payout_batch_id: string;
+    batch_status: string;
+    sender_batch_header: {
+      email_subject: string;
+      sender_batch_id: string;
+    };
+  };
+};
+
+export type PayoutBatchDetails = {
+  batch_header: {
+    payout_batch_id: string;
+    batch_status: 'DENIED' | 'PENDING' | 'PROCESSING' | 'SUCCESS' | 'CANCELED';
+    time_created: string;
+    time_completed: string;
+    sender_batch_header: {
+      sender_batch_id: string;
+      email_subject: string;
+    };
+    amount: {
+      value: string;
+      currency: string;
+    };
+    fees: {
+      value: string;
+      currency: string;
+    };
+  };
+  items: {
+    payout_item_id: string;
+    transaction_id: string;
+    transaction_status:
+      | 'SUCCESS'
+      | 'FAILED'
+      | 'PENDING'
+      | 'UNCLAIMED'
+      | 'RETURNED'
+      | 'ONHOLD'
+      | 'BLOCKED'
+      | 'REFUNDED'
+      | 'REVERSED';
+    payout_batch_id: string;
+    payout_item_fee: {
+      currency: string;
+      value: string;
+    };
+    payout_item: {
+      recipient_type: 'EMAIL';
+      amount: {
+        value: string;
+        currency: string;
+      };
+      note: string;
+      receiver: string;
+      sender_item_id: string;
+    };
+    time_processed: string;
+  }[];
+};

--- a/test/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.test.js
+++ b/test/cron/hourly/10-pay-paypal-scheduled-expenses-payouts.test.js
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { run as payPaypalScheduledExpenses } from '../../../cron/hourly/10-pay-paypal-scheduled-expenses-payouts';
+import status from '../../../server/constants/expense_status';
+import { PayoutMethodTypes } from '../../../server/models/PayoutMethod';
+import * as paypal from '../../../server/paymentProviders/paypal/payouts';
+import { fakeCollective, fakeExpense, fakePayoutMethod, multiple } from '../../test-helpers/fake-data';
+import * as utils from '../../utils';
+
+describe('cron/hourly/10-pay-paypal-scheduled-expenses-payouts', () => {
+  const sandbox = sinon.createSandbox();
+  let payExpensesBatch;
+
+  afterEach(sandbox.restore);
+  beforeEach(utils.resetTestDB);
+  beforeEach(() => {
+    payExpensesBatch = sandbox.stub(paypal, 'payExpensesBatch').resolves();
+  });
+
+  it('bundle expenses by hostId', async () => {
+    const collectives = await multiple(fakeCollective, 2, { isHostAccount: true });
+    const payoutMethod = await fakePayoutMethod({
+      type: PayoutMethodTypes.PAYPAL,
+      data: {
+        email: 'nicolas@cage.com',
+      },
+    });
+
+    for (const collective of collectives) {
+      await multiple(fakeExpense, 3, {
+        status: status.SCHEDULED_FOR_PAYMENT,
+        amount: 10000,
+        CollectiveId: collective.id,
+        currency: 'USD',
+        PayoutMethodId: payoutMethod.id,
+        category: 'Engineering',
+        type: 'INVOICE',
+        description: 'May Invoice',
+      });
+    }
+
+    await payPaypalScheduledExpenses();
+
+    for (let call = 0; call < payExpensesBatch.callCount; call++) {
+      const args = payExpensesBatch.getCall(call).args[0];
+      const hostIds = args.map(c => c.collective.HostCollectiveId);
+      expect(hostIds.every(id => id === hostIds[0])).to.be.true;
+    }
+  });
+});

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -525,9 +525,16 @@ describe('server/models/Collective', () => {
       status: expenseStatus.SCHEDULED_FOR_PAYMENT,
       amount: 20000,
     });
+    await fakeExpense({
+      CollectiveId: collective.id,
+      status: expenseStatus.PROCESSING,
+      amount: 10000,
+      // eslint-disable-next-line camelcase
+      data: { payout_batch_id: 1 },
+    });
 
     const balance = await collective.getBalance();
-    expect(balance).to.equal(45000 - 20000);
+    expect(balance).to.equal(45000 - 30000);
   });
 
   it('computes the number of backers', () =>

--- a/test/server/paymentProviders/paypal/payouts.test.js
+++ b/test/server/paymentProviders/paypal/payouts.test.js
@@ -1,0 +1,154 @@
+/* eslint-disable camelcase */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import status from '../../../../server/constants/expense_status';
+import * as paypalLib from '../../../../server/lib/paypal';
+import { PayoutMethodTypes } from '../../../../server/models/PayoutMethod';
+import * as paypalPayouts from '../../../../server/paymentProviders/paypal/payouts';
+import { fakeCollective, fakeConnectedAccount, fakeExpense, fakePayoutMethod } from '../../../test-helpers/fake-data';
+import * as utils from '../../../utils';
+
+describe('cron/hourly/check-pending-transferwise-transactions.js', () => {
+  const sandbox = sinon.createSandbox();
+  let expense, host, collective, payoutMethod;
+
+  afterEach(sandbox.restore);
+  beforeEach(utils.resetTestDB);
+
+  describe('payExpensesBatch', () => {
+    const sandbox = sinon.createSandbox();
+    let expense, host, collective, payoutMethod;
+    beforeEach(async () => {
+      host = await fakeCollective({ isHostAccount: true });
+      await fakeConnectedAccount({
+        CollectiveId: host.id,
+        service: 'paypal',
+        clientId: 'fake',
+        token: 'fake',
+      });
+      collective = await fakeCollective({ HostCollectiveId: host.id });
+      payoutMethod = await fakePayoutMethod({
+        type: PayoutMethodTypes.PAYPAL,
+        data: {
+          email: 'nicolas@cage.com',
+        },
+      });
+      expense = await fakeExpense({
+        status: status.SCHEDULED_FOR_PAYMENT,
+        amount: 10000,
+        CollectiveId: collective.id,
+        currency: 'USD',
+        PayoutMethodId: payoutMethod.id,
+        category: 'Engineering',
+        type: 'INVOICE',
+        description: 'May Invoice',
+      });
+      await fakeExpense({
+        status: status.PAID,
+        amount: 10000,
+        CollectiveId: collective.id,
+        currency: 'USD',
+        PayoutMethodId: payoutMethod.id,
+        category: 'Engineering',
+        type: 'INVOICE',
+        description: 'January Invoice',
+      });
+      expense.collective = collective;
+      expense.PayoutMethod = payoutMethod;
+      sandbox.stub(paypalLib, 'executePayouts').resolves({ batch_header: { payout_batch_id: 'fake' } });
+    });
+
+    it('should pay all expenses scheduled for payment', async () => {
+      await paypalPayouts.payExpensesBatch([expense]);
+      await expense.reload();
+
+      sinon.assert.calledOnce(paypalLib.executePayouts);
+      expect(expense.data).to.deep.equals({ payout_batch_id: 'fake' });
+    });
+  });
+
+  describe('checkBatchStatus', () => {
+    beforeEach(async () => {
+      host = await fakeCollective({ isHostAccount: true });
+      await fakeConnectedAccount({
+        CollectiveId: host.id,
+        service: 'paypal',
+        clientId: 'fake',
+        token: 'fake',
+      });
+      collective = await fakeCollective({ HostCollectiveId: host.id });
+      payoutMethod = await fakePayoutMethod({
+        type: PayoutMethodTypes.PAYPAL,
+        data: {
+          email: 'nicolas@cage.com',
+        },
+      });
+      expense = await fakeExpense({
+        status: status.PROCESSING,
+        amount: 10000,
+        CollectiveId: collective.id,
+        currency: 'USD',
+        PayoutMethodId: payoutMethod.id,
+        category: 'Engineering',
+        type: 'INVOICE',
+        description: 'May Invoice',
+        data: { payout_batch_id: 'fake-batch-id' },
+      });
+      await fakeExpense({
+        status: status.PAID,
+        amount: 10000,
+        CollectiveId: collective.id,
+        currency: 'USD',
+        PayoutMethodId: payoutMethod.id,
+        category: 'Engineering',
+        type: 'INVOICE',
+        description: 'January Invoice',
+      });
+      expense.collective = collective;
+      sandbox.stub(paypalLib, 'getBatchInfo');
+    });
+
+    it('should create a transaction and mark expense as paid if transaction status is SUCCESS', async () => {
+      paypalLib.getBatchInfo.resolves({
+        items: [
+          {
+            transaction_status: 'SUCCESS',
+            payout_item: { sender_item_id: expense.id.toString() },
+            payout_item_fee: {
+              currency: 'USD',
+              value: '1.23',
+            },
+          },
+        ],
+      });
+
+      await paypalPayouts.checkBatchStatus([expense]);
+      const [transaction] = await expense.getTransactions({ where: { type: 'DEBIT' } });
+
+      expect(paypalLib.getBatchInfo.getCall(0)).to.have.property('lastArg', 'fake-batch-id');
+      expect(expense).to.have.property('status', 'PAID');
+      expect(transaction).to.have.property('paymentProcessorFeeInHostCurrency', -123);
+      expect(transaction).to.have.property('netAmountInCollectiveCurrency', -10123);
+    });
+
+    const failedStatuses = ['FAILED', 'BLOCKED', 'REFUNDED', 'RETURNED', 'REVERSED'];
+    failedStatuses.map(transaction_status =>
+      it(`should set expense status to error if the transaction status is ${transaction_status}`, async () => {
+        paypalLib.getBatchInfo.resolves({
+          items: [
+            {
+              transaction_status,
+              payout_item: { sender_item_id: expense.id.toString() },
+            },
+          ],
+        });
+        await paypalPayouts.checkBatchStatus([expense]);
+        const transactions = await expense.getTransactions({ where: { type: 'DEBIT' } });
+
+        expect(expense).to.have.property('status', 'ERROR');
+        expect(transactions).to.have.length(0);
+      }),
+    );
+  });
+});

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -72,8 +72,8 @@ export const fakeCollective = async (collectiveData = {}) => {
   const type = collectiveData.type || CollectiveType.COLLECTIVE;
   const collective = await models.Collective.create({
     type,
-    name: randStr('Test Collective '),
-    slug: randStr('collective-'),
+    name: collectiveData.isHostAccount ? randStr('Test Host ') : randStr('Test Collective '),
+    slug: collectiveData.isHostAccount ? randStr('host-') : randStr('collective-'),
     description: randStr('Description '),
     currency: 'USD',
     twitterHandle: randStr('twitter'),


### PR DESCRIPTION
I was able to test this using PayPal's sandbox and it was a bit annoying, feel free to review the code and I'll make sure to set this up in staging once it is merged.

If you really want to test locally:
1. Enable payouts in your host updating settings to have `features.paypalPayouts = true`.
2. Go to your host settings -> sending money and use the Application from https://developer.paypal.com/developer/applications/
    - Use _PayPal OC Inc_ credentials from 1Password
3. Create an expense using PayPal email `paypal-buyer@opencollective.com` to any of the collectives hosted by the host you just connected
4. Approve and Schedule the expense for Payment
5. Manually run the workers
    1. `npm run script cron/hourly/10-pay-paypal-scheduled-expenses-payouts.js` should mark the expense as _processing_
    2. `npm run script cron/hourly/11-check-pending-paypal-expenses.js` should mark the expense as _paid_