### PR TITLE
Change occurences of "subscriptions" to "recurring contributions"

### DIFF
--- a/scripts/compile-email.js
+++ b/scripts/compile-email.js
@@ -391,7 +391,7 @@ data['user.monthlyreport'] = {
   recipient: { firstName: 'Xavier' },
   month: 'march',
   year: '2017',
-  manageSubscriptionsUrl: 'https://opencollective.com/subscriptions',
+  manageSubscriptionsUrl: 'https://opencollective.com/recurring-contributions',
   utm: Date.now(),
   fallbackUrl: 'opencollective.com/email/some_id',
   subscriptions: [

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -390,7 +390,7 @@ const sendOrderConfirmedEmail = async order => {
       relatedCollectives,
       monthlyInterval: interval === 'month',
       firstPayment: true,
-      subscriptionsLink: interval && `${config.host.website}/${fromCollective.slug}/subscriptions`,
+      subscriptionsLink: interval && `${config.host.website}/${fromCollective.slug}/recurring-contributions`,
     };
 
     return emailLib.send('thankyou', user.email, data, emailOptions);
@@ -415,7 +415,7 @@ export const sendOrderProcessingEmail = async order => {
     collective: collective.info,
     host: host.info,
     fromCollective: fromCollective.activity,
-    subscriptionsLink: `${config.host.website}/${fromCollective.slug}/subscriptions`,
+    subscriptionsLink: `${config.host.website}/${fromCollective.slug}/recurring-contributions`,
   };
   const instructions = get(host, 'settings.paymentMethods.manual.instructions');
   if (instructions) {

--- a/server/lib/subscriptions.js
+++ b/server/lib/subscriptions.js
@@ -305,7 +305,7 @@ export async function sendArchivedCollectiveEmail(order) {
       order: order.info,
       collective: order.collective.info,
       fromCollective: order.fromCollective.minimal,
-      subscriptionsLink: user.generateLoginLink(`/${order.fromCollective.slug}/subscriptions`),
+      subscriptionsLink: user.generateLoginLink(`/${order.fromCollective.slug}/recurring-contributions`),
     },
     {
       from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
@@ -324,7 +324,7 @@ export async function sendFailedEmail(order, lastAttempt) {
       order: order.info,
       collective: order.collective.info,
       fromCollective: order.fromCollective.minimal,
-      subscriptionsLink: `${config.host.website}/${order.fromCollective.slug}/subscriptions`,
+      subscriptionsLink: `${config.host.website}/${order.fromCollective.slug}/recurring-contributions`,
     },
     {
       from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
@@ -363,7 +363,7 @@ export async function sendThankYouEmail(order, transaction) {
       relatedCollectives,
       config: { host: config.host },
       interval: order.Subscription.interval,
-      subscriptionsLink: `${config.host.website}/${order.fromCollective.slug}/subscriptions`,
+      subscriptionsLink: `${config.host.website}/${order.fromCollective.slug}/recurring-contributions`,
     },
     {
       from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,

--- a/templates/emails/organization.collective.created.hbs
+++ b/templates/emails/organization.collective.created.hbs
@@ -37,8 +37,8 @@ Subject: Your Organization on Open Collective
 <p><b>Employee Donations</b>: Save a credit card on file and enable members of your organization to donate up to a
   certain amount per month.</p>
 
-<p><b>Subscription management</b>: You can edit or cancel recurring contributions <a
-    href="https://opencollective.com/{{collective.slug}}/subscriptions">here</a>.</p>
+<p><b>Recurring contribution management</b>: You can edit or cancel recurring contributions <a
+    href="https://opencollective.com/{{collective.slug}}/recurring-contributions">here</a>.</p>
 
 <p><b>Invoices</b>: Get documentation of aggregated or individual transactions <a
     href="https://opencollective.com/{{collective.slug}}/transactions">here</a>.</p>
@@ -46,7 +46,8 @@ Subject: Your Organization on Open Collective
 <p><b>Back Your Stack</b>: Use <a href="https://backyourstack.com">this tool</a> to discover your company’s open source
   dependencies, and support them on Open Collective. </p>
 
-<p>More questions? See our <a href="https://docs.opencollective.com/help/financial-contributors/financial-contributors">Financial Contributors
+<p>More questions? See our <a
+    href="https://docs.opencollective.com/help/financial-contributors/financial-contributors">Financial Contributors
     FAQ</a> or shoot us a message by replying to this email or on <a href="https://slack.opencollective.com">Slack</a>.
 </p>
 

--- a/templates/emails/organization.collective.created.hbs
+++ b/templates/emails/organization.collective.created.hbs
@@ -37,7 +37,7 @@ Subject: Your Organization on Open Collective
 <p><b>Employee Donations</b>: Save a credit card on file and enable members of your organization to donate up to a
   certain amount per month.</p>
 
-<p><b>Recurring contribution management</b>: You can edit or cancel recurring contributions <a
+<p><b>Recurring contributions management</b>: You can edit or cancel recurring contributions <a
     href="https://opencollective.com/{{collective.slug}}/recurring-contributions">here</a>.</p>
 
 <p><b>Invoices</b>: Get documentation of aggregated or individual transactions <a
@@ -46,8 +46,7 @@ Subject: Your Organization on Open Collective
 <p><b>Back Your Stack</b>: Use <a href="https://backyourstack.com">this tool</a> to discover your company’s open source
   dependencies, and support them on Open Collective. </p>
 
-<p>More questions? See our <a
-    href="https://docs.opencollective.com/help/financial-contributors/financial-contributors">Financial Contributors
+<p>More questions? See our <a href="https://docs.opencollective.com/help/financial-contributors/financial-contributors">Financial Contributors
     FAQ</a> or shoot us a message by replying to this email or on <a href="https://slack.opencollective.com">Slack</a>.
 </p>
 

--- a/templates/emails/payment.creditcard.expiring.hbs
+++ b/templates/emails/payment.creditcard.expiring.hbs
@@ -33,8 +33,7 @@ Subject: Your {{brand}} ending in {{name}} is about to expire
 </p>
 {{/if}}
 
-<p>To continue your recurring contributions without interruption, you should update this card before the end of the
-  month.</p>
+<p>To continue your recurring contributions without interruption, you should update this card before the end of the month.</p>
 
 <p>Add a new credit card <a href="{{updateDetailsLink}}">here</a> to keep your recurring contributions going.</p>
 

--- a/templates/emails/payment.creditcard.expiring.hbs
+++ b/templates/emails/payment.creditcard.expiring.hbs
@@ -33,9 +33,10 @@ Subject: Your {{brand}} ending in {{name}} is about to expire
 </p>
 {{/if}}
 
-<p>To continue your subscriptions without interruption, you should update this card before the end of the month.</p>
+<p>To continue your recurring contributions without interruption, you should update this card before the end of the
+  month.</p>
 
-<p>Add a new credit card <a href="{{updateDetailsLink}}">here</a> to keep your subscriptions going.</p>
+<p>Add a new credit card <a href="{{updateDetailsLink}}">here</a> to keep your recurring contributions going.</p>
 
 <p>If you have any questions, please contact <a href="https://opencollective.com/support">Open Collective support</a>.
 </p>

--- a/templates/emails/payment.failed.hbs
+++ b/templates/emails/payment.failed.hbs
@@ -1,5 +1,5 @@
 {{#if lastAttempt}}
-Subject: Payment failed: Subscription cancelled to {{collective.name}}
+Subject: Payment failed: Recurring contribution cancelled to {{collective.name}}
 {{else}}
 Subject: Payment failed: Update your info to continue supporting {{collective.name}}
 {{/if}}
@@ -15,23 +15,19 @@ Subject: Payment failed: Update your info to continue supporting {{collective.na
 {{/if}}
 
 {{#if lastAttempt}}
-<p>We wanted to let you know that due to your payment failure, we have cancelled your subscription of
-  {{{currency order.totalAmount currency=order.currency}}} to {{collective.name}}.
+<p>We wanted to let you know that due to your payment failure, we have cancelled your recurring contribution of
+{{{currency order.totalAmount currency=order.currency}}} to {{collective.name}}.
 
-  We are sad to see you go. You can resubscribe anytime at <a
-    href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</p>
+We are sad to see you go. You can resubscribe anytime at <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</p>
 {{else}}
-<p>We are having trouble authorizing your payment of {{{currency order.totalAmount currency=order.currency}}} to
-  {{collective.name}}.</p>
+<p>We are having trouble authorizing your payment of {{{currency order.totalAmount currency=order.currency}}} to {{collective.name}}.</p>
 
 <p>Please check your <a href="{{subscriptionsLink}}">recurring contributions and payment info</a>.</p>
 
-<p>We'll automatically retry your payment in a few days. If you believe your payment info is correct, please contact
-  your bank for more details.</p>
+<p>We'll automatically retry your payment in a few days. If you believe your payment info is correct, please contact your bank for more details.</p>
 {{/if}}
 
-<p>If you have questions, you can always email us at <a
-    href="mailto:support@opencollective.com?Subject=Payment%20issue">support@opencollective.com</a>.</p>
+<p>If you have questions, you can always email us at <a href="mailto:support@opencollective.com?Subject=Payment%20issue">support@opencollective.com</a>.</p>
 
 <p>Warmly,</p>
 
@@ -41,11 +37,10 @@ Subject: Payment failed: Update your info to continue supporting {{collective.na
 
 {{> footer}}
 
-<p
-  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-  OpenCollective, Inc.<br />
-  EIN: 47-3896707<br />
-  340 S LEMON AVE #3717<br />
-  Walnut CA 91789<br />
-  USA
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+OpenCollective, Inc.<br />
+EIN: 47-3896707<br />
+340 S LEMON AVE #3717<br />
+Walnut CA 91789<br />
+USA
 </p>

--- a/templates/emails/payment.failed.hbs
+++ b/templates/emails/payment.failed.hbs
@@ -16,18 +16,22 @@ Subject: Payment failed: Update your info to continue supporting {{collective.na
 
 {{#if lastAttempt}}
 <p>We wanted to let you know that due to your payment failure, we have cancelled your subscription of
-{{{currency order.totalAmount currency=order.currency}}} to {{collective.name}}.
+  {{{currency order.totalAmount currency=order.currency}}} to {{collective.name}}.
 
-We are sad to see you go. You can resubscribe anytime at <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</p>
+  We are sad to see you go. You can resubscribe anytime at <a
+    href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</p>
 {{else}}
-<p>We are having trouble authorizing your payment of {{{currency order.totalAmount currency=order.currency}}} to {{collective.name}}.</p>
+<p>We are having trouble authorizing your payment of {{{currency order.totalAmount currency=order.currency}}} to
+  {{collective.name}}.</p>
 
-<p>Please check your <a href="{{subscriptionsLink}}">subscriptions and payment info</a>.</p>
+<p>Please check your <a href="{{subscriptionsLink}}">recurring contributions and payment info</a>.</p>
 
-<p>We'll automatically retry your payment in a few days. If you believe your payment info is correct, please contact your bank for more details.</p>
+<p>We'll automatically retry your payment in a few days. If you believe your payment info is correct, please contact
+  your bank for more details.</p>
 {{/if}}
 
-<p>If you have questions, you can always email us at <a href="mailto:support@opencollective.com?Subject=Payment%20issue">support@opencollective.com</a>.</p>
+<p>If you have questions, you can always email us at <a
+    href="mailto:support@opencollective.com?Subject=Payment%20issue">support@opencollective.com</a>.</p>
 
 <p>Warmly,</p>
 
@@ -37,10 +41,11 @@ We are sad to see you go. You can resubscribe anytime at <a href="https://openco
 
 {{> footer}}
 
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-OpenCollective, Inc.<br />
-EIN: 47-3896707<br />
-340 S LEMON AVE #3717<br />
-Walnut CA 91789<br />
-USA
+<p
+  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+  OpenCollective, Inc.<br />
+  EIN: 47-3896707<br />
+  340 S LEMON AVE #3717<br />
+  Walnut CA 91789<br />
+  USA
 </p>

--- a/templates/emails/payment.failed.text.hbs
+++ b/templates/emails/payment.failed.text.hbs
@@ -25,7 +25,7 @@ We are having trouble authorizing your payment of
 {{{ currency order.totalAmount currency=order.currency}}} to
 {{collective.name}}.
 
-Please check your subscriptions and payment info at {{subscriptionsLink}}.
+Please check your recurring contributions and payment info at {{subscriptionsLink}}.
 
 We'll automatically retry your payment in a few days. If you believe
 your payment info is correct, please contact your bank for more
@@ -37,7 +37,7 @@ If you have any questions, you can always reach us at support@opencollective.com
 
 Warmly,
 
-  – Team Open Collective
+– Team Open Collective
 
 {{> footer.text}}
 

--- a/templates/emails/payment.failed.text.hbs
+++ b/templates/emails/payment.failed.text.hbs
@@ -1,5 +1,5 @@
 {{#if lastAttempt}}
-Subject: Payment failed: Subscription cancelled to {{collective.name}}
+Subject: Payment failed: Recurring contribution cancelled to {{collective.name}}
 {{else}}
 Subject: Payment failed: Update your info to continue supporting {{collective.name}}
 {{/if}}
@@ -13,7 +13,7 @@ Hi!
 {{#if lastAttempt}}
 
 We wanted to let you know that due to your payment failure, we have
-cancelled your subscription of {{{currency order.totalAmount currency=order.currency}}}
+cancelled your recurring contribution of {{{currency order.totalAmount currency=order.currency}}}
 to {{collective.name}}.
 
 We are sad to see you go. You can resubscribe anytime at
@@ -37,7 +37,7 @@ If you have any questions, you can always reach us at support@opencollective.com
 
 Warmly,
 
-– Team Open Collective
+  – Team Open Collective
 
 {{> footer.text}}
 

--- a/templates/emails/thankyou.brusselstogether.hbs
+++ b/templates/emails/thankyou.brusselstogether.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,33 +15,24 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}}.
-  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.
-</p>
+  {{#if firstPayment }}
+    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.</p>
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
+  {{/if}}
+  {{> charge_date_notice }}
 {{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  Your contribution helps us continue our activities.</p>
-{{/if}}
-{{> charge_date_notice }}
-{{else}}
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
-<p>Join our <a href="https://facebook.com/collectives/BrusselsTogether">Facebook Group</a> or join the conversation on
-  <a href="https://slack.brusselstogether.org">our slack</a>.
-  And don't forget to use the hashtag #BrusselsTogether whenever you share something on social networks about
-  initiatives that are happening that we need to support together.</p>
+<p>Join our <a href="https://facebook.com/collectives/BrusselsTogether">Facebook Group</a> or join the conversation on <a href="https://slack.brusselstogether.org">our slack</a>.
+And don't forget to use the hashtag #BrusselsTogether whenever you share something on social networks about initiatives that are happening that we need to support together.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -55,9 +45,8 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 
 {{> footer}}
 
-<p
-  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-  BrusselsTogether ASBL/VZW<br />
-  Tax number: 0664932030<br />
-  Rue de l'Industrie, 11<br />
-  1000 Brussels</p>
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+BrusselsTogether ASBL/VZW<br />
+Tax number: 0664932030<br />
+Rue de l'Industrie, 11<br />
+1000 Brussels</p>

--- a/templates/emails/thankyou.brusselstogether.hbs
+++ b/templates/emails/thankyou.brusselstogether.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,24 +16,33 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.</p>
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your contribution helps us continue our activities.</p>
-  {{/if}}
-  {{> charge_date_notice }}
+{{#if firstPayment }}
+<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}}.
+  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.
+</p>
 {{else}}
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  Your contribution helps us continue our activities.</p>
+{{/if}}
+{{> charge_date_notice }}
+{{else}}
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
-<p>Join our <a href="https://facebook.com/collectives/BrusselsTogether">Facebook Group</a> or join the conversation on <a href="https://slack.brusselstogether.org">our slack</a>.
-And don't forget to use the hashtag #BrusselsTogether whenever you share something on social networks about initiatives that are happening that we need to support together.</p>
+<p>Join our <a href="https://facebook.com/collectives/BrusselsTogether">Facebook Group</a> or join the conversation on
+  <a href="https://slack.brusselstogether.org">our slack</a>.
+  And don't forget to use the hashtag #BrusselsTogether whenever you share something on social networks about
+  initiatives that are happening that we need to support together.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -45,8 +55,9 @@ And don't forget to use the hashtag #BrusselsTogether whenever you share somethi
 
 {{> footer}}
 
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-BrusselsTogether ASBL/VZW<br />
-Tax number: 0664932030<br />
-Rue de l'Industrie, 11<br />
-1000 Brussels</p>
+<p
+  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+  BrusselsTogether ASBL/VZW<br />
+  Tax number: 0664932030<br />
+  Rue de l'Industrie, 11<br />
+  1000 Brussels</p>

--- a/templates/emails/thankyou.chsf.hbs
+++ b/templates/emails/thankyou.chsf.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -17,34 +18,46 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 <p> Welcome to the Consciousness Hacking family!</p>
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
-      {{> charge_date_notice}}
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your contribution helps us continue our work.</p>
-  {{/if}}
+{{#if firstPayment }}
+<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}}.
+  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
+{{> charge_date_notice}}
+{{else}}
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  Your contribution helps us continue our work.</p>
+{{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}.
   Your gift will help us continue our work.</p>
 {{/if}}
 
-<p>As a CH member, you get 1 free event per month. To get your free event, all you have to do is type in the email address you used to register for membership in eventbrite's purchase ticket section "<a href="https://res.cloudinary.com/opencollective/image/upload/v1515428737/Screen_Shot_2018-01-08_at_4.02.31_PM_qydkx7.png">Enter Promotional Code"</a> ...and your coded access will be accessed! </p>
+<p>As a CH member, you get 1 free event per month. To get your free event, all you have to do is type in the email
+  address you used to register for membership in eventbrite's purchase ticket section "<a
+    href="https://res.cloudinary.com/opencollective/image/upload/v1515428737/Screen_Shot_2018-01-08_at_4.02.31_PM_qydkx7.png">Enter
+    Promotional Code"</a> ...and your coded access will be accessed! </p>
 
-<p>You only get 1 FREE event per month as a member, so please pay for the other event so Consciousness Hacking can stay alive. If you register for more than 1 event per month using your code, we have the right to terminate your membership, and you may experience some karmic discomfort.</p>
+<p>You only get 1 FREE event per month as a member, so please pay for the other event so Consciousness Hacking can stay
+  alive. If you register for more than 1 event per month using your code, we have the right to terminate your
+  membership, and you may experience some karmic discomfort.</p>
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
   <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a><br />
+<p>Share this URL: <a
+    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a><br />
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -57,10 +70,11 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 
 {{> footer}}
 
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-OpenCollective, Inc.<br />
-EIN: 47-3896707<br />
-340 S LEMON AVE #3717<br />
-Walnut CA 91789<br />
-USA
+<p
+  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+  OpenCollective, Inc.<br />
+  EIN: 47-3896707<br />
+  340 S LEMON AVE #3717<br />
+  Walnut CA 91789<br />
+  USA
 </p>

--- a/templates/emails/thankyou.chsf.hbs
+++ b/templates/emails/thankyou.chsf.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -18,46 +17,34 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 <p> Welcome to the Consciousness Hacking family!</p>
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}}.
-  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
-{{> charge_date_notice}}
-{{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  Your contribution helps us continue our work.</p>
-{{/if}}
+  {{#if firstPayment }}
+    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
+      {{> charge_date_notice}}
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our work.</p>
+  {{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us continue our work.</p>
 {{/if}}
 
-<p>As a CH member, you get 1 free event per month. To get your free event, all you have to do is type in the email
-  address you used to register for membership in eventbrite's purchase ticket section "<a
-    href="https://res.cloudinary.com/opencollective/image/upload/v1515428737/Screen_Shot_2018-01-08_at_4.02.31_PM_qydkx7.png">Enter
-    Promotional Code"</a> ...and your coded access will be accessed! </p>
+<p>As a CH member, you get 1 free event per month. To get your free event, all you have to do is type in the email address you used to register for membership in eventbrite's purchase ticket section "<a href="https://res.cloudinary.com/opencollective/image/upload/v1515428737/Screen_Shot_2018-01-08_at_4.02.31_PM_qydkx7.png">Enter Promotional Code"</a> ...and your coded access will be accessed! </p>
 
-<p>You only get 1 FREE event per month as a member, so please pay for the other event so Consciousness Hacking can stay
-  alive. If you register for more than 1 event per month using your code, we have the right to terminate your
-  membership, and you may experience some karmic discomfort.</p>
+<p>You only get 1 FREE event per month as a member, so please pay for the other event so Consciousness Hacking can stay alive. If you register for more than 1 event per month using your code, we have the right to terminate your membership, and you may experience some karmic discomfort.</p>
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
   <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a
-    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a><br />
+<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a><br />
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -70,11 +57,10 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 
 {{> footer}}
 
-<p
-  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-  OpenCollective, Inc.<br />
-  EIN: 47-3896707<br />
-  340 S LEMON AVE #3717<br />
-  Walnut CA 91789<br />
-  USA
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+OpenCollective, Inc.<br />
+EIN: 47-3896707<br />
+340 S LEMON AVE #3717<br />
+Walnut CA 91789<br />
+USA
 </p>

--- a/templates/emails/thankyou.fearlesscitiesbrussels.hbs
+++ b/templates/emails/thankyou.fearlesscitiesbrussels.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,40 +15,28 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}}.
-  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.
-</p>
+  {{#if firstPayment }}
+    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.</p>
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
+  {{/if}}
+  {{> charge_date_notice }}
 {{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  Your contribution helps us continue our activities.</p>
-{{/if}}
-{{> charge_date_notice }}
-{{else}}
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us make the first Fearless Cities Brussels a reality. Thank you! 🙏</p>
 {{/if}}
 
-<p>Don't forget to <a href="https://opencollective.com/fearlesscitiesbrussels/events/september-2018"></a>register for
-  the event</a>.</p>
+<p>Don't forget to <a href="https://opencollective.com/fearlesscitiesbrussels/events/september-2018"></a>register for the event</a>.</p>
 
-<p>Till then, please help us make some noise about it by sharing the event on social media with the hashtag
-  #fearlesscities.</p>
+<p>Till then, please help us make some noise about it by sharing the event on social media with the hashtag #fearlesscities.</p>
 
 <p>We are also looking for volunteers to help us with the organization of the event.
-  Please take a look at the <a
-    href="https://docs.google.com/spreadsheets/d/1x_z1CpyjfRfogYa0iIBpKHiwAMcyWUNi7laXMn2ePWY/edit?usp=sharing">list of
-    things that we still need to do</a> and see if there is anyway you can help. That would be amazing. Among other
-  things, we are still looking for people to help us with child care, video recording, distributing flyers.</p>
+Please take a look at the <a href="https://docs.google.com/spreadsheets/d/1x_z1CpyjfRfogYa0iIBpKHiwAMcyWUNi7laXMn2ePWY/edit?usp=sharing">list of things that we still need to do</a> and see if there is anyway you can help. That would be amazing. Among other things, we are still looking for people to help us with child care, video recording, distributing flyers.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -62,9 +49,8 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 
 {{> footer}}
 
-<p
-  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-  BrusselsTogether ASBL/VZW<br />
-  Tax number: 0664932030<br />
-  Rue de l'Industrie, 11<br />
-  1000 Brussels</p>
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+BrusselsTogether ASBL/VZW<br />
+Tax number: 0664932030<br />
+Rue de l'Industrie, 11<br />
+1000 Brussels</p>

--- a/templates/emails/thankyou.fearlesscitiesbrussels.hbs
+++ b/templates/emails/thankyou.fearlesscitiesbrussels.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,28 +16,40 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.</p>
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your contribution helps us continue our activities.</p>
-  {{/if}}
-  {{> charge_date_notice }}
+{{#if firstPayment }}
+<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}}.
+  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our activities.
+</p>
 {{else}}
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  Your contribution helps us continue our activities.</p>
+{{/if}}
+{{> charge_date_notice }}
+{{else}}
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}.
   Your gift will help us make the first Fearless Cities Brussels a reality. Thank you! 🙏</p>
 {{/if}}
 
-<p>Don't forget to <a href="https://opencollective.com/fearlesscitiesbrussels/events/september-2018"></a>register for the event</a>.</p>
+<p>Don't forget to <a href="https://opencollective.com/fearlesscitiesbrussels/events/september-2018"></a>register for
+  the event</a>.</p>
 
-<p>Till then, please help us make some noise about it by sharing the event on social media with the hashtag #fearlesscities.</p>
+<p>Till then, please help us make some noise about it by sharing the event on social media with the hashtag
+  #fearlesscities.</p>
 
 <p>We are also looking for volunteers to help us with the organization of the event.
-Please take a look at the <a href="https://docs.google.com/spreadsheets/d/1x_z1CpyjfRfogYa0iIBpKHiwAMcyWUNi7laXMn2ePWY/edit?usp=sharing">list of things that we still need to do</a> and see if there is anyway you can help. That would be amazing. Among other things, we are still looking for people to help us with child care, video recording, distributing flyers.</p>
+  Please take a look at the <a
+    href="https://docs.google.com/spreadsheets/d/1x_z1CpyjfRfogYa0iIBpKHiwAMcyWUNi7laXMn2ePWY/edit?usp=sharing">list of
+    things that we still need to do</a> and see if there is anyway you can help. That would be amazing. Among other
+  things, we are still looking for people to help us with child care, video recording, distributing flyers.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -49,8 +62,9 @@ Please take a look at the <a href="https://docs.google.com/spreadsheets/d/1x_z1C
 
 {{> footer}}
 
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-BrusselsTogether ASBL/VZW<br />
-Tax number: 0664932030<br />
-Rue de l'Industrie, 11<br />
-1000 Brussels</p>
+<p
+  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+  BrusselsTogether ASBL/VZW<br />
+  Tax number: 0664932030<br />
+  Rue de l'Industrie, 11<br />
+  1000 Brussels</p>

--- a/templates/emails/thankyou.foundation.hbs
+++ b/templates/emails/thankyou.foundation.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,25 +15,18 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}}.
-  Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Collective
-  Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your
-  donation.</p>
-{{> charge_date_notice}}
-{{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization
-  under IRS Section 501(c)(3), acknowledges your donation.</p>
-{{/if}}
+  {{#if firstPayment }}
+    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
+      Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your donation.</p>
+      {{> charge_date_notice}}
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+       As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your donation.</p>
+  {{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}.
-  As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization
-  under IRS Section 501(c)(3), acknowledges your donation.</p>
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your donation.</p>
 {{/if}}
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
@@ -42,31 +34,24 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a
-    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
+<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
 
 <p>
-  Pía Mancini<br />
-  Open Collective Foundation<br />
-  340 S. Lemon Ave, #3717<br />
-  Walnut, CA 91789<br />
-  EIN 81-4004928
+Pía Mancini<br/>
+Open Collective Foundation<br/>
+340 S. Lemon Ave, #3717<br/>
+Walnut, CA 91789<br/>
+EIN 81-4004928
 </p>
 
-<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your
-  records. This email certifies that you have made this contribution as a charitable contribution and you are not
-  receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Open
-  Collective Foundation, registered 501(c)3 Nonprofit TAX ID: 81-4004928. </p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your records. This email certifies that you have made this contribution as a charitable contribution and you are not receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Open Collective Foundation, registered 501(c)3 Nonprofit TAX ID: 81-4004928. </p>
 
 {{#if relatedCollectives.length}}
 {{> relatedcollectives}}

--- a/templates/emails/thankyou.foundation.hbs
+++ b/templates/emails/thankyou.foundation.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,18 +16,25 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your donation.</p>
-      {{> charge_date_notice}}
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-       As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your donation.</p>
-  {{/if}}
+{{#if firstPayment }}
+<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}}.
+  Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Collective
+  Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your
+  donation.</p>
+{{> charge_date_notice}}
+{{else}}
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization
+  under IRS Section 501(c)(3), acknowledges your donation.</p>
+{{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
-As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization under IRS Section 501(c)(3), acknowledges your donation.</p>
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}.
+  As the collective's fiscal sponsor, Open Collective Foundation, a public charity recognized tax-exempt organization
+  under IRS Section 501(c)(3), acknowledges your donation.</p>
 {{/if}}
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
@@ -34,24 +42,31 @@ As the collective's fiscal sponsor, Open Collective Foundation, a public charity
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
+<p>Share this URL: <a
+    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
 
 <p>
-Pía Mancini<br/>
-Open Collective Foundation<br/>
-340 S. Lemon Ave, #3717<br/>
-Walnut, CA 91789<br/>
-EIN 81-4004928
+  Pía Mancini<br />
+  Open Collective Foundation<br />
+  340 S. Lemon Ave, #3717<br />
+  Walnut, CA 91789<br />
+  EIN 81-4004928
 </p>
 
-<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your records. This email certifies that you have made this contribution as a charitable contribution and you are not receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Open Collective Foundation, registered 501(c)3 Nonprofit TAX ID: 81-4004928. </p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your
+  records. This email certifies that you have made this contribution as a charitable contribution and you are not
+  receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Open
+  Collective Foundation, registered 501(c)3 Nonprofit TAX ID: 81-4004928. </p>
 
 {{#if relatedCollectives.length}}
 {{> relatedcollectives}}

--- a/templates/emails/thankyou.hbs
+++ b/templates/emails/thankyou.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,20 +15,17 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}}.
-  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
-{{> charge_date_notice}}
-{{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  Your contribution helps us continue our work.</p>
-{{/if}}
+  {{#if firstPayment }}
+    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
+      {{> charge_date_notice}}
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our work.</p>
+  {{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
   Your gift will help us continue our work.</p>
 {{/if}}
 
@@ -38,15 +34,11 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a
-    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
+<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.hbs
+++ b/templates/emails/thankyou.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,17 +16,20 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
-      {{> charge_date_notice}}
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your contribution helps us continue our work.</p>
-  {{/if}}
+{{#if firstPayment }}
+<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}}.
+  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue our work.</p>
+{{> charge_date_notice}}
+{{else}}
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  Your contribution helps us continue our work.</p>
+{{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}.
   Your gift will help us continue our work.</p>
 {{/if}}
 
@@ -34,11 +38,15 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
+<p>Share this URL: <a
+    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.ispcwa.hbs
+++ b/templates/emails/thankyou.ispcwa.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,27 +15,19 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}}. Your first payment was received on {{{moment order.createdAt}}}. Your gift will help us continue our
-  activities.</p>
+	<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}. Your first payment was received on {{{moment order.createdAt}}}. Your gift will help us continue our activities.</p>
 {{else}}
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment transaction.createdAt}}}.
+	<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment transaction.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
-<p>Please register for the event with John Poulsen before March the 20th: <a
-    href="https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480">https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480</a>
-</p>
+<p>Please register for the event with John Poulsen before March the 20th: <a href="https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480">https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480</a></p>
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
   <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.ispcwa.hbs
+++ b/templates/emails/thankyou.ispcwa.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,19 +16,27 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-	<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}. Your first payment was received on {{{moment order.createdAt}}}. Your gift will help us continue our activities.</p>
+<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}}. Your first payment was received on {{{moment order.createdAt}}}. Your gift will help us continue our
+  activities.</p>
 {{else}}
-	<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment transaction.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment transaction.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
-<p>Please register for the event with John Poulsen before March the 20th: <a href="https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480">https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480</a></p>
+<p>Please register for the event with John Poulsen before March the 20th: <a
+    href="https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480">https://www.eventbrite.com.au/e/ispc-wa-networking-event-with-john-poulsen-registration-21584720480</a>
+</p>
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
   <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>

--- a/templates/emails/thankyou.kendraio.hbs
+++ b/templates/emails/thankyou.kendraio.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}}/{{interval}} contribution to {{group.name}}
+Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}}/{{interval}} contribution to
+{{group.name}}
 {{else}}
 Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}} contribution to {{group.name}}
 {{/if}}
@@ -15,16 +16,20 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We would like to thank you for your pledge to give {{{currency donation.amount currency=donation.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment donation.createdAt}}}. Your contribution helps us continue our activities.</p>
-      {{> charge_date_notice}}
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency donation.amount currency=donation.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your contribution helps us continue our activities.</p>
-  {{/if}}
+{{#if firstPayment }}
+<p>We would like to thank you for your pledge to give {{{currency donation.amount currency=donation.currency}}} per
+  {{interval}}.
+  Your first payment was received on {{{moment donation.createdAt}}}. Your contribution helps us continue our
+  activities.</p>
+{{> charge_date_notice}}
 {{else}}
-<p>We would like to thank you for your contribution of {{{currency donation.amount currency=donation.currency}}} on {{{moment donation.createdAt}}}.
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency donation.amount currency=donation.currency}}} was received on {{{moment transaction.createdAt}}}.
+  Your contribution helps us continue our activities.</p>
+{{/if}}
+{{else}}
+<p>We would like to thank you for your contribution of {{{currency donation.amount currency=donation.currency}}} on
+  {{{moment donation.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
@@ -33,7 +38,10 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -42,24 +50,26 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
   – The {{group.name}} open collective
 </p>
 
-<p>Follow us on <a href="https://twitter.com/kendraio">twitter</a></p> or join us on <a href="https://slack.kendra.io/">slack</a></p>
+<p>Follow us on <a href="https://twitter.com/kendraio">twitter</a></p> or join us on <a
+  href="https://slack.kendra.io/">slack</a></p>
 <p>Kendraio ( https://www.kendra.io ) is hosted by:
-Kendra Foundation (company number 4643358)
-Registered (non-postal) address:
-27 Old Gloucester Street
-London
-WC1N 3AX
-United Kingdom
+  Kendra Foundation (company number 4643358)
+  Registered (non-postal) address:
+  27 Old Gloucester Street
+  London
+  WC1N 3AX
+  United Kingdom
 </p>
 
 {{> relatedgroups}}
 
 {{> footer}}
 
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-OpenCollective, Inc.<br />
-EIN: 47-3896707<br />
-340 S LEMON AVE #3717<br />
-Walnut CA 91789<br />
-USA
+<p
+  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+  OpenCollective, Inc.<br />
+  EIN: 47-3896707<br />
+  340 S LEMON AVE #3717<br />
+  Walnut CA 91789<br />
+  USA
 </p>

--- a/templates/emails/thankyou.kendraio.hbs
+++ b/templates/emails/thankyou.kendraio.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}}/{{interval}} contribution to
-{{group.name}}
+Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}}/{{interval}} contribution to {{group.name}}
 {{else}}
 Subject: Thank you for your {{{currency donation.amount currency=donation.currency}}} contribution to {{group.name}}
 {{/if}}
@@ -16,20 +15,16 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We would like to thank you for your pledge to give {{{currency donation.amount currency=donation.currency}}} per
-  {{interval}}.
-  Your first payment was received on {{{moment donation.createdAt}}}. Your contribution helps us continue our
-  activities.</p>
-{{> charge_date_notice}}
+  {{#if firstPayment }}
+    <p>We would like to thank you for your pledge to give {{{currency donation.amount currency=donation.currency}}} per {{interval}}.
+      Your first payment was received on {{{moment donation.createdAt}}}. Your contribution helps us continue our activities.</p>
+      {{> charge_date_notice}}
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency donation.amount currency=donation.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
+  {{/if}}
 {{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency donation.amount currency=donation.currency}}} was received on {{{moment transaction.createdAt}}}.
-  Your contribution helps us continue our activities.</p>
-{{/if}}
-{{else}}
-<p>We would like to thank you for your contribution of {{{currency donation.amount currency=donation.currency}}} on
-  {{{moment donation.createdAt}}}.
+<p>We would like to thank you for your contribution of {{{currency donation.amount currency=donation.currency}}} on {{{moment donation.createdAt}}}.
   Your gift will help us continue our activities.</p>
 {{/if}}
 
@@ -38,10 +33,7 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -50,26 +42,24 @@ Subject: Thank you for your {{{currency donation.amount currency=donation.curren
   – The {{group.name}} open collective
 </p>
 
-<p>Follow us on <a href="https://twitter.com/kendraio">twitter</a></p> or join us on <a
-  href="https://slack.kendra.io/">slack</a></p>
+<p>Follow us on <a href="https://twitter.com/kendraio">twitter</a></p> or join us on <a href="https://slack.kendra.io/">slack</a></p>
 <p>Kendraio ( https://www.kendra.io ) is hosted by:
-  Kendra Foundation (company number 4643358)
-  Registered (non-postal) address:
-  27 Old Gloucester Street
-  London
-  WC1N 3AX
-  United Kingdom
+Kendra Foundation (company number 4643358)
+Registered (non-postal) address:
+27 Old Gloucester Street
+London
+WC1N 3AX
+United Kingdom
 </p>
 
 {{> relatedgroups}}
 
 {{> footer}}
 
-<p
-  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-  OpenCollective, Inc.<br />
-  EIN: 47-3896707<br />
-  340 S LEMON AVE #3717<br />
-  Walnut CA 91789<br />
-  USA
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+OpenCollective, Inc.<br />
+EIN: 47-3896707<br />
+340 S LEMON AVE #3717<br />
+Walnut CA 91789<br />
+USA
 </p>

--- a/templates/emails/thankyou.opensource.hbs
+++ b/templates/emails/thankyou.opensource.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,24 +15,18 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}}.
-  Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Source
-  Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
-{{> charge_date_notice}}
-{{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS
-  Section 501(c)(6), acknowledges your donation.</p>
-{{/if}}
+  {{#if firstPayment }}
+    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
+      Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
+      {{> charge_date_notice}}
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
+  {{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}.
-  As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS
-  Section 501(c)(6), acknowledges your donation.</p>
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
+  As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
 {{/if}}
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
@@ -41,25 +34,21 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a
-    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
+<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
 
 <p>
-  Alanna Irving - Executive Director<br />
-  Open Source Collective<br />
-  340 S. Lemon Ave, #3717<br />
-  Walnut, CA 91789<br />
-  EIN 82-2037583
+Alanna Irving - Executive Director<br/>
+Open Source Collective<br/>
+340 S. Lemon Ave, #3717<br/>
+Walnut, CA 91789<br/>
+EIN 82-2037583
 </p>
 
 {{#if relatedCollectives.length}}

--- a/templates/emails/thankyou.opensource.hbs
+++ b/templates/emails/thankyou.opensource.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,18 +16,24 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}}.
-      Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
-      {{> charge_date_notice}}
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
-  {{/if}}
+{{#if firstPayment }}
+<p>We would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}}.
+  Your first payment was received on {{{moment order.createdAt}}}. As the collective's fiscal sponsor, Open Source
+  Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
+{{> charge_date_notice}}
+{{else}}
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS
+  Section 501(c)(6), acknowledges your donation.</p>
+{{/if}}
 {{else}}
 
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.
-  As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS Section 501(c)(6), acknowledges your donation.</p>
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}.
+  As the collective's fiscal sponsor, Open Source Collective, a public recognized tax-exempt organization under IRS
+  Section 501(c)(6), acknowledges your donation.</p>
 {{/if}}
 
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
@@ -34,21 +41,25 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
+<p>Share this URL: <a
+    href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
 </p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
 
 <p>
-Alanna Irving - Executive Director<br/>
-Open Source Collective<br/>
-340 S. Lemon Ave, #3717<br/>
-Walnut, CA 91789<br/>
-EIN 82-2037583
+  Alanna Irving - Executive Director<br />
+  Open Source Collective<br />
+  340 S. Lemon Ave, #3717<br />
+  Walnut, CA 91789<br />
+  EIN 82-2037583
 </p>
 
 {{#if relatedCollectives.length}}

--- a/templates/emails/thankyou.sfartandfilm.hbs
+++ b/templates/emails/thankyou.sfartandfilm.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,21 +16,26 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>We want to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} per {{interval}} to San Francisco Art & Film for Teenagers.
-      Your first payment was received on {{{moment order.createdAt}}}.</p>
-    {{> charge_date_notice }}
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.</p>
-  {{/if}}
+{{#if firstPayment }}
+<p>We want to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}} to San Francisco Art & Film for Teenagers.
+  Your first payment was received on {{{moment order.createdAt}}}.</p>
+{{> charge_date_notice }}
 {{else}}
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.</p>
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.</p>
+{{/if}}
+{{else}}
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}.</p>
 {{/if}}
 
-<p>SF Art & Film remains steadfast in its goal of making the arts a vital presence in the lives of young people and your extraordinary generosity is what makes it possible. We hope you’ll continue to introduce people like yourself—people who understand the importance of art education—to our program.</p>
+<p>SF Art & Film remains steadfast in its goal of making the arts a vital presence in the lives of young people and your
+  extraordinary generosity is what makes it possible. We hope you’ll continue to introduce people like yourself—people
+  who understand the importance of art education—to our program.</p>
 <p>We greatly appreciate your support.</p>
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
-<a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
+  <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 </p>
 
 <p>Many Thanks,</p>
@@ -39,20 +45,25 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   Director
   San Francisco Art & Film for Teenagers
 </p>
-<p>Your contribution is tax-deductible to the extent allowed by law. You may save this receipt for your records. San Francisco Art & Film for Teenagers is a qualified non-profit organization with 501-C status, tax ID: 94-3310464.</p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save this receipt for your records. San
+  Francisco Art & Film for Teenagers is a qualified non-profit organization with 501-C status, tax ID: 94-3310464.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 {{> relatedcollectives}}
 
 {{> footer}}
 
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-OpenCollective, Inc.<br />
-EIN: 47-3896707<br />
-340 S LEMON AVE #3717<br />
-Walnut CA 91789<br />
-USA
+<p
+  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+  OpenCollective, Inc.<br />
+  EIN: 47-3896707<br />
+  340 S LEMON AVE #3717<br />
+  Walnut CA 91789<br />
+  USA
 </p>

--- a/templates/emails/thankyou.sfartandfilm.hbs
+++ b/templates/emails/thankyou.sfartandfilm.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,26 +15,21 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>We want to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}} to San Francisco Art & Film for Teenagers.
-  Your first payment was received on {{{moment order.createdAt}}}.</p>
-{{> charge_date_notice }}
+  {{#if firstPayment }}
+    <p>We want to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} per {{interval}} to San Francisco Art & Film for Teenagers.
+      Your first payment was received on {{{moment order.createdAt}}}.</p>
+    {{> charge_date_notice }}
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.</p>
+  {{/if}}
 {{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.</p>
-{{/if}}
-{{else}}
-<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}.</p>
+<p>We would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}.</p>
 {{/if}}
 
-<p>SF Art & Film remains steadfast in its goal of making the arts a vital presence in the lives of young people and your
-  extraordinary generosity is what makes it possible. We hope you’ll continue to introduce people like yourself—people
-  who understand the importance of art education—to our program.</p>
+<p>SF Art & Film remains steadfast in its goal of making the arts a vital presence in the lives of young people and your extraordinary generosity is what makes it possible. We hope you’ll continue to introduce people like yourself—people who understand the importance of art education—to our program.</p>
 <p>We greatly appreciate your support.</p>
 <p>You can follow our future activities and how we will be spending the money on our open collective page:
-  <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
+<a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.
 </p>
 
 <p>Many Thanks,</p>
@@ -45,25 +39,20 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   Director
   San Francisco Art & Film for Teenagers
 </p>
-<p>Your contribution is tax-deductible to the extent allowed by law. You may save this receipt for your records. San
-  Francisco Art & Film for Teenagers is a qualified non-profit organization with 501-C status, tax ID: 94-3310464.</p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save this receipt for your records. San Francisco Art & Film for Teenagers is a qualified non-profit organization with 501-C status, tax ID: 94-3310464.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 {{> relatedcollectives}}
 
 {{> footer}}
 
-<p
-  style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-  OpenCollective, Inc.<br />
-  EIN: 47-3896707<br />
-  340 S LEMON AVE #3717<br />
-  Walnut CA 91789<br />
-  USA
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+OpenCollective, Inc.<br />
+EIN: 47-3896707<br />
+340 S LEMON AVE #3717<br />
+Walnut CA 91789<br />
+USA
 </p>

--- a/templates/emails/thankyou.sustainoss.hbs
+++ b/templates/emails/thankyou.sustainoss.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,45 +16,53 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment }}
-    <p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} per {{interval}} to SustainOSS .
-      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue growing the SustainOSS ecosystem and projects.</p>
-    {{> charge_date_notice}}
-  {{else}}
-    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-      Your contribution helps us continue our activities.</p>
-  {{/if}}
+{{#if firstPayment }}
+<p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} per {{interval}}
+  to SustainOSS .
+  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue growing the
+  SustainOSS ecosystem and projects.</p>
+{{> charge_date_notice}}
 {{else}}
-<p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}} to SustainOSS.</p>
+<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  Your contribution helps us continue our activities.</p>
+{{/if}}
+{{else}}
+<p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}} to SustainOSS.</p>
 {{/if}}
 
 <p>Next steps:
 <ul>
   <li>You can follow our activities and how we will be spending the money on our open collective page:
-  <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</li>
+    <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</li>
   <li>Follow us on <a href="https://twitter.com/sustainoss">Twitter</a></li>
   <li>Open Source with us on <a href="https://github.com/sustainers">GitHub</a></li>
   <li><a href="slack.opencollective.com">Slack</a> with us on #sustain @ Open Collective.</li>
- </p>
+  </p>
 
-<p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
-</p>
+  <p>
+    P.S: You can download a PDF receipt for your contribution <a
+      href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+      page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+      href="{{subscriptionsLink}}">here</a>{{/if}}.
+  </p>
 
-<p>Warmly,</p>
+  <p>Warmly,</p>
 
-<p>
-  – The {{collective.name}} open collective
-</p>
+  <p>
+    – The {{collective.name}} open collective
+  </p>
 
-{{> relatedcollectives}}
+  {{> relatedcollectives}}
 
-{{> footer}}
+  {{> footer}}
 
-<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-OpenCollective, Inc.<br />
-EIN: 47-3896707<br />
-340 S LEMON AVE #3717<br />
-Walnut CA 91789<br />
-USA
-</p>
+  <p
+    style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+    OpenCollective, Inc.<br />
+    EIN: 47-3896707<br />
+    340 S LEMON AVE #3717<br />
+    Walnut CA 91789<br />
+    USA
+  </p>

--- a/templates/emails/thankyou.sustainoss.hbs
+++ b/templates/emails/thankyou.sustainoss.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,53 +15,45 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment }}
-<p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} per {{interval}}
-  to SustainOSS .
-  Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue growing the
-  SustainOSS ecosystem and projects.</p>
-{{> charge_date_notice}}
+  {{#if firstPayment }}
+    <p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} per {{interval}} to SustainOSS .
+      Your first payment was received on {{{moment order.createdAt}}}. Your contribution helps us continue growing the SustainOSS ecosystem and projects.</p>
+    {{> charge_date_notice}}
+  {{else}}
+    <p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+      Your contribution helps us continue our activities.</p>
+  {{/if}}
 {{else}}
-<p>We would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  Your contribution helps us continue our activities.</p>
-{{/if}}
-{{else}}
-<p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}} to SustainOSS.</p>
+<p>Thank you so much for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}} to SustainOSS.</p>
 {{/if}}
 
 <p>Next steps:
 <ul>
   <li>You can follow our activities and how we will be spending the money on our open collective page:
-    <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</li>
+  <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>.</li>
   <li>Follow us on <a href="https://twitter.com/sustainoss">Twitter</a></li>
   <li>Open Source with us on <a href="https://github.com/sustainers">GitHub</a></li>
   <li><a href="slack.opencollective.com">Slack</a> with us on #sustain @ Open Collective.</li>
-  </p>
+ </p>
 
-  <p>
-    P.S: You can download a PDF receipt for your contribution <a
-      href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-      page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-      href="{{subscriptionsLink}}">here</a>{{/if}}.
-  </p>
+<p>
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+</p>
 
-  <p>Warmly,</p>
+<p>Warmly,</p>
 
-  <p>
-    – The {{collective.name}} open collective
-  </p>
+<p>
+  – The {{collective.name}} open collective
+</p>
 
-  {{> relatedcollectives}}
+{{> relatedcollectives}}
 
-  {{> footer}}
+{{> footer}}
 
-  <p
-    style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
-    OpenCollective, Inc.<br />
-    EIN: 47-3896707<br />
-    340 S LEMON AVE #3717<br />
-    Walnut CA 91789<br />
-    USA
-  </p>
+<p style="text-align:center;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:12px;color:#999;">
+OpenCollective, Inc.<br />
+EIN: 47-3896707<br />
+340 S LEMON AVE #3717<br />
+Walnut CA 91789<br />
+USA
+</p>

--- a/templates/emails/thankyou.wwcode.hbs
+++ b/templates/emails/thankyou.wwcode.hbs
@@ -1,6 +1,5 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
-{{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -16,34 +15,23 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-{{#if firstPayment}}
-<p>I would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
-  {{interval}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women
-  leaders in tech.</p>
-{{> charge_date_notice }}
+  {{#if firstPayment}}
+    <p>I would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
+    {{> charge_date_notice }}
+  {{else}}
+    <p>I would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+    Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
+  {{/if}}
 {{else}}
-<p>I would like to thank you for your continued support. Your latest {{interval}}ly contribution of
-  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-  Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
-{{/if}}
-{{else}}
-<p>I would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
-  {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.
-</p>
+<p>I would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
 {{/if}}
 
-<p>With your support, we are able to extend our program reach. Through this, we are able to provide an avenue into tech,
-  empower women with skills needed for professional advancement, and provide environments where networking and
-  mentorship are valued.</p>
+<p>With your support, we are able to extend our program reach. Through this, we are able to provide an avenue into tech, empower women with skills needed for professional advancement, and provide environments where networking and mentorship are valued.</p>
 
-<p>On behalf of the Women Who Code Board of Executives, our leadership team, and our members worldwide, thank you for
-  furthering our mission. We appreciate and value your contribution and continued support of our community.</p>
+<p>On behalf of the Women Who Code Board of Executives, our leadership team, and our members worldwide, thank you for furthering our mission. We appreciate and value your contribution and continued support of our community.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a
-    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
-    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
-    href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -55,9 +43,6 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   EIN: 46 – 4218859
 </p>
 
-<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your
-  records. This email certifies that you have made this contribution as a charitable contribution and you are not
-  receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Women
-  Who Code, registered 501(c)3 Nonprofit TAX ID: 46-4218859. </p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your records. This email certifies that you have made this contribution as a charitable contribution and you are not receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Women Who Code, registered 501(c)3 Nonprofit TAX ID: 46-4218859. </p>
 
 {{> footer}}

--- a/templates/emails/thankyou.wwcode.hbs
+++ b/templates/emails/thankyou.wwcode.hbs
@@ -1,5 +1,6 @@
 {{#if interval }}
-Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to {{collective.name}}
+Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}}/{{interval}} contribution to
+{{collective.name}}
 {{else}}
 Subject: Thank you for your {{{currency order.totalAmount currency=order.currency}}} contribution to {{collective.name}}
 {{/if}}
@@ -15,23 +16,34 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
 {{/if}}
 
 {{#if interval}}
-  {{#if firstPayment}}
-    <p>I would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per {{interval}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
-    {{> charge_date_notice }}
-  {{else}}
-    <p>I would like to thank you for your continued support. Your latest {{interval}}ly contribution of {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
-    Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
-  {{/if}}
+{{#if firstPayment}}
+<p>I would like to thank you for your pledge to give {{{currency order.totalAmount currency=order.currency}}} per
+  {{interval}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women
+  leaders in tech.</p>
+{{> charge_date_notice }}
 {{else}}
-<p>I would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
+<p>I would like to thank you for your continued support. Your latest {{interval}}ly contribution of
+  {{{currency order.totalAmount currency=order.currency}}} was received on {{{moment transaction.createdAt}}}.
+  Your generous gift helps us promote, inspire, and advance more women leaders in tech.</p>
+{{/if}}
+{{else}}
+<p>I would like to thank you for your contribution of {{{currency order.totalAmount currency=order.currency}}} on
+  {{{moment order.createdAt}}}. Your generous gift helps us promote, inspire, and advance more women leaders in tech.
+</p>
 {{/if}}
 
-<p>With your support, we are able to extend our program reach. Through this, we are able to provide an avenue into tech, empower women with skills needed for professional advancement, and provide environments where networking and mentorship are valued.</p>
+<p>With your support, we are able to extend our program reach. Through this, we are able to provide an avenue into tech,
+  empower women with skills needed for professional advancement, and provide environments where networking and
+  mentorship are valued.</p>
 
-<p>On behalf of the Women Who Code Board of Executives, our leadership team, and our members worldwide, thank you for furthering our mission. We appreciate and value your contribution and continued support of our community.</p>
+<p>On behalf of the Women Who Code Board of Executives, our leadership team, and our members worldwide, thank you for
+  furthering our mission. We appreciate and value your contribution and continued support of our community.</p>
 
 <p>
-  P.S: You can download a PDF receipt for your contribution <a href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions page</a>{{#if subscriptionsLink}}, and you can manage your subscriptions <a href="{{subscriptionsLink}}">here</a>{{/if}}.
+  P.S: You can download a PDF receipt for your contribution <a
+    href="{{config.host.website}}/{{fromCollective.slug}}/transactions">on your transactions
+    page</a>{{#if subscriptionsLink}}, and you can manage your recurring contributions <a
+    href="{{subscriptionsLink}}">here</a>{{/if}}.
 </p>
 
 <p>Warmly,</p>
@@ -43,6 +55,9 @@ Subject: Thank you for your {{{currency order.totalAmount currency=order.currenc
   EIN: 46 – 4218859
 </p>
 
-<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your records. This email certifies that you have made this contribution as a charitable contribution and you are not receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Women Who Code, registered 501(c)3 Nonprofit TAX ID: 46-4218859. </p>
+<p>Your contribution is tax-deductible to the extent allowed by law. You may save or print this receipt for your
+  records. This email certifies that you have made this contribution as a charitable contribution and you are not
+  receiving any goods or services in return. This receipt may be useful to you when completing your tax return. Women
+  Who Code, registered 501(c)3 Nonprofit TAX ID: 46-4218859. </p>
 
 {{> footer}}

--- a/templates/emails/user.card.claimed.hbs
+++ b/templates/emails/user.card.claimed.hbs
@@ -1,31 +1,42 @@
-Subject: {{#ifCond currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶 {{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷 {{/ifCond}}You received {{{currency initialBalance currency=currency}}} from {{emitter.name}} to donate on Open Collective
+Subject: {{#ifCond currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶
+{{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷 {{/ifCond}}You received {{{currency initialBalance currency=currency}}}
+from {{emitter.name}} to donate on Open Collective
 
 {{> header}}
 
 
 <table>
   <tr>
-   <td>
-     <center>
-      <h1>{{#ifCond currency '===' 'USD'}}💵{{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶{{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷{{/ifCond}}</h1>
-      <p>The {{{currency initialBalance currency=currency}}} gift card offered by <a href="{{config.host.website}}/{{emitter.slug}}">{{emitter.name}}</a> has been added to your Open Collective account. 🎉</p>
-      <p>&nbsp;</p>
-     </center>
-   </td>
-   <td></td>
-   <td valign="top">
-     {{> collectivecard emitter}}
-   </td>
+    <td>
+      <center>
+        <h1>
+          {{#ifCond currency '===' 'USD'}}💵{{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶{{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷{{/ifCond}}
+        </h1>
+        <p>The {{{currency initialBalance currency=currency}}} gift card offered by <a
+            href="{{config.host.website}}/{{emitter.slug}}">{{emitter.name}}</a> has been added to your Open Collective
+          account. 🎉</p>
+        <p>&nbsp;</p>
+      </center>
+    </td>
+    <td></td>
+    <td valign="top">
+      {{> collectivecard emitter}}
+    </td>
   </tr>
 </table>
 
-<p>Click on the button below to log in, choose the project(s) that you want to support and select <b>{{name}}</b> from the list of available payment methods.</p>
+<p>Click on the button below to log in, choose the project(s) that you want to support and select <b>{{name}}</b> from
+  the list of available payment methods.</p>
 
 <center>
-  <a href="{{loginLink}}" class="btn blue"><div>One-click login</div></a>
+  <a href="{{loginLink}}" class="btn blue">
+    <div>One-click login</div>
+  </a>
 </center>
 
-<p>You can donate the full amount to one project or divide it between several projects. You can also start subscriptions. We will let you know when the gift card runs out. <strong>Hurry up, as this card expires on {{{moment expiryDate}}}</strong>.</p>
+<p>You can donate the full amount to one project or divide it between several projects. You can also start
+  recurring contributions. We will let you know when the gift card runs out. <strong>Hurry up, as this card expires on
+    {{{moment expiryDate}}}</strong>.</p>
 
 
 {{> footer}}

--- a/templates/emails/user.card.claimed.hbs
+++ b/templates/emails/user.card.claimed.hbs
@@ -1,42 +1,31 @@
-Subject: {{#ifCond currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶
-{{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷 {{/ifCond}}You received {{{currency initialBalance currency=currency}}}
-from {{emitter.name}} to donate on Open Collective
+Subject: {{#ifCond currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶 {{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷 {{/ifCond}}You received {{{currency initialBalance currency=currency}}} from {{emitter.name}} to donate on Open Collective
 
 {{> header}}
 
 
 <table>
   <tr>
-    <td>
-      <center>
-        <h1>
-          {{#ifCond currency '===' 'USD'}}💵{{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶{{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷{{/ifCond}}
-        </h1>
-        <p>The {{{currency initialBalance currency=currency}}} gift card offered by <a
-            href="{{config.host.website}}/{{emitter.slug}}">{{emitter.name}}</a> has been added to your Open Collective
-          account. 🎉</p>
-        <p>&nbsp;</p>
-      </center>
-    </td>
-    <td></td>
-    <td valign="top">
-      {{> collectivecard emitter}}
-    </td>
+   <td>
+     <center>
+      <h1>{{#ifCond currency '===' 'USD'}}💵{{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶{{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷{{/ifCond}}</h1>
+      <p>The {{{currency initialBalance currency=currency}}} gift card offered by <a href="{{config.host.website}}/{{emitter.slug}}">{{emitter.name}}</a> has been added to your Open Collective account. 🎉</p>
+      <p>&nbsp;</p>
+     </center>
+   </td>
+   <td></td>
+   <td valign="top">
+     {{> collectivecard emitter}}
+   </td>
   </tr>
 </table>
 
-<p>Click on the button below to log in, choose the project(s) that you want to support and select <b>{{name}}</b> from
-  the list of available payment methods.</p>
+<p>Click on the button below to log in, choose the project(s) that you want to support and select <b>{{name}}</b> from the list of available payment methods.</p>
 
 <center>
-  <a href="{{loginLink}}" class="btn blue">
-    <div>One-click login</div>
-  </a>
+  <a href="{{loginLink}}" class="btn blue"><div>One-click login</div></a>
 </center>
 
-<p>You can donate the full amount to one project or divide it between several projects. You can also start
-  recurring contributions. We will let you know when the gift card runs out. <strong>Hurry up, as this card expires on
-    {{{moment expiryDate}}}</strong>.</p>
+<p>You can donate the full amount to one project or divide it between several projects. You can also start recurring contributions. We will let you know when the gift card runs out. <strong>Hurry up, as this card expires on {{{moment expiryDate}}}</strong>.</p>
 
 
 {{> footer}}

--- a/templates/emails/user.monthlyreport.hbs
+++ b/templates/emails/user.monthlyreport.hbs
@@ -1,16 +1,7 @@
 Subject: {{{capitalize month}}} Report
 
 <style>
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p {
-    margin: 0;
-  }
-
+  h1, h2, h3, h4, h5, h6, p { margin: 0; }
   p {
     font-family: Helvetica;
     font-size: 14px;
@@ -18,14 +9,12 @@ Subject: {{{capitalize month}}} Report
     color: #494b4d;
     margin: 10px 0px;
   }
-
   h1 {
     font-family: Helvetica;
     font-size: 24px;
     font-weight: 600;
     color: #494b4d;
   }
-
   h2 {
     font-family: Helvetica;
     font-size: 20px;
@@ -33,7 +22,6 @@ Subject: {{{capitalize month}}} Report
     line-height: 1.4;
     color: #494b4d;
   }
-
   a {
     color: #3a9fe8;
     text-decoration: none;
@@ -41,13 +29,11 @@ Subject: {{{capitalize month}}} Report
 </style>
 
 <style>
-  html,
-  body {
+  html, body {
     margin: 0;
     padding: 0;
     width: 100%;
   }
-
   .MonthlyReport {
     padding-bottom: 20px;
     padding-top: 64px;
@@ -55,18 +41,14 @@ Subject: {{{capitalize month}}} Report
     padding-right: 4px;
     width: 100%;
   }
-
   .Wrapper {
     max-width: 620px;
     margin: 0 auto;
   }
-
-  .Wrapper>p {
+  .Wrapper > p {
     margin-bottom: 60px;
   }
-
-  .Wrapper>p,
-  .Wrapper>a {
+  .Wrapper > p, .Wrapper > a  {
     font-family: Helvetica;
     font-size: 10px;
     line-height: 1.9;
@@ -87,12 +69,10 @@ Subject: {{{capitalize month}}} Report
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .ContainerLogo {
     display: block;
     margin: 0 auto;
-    margin-top: -44px;
-    /* (60-24) + 8border */
+    margin-top: -44px; /* (60-24) + 8border */
     width: 80px;
     height: 80px;
     background-color: #fff;
@@ -103,7 +83,6 @@ Subject: {{{capitalize month}}} Report
     background-size: 64px;
     background-position: center;
   }
-
   .ContainerLogoName {
     width: 220px;
     height: 32px;
@@ -113,8 +92,7 @@ Subject: {{{capitalize month}}} Report
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;
-    margin-top: 16px;
-    /*opt*/
+    margin-top: 16px; /*opt*/
   }
 </style>
 
@@ -122,27 +100,22 @@ Subject: {{{capitalize month}}} Report
   .Section {
     padding: 0 8px;
   }
-
   .Section.Intro {
     padding-bottom: 68px;
   }
-
   .Section.Intro h2 {
     margin-bottom: 12px;
   }
-
   .Section.Subscriptions {
     border-top: 1px solid #d5d7d9;
     padding-bottom: 48px;
   }
-
-  .Section.Subscriptions>h1 {
+  .Section.Subscriptions > h1 {
     margin: -14px 0 0 -8px;
     background-color: white;
     display: inline-block;
     padding: 0 10px 0 8px;
   }
-
   .Section.Subscriptions .Date {
     text-transform: uppercase;
     margin: 8px 0px 44px 0px;
@@ -154,7 +127,6 @@ Subject: {{{capitalize month}}} Report
     letter-spacing: 3px;
     color: #aaaeb3;
   }
-
   .Section.Interest {
     border-top: 1px solid #d5d7d9;
     background-color: #fafcfd;
@@ -163,7 +135,6 @@ Subject: {{{capitalize month}}} Report
     padding-right: 8px;
     width: 100%;
   }
-
   .Section.Interest .Cards {
     padding-top: 32px;
     padding-bottom: 32px;
@@ -171,11 +142,9 @@ Subject: {{{capitalize month}}} Report
     overflow: hidden;
     text-align: center;
   }
-
   .Section.Interest .CollectiveCard {
     margin: 10px;
   }
-
   .Section.Interest h3 {
     font-family: Montserrat, Helvetica;
     font-size: 16px;
@@ -183,7 +152,6 @@ Subject: {{{capitalize month}}} Report
     text-align: center;
     color: #494b4d;
   }
-
   .Section.Notice {
     background-color: #fafcfd;
     padding-top: 24px;
@@ -191,7 +159,6 @@ Subject: {{{capitalize month}}} Report
     padding-left: 8px;
     padding-right: 8px;
   }
-
   .Section.Notice p {
     font-family: Helvetica;
     font-size: 13px;
@@ -199,15 +166,12 @@ Subject: {{{capitalize month}}} Report
     text-align: center;
     color: #6d7073;
   }
-
-  .Section.Notice>p {
+  .Section.Notice > p {
     margin-bottom: 8px;
   }
-
-  .Section.Notice>p:last-child {
+  .Section.Notice > p:last-child {
     margin-bottom: 0;
   }
-
   ul.intro li {
     font-size: 14px;
     line-height: 2;
@@ -221,32 +185,26 @@ Subject: {{{capitalize month}}} Report
     .Wrapper {
       max-width: 600px !important;
     }
-
     .Section.Intro {
       padding: 0 8px !important;
       padding-bottom: 48px !important;
     }
-
     .Section.Intro p {
       font-size: 12px !important;
       line-height: 2 !important;
     }
-
     .Section.Intro h1 {
       font-size: 20px !important;
       line-height: 1 !important;
     }
-
     .Section.Intro .Date {
       font-size: 12px !important;
       margin-bottom: 32px !important;
     }
-
     .Section.Subscriptions {
       padding: 0 8px !important;
       padding-bottom: 48px !important;
     }
-
     .Section.Notice {
       padding-bottom: 60px !important;
     }
@@ -256,55 +214,36 @@ Subject: {{{capitalize month}}} Report
 
 <div class="MonthlyReport">
   <div class="Wrapper">
-    <!-- <p>If you are having problems viewing this email, please <a href='{{fallbackUrl}}">click here</a>.</p> -->
+   <!-- <p>If you are having problems viewing this email, please <a href='{{fallbackUrl}}">click here</a>.</p> -->
     <div class="Container">
       <a class="ContainerLogo" href="//opencollective.com"></a>
       <div class="ContainerLogoName"></div>
       <div class="Section Intro">
         <h2>Hi {{fromCollective.name}} 👋</h2>
         <ul class="intro">
-          <li>In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a
-            total of {{stats.totalDonatedString}}. Thank you for your
-            {{{pluralize "contribution" n=stats.collectives}}}! 🙌
-            {{#if stats.expenses}}<br />They've spent a total of
-            {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}</li>
+          <li>In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a total of {{stats.totalDonatedString}}. Thank you for your {{{pluralize "contribution" n=stats.collectives}}}! 🙌
+          {{#if stats.expenses}}<br />They've spent a total of {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}</li>
           {{#each collectives}}
-          {{#if nextGoal}}
-          <li><a href="{{../config.host.website}}/{{slug}}">{{name}}</a> needs
-            {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per
-            {{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}}
-            there).
-            {{#if order.Subscription}}
-            You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}}
-            per {{order.Subscription.interval}}.
-            (<a href="{{../config.host.website}}/{{../fromCollective.slug}}/recurring-contributions">increase your
-              contribution</a>)
-            (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their
-              goal</a>)
-            {{else}}
-            You have contributed {{{order.totalAmount}}}.
-            (<a href="{{../config.host.website}}/{{slug}}/donate">increase your contribution</a>)
-            (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their
-              goal</a>)
+            {{#if nextGoal}}
+              <li><a href="{{../config.host.website}}/{{slug}}">{{name}}</a> needs {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per {{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}} there). 
+              {{#if order.Subscription}}
+              You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}} per {{order.Subscription.interval}}.
+              (<a href="{{../config.host.website}}/{{../fromCollective.slug}}/recurring-contributions">increase your contribution</a>)
+              (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their goal</a>)
+              {{else}}
+              You have contributed {{{order.totalAmount}}}.
+              (<a href="{{../config.host.website}}/{{slug}}/donate">increase your contribution</a>)
+              (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their goal</a>)
+              {{/if}}
+              </li>
             {{/if}}
-          </li>
-          {{/if}}
           {{/each}}
           {{#if tags.opensource}}
-          {{#if ORGANIZATION}}
-          <li>
-            <font color="red"><b>NEW!</b></font> Check your profile on <a
-              href="https://backyourstack.com/{{fromCollective.slug}}">backyourstack.com/{{fromCollective.slug}}</a> to
-            find out what are the open source projects that your organization is depending on and that need financial
-            support! (note: you may need to adapt the url to match your organization slug on Github)
-          </li>
-          {{else}}
-          <li>
-            <font color="red"><b>NEW!</b></font> We built <a href="https://backyourstack.com/">backyourstack.com</a> to
-            help you discover the open source projects that your organization is depending on and that need financial
-            support!
-          </li>
-          {{/if}}
+            {{#if ORGANIZATION}}
+              <li><font color="red"><b>NEW!</b></font> Check your profile on <a href="https://backyourstack.com/{{fromCollective.slug}}">backyourstack.com/{{fromCollective.slug}}</a> to find out what are the open source projects that your organization is depending on and that need financial support! (note: you may need to adapt the url to match your organization slug on Github)</li>
+            {{else}}
+              <li><font color="red"><b>NEW!</b></font> We built <a href="https://backyourstack.com/">backyourstack.com</a> to help you discover the open source projects that your organization is depending on and that need financial support!</li>
+            {{/if}}
           {{/if}}
         </ul>
       </div>
@@ -313,43 +252,33 @@ Subject: {{{capitalize month}}} Report
         <span class="Date">{{month}} {{year}}</span>
         <table>
           {{#each collectives}}
-          <tr>
-            <td>{{> mr-subscription}}</td>
-          </tr>
-          <tr>
-            <td height="20"></td>
-          </tr>
+          <tr><td>{{> mr-subscription}}</td></tr>
+          <tr><td height="20"></td></tr>
           {{/each}}
         </table>
       </div>
       {{#if relatedCollectives.length}}
-      <table class="Section Interest">
-        <tr>
-          <td>
-            <h3>Collectives that might interest you:</h3>
-            <div class="Cards CardsCount-{{relatedCollectives.length}}">
-              {{#each relatedCollectives}}
-              {{> collectivecard}}
-              {{/each}}
-            </div>
-          </td>
-        </tr>
-      </table>
+      <table class="Section Interest"><tr><td>
+        <h3>Collectives that might interest you:</h3>
+        <div class="Cards CardsCount-{{relatedCollectives.length}}">
+          {{#each relatedCollectives}}
+            {{> collectivecard}}
+          {{/each}}
+        </div>
+      </td></tr></table>
       {{/if}}
       <div class="Section Notice">
-        <p>We hope that you find this report useful. Do not hesitate to send us your feedback or ideas. Just reply to
-          this email!</p>
+        <p>We hope that you find this report useful. Do not hesitate to send us your feedback or ideas. Just reply to this email!</p>
 
         <p>To manage your recurring contributions, <a href="{{manageSubscriptionsUrl}}?{{utm}}">click here</a>.</p>
 
         <p>
-          {{#if notificationTypeLabel}}
-          To unsubscribe from {{notificationTypeLabel}}, <a href="{{unsubscribeUrl}}">click here</a>.<br /><br />
-          {{/if}}
+        {{#if notificationTypeLabel}}
+        To unsubscribe from {{notificationTypeLabel}}, <a href="{{unsubscribeUrl}}">click here</a>.<br /><br />
+        {{/if}}
         </p>
 
-        <p>You can also follow us on <a href="https://twitter.com/opencollect">Twitter</a> or come chat with us on our
-          public <a href="https://opencollective.slack.com">Slack Channel</a>.</p>
+        <p>You can also follow us on <a href="https://twitter.com/opencollect">Twitter</a> or come chat with us on our public <a href="https://opencollective.slack.com">Slack Channel</a>.</p>
       </div>
       {{> mr-footer}}
     </div>

--- a/templates/emails/user.monthlyreport.hbs
+++ b/templates/emails/user.monthlyreport.hbs
@@ -1,7 +1,16 @@
 Subject: {{{capitalize month}}} Report
 
 <style>
-  h1, h2, h3, h4, h5, h6, p { margin: 0; }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p {
+    margin: 0;
+  }
+
   p {
     font-family: Helvetica;
     font-size: 14px;
@@ -9,12 +18,14 @@ Subject: {{{capitalize month}}} Report
     color: #494b4d;
     margin: 10px 0px;
   }
+
   h1 {
     font-family: Helvetica;
     font-size: 24px;
     font-weight: 600;
     color: #494b4d;
   }
+
   h2 {
     font-family: Helvetica;
     font-size: 20px;
@@ -22,6 +33,7 @@ Subject: {{{capitalize month}}} Report
     line-height: 1.4;
     color: #494b4d;
   }
+
   a {
     color: #3a9fe8;
     text-decoration: none;
@@ -29,11 +41,13 @@ Subject: {{{capitalize month}}} Report
 </style>
 
 <style>
-  html, body {
+  html,
+  body {
     margin: 0;
     padding: 0;
     width: 100%;
   }
+
   .MonthlyReport {
     padding-bottom: 20px;
     padding-top: 64px;
@@ -41,14 +55,18 @@ Subject: {{{capitalize month}}} Report
     padding-right: 4px;
     width: 100%;
   }
+
   .Wrapper {
     max-width: 620px;
     margin: 0 auto;
   }
-  .Wrapper > p {
+
+  .Wrapper>p {
     margin-bottom: 60px;
   }
-  .Wrapper > p, .Wrapper > a  {
+
+  .Wrapper>p,
+  .Wrapper>a {
     font-family: Helvetica;
     font-size: 10px;
     line-height: 1.9;
@@ -69,10 +87,12 @@ Subject: {{{capitalize month}}} Report
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
+
   .ContainerLogo {
     display: block;
     margin: 0 auto;
-    margin-top: -44px; /* (60-24) + 8border */
+    margin-top: -44px;
+    /* (60-24) + 8border */
     width: 80px;
     height: 80px;
     background-color: #fff;
@@ -83,6 +103,7 @@ Subject: {{{capitalize month}}} Report
     background-size: 64px;
     background-position: center;
   }
+
   .ContainerLogoName {
     width: 220px;
     height: 32px;
@@ -92,7 +113,8 @@ Subject: {{{capitalize month}}} Report
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;
-    margin-top: 16px; /*opt*/
+    margin-top: 16px;
+    /*opt*/
   }
 </style>
 
@@ -100,22 +122,27 @@ Subject: {{{capitalize month}}} Report
   .Section {
     padding: 0 8px;
   }
+
   .Section.Intro {
     padding-bottom: 68px;
   }
+
   .Section.Intro h2 {
     margin-bottom: 12px;
   }
+
   .Section.Subscriptions {
     border-top: 1px solid #d5d7d9;
     padding-bottom: 48px;
   }
-  .Section.Subscriptions > h1 {
+
+  .Section.Subscriptions>h1 {
     margin: -14px 0 0 -8px;
     background-color: white;
     display: inline-block;
     padding: 0 10px 0 8px;
   }
+
   .Section.Subscriptions .Date {
     text-transform: uppercase;
     margin: 8px 0px 44px 0px;
@@ -127,6 +154,7 @@ Subject: {{{capitalize month}}} Report
     letter-spacing: 3px;
     color: #aaaeb3;
   }
+
   .Section.Interest {
     border-top: 1px solid #d5d7d9;
     background-color: #fafcfd;
@@ -135,6 +163,7 @@ Subject: {{{capitalize month}}} Report
     padding-right: 8px;
     width: 100%;
   }
+
   .Section.Interest .Cards {
     padding-top: 32px;
     padding-bottom: 32px;
@@ -142,9 +171,11 @@ Subject: {{{capitalize month}}} Report
     overflow: hidden;
     text-align: center;
   }
+
   .Section.Interest .CollectiveCard {
     margin: 10px;
   }
+
   .Section.Interest h3 {
     font-family: Montserrat, Helvetica;
     font-size: 16px;
@@ -152,6 +183,7 @@ Subject: {{{capitalize month}}} Report
     text-align: center;
     color: #494b4d;
   }
+
   .Section.Notice {
     background-color: #fafcfd;
     padding-top: 24px;
@@ -159,6 +191,7 @@ Subject: {{{capitalize month}}} Report
     padding-left: 8px;
     padding-right: 8px;
   }
+
   .Section.Notice p {
     font-family: Helvetica;
     font-size: 13px;
@@ -166,12 +199,15 @@ Subject: {{{capitalize month}}} Report
     text-align: center;
     color: #6d7073;
   }
-  .Section.Notice > p {
+
+  .Section.Notice>p {
     margin-bottom: 8px;
   }
-  .Section.Notice > p:last-child {
+
+  .Section.Notice>p:last-child {
     margin-bottom: 0;
   }
+
   ul.intro li {
     font-size: 14px;
     line-height: 2;
@@ -185,26 +221,32 @@ Subject: {{{capitalize month}}} Report
     .Wrapper {
       max-width: 600px !important;
     }
+
     .Section.Intro {
       padding: 0 8px !important;
       padding-bottom: 48px !important;
     }
+
     .Section.Intro p {
       font-size: 12px !important;
       line-height: 2 !important;
     }
+
     .Section.Intro h1 {
       font-size: 20px !important;
       line-height: 1 !important;
     }
+
     .Section.Intro .Date {
       font-size: 12px !important;
       margin-bottom: 32px !important;
     }
+
     .Section.Subscriptions {
       padding: 0 8px !important;
       padding-bottom: 48px !important;
     }
+
     .Section.Notice {
       padding-bottom: 60px !important;
     }
@@ -214,36 +256,55 @@ Subject: {{{capitalize month}}} Report
 
 <div class="MonthlyReport">
   <div class="Wrapper">
-   <!-- <p>If you are having problems viewing this email, please <a href='{{fallbackUrl}}">click here</a>.</p> -->
+    <!-- <p>If you are having problems viewing this email, please <a href='{{fallbackUrl}}">click here</a>.</p> -->
     <div class="Container">
       <a class="ContainerLogo" href="//opencollective.com"></a>
       <div class="ContainerLogoName"></div>
       <div class="Section Intro">
         <h2>Hi {{fromCollective.name}} 👋</h2>
         <ul class="intro">
-          <li>In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a total of {{stats.totalDonatedString}}. Thank you for your {{{pluralize "contribution" n=stats.collectives}}}! 🙌
-          {{#if stats.expenses}}<br />They've spent a total of {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}</li>
+          <li>In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a
+            total of {{stats.totalDonatedString}}. Thank you for your
+            {{{pluralize "contribution" n=stats.collectives}}}! 🙌
+            {{#if stats.expenses}}<br />They've spent a total of
+            {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}</li>
           {{#each collectives}}
-            {{#if nextGoal}}
-              <li><a href="{{../config.host.website}}/{{slug}}">{{name}}</a> needs {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per {{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}} there). 
-              {{#if order.Subscription}}
-              You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}} per {{order.Subscription.interval}}.
-              (<a href="{{../config.host.website}}/{{../fromCollective.slug}}/subscriptions">increase your contribution</a>)
-              (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their goal</a>)
-              {{else}}
-              You have contributed {{{order.totalAmount}}}.
-              (<a href="{{../config.host.website}}/{{slug}}/donate">increase your contribution</a>)
-              (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their goal</a>)
-              {{/if}}
-              </li>
+          {{#if nextGoal}}
+          <li><a href="{{../config.host.website}}/{{slug}}">{{name}}</a> needs
+            {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per
+            {{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}}
+            there).
+            {{#if order.Subscription}}
+            You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}}
+            per {{order.Subscription.interval}}.
+            (<a href="{{../config.host.website}}/{{../fromCollective.slug}}/recurring-contributions">increase your
+              contribution</a>)
+            (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their
+              goal</a>)
+            {{else}}
+            You have contributed {{{order.totalAmount}}}.
+            (<a href="{{../config.host.website}}/{{slug}}/donate">increase your contribution</a>)
+            (<a href="https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}}">share their
+              goal</a>)
             {{/if}}
+          </li>
+          {{/if}}
           {{/each}}
           {{#if tags.opensource}}
-            {{#if ORGANIZATION}}
-              <li><font color="red"><b>NEW!</b></font> Check your profile on <a href="https://backyourstack.com/{{fromCollective.slug}}">backyourstack.com/{{fromCollective.slug}}</a> to find out what are the open source projects that your organization is depending on and that need financial support! (note: you may need to adapt the url to match your organization slug on Github)</li>
-            {{else}}
-              <li><font color="red"><b>NEW!</b></font> We built <a href="https://backyourstack.com/">backyourstack.com</a> to help you discover the open source projects that your organization is depending on and that need financial support!</li>
-            {{/if}}
+          {{#if ORGANIZATION}}
+          <li>
+            <font color="red"><b>NEW!</b></font> Check your profile on <a
+              href="https://backyourstack.com/{{fromCollective.slug}}">backyourstack.com/{{fromCollective.slug}}</a> to
+            find out what are the open source projects that your organization is depending on and that need financial
+            support! (note: you may need to adapt the url to match your organization slug on Github)
+          </li>
+          {{else}}
+          <li>
+            <font color="red"><b>NEW!</b></font> We built <a href="https://backyourstack.com/">backyourstack.com</a> to
+            help you discover the open source projects that your organization is depending on and that need financial
+            support!
+          </li>
+          {{/if}}
           {{/if}}
         </ul>
       </div>
@@ -252,33 +313,43 @@ Subject: {{{capitalize month}}} Report
         <span class="Date">{{month}} {{year}}</span>
         <table>
           {{#each collectives}}
-          <tr><td>{{> mr-subscription}}</td></tr>
-          <tr><td height="20"></td></tr>
+          <tr>
+            <td>{{> mr-subscription}}</td>
+          </tr>
+          <tr>
+            <td height="20"></td>
+          </tr>
           {{/each}}
         </table>
       </div>
       {{#if relatedCollectives.length}}
-      <table class="Section Interest"><tr><td>
-        <h3>Collectives that might interest you:</h3>
-        <div class="Cards CardsCount-{{relatedCollectives.length}}">
-          {{#each relatedCollectives}}
-            {{> collectivecard}}
-          {{/each}}
-        </div>
-      </td></tr></table>
+      <table class="Section Interest">
+        <tr>
+          <td>
+            <h3>Collectives that might interest you:</h3>
+            <div class="Cards CardsCount-{{relatedCollectives.length}}">
+              {{#each relatedCollectives}}
+              {{> collectivecard}}
+              {{/each}}
+            </div>
+          </td>
+        </tr>
+      </table>
       {{/if}}
       <div class="Section Notice">
-        <p>We hope that you find this report useful. Do not hesitate to send us your feedback or ideas. Just reply to this email!</p>
+        <p>We hope that you find this report useful. Do not hesitate to send us your feedback or ideas. Just reply to
+          this email!</p>
 
-        <p>To manage your subscriptions, <a href="{{manageSubscriptionsUrl}}?{{utm}}">click here</a>.</p>
+        <p>To manage your recurring contributions, <a href="{{manageSubscriptionsUrl}}?{{utm}}">click here</a>.</p>
 
         <p>
-        {{#if notificationTypeLabel}}
-        To unsubscribe from {{notificationTypeLabel}}, <a href="{{unsubscribeUrl}}">click here</a>.<br /><br />
-        {{/if}}
+          {{#if notificationTypeLabel}}
+          To unsubscribe from {{notificationTypeLabel}}, <a href="{{unsubscribeUrl}}">click here</a>.<br /><br />
+          {{/if}}
         </p>
 
-        <p>You can also follow us on <a href="https://twitter.com/opencollect">Twitter</a> or come chat with us on our public <a href="https://opencollective.slack.com">Slack Channel</a>.</p>
+        <p>You can also follow us on <a href="https://twitter.com/opencollect">Twitter</a> or come chat with us on our
+          public <a href="https://opencollective.slack.com">Slack Channel</a>.</p>
       </div>
       {{> mr-footer}}
     </div>

--- a/templates/emails/user.monthlyreport.text.hbs
+++ b/templates/emails/user.monthlyreport.text.hbs
@@ -1,14 +1,17 @@
 Hi {{fromCollective.name}} 👋
 
-In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a total of {{stats.totalDonatedString}}. Thank you for your {{{pluralize "contribution" n=stats.collectives}}}! 🙌
+In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a total of
+{{stats.totalDonatedString}}. Thank you for your {{{pluralize "contribution" n=stats.collectives}}}! 🙌
 {{#if stats.expenses}}They've spent a total of {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}
 {{#each collectives}}
 {{#if nextGoal}}
 
-{{name}} needs {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per {{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}} there). 
+{{name}} needs {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per
+{{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}} there).
 {{#if order.Subscription}}
-You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}} per {{order.Subscription.interval}}.
-[increase your contribution]({{../config.host.website}}/{{../fromCollective.slug}}/subscriptions)
+You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}} per
+{{order.Subscription.interval}}.
+[increase your contribution]({{../config.host.website}}/{{../fromCollective.slug}}/recurring-contributions)
 [share their goal](https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}})
 {{else}}
 You have contributed {{{order.totalAmount}}}.
@@ -25,12 +28,17 @@ You have contributed {{{order.totalAmount}}}.
 {{name}}:
 {{publicUrl}}
 Backers: {{stats.backers.lastMonth}} (+{{stats.backers.new}}{{#if stats.backers.lost}}, -{{stats.backers.lost}}{{/if}})
-Current balance: {{{currency stats.balance currency=currency}}} (+{{{currency stats.totalDonations currency=currency}}}{{#if stats.totalPaidExpenses}}, -{{{currency stats.totalPaidExpenses currency=currency}}}{{/if}}) 
+Current balance: {{{currency stats.balance currency=currency}}}
+(+{{{currency stats.totalDonations currency=currency}}}{{#if stats.totalPaidExpenses}},
+-{{{currency stats.totalPaidExpenses currency=currency}}}{{/if}})
 {{#if nextGoal}}
-Next goal: {{{currency nextGoal.amount currency=currency}}}{{#if nextGoal.interval}}/{{nextGoal.interval}}{{/if}} to {{nextGoal.title}} ({{nextGoal.percentage}} - missing {{{currency nextGoal.missing.amount currency=currency}}}{{#if nextGoal.missing.interval}}/{{nextGoal.missing.interval}}{{/if}})
+Next goal: {{{currency nextGoal.amount currency=currency}}}{{#if nextGoal.interval}}/{{nextGoal.interval}}{{/if}} to
+{{nextGoal.title}} ({{nextGoal.percentage}} - missing
+{{{currency nextGoal.missing.amount currency=currency}}}{{#if nextGoal.missing.interval}}/{{nextGoal.missing.interval}}{{/if}})
 {{/if}}
 {{#if order.Subscription}}
-Your contribution: {{currency order.Subscription.amount currency=order.Subscription.currency}} per {{order.Subscription.interval}}
+Your contribution: {{currency order.Subscription.amount currency=order.Subscription.currency}} per
+{{order.Subscription.interval}}
 Member since: {{{moment order.subscription.createdAt format="MMMM YYYY"}}}
 {{else}}
 Your contribution: {{order.totalAmount}}
@@ -39,36 +47,36 @@ Your contribution: {{order.totalAmount}}
 
 Latest {{{pluralize "update" n=updates.length}}}:
 {{#each updates}}
-  - {{{moment publishedAt timezone=timezone format="MM/DD"}}} {{title}}
-  {{../config.host.website}}/{{../slug}}/updates/{{slug}}
+- {{{moment publishedAt timezone=timezone format="MM/DD"}}} {{title}}
+{{../config.host.website}}/{{../slug}}/updates/{{slug}}
 {{/each}}
 {{/if}}
 {{#if events.upcoming}}
 
 Upcoming {{{pluralize "event" n=events.upcoming.length}}}:
 {{#each events.upcoming}}
-  - {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
-    {{../config.host.website}}/{{../slug}}/events/{{slug}}
-    RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
+- {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
+{{../config.host.website}}/{{../slug}}/events/{{slug}}
+RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
 {{/each}}
 {{/if}}
 {{#if events.past}}
 
 Past {{{pluralize "event" n=events.past.length}}}:
 {{#each events.past}}
-  - {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
-    {{../config.host.website}}/{{../slug}}/events/{{slug}}
-    RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
+- {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
+{{../config.host.website}}/{{../slug}}/events/{{slug}}
+RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
 {{/each}}
 {{/if}}
 
 Latest {{{pluralize "expense" n=expenses.length}}}:
-  {{#each expenses}}
-  - {{{moment createdAt format="MM/DD"}}} {{{currency amount currency=../currency}}} {{description}} {{status}}
-  {{else}}
-  (no expense filed)
-  {{/each}}
-  View all expenses on {{../config.host.website}}/{{slug}}/expenses
+{{#each expenses}}
+- {{{moment createdAt format="MM/DD"}}} {{{currency amount currency=../currency}}} {{description}} {{status}}
+{{else}}
+(no expense filed)
+{{/each}}
+View all expenses on {{../config.host.website}}/{{slug}}/expenses
 
 {{/each}}
 
@@ -82,6 +90,6 @@ Latest {{{pluralize "expense" n=expenses.length}}}:
 {{/each}}
 
 
-To manage your subscriptions, follow this url: {{manageSubscriptionsUrl}}
+To manage your recurring contributions, follow this url: {{manageSubscriptionsUrl}}
 
 {{>footer.text}}

--- a/templates/emails/user.monthlyreport.text.hbs
+++ b/templates/emails/user.monthlyreport.text.hbs
@@ -1,16 +1,13 @@
 Hi {{fromCollective.name}} 👋
 
-In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a total of
-{{stats.totalDonatedString}}. Thank you for your {{{pluralize "contribution" n=stats.collectives}}}! 🙌
+In {{month}}, you have backed {{stats.collectives}} {{{pluralize "collective" n=stats.collectives}}} for a total of {{stats.totalDonatedString}}. Thank you for your {{{pluralize "contribution" n=stats.collectives}}}! 🙌
 {{#if stats.expenses}}They've spent a total of {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}
 {{#each collectives}}
 {{#if nextGoal}}
 
-{{name}} needs {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per
-{{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}} there).
+{{name}} needs {{{currency nextGoal.missing.amount currency=currency}}} more {{#if nextGoal.missing.interval}}per {{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}} there). 
 {{#if order.Subscription}}
-You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}} per
-{{order.Subscription.interval}}.
+You are currently contributing {{{currency order.Subscription.amount currency=order.Subscription.currency}}} per {{order.Subscription.interval}}.
 [increase your contribution]({{../config.host.website}}/{{../fromCollective.slug}}/recurring-contributions)
 [share their goal](https://twitter.com/intent/tweet?text={{{encodeURIComponent nextGoal.tweet}}})
 {{else}}
@@ -28,17 +25,12 @@ You have contributed {{{order.totalAmount}}}.
 {{name}}:
 {{publicUrl}}
 Backers: {{stats.backers.lastMonth}} (+{{stats.backers.new}}{{#if stats.backers.lost}}, -{{stats.backers.lost}}{{/if}})
-Current balance: {{{currency stats.balance currency=currency}}}
-(+{{{currency stats.totalDonations currency=currency}}}{{#if stats.totalPaidExpenses}},
--{{{currency stats.totalPaidExpenses currency=currency}}}{{/if}})
+Current balance: {{{currency stats.balance currency=currency}}} (+{{{currency stats.totalDonations currency=currency}}}{{#if stats.totalPaidExpenses}}, -{{{currency stats.totalPaidExpenses currency=currency}}}{{/if}}) 
 {{#if nextGoal}}
-Next goal: {{{currency nextGoal.amount currency=currency}}}{{#if nextGoal.interval}}/{{nextGoal.interval}}{{/if}} to
-{{nextGoal.title}} ({{nextGoal.percentage}} - missing
-{{{currency nextGoal.missing.amount currency=currency}}}{{#if nextGoal.missing.interval}}/{{nextGoal.missing.interval}}{{/if}})
+Next goal: {{{currency nextGoal.amount currency=currency}}}{{#if nextGoal.interval}}/{{nextGoal.interval}}{{/if}} to {{nextGoal.title}} ({{nextGoal.percentage}} - missing {{{currency nextGoal.missing.amount currency=currency}}}{{#if nextGoal.missing.interval}}/{{nextGoal.missing.interval}}{{/if}})
 {{/if}}
 {{#if order.Subscription}}
-Your contribution: {{currency order.Subscription.amount currency=order.Subscription.currency}} per
-{{order.Subscription.interval}}
+Your contribution: {{currency order.Subscription.amount currency=order.Subscription.currency}} per {{order.Subscription.interval}}
 Member since: {{{moment order.subscription.createdAt format="MMMM YYYY"}}}
 {{else}}
 Your contribution: {{order.totalAmount}}
@@ -47,36 +39,36 @@ Your contribution: {{order.totalAmount}}
 
 Latest {{{pluralize "update" n=updates.length}}}:
 {{#each updates}}
-- {{{moment publishedAt timezone=timezone format="MM/DD"}}} {{title}}
-{{../config.host.website}}/{{../slug}}/updates/{{slug}}
+  - {{{moment publishedAt timezone=timezone format="MM/DD"}}} {{title}}
+  {{../config.host.website}}/{{../slug}}/updates/{{slug}}
 {{/each}}
 {{/if}}
 {{#if events.upcoming}}
 
 Upcoming {{{pluralize "event" n=events.upcoming.length}}}:
 {{#each events.upcoming}}
-- {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
-{{../config.host.website}}/{{../slug}}/events/{{slug}}
-RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
+  - {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
+    {{../config.host.website}}/{{../slug}}/events/{{slug}}
+    RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
 {{/each}}
 {{/if}}
 {{#if events.past}}
 
 Past {{{pluralize "event" n=events.past.length}}}:
 {{#each events.past}}
-- {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
-{{../config.host.website}}/{{../slug}}/events/{{slug}}
-RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
+  - {{{moment startsAt timezone=timezone format="MMMM Do HH:mm"}}} {{name}} @ {{locationName}}
+    {{../config.host.website}}/{{../slug}}/events/{{slug}}
+    RSVPs: {{stats.confirmed}} {{#if stats.interested}}(+{{stats.interested}} interested){{/if}}
 {{/each}}
 {{/if}}
 
 Latest {{{pluralize "expense" n=expenses.length}}}:
-{{#each expenses}}
-- {{{moment createdAt format="MM/DD"}}} {{{currency amount currency=../currency}}} {{description}} {{status}}
-{{else}}
-(no expense filed)
-{{/each}}
-View all expenses on {{../config.host.website}}/{{slug}}/expenses
+  {{#each expenses}}
+  - {{{moment createdAt format="MM/DD"}}} {{{currency amount currency=../currency}}} {{description}} {{status}}
+  {{else}}
+  (no expense filed)
+  {{/each}}
+  View all expenses on {{../config.host.website}}/{{slug}}/expenses
 
 {{/each}}
 

--- a/templates/emails/user.yearlyreport.hbs
+++ b/templates/emails/user.yearlyreport.hbs
@@ -65,8 +65,7 @@ Subject: 🏅Your year on Open Collective
 <div class="stats">
   <div class="largeEmoji">🎁</div>
   <p>{{tweet.text}}<br />
-    <a href="https://opencollective.com/{{collective.slug}}?{{utm}}">https://opencollective.com/{{collective.slug}}</a>
-  </p>
+    <a href="https://opencollective.com/{{collective.slug}}?{{utm}}">https://opencollective.com/{{collective.slug}}</a></p>
   <a href="{{tweet.url}}">
     <div class="btn">Tweet this!</div>
   </a>
@@ -135,10 +134,8 @@ Subject: 🏅Your year on Open Collective
 
 <p>
   <b>📍Don't forget:</b><br />
-  - You can discover other great collectives to support on <a
-    href="https://opencollective.com/discover?{{utm}}">https://opencollective.com/discover</a><br />
-  - You can manage your recurring contributions on <a
-    href="https://opencollective.com/{{collective.slug}}/recurring-contributions?{{utm}}">https://opencollective.com/{{collective.slug}}/recurring-contributions</a><br />
+  - You can discover other great collectives to support on <a href="https://opencollective.com/discover?{{utm}}">https://opencollective.com/discover</a><br />
+  - You can manage your recurring contributions on <a href="https://opencollective.com/{{collective.slug}}/recurring-contributions?{{utm}}">https://opencollective.com/{{collective.slug}}/recurring-contributions</a><br />
   - We are an open collective ourselves and <a href="https://github.com/opencollective/opencollective">our code is
     available on Github</a> under MIT license. We welcome contributions of any kind! 😊
 </p>

--- a/templates/emails/user.yearlyreport.hbs
+++ b/templates/emails/user.yearlyreport.hbs
@@ -65,7 +65,8 @@ Subject: 🏅Your year on Open Collective
 <div class="stats">
   <div class="largeEmoji">🎁</div>
   <p>{{tweet.text}}<br />
-    <a href="https://opencollective.com/{{collective.slug}}?{{utm}}">https://opencollective.com/{{collective.slug}}</a></p>
+    <a href="https://opencollective.com/{{collective.slug}}?{{utm}}">https://opencollective.com/{{collective.slug}}</a>
+  </p>
   <a href="{{tweet.url}}">
     <div class="btn">Tweet this!</div>
   </a>
@@ -134,8 +135,10 @@ Subject: 🏅Your year on Open Collective
 
 <p>
   <b>📍Don't forget:</b><br />
-  - You can discover other great collectives to support on <a href="https://opencollective.com/discover?{{utm}}">https://opencollective.com/discover</a><br />
-  - You can manage your subscriptions on <a href="https://opencollective.com/{{collective.slug}}/subscriptions?{{utm}}">https://opencollective.com/{{collective.slug}}/subscriptions</a><br />
+  - You can discover other great collectives to support on <a
+    href="https://opencollective.com/discover?{{utm}}">https://opencollective.com/discover</a><br />
+  - You can manage your recurring contributions on <a
+    href="https://opencollective.com/{{collective.slug}}/recurring-contributions?{{utm}}">https://opencollective.com/{{collective.slug}}/recurring-contributions</a><br />
   - We are an open collective ourselves and <a href="https://github.com/opencollective/opencollective">our code is
     available on Github</a> under MIT license. We welcome contributions of any kind! 😊
 </p>

--- a/templates/emails/user.yearlyreport.text.hbs
+++ b/templates/emails/user.yearlyreport.text.hbs
@@ -2,36 +2,31 @@ Hi {{collective.name}}!
 
 {{year}} is already ending 🎉. That was fast!
 
-In these troubled times of social unrest and climate change, we believe more than ever in the strength of our communities.
-Whereas big institutions that surround us are increasingly unable to make our voice heard, our communities make our contributions matter.
+In these troubled times of social unrest and climate change, we believe more than ever in the strength of our
+communities.
+Whereas big institutions that surround us are increasingly unable to make our voice heard, our communities make our
+contributions matter.
 They give us an opportunity to connect and to learn from each other.
 They give us the opportunity to make meaningful contributions. They give us meaning.
 
-But we need to nurture them. They need us. They need us to contribute with our time and our skills, to attend their events, to promote them in our social networks and to support them financially.
-If we all do that, we will be surrounded by thriving communities that will give everyone of us the opportunity to do meaningful contributions in the world 🌍
+But we need to nurture them. They need us. They need us to contribute with our time and our skills, to attend their
+events, to promote them in our social networks and to support them financially.
+If we all do that, we will be surrounded by thriving communities that will give everyone of us the opportunity to do
+meaningful contributions in the world 🌍
 
-In {{year}} you have contributed a total of {{stats.totalDonationsString}} across {{stats.totalCollectives}} {{{pluralize "collective" n=stats.totalCollectives}}}:
+In {{year}} you have contributed a total of {{stats.totalDonationsString}} across {{stats.totalCollectives}}
+{{{pluralize "collective" n=stats.totalCollectives}}}:
 
 {{#each hosts}}
 {{name}}
-  {{#each collectives}}
-  {{{currency totalDonations currency=currency}}} to {{name}} https://opencollective.com/{{slug}}
-  {{/each}}
+{{#each collectives}}
+{{{currency totalDonations currency=currency}}} to {{name}} https://opencollective.com/{{slug}}
+{{/each}}
 
 {{/each}}
->>> Tweet these stats <<<
-{{{tweet.url}}}
-
-Thank you for the contributions that you made this year. Thank you for playing your part in building this future 🙏.
-
-
-Don't forget:
-- You can manage your subscriptions here: https://opencollective.com/{{collective.slug}}/subscriptions
-- You can discover other great collectives to support here: https://opencollective.com/discover
-- We are an open collective ourselves and our code is under MIT license. We welcome contributions of any kind! 😊 https://github.com/opencollective/opencollective
-
-
-- For the Open Collective Community
-@PiaMancini and @xdamman
-
-{{>footer.text}}
+>>> Tweet these stats <<< {{{tweet.url}}} Thank you for the contributions that you made this year. Thank you for playing
+  your part in building this future 🙏. Don't forget: - You can manage your recurring contributions here:
+  https://opencollective.com/{{collective.slug}}/recurring-contributions - You can discover other great collectives to
+  support here: https://opencollective.com/discover - We are an open collective ourselves and our code is under MIT
+  license. We welcome contributions of any kind! 😊 https://github.com/opencollective/opencollective - For the Open
+  Collective Community @PiaMancini and @xdamman {{>footer.text}}

--- a/templates/emails/user.yearlyreport.text.hbs
+++ b/templates/emails/user.yearlyreport.text.hbs
@@ -2,31 +2,36 @@ Hi {{collective.name}}!
 
 {{year}} is already ending 🎉. That was fast!
 
-In these troubled times of social unrest and climate change, we believe more than ever in the strength of our
-communities.
-Whereas big institutions that surround us are increasingly unable to make our voice heard, our communities make our
-contributions matter.
+In these troubled times of social unrest and climate change, we believe more than ever in the strength of our communities.
+Whereas big institutions that surround us are increasingly unable to make our voice heard, our communities make our contributions matter.
 They give us an opportunity to connect and to learn from each other.
 They give us the opportunity to make meaningful contributions. They give us meaning.
 
-But we need to nurture them. They need us. They need us to contribute with our time and our skills, to attend their
-events, to promote them in our social networks and to support them financially.
-If we all do that, we will be surrounded by thriving communities that will give everyone of us the opportunity to do
-meaningful contributions in the world 🌍
+But we need to nurture them. They need us. They need us to contribute with our time and our skills, to attend their events, to promote them in our social networks and to support them financially.
+If we all do that, we will be surrounded by thriving communities that will give everyone of us the opportunity to do meaningful contributions in the world 🌍
 
-In {{year}} you have contributed a total of {{stats.totalDonationsString}} across {{stats.totalCollectives}}
-{{{pluralize "collective" n=stats.totalCollectives}}}:
+In {{year}} you have contributed a total of {{stats.totalDonationsString}} across {{stats.totalCollectives}} {{{pluralize "collective" n=stats.totalCollectives}}}:
 
 {{#each hosts}}
 {{name}}
-{{#each collectives}}
-{{{currency totalDonations currency=currency}}} to {{name}} https://opencollective.com/{{slug}}
-{{/each}}
+  {{#each collectives}}
+  {{{currency totalDonations currency=currency}}} to {{name}} https://opencollective.com/{{slug}}
+  {{/each}}
 
 {{/each}}
->>> Tweet these stats <<< {{{tweet.url}}} Thank you for the contributions that you made this year. Thank you for playing
-  your part in building this future 🙏. Don't forget: - You can manage your recurring contributions here:
-  https://opencollective.com/{{collective.slug}}/recurring-contributions - You can discover other great collectives to
-  support here: https://opencollective.com/discover - We are an open collective ourselves and our code is under MIT
-  license. We welcome contributions of any kind! 😊 https://github.com/opencollective/opencollective - For the Open
-  Collective Community @PiaMancini and @xdamman {{>footer.text}}
+>>> Tweet these stats <<<
+{{{tweet.url}}}
+
+Thank you for the contributions that you made this year. Thank you for playing your part in building this future 🙏.
+
+
+Don't forget:
+- You can manage your recurring contributions here: https://opencollective.com/{{collective.slug}}/recurring-contributions
+- You can discover other great collectives to support here: https://opencollective.com/discover
+- We are an open collective ourselves and our code is under MIT license. We welcome contributions of any kind! 😊 https://github.com/opencollective/opencollective
+
+
+- For the Open Collective Community
+@PiaMancini and @xdamman
+
+{{>footer.text}}

--- a/test/server/lib/subscriptions.test.js
+++ b/test/server/lib/subscriptions.test.js
@@ -261,7 +261,7 @@ describe('server/lib/subscriptions', () => {
           order: order.info,
           collective: order.collective.info,
           fromCollective: order.fromCollective.minimal,
-          subscriptionsLink: `${config.host.website}/cslug/subscriptions`,
+          subscriptionsLink: `${config.host.website}/cslug/recurring-contributions`,
         });
 
       // When the status of the order is handled
@@ -290,7 +290,7 @@ describe('server/lib/subscriptions', () => {
           order: order.info,
           collective: order.collective.info,
           fromCollective: order.fromCollective.minimal,
-          subscriptionsLink: `${config.host.website}/cslug/subscriptions`,
+          subscriptionsLink: `${config.host.website}/cslug/recurring-contributions`,
         });
 
       // When the status of the order is handled


### PR DESCRIPTION
* Changes email template links from `opencollective.com/subscriptions` or `opencollective.com/{slug}/subscriptions` to `opencollective.com/recurring-contributions` or `opencollective.com/{slug}/recurring-contributions`
* Update mentions of 'manage your subscriptions' etc to 'manage your contributions'
* Does not change the names of libraries, functions, etc named `subscriptions`, seems unnecessary