### PR TITLE
refactor: migrate collective long description to html

### DIFF
--- a/migrations/20200606105847-convert-collective-long-description-to-html.js
+++ b/migrations/20200606105847-convert-collective-long-description-to-html.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import Promise from 'bluebird';
 import showdown from 'showdown';
 
 const converter = new showdown.Converter();
@@ -16,8 +15,8 @@ module.exports = {
       { type: Sequelize.QueryTypes.SELECT },
     );
 
-    await Promise.map(collectives, collective =>
-      queryInterface.sequelize.query(
+    for (const collective of collectives) {
+      await queryInterface.sequelize.query(
         `
         UPDATE "Collectives" c
         SET "longDescription" = :longDescription
@@ -29,11 +28,11 @@ module.exports = {
             id: collective.id,
           },
         },
-      ),
-    );
+      );
+    }
   },
 
-  down: async (queryInterface, Sequelize) => {
+  down: () => {
     // can't rollback this one
   },
 };

--- a/migrations/20200606105847-convert-collective-long-description-to-html.js
+++ b/migrations/20200606105847-convert-collective-long-description-to-html.js
@@ -1,0 +1,60 @@
+'use strict';
+
+import Promise from 'bluebird';
+import showdown from 'showdown';
+
+const converter = new showdown.Converter();
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const collectives = await queryInterface.sequelize.query(
+      `
+        SELECT * FROM "Collectives"
+        WHERE LENGTH("longDescription") > 0 AND "longDescription" NOT LIKE '<%';
+      `,
+      { type: Sequelize.QueryTypes.SELECT },
+    );
+
+    await Promise.map(collectives, collective =>
+      queryInterface.sequelize.query(
+        `
+        UPDATE "Collectives" c
+        SET "longDescription" = :longDescription
+        WHERE c.id = :id
+      `,
+        {
+          replacements: {
+            longDescription: converter.makeHtml(collective.longDescription),
+            id: collective.id,
+          },
+        },
+      ),
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const collectives = await queryInterface.sequelize.query(
+      `
+        SELECT * FROM "Collectives"
+        WHERE LENGTH("longDescription") > 0;
+      `,
+      { type: Sequelize.QueryTypes.SELECT },
+    );
+
+    await Promise.map(collectives, collective =>
+      queryInterface.sequelize.query(
+        `
+        UPDATE "Collectives" c
+        SET "longDescription" = :longDescription
+        WHERE c.id = :id
+      `,
+        {
+          replacements: {
+            longDescription: converter.makeMarkdown(collective.longDescription),
+            id: collective.id,
+          },
+        },
+      ),
+    );
+  },
+};

--- a/migrations/20200606105847-convert-collective-long-description-to-html.js
+++ b/migrations/20200606105847-convert-collective-long-description-to-html.js
@@ -34,28 +34,6 @@ module.exports = {
   },
 
   down: async (queryInterface, Sequelize) => {
-    const collectives = await queryInterface.sequelize.query(
-      `
-        SELECT * FROM "Collectives"
-        WHERE LENGTH("longDescription") > 0;
-      `,
-      { type: Sequelize.QueryTypes.SELECT },
-    );
-
-    await Promise.map(collectives, collective =>
-      queryInterface.sequelize.query(
-        `
-        UPDATE "Collectives" c
-        SET "longDescription" = :longDescription
-        WHERE c.id = :id
-      `,
-        {
-          replacements: {
-            longDescription: converter.makeMarkdown(collective.longDescription),
-            id: collective.id,
-          },
-        },
-      ),
-    );
+    // can't rollback this one
   },
 };

--- a/migrations/20200606105847-convert-collective-long-description-to-html.js
+++ b/migrations/20200606105847-convert-collective-long-description-to-html.js
@@ -10,7 +10,8 @@ module.exports = {
     const collectives = await queryInterface.sequelize.query(
       `
         SELECT "id", "longDescription" FROM "Collectives"
-        WHERE LENGTH("longDescription") > 0 AND "longDescription" NOT LIKE '<%';
+        WHERE LENGTH("longDescription") > 0 AND "longDescription" NOT LIKE '<%'
+        AND "deletedAt" IS NULL;
       `,
       { type: Sequelize.QueryTypes.SELECT },
     );

--- a/migrations/20200606105847-convert-collective-long-description-to-html.js
+++ b/migrations/20200606105847-convert-collective-long-description-to-html.js
@@ -32,7 +32,7 @@ module.exports = {
     }
   },
 
-  down: () => {
+  down: async () => {
     // can't rollback this one
   },
 };

--- a/migrations/20200606105847-convert-collective-long-description-to-html.js
+++ b/migrations/20200606105847-convert-collective-long-description-to-html.js
@@ -9,7 +9,7 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     const collectives = await queryInterface.sequelize.query(
       `
-        SELECT * FROM "Collectives"
+        SELECT "id", "longDescription" FROM "Collectives"
         WHERE LENGTH("longDescription") > 0 AND "longDescription" NOT LIKE '<%';
       `,
       { type: Sequelize.QueryTypes.SELECT },


### PR DESCRIPTION
Refers https://github.com/opencollective/opencollective/issues/3207

Related Frontend PR https://github.com/opencollective/opencollective-frontend/pull/4357

Created a migration that takes all collectives with a markdown description and converts to HTML