### PR TITLE
GraphQL v2 Tier updates

### DIFF
--- a/server/graphql/v2/collection/TierCollection.js
+++ b/server/graphql/v2/collection/TierCollection.js
@@ -1,0 +1,18 @@
+import { GraphQLList, GraphQLObjectType } from 'graphql';
+
+import { Collection, CollectionFields } from '../interface/Collection';
+import { Tier } from '../object/Tier';
+
+export const TierCollection = new GraphQLObjectType({
+  name: 'TierCollection',
+  interfaces: [Collection],
+  description: 'A collection of "Tiers"',
+  fields: () => {
+    return {
+      ...CollectionFields,
+      nodes: {
+        type: new GraphQLList(Tier),
+      },
+    };
+  },
+});

--- a/server/graphql/v2/enum/TierAmountType.js
+++ b/server/graphql/v2/enum/TierAmountType.js
@@ -1,0 +1,9 @@
+import { GraphQLEnumType } from 'graphql';
+
+export const TierAmountType = new GraphQLEnumType({
+  name: 'TierAmountType',
+  values: {
+    FIXED: {},
+    FLEXIBLE: {},
+  },
+});

--- a/server/graphql/v2/enum/TierInterval.js
+++ b/server/graphql/v2/enum/TierInterval.js
@@ -1,0 +1,9 @@
+import { GraphQLEnumType } from 'graphql';
+
+export const TierInterval = new GraphQLEnumType({
+  name: 'TierInterval',
+  values: {
+    month: {},
+    year: {},
+  },
+});

--- a/server/graphql/v2/enum/index.js
+++ b/server/graphql/v2/enum/index.js
@@ -11,4 +11,6 @@ export { OrderDirectionType } from './OrderDirectionType';
 export { OrderFrequency } from './OrderFrequency';
 export { OrderStatus } from './OrderStatus';
 export { PaymentMethodType } from './PaymentMethodType';
+export { TierAmountType } from './TierAmountType';
+export { TierInterval } from './TierInterval';
 export { TransactionType } from './TransactionType';

--- a/server/graphql/v2/input/AmountInput.js
+++ b/server/graphql/v2/input/AmountInput.js
@@ -1,9 +1,10 @@
-import { GraphQLFloat, GraphQLObjectType } from 'graphql';
+import { GraphQLFloat, GraphQLInputObjectType, GraphQLInt } from 'graphql';
 
 import { Currency } from '../enum/Currency';
 
-export const AmountInput = new GraphQLObjectType({
+export const AmountInput = new GraphQLInputObjectType({
   name: 'AmountInput',
+  description: 'Input type for an amount with the value and currency',
   fields: () => ({
     value: {
       type: GraphQLFloat,
@@ -12,6 +13,10 @@ export const AmountInput = new GraphQLObjectType({
     currency: {
       type: Currency,
       description: 'The currency string',
+    },
+    valueInCents: {
+      type: GraphQLInt,
+      description: 'The value in cents',
     },
   }),
 });

--- a/server/graphql/v2/input/PaymentMethodReferenceInput.js
+++ b/server/graphql/v2/input/PaymentMethodReferenceInput.js
@@ -18,11 +18,8 @@ export const PaymentMethodReferenceInput = new GraphQLInputObjectType({
  * Retrieves a payment method
  *
  * @param {string|number} input - id of the payment method
- * @param {object} params
- *    - dbTransaction: An SQL transaction to run the query. Will skip `loaders`
- *    - lock: If true and `dbTransaction` is set, the row will be locked
  */
-export const fetchPaymentMethodWithReference = async (input, { throwIfMissing = false } = {}) => {
+export const fetchPaymentMethodWithReference = async input => {
   // Load payment by ID using GQL loaders if we're not using a transaction & loaders are available
   const loadPaymentById = id => {
     return models.PaymentMethod.findByPk(id);
@@ -35,7 +32,7 @@ export const fetchPaymentMethodWithReference = async (input, { throwIfMissing = 
   } else {
     throw new Error('Please provide an id');
   }
-  if (!paymentMethod && throwIfMissing) {
+  if (!paymentMethod) {
     throw new NotFound('Payment Method Not Found');
   }
   return paymentMethod;

--- a/server/graphql/v2/input/TierReferenceInput.js
+++ b/server/graphql/v2/input/TierReferenceInput.js
@@ -1,11 +1,34 @@
-import { GraphQLInputObjectType, GraphQLInt } from 'graphql';
+import { GraphQLInputObjectType, GraphQLString } from 'graphql';
+
+import models from '../../../models';
+import { NotFound } from '../../errors';
+import { idDecode } from '../identifiers';
 
 export const TierReferenceInput = new GraphQLInputObjectType({
   name: 'TierReferenceInput',
   fields: () => ({
-    legacyId: {
-      type: GraphQLInt,
-      description: 'The legacy id assigned to the Tier',
+    id: {
+      type: GraphQLString,
+      description: 'The id assigned to the Tier',
     },
   }),
 });
+
+/**
+ * Retrieves a tier
+ *
+ * @param {string|number} input - id of the tier
+ */
+export const fetchTierWithReference = async input => {
+  let tier;
+  if (input.id) {
+    const id = idDecode(input.id, 'tier');
+    tier = await models.Tier.findByPk(id);
+  } else {
+    throw new Error('Please provide an id');
+  }
+  if (!tier) {
+    throw new NotFound('Payment Method Not Found');
+  }
+  return tier;
+};

--- a/server/graphql/v2/object/Amount.js
+++ b/server/graphql/v2/object/Amount.js
@@ -5,20 +5,24 @@ import { Currency } from '../enum/Currency';
 export const Amount = new GraphQLObjectType({
   name: 'Amount',
   description: 'A financial amount.',
-  fields: () => {
-    return {
-      value: {
-        type: GraphQLFloat,
-        resolve(amount) {
-          return parseInt(amount.value, 10) / 100;
-        },
+  fields: {
+    value: {
+      type: GraphQLFloat,
+      resolve(amount) {
+        return parseInt(amount.value, 10) / 100;
       },
-      currency: {
-        type: Currency,
-        resolve(amount) {
-          return amount.currency;
-        },
+    },
+    currency: {
+      type: Currency,
+      resolve(amount) {
+        return amount.currency;
       },
-    };
+    },
+    valueInCents: {
+      type: GraphQLFloat,
+      resolve(amount) {
+        return parseInt(amount.value, 10);
+      },
+    },
   },
 });

--- a/server/graphql/v2/object/Collective.js
+++ b/server/graphql/v2/object/Collective.js
@@ -1,8 +1,10 @@
-import { GraphQLBoolean, GraphQLInt, GraphQLObjectType } from 'graphql';
+import { GraphQLBoolean, GraphQLInt, GraphQLNonNull, GraphQLObjectType } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
 
 import { types as collectiveTypes } from '../../../constants/collectives';
+import models from '../../../models';
 import { hostResolver } from '../../common/collective';
+import { TierCollection } from '../collection/TierCollection';
 import { AccountType } from '../enum/AccountType';
 import { Account, AccountFields } from '../interface/Account';
 
@@ -68,6 +70,14 @@ export const Collective = new GraphQLObjectType({
           } else {
             return stats[args.accountType] || 0;
           }
+        },
+      },
+      tiers: {
+        type: new GraphQLNonNull(TierCollection),
+        async resolve(collective) {
+          const query = { where: { CollectiveId: collective.id }, order: [['amount', 'ASC']] };
+          const result = await models.Tier.findAndCountAll(query);
+          return { nodes: result.rows, totalCount: result.count };
         },
       },
     };

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -26,21 +26,12 @@ export const PaymentMethod = new GraphQLObjectType({
       name: {
         // last 4 digit of card number for Stripe
         type: GraphQLString,
-        resolve(paymentMethod) {
-          return paymentMethod.name;
-        },
       },
       service: {
         type: GraphQLString,
-        resolve(paymentMethod) {
-          return paymentMethod.service;
-        },
       },
       type: {
         type: GraphQLString,
-        resolve(paymentMethod) {
-          return paymentMethod.type;
-        },
       },
       balance: {
         type: Amount,

--- a/server/graphql/v2/object/Tier.js
+++ b/server/graphql/v2/object/Tier.js
@@ -1,9 +1,11 @@
-import { GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString } from 'graphql';
+import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 
 import models, { Op } from '../../../models';
 import { OrderCollection } from '../collection/OrderCollection';
-import { OrderStatus } from '../enum/OrderStatus';
+import { OrderStatus, TierAmountType, TierInterval } from '../enum';
 import { idEncode } from '../identifiers';
+
+import { Amount } from './Amount';
 
 export const Tier = new GraphQLObjectType({
   name: 'Tier',
@@ -24,9 +26,6 @@ export const Tier = new GraphQLObjectType({
       },
       slug: {
         type: GraphQLString,
-        resolve(tier) {
-          return tier.slug;
-        },
       },
       name: {
         type: GraphQLString,
@@ -36,9 +35,6 @@ export const Tier = new GraphQLObjectType({
       },
       description: {
         type: GraphQLString,
-        resolve(tier) {
-          return tier.description;
-        },
       },
       orders: {
         description: 'Get all orders',
@@ -60,6 +56,27 @@ export const Tier = new GraphQLObjectType({
           const result = await models.Order.findAndCountAll({ where, limit: args.limit, offset: args.offset });
 
           return { nodes: result.rows, totalCount: result.count, limit: args.limit, offset: args.offset };
+        },
+      },
+      amount: {
+        type: Amount,
+        resolve(tier) {
+          return { value: tier.amount, currency: tier.currency };
+        },
+      },
+      interval: {
+        type: TierInterval,
+      },
+      presets: {
+        type: new GraphQLList(GraphQLInt),
+      },
+      amountType: {
+        type: new GraphQLNonNull(TierAmountType),
+      },
+      minimumAmount: {
+        type: Amount,
+        resolve(tier) {
+          return { value: tier.minimumAmount };
         },
       },
     };


### PR DESCRIPTION
* Adds more fields to the Tier object to be used on the frontend
* Adds a TierCollection
* Allows you to query Tiers on a Collective in v2
* Updates the `updateOrder` mutation to use the new v2 stuff passed from the frontend