### PR TITLE
Remove supertest-as-promised

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17889,16 +17889,6 @@
         }
       }
     },
-    "supertest-as-promised": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/supertest-as-promised/-/supertest-as-promised-4.0.2.tgz",
-      "integrity": "sha1-BGTyvSVlaNSlm86EJpwFSPaHnxo=",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.3.1",
-        "methods": "^1.1.1"
-      }
-    },
     "supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "prettier": "2.0.5",
     "sinon": "^9.0.2",
     "supertest": "^4.0.2",
-    "supertest-as-promised": "^4.0.2",
     "typescript": "^3.9.6"
   },
   "scripts": {

--- a/test/server/routes/notFound.test.js
+++ b/test/server/routes/notFound.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import request from 'supertest-as-promised';
+import request from 'supertest';
 
 import app from '../../../server/index';
 import * as utils from '../../utils';
@@ -18,10 +18,6 @@ describe('server/routes/notFound', () => {
       req = request(expressApp).get(`/blablabla?api_key=${application.api_key}`);
     });
 
-    it('THEN returns 404', () =>
-      req
-        .expect(404)
-        .toPromise()
-        .tap(res => expect(res.error.text).to.equal('Not Found')));
+    it('THEN returns 404', () => req.expect(404).then(res => expect(res.error.text).to.equal('Not Found')));
   });
 });

--- a/test/server/routes/users.test.js
+++ b/test/server/routes/users.test.js
@@ -3,7 +3,7 @@ import config from 'config';
 import moment from 'moment';
 import nodemailer from 'nodemailer';
 import sinon from 'sinon';
-import request from 'supertest-as-promised';
+import request from 'supertest';
 
 import app from '../../../server/index';
 import * as auth from '../../../server/lib/auth.js';


### PR DESCRIPTION
The npm package [supertest-as-promised](https://www.npmjs.com/package/supertest-as-promised) has put a deprecation notice on their package. The original `supertest` now handles promises in the same way. We were only using it in two tests.