### PR TITLE
Remove valueInCents from Amount types

### DIFF
--- a/server/graphql/v2/input/AmountInput.js
+++ b/server/graphql/v2/input/AmountInput.js
@@ -1,4 +1,4 @@
-import { GraphQLFloat, GraphQLInputObjectType, GraphQLInt } from 'graphql';
+import { GraphQLFloat, GraphQLInputObjectType } from 'graphql';
 
 import { Currency } from '../enum/Currency';
 
@@ -13,10 +13,6 @@ export const AmountInput = new GraphQLInputObjectType({
     currency: {
       type: Currency,
       description: 'The currency string',
-    },
-    valueInCents: {
-      type: GraphQLInt,
-      description: 'The value in cents',
     },
   }),
 });

--- a/server/graphql/v2/object/Amount.js
+++ b/server/graphql/v2/object/Amount.js
@@ -18,11 +18,5 @@ export const Amount = new GraphQLObjectType({
         return amount.currency;
       },
     },
-    valueInCents: {
-      type: GraphQLFloat,
-      resolve(amount) {
-        return parseInt(amount.value, 10);
-      },
-    },
   },
 });


### PR DESCRIPTION
I misunderstood some of the discussion around value on the Amount types so now removing the unneeded `valueInCents` field