### PR TITLE
createOrder: Disable custom contirbution check

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -196,9 +196,6 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     if (!collective) {
       throw new Error(`No collective found: ${order.collective.id || order.collective.website}`);
     }
-    if (collective.settings?.disableCustomContributions && !order.tier) {
-      throw new Error(`Custom contributions are disabled for the selected collective`);
-    }
 
     if (order.fromCollective && order.fromCollective.id === collective.id) {
       throw new Error('Orders cannot be created for a collective by that same collective.');


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/3348#issuecomment-661950927

We could also check the `paymentMethod` to know if it's `service=opencollective`, but:
- Allowing this is not a security issue
- This check doesn't bring much value
- Loading the payment method at this point can be a bit tedious