### PR TITLE
Restrict access to ConnectedAccount username

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1891,8 +1891,16 @@ export const ConnectedAccountType = new GraphQLObjectType({
       },
       username: {
         type: GraphQLString,
-        resolve(ca) {
-          return ca.username;
+        resolve(ca, args, req) {
+          // Services which we consider the username to be public
+          const publicServices = ['github', 'twitter'];
+          if (req.remoteUser.isAdmin(ca.CollectiveId)) {
+            return ca.username;
+          } else if (publicServices.includes(ca.service)) {
+            return ca.username;
+          } else {
+            return null;
+          }
         },
       },
       settings: {


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective-security/issues/34

This property is only leaking on V1 and it is currently being used to display GitHub and Twitter usernames.
I think this is a genuine application and I'm keeping it enabled for these services.