### PR TITLE
MemberInvitation: Increase invitations count limit

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -55,7 +55,7 @@
     "searchEmailPerHour": 150,
     "searchEmailPerHourPerIp": 50,
     "collectiveEmailMessagePerHour": 5,
-    "maxMemberInvitationsPerCollective": 20
+    "maxMemberInvitationsPerCollective": 50
   },
   "email": {
     "from": "Open Collective <info@opencollective.com>"


### PR DESCRIPTION
The goal of this limit is mainly to prevent having someone inviting all Open Collective users to their collectives. A collective recently hit this limit with a legit use case, it should be safe to increase it to `50`.