### PR TITLE
EmailExpenseCreated: Fix layout with tables

### DIFF
--- a/templates/emails/collective.expense.created.hbs
+++ b/templates/emails/collective.expense.created.hbs
@@ -16,30 +16,32 @@ Subject: New expense on {{collective.name}}: {{{currency expense.amount currency
 
   <h3 style="margin: 24px;">Expense items</h3>
 
-  <div>
-    {{#each items}}
-      <div style="display: flex; padding: 12px 0; margin: 0 24px; justify-content: space-between; align-items: center; border-bottom: 1px dotted rgb(196, 199, 204);">
-        <div style="display: flex;">
+  <table style="width: 100%;">
+    <tbody>
+      {{#each items}}
+        <tr>
           {{#if this.url}}
-            <div style="margin-right: 16px;">
+            <td style="width: 66px; border-bottom: 1px dotted rgb(196, 199, 204); padding: 12px 0;">
               <div style="border: 1px solid #dcdee0; width: 48px; height: 48px; padding: 4px;">
                 <a href="{{this.url}}">
                   <div class="preview" style="width: 100%; height: 100%; z-index:0; background-size: contain; background-image: url('https://res.cloudinary.com/opencollective/image/fetch/w_640,f_jpg/{{this.url}}')"></div>
                 </a>
               </div>
-            </div>
+            </td>
           {{/if}}
-          <div style="display: flex; flex-direction: column; text-align: left; justify-content: center;">
-            <span style="margin-bottom: 4px;">{{this.description}}</span>
-            <span style="color: #9D9FA3;">{{moment this.incurredAt}}</span>
-          </div>
-        </div>
-        <p>
-          {{{currency this.amount currency=../expense.currency precision=2}}}
-        </p>
-      </div>
-    {{/each}}
-  </div>
+          <td style="border-bottom: 1px dotted rgb(196, 199, 204); padding: 12px 0;">
+            <p style="margin: 0; margin-bottom: 4px;">{{this.description}}</p>
+            <p style="margin: 0; color: #9D9FA3;">{{moment this.incurredAt}}</p>
+          </td>
+          <td style="border-bottom: 1px dotted rgb(196, 199, 204); padding: 12px 0;">
+            <p style="text-align: right;">
+              {{{currency this.amount currency=../expense.currency precision=2}}}
+            </p>
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
 
   <br />
   <br />


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3186

The layout [previously implemented](https://github.com/opencollective/opencollective-api/pull/3844) was using CSS flex, which has limited support in email clients. This PRs re-implements the same layout using `table`.

Screenshot in thunderbird:

![image](https://user-images.githubusercontent.com/1556356/83613761-8b539c00-a584-11ea-87c5-d41315ae440a.png)
