### PR TITLE
Use a graphql loader for userTaxFormRequiredBeforePayment & requiredLegalDocuments

### DIFF
--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -96,7 +96,7 @@ export const userTaxFormRequiredBeforePayment = (req): DataLoader<number, boolea
       LEFT JOIN "LegalDocuments" ld ON ld."CollectiveId" = e."FromCollectiveId"
                                         AND ld.year = date_part('year', e."incurredAt")
                                         AND ld."documentType" = 'US_TAX_FORM'
-      WHERE e.status IN ('PENDING', 'APPROVED', 'PAID', 'PROCESSING')
+      WHERE e.status IN ('PENDING', 'APPROVED', 'PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT')
       AND e."UserId" IN (SELECT "UserId" FROM "Expenses" WHERE "Expenses".id IN (:expenseIds))
       AND e.type NOT IN ('RECEIPT')
       AND "incurredAt" BETWEEN e."incurredAt" AND (e."incurredAt" + interval '1 year')

--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -24,16 +24,16 @@ const userTaxFormRequiredBeforePaymentQuery = `
   FROM "Expenses" e
   INNER JOIN "Collectives" c ON c.id = e."CollectiveId"
   LEFT JOIN "RequiredLegalDocuments" d ON d."HostCollectiveId" = c."HostCollectiveId"
-                                        AND d."documentType" = 'US_TAX_FORM'
+                                      AND d."documentType" = 'US_TAX_FORM'
   LEFT JOIN "LegalDocuments" ld ON ld."CollectiveId" = e."FromCollectiveId"
-                                  AND ld.year = date_part('year', e."incurredAt")
-                                  AND ld."documentType" = 'US_TAX_FORM'
+                                AND ld.year = date_part('year', e."incurredAt")
+                                AND ld."documentType" = 'US_TAX_FORM'
   WHERE e.status IN ('PENDING', 'APPROVED', 'PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT')
-  AND e.id IN (:expenseIds)
   AND e.type NOT IN ('RECEIPT')
-  AND "incurredAt" BETWEEN e."incurredAt" AND (e."incurredAt" + interval '1 year')
   AND e."deletedAt" IS NULL
+  AND "incurredAt" BETWEEN date_trunc('year', e."incurredAt") AND (date_trunc('year', e."incurredAt") + interval '1 year')
   GROUP BY e."UserId"
+  HAVING MAX(e.id) IN (:expenseIds)
 `
 
 

--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -29,7 +29,7 @@ const userTaxFormRequiredBeforePaymentQuery = `
                                   AND ld.year = date_part('year', e."incurredAt")
                                   AND ld."documentType" = 'US_TAX_FORM'
   WHERE e.status IN ('PENDING', 'APPROVED', 'PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT')
-  AND e."UserId" IN (SELECT "UserId" FROM "Expenses" WHERE "Expenses".id IN (:expenseIds))
+  AND e.id IN (:expenseIds)
   AND e.type NOT IN ('RECEIPT')
   AND "incurredAt" BETWEEN e."incurredAt" AND (e."incurredAt" + interval '1 year')
   AND e."deletedAt" IS NULL

--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -24,7 +24,7 @@ const userTaxFormRequiredBeforePaymentQuery = `
   FROM "Expenses" e
   INNER JOIN "Expenses" er ON e."UserId" = er."UserId"
   INNER JOIN "Collectives" c ON c.id = e."CollectiveId"
-  LEFT JOIN "RequiredLegalDocuments" d ON d."HostCollectiveId" = c."HostCollectiveId"
+  INNER JOIN "RequiredLegalDocuments" d ON d."HostCollectiveId" = c."HostCollectiveId"
                                     AND d."documentType" = 'US_TAX_FORM'
   LEFT JOIN "LegalDocuments" ld ON ld."CollectiveId" = e."FromCollectiveId"
                                 AND ld.year = date_part('year', e."incurredAt")

--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -22,14 +22,14 @@ const userTaxFormRequiredBeforePaymentQuery = `
     MAX(d."documentType") as "requiredDocument",
     SUM (e."amount") AS total
   FROM "Expenses" e
-  INNER JOIN "Expenses" er ON er.id IN (:expenseIds)
+  INNER JOIN "Expenses" er ON e."UserId" = er."UserId"
   INNER JOIN "Collectives" c ON c.id = e."CollectiveId"
   LEFT JOIN "RequiredLegalDocuments" d ON d."HostCollectiveId" = c."HostCollectiveId"
                                     AND d."documentType" = 'US_TAX_FORM'
   LEFT JOIN "LegalDocuments" ld ON ld."CollectiveId" = e."FromCollectiveId"
                                 AND ld.year = date_part('year', e."incurredAt")
                                 AND ld."documentType" = 'US_TAX_FORM'
-  WHERE e."UserId" = er."UserId"
+  WHERE er.id IN (:expenseIds)
   AND e.status IN ('PENDING', 'APPROVED', 'PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT')
   AND e.type NOT IN ('RECEIPT')
   AND e."deletedAt" IS NULL

--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -37,6 +37,11 @@ export const loaders = req => {
   context.loaders.Expense.activities = expenseLoaders.generateExpenseActivitiesLoader(req, cache);
   context.loaders.Expense.attachedFiles = expenseLoaders.attachedFiles(req, cache);
   context.loaders.Expense.items = expenseLoaders.generateExpenseItemsLoader(req, cache);
+  context.loaders.Expense.userTaxFormRequiredBeforePayment = expenseLoaders.userTaxFormRequiredBeforePayment(
+    req,
+    cache,
+  );
+  context.loaders.Expense.requiredLegalDocuments = expenseLoaders.requiredLegalDocuments(req, cache);
 
   // Payout method
   context.loaders.PayoutMethod.paypalByCollectiveId = generateCollectivePaypalPayoutMethodsLoader(req, cache);

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -23,7 +23,6 @@ import orderStatus from '../../constants/order_status';
 import roles from '../../constants/roles';
 import { getCollectiveAvatarUrl } from '../../lib/collectivelib';
 import { getContributorsForTier } from '../../lib/contributors';
-import { isUserTaxFormRequiredBeforePayment } from '../../lib/tax-forms';
 import { stripTags } from '../../lib/utils';
 import models, { Op, sequelize } from '../../models';
 import { PayoutMethodTypes } from '../../models/PayoutMethod';
@@ -914,15 +913,8 @@ export const ExpenseType = new GraphQLObjectType({
       },
       userTaxFormRequiredBeforePayment: {
         type: GraphQLBoolean,
-        async resolve(expense) {
-          const incurredYear = moment(expense.incurredAt).year();
-
-          return isUserTaxFormRequiredBeforePayment({
-            year: incurredYear,
-            invoiceTotalThreshold: 600e2,
-            expenseCollectiveId: expense.CollectiveId,
-            UserId: expense.UserId,
-          });
+        async resolve(expense, _, req) {
+          return req.loaders.Expense.userTaxFormRequiredBeforePayment.load(expense.id);
         },
       },
       user: {

--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -1,10 +1,7 @@
 import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
-import moment from 'moment';
 
-import { isUserTaxFormRequiredBeforePayment } from '../../../lib/tax-forms';
 import models, { Op } from '../../../models';
-import { LEGAL_DOCUMENT_TYPE } from '../../../models/LegalDocument';
 import { allowContextPermission, PERMISSION_TYPE } from '../../common/context-permissions';
 import * as ExpensePermissionsLib from '../../common/expenses';
 import { CommentCollection } from '../collection/CommentCollection';
@@ -215,16 +212,7 @@ const Expense = new GraphQLObjectType({
           if (!req.remoteUser?.isAdmin(expense.FromCollectiveId)) {
             return [];
           }
-
-          const incurredYear = moment(expense.incurredAt).year();
-          const isW9FormRequired = await isUserTaxFormRequiredBeforePayment({
-            year: incurredYear,
-            invoiceTotalThreshold: 600e2,
-            expenseCollectiveId: expense.CollectiveId,
-            UserId: expense.UserId,
-          });
-
-          return isW9FormRequired ? [LEGAL_DOCUMENT_TYPE.US_TAX_FORM] : [];
+          return req.loaders.Expense.requiredLegalDocuments.load(expense.id);
         },
       },
     };

--- a/test/server/graphql/loaders/expense.test.js
+++ b/test/server/graphql/loaders/expense.test.js
@@ -54,7 +54,7 @@ describe('server/graphql/loaders/expense', () => {
         });
         const result1 = await loader.load(firstExpense.id);
         const result2 = await loader.load(secondExpense.id);
-        expect(result1).to.be.true;
+        expect(result1).to.be.false;
         expect(result2).to.be.true;
       });
     });

--- a/test/server/graphql/loaders/expense.test.js
+++ b/test/server/graphql/loaders/expense.test.js
@@ -54,7 +54,7 @@ describe('server/graphql/loaders/expense', () => {
         });
         const result1 = await loader.load(firstExpense.id);
         const result2 = await loader.load(secondExpense.id);
-        expect(result1).to.be.false;
+        expect(result1).to.be.true;
         expect(result2).to.be.true;
       });
     });

--- a/test/server/graphql/loaders/expense.test.js
+++ b/test/server/graphql/loaders/expense.test.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import { loaders } from '../../../../server/graphql/loaders';
 import { requiredLegalDocuments, userTaxFormRequiredBeforePayment } from '../../../../server/graphql/loaders/expenses';
-import models from '../../../../server/models';
 import { fakeCollective, fakeExpense, fakeHostWithRequiredLegalDocument } from '../../../test-helpers/fake-data';
 
 const US_TAX_FORM_THRESHOLD = 600e2;
@@ -22,11 +21,6 @@ describe('server/graphql/loaders/expense', () => {
       });
 
       expenseWithOutUserTaxForm = await fakeExpense();
-      // await models.LegalDocument.create({
-      //   year: '2020',
-      //   requestStatus: 'RECEIVED',
-      //   CollectiveId: expenseWithUserTaxForm.FromCollectiveId
-      // })
     });
 
     it('requires user tax form before payment', async () => {

--- a/test/server/graphql/loaders/expense.test.js
+++ b/test/server/graphql/loaders/expense.test.js
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+
+import { loaders } from '../../../../server/graphql/loaders';
+import { requiredLegalDocuments, userTaxFormRequiredBeforePayment } from '../../../../server/graphql/loaders/expenses';
+import models from '../../../../server/models';
+import { fakeCollective, fakeExpense, fakeHostWithRequiredLegalDocument } from '../../../test-helpers/fake-data';
+
+const US_TAX_FORM_THRESHOLD = 600e2;
+
+describe('server/graphql/loaders/expense', () => {
+  describe('userTaxFormRequiredBeforePayment', () => {
+    const req = {};
+
+    let host, collective, expenseWithUserTaxForm, expenseWithOutUserTaxForm;
+
+    before(async () => {
+      host = await fakeHostWithRequiredLegalDocument();
+      collective = await fakeCollective({ HostCollectiveId: host.id });
+      expenseWithUserTaxForm = await fakeExpense({
+        amount: US_TAX_FORM_THRESHOLD + 100e2,
+        CollectiveId: collective.id,
+      });
+
+      expenseWithOutUserTaxForm = await fakeExpense();
+      // await models.LegalDocument.create({
+      //   year: '2020',
+      //   requestStatus: 'RECEIVED',
+      //   CollectiveId: expenseWithUserTaxForm.FromCollectiveId
+      // })
+    });
+
+    it('requires user tax form before payment', async () => {
+      const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
+      const result = await loader.load(expenseWithUserTaxForm.id);
+      expect(result).to.be.true;
+    });
+
+    it('does not require user tax form before payment', async () => {
+      const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
+      const result = await loader.load(expenseWithOutUserTaxForm.id);
+      expect(result).to.be.false;
+    });
+  });
+});
+
+describe('server/graphql/loaders/expense', () => {
+  describe('requiredLegalDocuments', () => {
+    const req = {};
+
+    let host, collective, expenseWithUserTaxForm, expenseWithOutUserTaxForm;
+
+    before(async () => {
+      host = await fakeHostWithRequiredLegalDocument();
+      collective = await fakeCollective({ HostCollectiveId: host.id });
+      expenseWithUserTaxForm = await fakeExpense({
+        amount: US_TAX_FORM_THRESHOLD + 100e2,
+        CollectiveId: collective.id,
+      });
+      expenseWithOutUserTaxForm = await fakeExpense();
+    });
+
+    it('returns required legal documents', async () => {
+      const loader = requiredLegalDocuments({ loaders: loaders(req) });
+      const result = await loader.load(expenseWithUserTaxForm.id);
+      expect(result).to.have.length(1);
+    });
+
+    it('returns no required legal document', async () => {
+      const loader = requiredLegalDocuments({ loaders: loaders(req) });
+      const result = await loader.load(expenseWithOutUserTaxForm.id);
+      expect(result).to.have.length(0);
+    });
+  });
+});

--- a/test/server/graphql/loaders/expense.test.js
+++ b/test/server/graphql/loaders/expense.test.js
@@ -2,7 +2,14 @@ import { expect } from 'chai';
 
 import { loaders } from '../../../../server/graphql/loaders';
 import { requiredLegalDocuments, userTaxFormRequiredBeforePayment } from '../../../../server/graphql/loaders/expenses';
-import { fakeCollective, fakeExpense, fakeHostWithRequiredLegalDocument } from '../../../test-helpers/fake-data';
+import models from '../../../../server/models';
+import { LEGAL_DOCUMENT_TYPE } from '../../../../server/models/LegalDocument';
+import {
+  fakeCollective,
+  fakeExpense,
+  fakeHostWithRequiredLegalDocument,
+  fakeUser,
+} from '../../../test-helpers/fake-data';
 
 const US_TAX_FORM_THRESHOLD = 600e2;
 
@@ -10,29 +17,85 @@ describe('server/graphql/loaders/expense', () => {
   describe('userTaxFormRequiredBeforePayment', () => {
     const req = {};
 
-    let host, collective, expenseWithUserTaxForm, expenseWithOutUserTaxForm;
+    let host, collective;
 
     before(async () => {
       host = await fakeHostWithRequiredLegalDocument();
       collective = await fakeCollective({ HostCollectiveId: host.id });
-      expenseWithUserTaxForm = await fakeExpense({
-        amount: US_TAX_FORM_THRESHOLD + 100e2,
-        CollectiveId: collective.id,
+    });
+
+    describe('requires user tax form before payment', () => {
+      it('when one expense is above threshold', async () => {
+        const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
+        const expenseWithUserTaxForm = await fakeExpense({
+          amount: US_TAX_FORM_THRESHOLD + 1,
+          CollectiveId: collective.id,
+        });
+        const result = await loader.load(expenseWithUserTaxForm.id);
+        expect(result).to.be.true;
       });
 
-      expenseWithOutUserTaxForm = await fakeExpense();
+      it('when the sum of multiple expenses is above threshold', async () => {
+        const user = await fakeUser();
+        const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
+        const firstExpense = await fakeExpense({
+          amount: US_TAX_FORM_THRESHOLD - 100,
+          CollectiveId: collective.id,
+          FromCollectiveId: user.CollectiveId,
+          UserId: user.id,
+          type: 'INVOICE',
+        });
+        const secondExpense = await fakeExpense({
+          amount: 200,
+          CollectiveId: collective.id,
+          FromCollectiveId: user.CollectiveId,
+          UserId: user.id,
+          type: 'INVOICE',
+        });
+        const result1 = await loader.load(firstExpense.id);
+        const result2 = await loader.load(secondExpense.id);
+        expect(result1).to.be.true;
+        expect(result2).to.be.true;
+      });
     });
 
-    it('requires user tax form before payment', async () => {
-      const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
-      const result = await loader.load(expenseWithUserTaxForm.id);
-      expect(result).to.be.true;
-    });
+    describe('does not require user tax form before payment', () => {
+      it('When under threshold', async () => {
+        const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
+        const expenseWithOutUserTaxForm = await fakeExpense({
+          amount: US_TAX_FORM_THRESHOLD - 100,
+          CollectiveId: collective.id,
+        });
+        const result = await loader.load(expenseWithOutUserTaxForm.id);
+        expect(result).to.be.false;
+      });
 
-    it('does not require user tax form before payment', async () => {
-      const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
-      const result = await loader.load(expenseWithOutUserTaxForm.id);
-      expect(result).to.be.false;
+      it('When legal document has already been submitted', async () => {
+        const user = await fakeUser();
+        const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
+        const expenseWithUserTaxForm = await fakeExpense({
+          amount: US_TAX_FORM_THRESHOLD + 100e2,
+          CollectiveId: collective.id,
+          FromCollectiveId: user.CollectiveId,
+          UserId: user.id,
+        });
+        await models.LegalDocument.create({
+          year: parseInt(new Date().toISOString().split('-')),
+          documentType: LEGAL_DOCUMENT_TYPE.US_TAX_FORM,
+          documentLink: 'https://opencollective.com/tos',
+          requestStatus: 'RECEIVED',
+          CollectiveId: user.CollectiveId,
+        });
+        const result = await loader.load(expenseWithUserTaxForm.id);
+        expect(result).to.be.false;
+      });
+
+      it('When host does not have requiredLegalDocument', async () => {
+        const loader = userTaxFormRequiredBeforePayment({ loaders: loaders(req) });
+        const expenseWithOutUserTaxForm = await fakeExpense();
+        const result = await loader.load(expenseWithOutUserTaxForm.id);
+        expect(result).to.be.false;
+      });
     });
   });
 });

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -66,8 +66,20 @@ export const fakeHost = async hostData => {
   });
 };
 
+/** Create a fake host */
+export const fakeHostWithRequiredLegalDocument = async (hostData = {}) => {
+  const host = await fakeHost(hostData);
+  const requiredDoc = {
+    HostCollectiveId: host.id,
+    documentType: 'US_TAX_FORM',
+  };
+
+  await models.RequiredLegalDocument.create(requiredDoc);
+  return host;
+};
+
 /**
- * Creates a fake update. All params are optionals.
+ * Creates a fake collective. All params are optionals.
  */
 export const fakeCollective = async (collectiveData = {}) => {
   const type = collectiveData.type || CollectiveType.COLLECTIVE;


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/3123

This PR, adds `userTaxFormRequiredBeforePayment` and `requiredLegalDocuments` to expense loader, along with respectives unit tests.
 