### PR TITLE
Add PaymentMethod to Account interface

### DIFF
--- a/server/graphql/v2/enum/PaymentMethodType.js
+++ b/server/graphql/v2/enum/PaymentMethodType.js
@@ -1,0 +1,11 @@
+import { GraphQLEnumType } from 'graphql';
+
+export const PaymentMethodType = new GraphQLEnumType({
+  name: 'PaymentMethodType',
+  values: {
+    CREDIT_CARD: {},
+    GIFT_CARD: {},
+    PREPAID_BUDGET: {},
+    COLLECTIVE_BALANCE: {},
+  },
+});

--- a/server/graphql/v2/enum/index.js
+++ b/server/graphql/v2/enum/index.js
@@ -10,4 +10,5 @@ export { MemberRole } from './MemberRole';
 export { OrderDirectionType } from './OrderDirectionType';
 export { OrderFrequency } from './OrderFrequency';
 export { OrderStatus } from './OrderStatus';
+export { PaymentMethodType } from './PaymentMethodType';
 export { TransactionType } from './TransactionType';

--- a/server/graphql/v2/input/AccountReferenceInput.js
+++ b/server/graphql/v2/input/AccountReferenceInput.js
@@ -35,7 +35,6 @@ export const fetchAccountWithReference = async (
   input,
   { loaders = null, throwIfMissing = false, dbTransaction = undefined, lock = false } = {},
 ) => {
-  // Load collective by ID using GQL loaders if we're not using a transaction & loaders are available
   const loadCollectiveById = id => {
     if (!loaders || dbTransaction) {
       return models.Collective.findByPk(id, { transaction: dbTransaction, lock });

--- a/server/graphql/v2/input/PaymentMethodReferenceInput.js
+++ b/server/graphql/v2/input/PaymentMethodReferenceInput.js
@@ -9,7 +9,7 @@ export const PaymentMethodReferenceInput = new GraphQLInputObjectType({
   fields: () => ({
     id: {
       type: GraphQLString,
-      description: 'The encrypted id assigned to the payment method',
+      description: 'The id assigned to the payment method',
     },
   }),
 });
@@ -22,17 +22,10 @@ export const PaymentMethodReferenceInput = new GraphQLInputObjectType({
  *    - dbTransaction: An SQL transaction to run the query. Will skip `loaders`
  *    - lock: If true and `dbTransaction` is set, the row will be locked
  */
-export const fetchPaymentMethodWithReference = async (
-  input,
-  { loaders = null, throwIfMissing = false, dbTransaction = undefined, lock = false } = {},
-) => {
+export const fetchPaymentMethodWithReference = async (input, { throwIfMissing = false } = {}) => {
   // Load payment by ID using GQL loaders if we're not using a transaction & loaders are available
   const loadPaymentById = id => {
-    if (!loaders || dbTransaction) {
-      return models.PaymentMethod.findByPk(id, { transaction: dbTransaction, lock });
-    } else {
-      return loaders.PaymentMethod.byId.load(id);
-    }
+    return models.PaymentMethod.findByPk(id);
   };
 
   let paymentMethod;

--- a/server/graphql/v2/input/PaymentMethodReferenceInput.js
+++ b/server/graphql/v2/input/PaymentMethodReferenceInput.js
@@ -1,11 +1,11 @@
-import { GraphQLInputObjectType, GraphQLInt } from 'graphql';
+import { GraphQLInputObjectType, GraphQLString } from 'graphql';
 
 export const PaymentMethodReferenceInput = new GraphQLInputObjectType({
   name: 'PaymentMethodReferenceInput',
   fields: () => ({
-    legacyId: {
-      type: GraphQLInt,
-      description: 'The legacy id assigned to the payment method',
+    id: {
+      type: GraphQLString,
+      description: 'The encrypted id assigned to the payment method',
     },
   }),
 });

--- a/server/graphql/v2/input/PaymentMethodReferenceInput.js
+++ b/server/graphql/v2/input/PaymentMethodReferenceInput.js
@@ -1,5 +1,9 @@
 import { GraphQLInputObjectType, GraphQLString } from 'graphql';
 
+import models from '../../../models';
+import { NotFound } from '../../errors';
+import { idDecode } from '../identifiers';
+
 export const PaymentMethodReferenceInput = new GraphQLInputObjectType({
   name: 'PaymentMethodReferenceInput',
   fields: () => ({
@@ -9,3 +13,37 @@ export const PaymentMethodReferenceInput = new GraphQLInputObjectType({
     },
   }),
 });
+
+/**
+ * Retrieves a payment method
+ *
+ * @param {string|number} input - id of the payment method
+ * @param {object} params
+ *    - dbTransaction: An SQL transaction to run the query. Will skip `loaders`
+ *    - lock: If true and `dbTransaction` is set, the row will be locked
+ */
+export const fetchPaymentMethodWithReference = async (
+  input,
+  { loaders = null, throwIfMissing = false, dbTransaction = undefined, lock = false } = {},
+) => {
+  // Load payment by ID using GQL loaders if we're not using a transaction & loaders are available
+  const loadPaymentById = id => {
+    if (!loaders || dbTransaction) {
+      return models.PaymentMethod.findByPk(id, { transaction: dbTransaction, lock });
+    } else {
+      return loaders.PaymentMethod.byId.load(id);
+    }
+  };
+
+  let paymentMethod;
+  if (input.id) {
+    const id = idDecode(input.id, 'paymentMethod');
+    paymentMethod = await loadPaymentById(id);
+  } else {
+    throw new Error('Please provide an id');
+  }
+  if (!paymentMethod && throwIfMissing) {
+    throw new NotFound('Payment Method Not Found');
+  }
+  return paymentMethod;
+};

--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -25,6 +25,7 @@ import { IsMemberOfFields } from '../interface/IsMemberOf';
 import { AccountStats } from '../object/AccountStats';
 import { ConnectedAccount } from '../object/ConnectedAccount';
 import { Location } from '../object/Location';
+import { PaymentMethod } from '../object/PaymentMethod';
 import PayoutMethod from '../object/PayoutMethod';
 import { TagStats } from '../object/TagStats';
 import { TransferWise } from '../object/TransferWise';
@@ -198,6 +199,16 @@ const accountFieldsDefinition = () => ({
   payoutMethods: {
     type: new GraphQLList(PayoutMethod),
     description: 'The list of payout methods that this collective can use to get paid',
+  },
+  paymentMethods: {
+    type: new GraphQLList(PaymentMethod),
+    args: {
+      types: {
+        type: new GraphQLList(GraphQLString),
+        description: 'Filter on given types (creditcard, virtualcard...)',
+      },
+    },
+    description: 'The list of payment methods that this collective can use to pay for Orders',
   },
   connectedAccounts: {
     type: new GraphQLList(ConnectedAccount),
@@ -414,6 +425,27 @@ export const AccountFields = {
       } else {
         return req.loaders.PayoutMethod.byCollectiveId.load(collective.id);
       }
+    },
+  },
+  paymentMethods: {
+    type: new GraphQLList(PaymentMethod),
+    args: {
+      types: { type: new GraphQLList(GraphQLString) },
+    },
+    description: 'The list of payment methods that this collective can use to pay for Orders',
+    async resolve(collective, args, req) {
+      let paymentMethods = await req.loaders.PaymentMethod.findByCollectiveId.load(collective.id);
+
+      // Filter only "saved" stripe Payment Methods
+      paymentMethods = paymentMethods.filter(pm => pm.service !== 'stripe' || pm.saved);
+
+      paymentMethods = paymentMethods.filter(pm => !(pm.data && pm.data.hidden));
+
+      if (args.types) {
+        paymentMethods = paymentMethods.filter(pm => args.types.includes(pm.type));
+      }
+
+      return paymentMethods;
     },
   },
   connectedAccounts: {

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -6,7 +6,7 @@ import models from '../../../models';
 import { NotFound, Unauthorized } from '../../errors';
 import { getDecodedId } from '../identifiers';
 import { OrderReferenceInput } from '../input/OrderReferenceInput';
-import { PaymentMethodReferenceInput } from '../input/PaymentMethodReferenceInput';
+import { fetchPaymentMethodWithReference, PaymentMethodReferenceInput } from '../input/PaymentMethodReferenceInput';
 import { TierReferenceInput } from '../input/TierReferenceInput';
 import { Order } from '../object/Order';
 
@@ -170,14 +170,10 @@ const orderMutations = {
         throw new Error('Order must be active to be updated');
       }
 
-      const decodedPMId = getDecodedId(args.paymentMethod.id);
-
       // payment method
       if (paymentMethod !== undefined) {
         // unlike v1 we don't have to check/assign new payment method, that will be taken care of in another mutation
-        const newPaymentMethod = await models.PaymentMethod.findOne({
-          where: { id: decodedPMId },
-        });
+        const newPaymentMethod = await fetchPaymentMethodWithReference(args.paymentMethod);
         if (!newPaymentMethod) {
           throw new Error('Payment method not found with this id', paymentMethod.id);
         }
@@ -188,34 +184,41 @@ const orderMutations = {
         order = await order.update({ PaymentMethodId: newPaymentMethod.id });
       }
 
-      // tier
       let tierInfo;
-      // get tier info if it's a named tier
-      if (tier.legacyId !== null) {
-        tierInfo = await models.Tier.findByPk(tier.legacyId);
-        if (!tierInfo) {
-          throw new Error(`No tier found with tier id: ${tier.legacyId} for collective ${order.CollectiveId}`);
-        } else if (tierInfo.CollectiveId !== order.CollectiveId) {
-          throw new Error(`This tier (#${tierInfo.id}) doesn't belong to the given Collective #${order.CollectiveId}`);
+
+      // tier
+      if (tier !== undefined) {
+        // get tier info if it's a named tier
+        if (tier.legacyId !== null) {
+          tierInfo = await models.Tier.findByPk(tier.legacyId);
+          if (!tierInfo) {
+            throw new Error(`No tier found with tier id: ${tier.legacyId} for collective ${order.CollectiveId}`);
+          } else if (tierInfo.CollectiveId !== order.CollectiveId) {
+            throw new Error(
+              `This tier (#${tierInfo.id}) doesn't belong to the given Collective #${order.CollectiveId}`,
+            );
+          }
         }
-      }
-      // check if the tier is different from the previous tier
-      if (tier.legacyId !== order.TierId) {
-        order = await order.update({ TierId: tier.legacyId });
+        // check if the tier is different from the previous tier
+        if (tier.legacyId !== order.TierId) {
+          order = await order.update({ TierId: tier.legacyId });
+        }
       }
 
       // amount
-      if (amount !== order.totalAmount) {
-        if (amount < 100) {
-          throw new Error('Invalid amount.');
-        }
+      if (amount !== undefined) {
+        if (amount !== order.totalAmount) {
+          if (amount < 100) {
+            throw new Error('Invalid amount.');
+          }
 
-        // If using a named tier, amount can never be less than the minimum amount
-        if (tierInfo && tierInfo.amountType === 'FLEXIBLE' && amount < tierInfo.minimumAmount) {
-          throw new Error('Amount is less than minimum value allowed for this Tier.');
-        }
+          // If using a named tier, amount can never be less than the minimum amount
+          if (tierInfo && tierInfo.amountType === 'FLEXIBLE' && amount < tierInfo.minimumAmount) {
+            throw new Error('Amount is less than minimum value allowed for this Tier.');
+          }
 
-        order = await order.update({ totalAmount: amount });
+          order = await order.update({ totalAmount: amount });
+        }
       }
 
       return order;

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -186,6 +186,22 @@ const orderMutations = {
 
       let tierInfo;
 
+      // amount
+      if (amount !== undefined) {
+        if (amount !== order.totalAmount) {
+          if (amount < 100) {
+            throw new Error('Invalid amount.');
+          }
+
+          // If using a named tier, amount can never be less than the minimum amount
+          if (tierInfo && tierInfo.amountType === 'FLEXIBLE' && amount < tierInfo.minimumAmount) {
+            throw new Error('Amount is less than minimum value allowed for this Tier.');
+          }
+
+          order = await order.update({ totalAmount: amount });
+        }
+      }
+
       // tier
       if (tier !== undefined) {
         // get tier info if it's a named tier
@@ -202,22 +218,6 @@ const orderMutations = {
         // check if the tier is different from the previous tier
         if (tier.legacyId !== order.TierId) {
           order = await order.update({ TierId: tier.legacyId });
-        }
-      }
-
-      // amount
-      if (amount !== undefined) {
-        if (amount !== order.totalAmount) {
-          if (amount < 100) {
-            throw new Error('Invalid amount.');
-          }
-
-          // If using a named tier, amount can never be less than the minimum amount
-          if (tierInfo && tierInfo.amountType === 'FLEXIBLE' && amount < tierInfo.minimumAmount) {
-            throw new Error('Amount is less than minimum value allowed for this Tier.');
-          }
-
-          order = await order.update({ totalAmount: amount });
         }
       }
 

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -170,14 +170,16 @@ const orderMutations = {
         throw new Error('Order must be active to be updated');
       }
 
+      const decodedPMId = getDecodedId(args.paymentMethod.id);
+
       // payment method
       if (paymentMethod !== undefined) {
         // unlike v1 we don't have to check/assign new payment method, that will be taken care of in another mutation
         const newPaymentMethod = await models.PaymentMethod.findOne({
-          where: { id: paymentMethod.legacyId },
+          where: { id: decodedPMId },
         });
         if (!newPaymentMethod) {
-          throw new Error('Payment method not found with this id', paymentMethod.legacyId);
+          throw new Error('Payment method not found with this id', paymentMethod.id);
         }
         if (!req.remoteUser.isAdmin(newPaymentMethod.CollectiveId)) {
           throw new Unauthorized("You don't have permission to use this payment method");

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -1,6 +1,9 @@
 import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
+import GraphQLJSON from 'graphql-type-json';
+import { pick } from 'lodash';
 
 import { idEncode } from '../identifiers';
+import { Account } from '../interface/Account';
 
 export const PaymentMethod = new GraphQLObjectType({
   name: 'PaymentMethod',
@@ -24,6 +27,66 @@ export const PaymentMethod = new GraphQLObjectType({
         type: GraphQLString,
         resolve(paymentMethod) {
           return paymentMethod.name;
+        },
+      },
+      service: {
+        type: GraphQLString,
+        resolve(paymentMethod) {
+          return paymentMethod.service;
+        },
+      },
+      type: {
+        type: GraphQLString,
+        resolve(paymentMethod) {
+          return paymentMethod.type;
+        },
+      },
+      balance: {
+        type: GraphQLInt,
+        description: 'Returns the balance in the currency of this paymentMethod',
+        async resolve(paymentMethod, args, req) {
+          const balance = await paymentMethod.getBalanceForUser(req.remoteUser);
+          return balance.amount;
+        },
+      },
+      currency: {
+        type: GraphQLString,
+        resolve(paymentMethod) {
+          return paymentMethod.currency;
+        },
+      },
+      account: {
+        type: Account,
+        resolve(paymentMethod, _, req) {
+          return req.loaders.Collective.byId.load(paymentMethod.CollectiveId);
+        },
+      },
+      data: {
+        type: GraphQLJSON,
+        resolve(paymentMethod, _, req) {
+          if (!paymentMethod.data) {
+            return null;
+          }
+
+          // Protect and whitelist fields for virtualcard
+          if (paymentMethod.type === 'virtualcard') {
+            if (!req.remoteUser || !req.remoteUser.isAdmin(paymentMethod.CollectiveId)) {
+              return null;
+            }
+            return pick(paymentMethod.data, ['email']);
+          }
+
+          const data = paymentMethod.data;
+          // white list fields to send back; removes fields like CustomerIdForHost
+          const dataSubset = {
+            fullName: data.fullName,
+            expMonth: data.expMonth,
+            expYear: data.expYear,
+            brand: data.brand,
+            country: data.country,
+            last4: data.last4,
+          };
+          return dataSubset;
         },
       },
     };

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -78,14 +78,8 @@ export const PaymentMethod = new GraphQLObjectType({
 
           const data = paymentMethod.data;
           // white list fields to send back; removes fields like CustomerIdForHost
-          const dataSubset = {
-            fullName: data.fullName,
-            expMonth: data.expMonth,
-            expYear: data.expYear,
-            brand: data.brand,
-            country: data.country,
-            last4: data.last4,
-          };
+          const dataSubset = pick(data, ['fullName', 'expMonth', 'expYear', 'brand', 'country', 'last4']);
+
           return dataSubset;
         },
       },

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -4,6 +4,7 @@ import { pick } from 'lodash';
 
 import { idEncode } from '../identifiers';
 import { Account } from '../interface/Account';
+import { Amount } from '../object/Amount';
 
 export const PaymentMethod = new GraphQLObjectType({
   name: 'PaymentMethod',
@@ -42,17 +43,11 @@ export const PaymentMethod = new GraphQLObjectType({
         },
       },
       balance: {
-        type: GraphQLInt,
-        description: 'Returns the balance in the currency of this paymentMethod',
+        type: Amount,
+        description: 'Returns the balance amount and the currency of this paymentMethod',
         async resolve(paymentMethod, args, req) {
           const balance = await paymentMethod.getBalanceForUser(req.remoteUser);
-          return balance.amount;
-        },
-      },
-      currency: {
-        type: GraphQLString,
-        resolve(paymentMethod) {
-          return paymentMethod.currency;
+          return { value: balance.amount, currency: paymentMethod.currency };
         },
       },
       account: {


### PR DESCRIPTION
Adds Payment Method to Account interface, and allows us to query payment methods on v2 Accounts on the frontend. This also means we can get rid of the legacyId in the v2 Payment Method object and use the encoded ids.