### PR TITLE
Skip member notification for feesOnTop

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -317,7 +317,7 @@ export const executeOrder = async (user, order, options) => {
         { id: user.id, CollectiveId: order.FromCollectiveId },
         roles.BACKER,
         {},
-        { order },
+        { skipActivity: true },
       );
     }
 


### PR DESCRIPTION
Skipping the activity creation for the backer membership we create when a user donate through feesOnTop.