### PR TITLE
fix "Fees On Top" activity when no platformFee set

### DIFF
--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -186,7 +186,10 @@ export default function (Sequelize, DataTypes) {
         activity() {
           return {
             id: this.id,
-            totalAmount: this.data?.isFeesOnTop ? this.totalAmount - this.data.platformFee : this.totalAmount,
+            totalAmount:
+              this.data?.isFeesOnTop && this.data?.platformFee
+                ? this.totalAmount - this.data.platformFee
+                : this.totalAmount,
             currency: this.currency,
             description: this.description,
             publicMessage: this.publicMessage,


### PR DESCRIPTION
When platformFee is 0 we don't store in Order, so `totalAmount` - `undefined` would end up being `NaN`.