### PR TITLE
feat: include financial contributor contact email in notification

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1473,12 +1473,14 @@ export default function (Sequelize, DataTypes) {
 
     const urlPath = await this.getUrlPath();
     const memberCollective = await models.Collective.findByPk(member.MemberCollectiveId, sequelizeParams);
+    const memberCollectiveUser = await models.User.findByPk(member.CreatedByUserId, sequelizeParams);
 
     const data = {
       collective: { ...this.minimal, urlPath },
       member: {
         ...member.info,
         memberCollective: memberCollective.activity,
+        memberCollectiveUser: memberCollectiveUser.info,
       },
       order: order && {
         ...order.activity,

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1473,14 +1473,18 @@ export default function (Sequelize, DataTypes) {
 
     const urlPath = await this.getUrlPath();
     const memberCollective = await models.Collective.findByPk(member.MemberCollectiveId, sequelizeParams);
-    const memberCollectiveUser = await models.User.findByPk(member.CreatedByUserId, sequelizeParams);
+
+    let memberCollectiveUser;
+    if (memberCollective.type === types.USER && !memberCollective.isIncognito) {
+      memberCollectiveUser = await models.User.findOne({ where: { CollectiveId: memberCollective.id } });
+    }
 
     const data = {
       collective: { ...this.minimal, urlPath },
       member: {
         ...member.info,
         memberCollective: memberCollective.activity,
-        memberCollectiveUser: memberCollectiveUser.info,
+        memberCollectiveUser: memberCollectiveUser ? memberCollectiveUser.info : undefined,
       },
       order: order && {
         ...order.activity,

--- a/templates/emails/collective.member.created.hbs
+++ b/templates/emails/collective.member.created.hbs
@@ -15,7 +15,7 @@ Subject: {{member.memberCollective.name}} joined {{collective.name}} as {{{toLow
   {{{toLowerCase member.role}}} of <a href="{{config.host.website}}{{collective.urlPath}}">{{collective.name}}</a>.</p>
 
 {{#if order.publicMessage}}
-<p class="pullQuote">“{{order.publicMessage}}”<br />- {{member.memberCollective.name}}</p>
+  <p class="pullQuote">“{{order.publicMessage}}”<br />- {{member.memberCollective.name}}</p>
 {{/if}}
 
 {{#if tweet}}
@@ -56,6 +56,11 @@ Subject: {{member.memberCollective.name}} joined {{collective.name}} as {{{toLow
       <br />
       <a
         href="{{config.host.website}}/{{member.memberCollective.slug}}">{{config.host.website}}/{{member.memberCollective.slug}}</a>
+      <br/>
+
+      {{#if member.memberCollectiveUser.email}}
+        <b>Email: </b>{{member.memberCollectiveUser.email}} 
+      {{/if}}
     </td>
   </tr>
 </table>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2297

#### Short description of what this resolves:
Now new backer notification will display contact email of a financial contributor if available.

#### Changes proposed in this pull request:

If email is available display it in about section.

# Screenshot

![notification](https://user-images.githubusercontent.com/46647141/83936024-ebdd1600-a7dc-11ea-8810-5bddf640803a.jpeg)
