### PR TITLE
Account for fees on top in our platform reports.

### DIFF
--- a/reports/platform-report.js
+++ b/reports/platform-report.js
@@ -191,16 +191,14 @@ async function PlatformReport(year, month) {
       { startDate, endDate },
     );
 
-    hosts = await Promise.all(
-      hosts.map(async host => {
-        const isUSD = host.currency === 'USD';
-        return {
-          ...host,
-          isUSD,
-          totalFeesDue: isUSD ? (host.feesOnTopDue || 0) + host.platformFeesDue : null,
-        };
-      }),
-    );
+    hosts = hosts.map(host => {
+      const isUSD = host.currency === 'USD';
+      return {
+        ...host,
+        isUSD,
+        totalFeesDue: isUSD ? (host.feesOnTopDue || 0) + host.platformFeesDue : null,
+      };
+    });
 
     const activeHosts = await getNumberOfActiveHosts(startDate, endDate);
     const previousActiveHosts = await getNumberOfActiveHosts(previousStartDate, startDate);

--- a/templates/emails/report.platform.hbs
+++ b/templates/emails/report.platform.hbs
@@ -133,9 +133,36 @@ Subject: {{month}} {{year}} Platform Report
         <td align="right">{{{currency platformFeesPaypal currency=currency}}}</td>
       </tr>
       <tr>
-        <th colspan=2>Fees still due:</th>
+        <th colspan=2>Fees on top:</th>
         <td></td>
-        <td align="right">{{{currency platformFeesDue currency=currency}}}</td>
+        <td align="right">{{{currency feesOnTop currency='USD'}}}</td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>Stripe (already paid automatically):</td>
+        <td></td>
+        <td align="right">{{{currency feesOnTopStripe currency='USD'}}}</td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>Manually added funds:</td>
+        <td></td>
+        <td align="right">{{{currency feesOnTopManual currency='USD'}}}</td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>PayPal:</td>
+        <td></td>
+        <td align="right">{{{currency feesOnTopPaypal currency='USD'}}}</td>
+      </tr>
+      <tr>
+        <th colspan=2>Fees still due: (OnTop + Platform)</th>
+        <td></td>
+        {{#if isUSD}}
+        <td align="right">{{{currency totalFeesDue currency=currency}}}</td>
+        {{else}}
+        <td align="right">{{{currency platformFeesDue currency=currency}}} + {{{currency feesOnTopDue currency='USD'}}} </td>
+        {{/if}}
       </tr>
     </table>
     {{/if}}
@@ -151,6 +178,7 @@ Subject: {{month}} {{year}} Platform Report
         <th>total revenue</th>
         <th>host fees</th>
         <th>platform fees</th>
+        <th>fees on top (USD)</th>
       </tr>
       {{#each hosts}}
       <tr>
@@ -160,6 +188,7 @@ Subject: {{month}} {{year}} Platform Report
         <td align="right">{{{currency totalRevenue currency=currency}}}</td>
         <td align="right">{{{currency hostFees currency=currency}}}</td>
         <td align="right">{{{currency platformFees currency=currency}}}</td>
+        <td align="right">{{{currency feesOnTop currency='USD'}}}</td>
       </tr>
       {{/each}}
 


### PR DESCRIPTION
For context on the way the fees on top transactions work:
  - The original transaction has 0 `platformFee`.
  - We create a new pair of transactions between donor and OpenCollective (id: 1).
    - These transactions are always in USD.
    - These transactions have the fee on top amount as the `amount` and `data.isFeeOnTop = true`.

Updates in the monthly report:
![Screenshot from 2020-07-09 18 55 29](https://user-images.githubusercontent.com/2119706/87095722-a49cd780-c217-11ea-927a-20576d9f33ba.png)

Updates in the weekly report:
![Screenshot from 2020-07-09 18 52 56](https://user-images.githubusercontent.com/2119706/87095726-a5ce0480-c217-11ea-9f2f-35cba70279ca.png)
