### PR TITLE
GQLV1/Expense: Use a loader to fetch user

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -927,8 +927,8 @@ export const ExpenseType = new GraphQLObjectType({
       },
       user: {
         type: UserType,
-        resolve(expense) {
-          return expense.getUser();
+        async resolve(expense, _, req) {
+          return req.loaders.User.byId.load(expense.UserId);
         },
       },
       fromCollective: {


### PR DESCRIPTION
We're going to fetch this field more often with https://github.com/opencollective/opencollective-frontend/pull/4489. This will make sure we do it in a performant way.