### PR TITLE
Remove option to send invoices by email

### DIFF
--- a/server/lib/collectivelib.js
+++ b/server/lib/collectivelib.js
@@ -61,7 +61,6 @@ export const COLLECTIVE_SETTINGS_KEYS_LIST = [
   'matchingFund',
   'paymentMethods',
   'recommendedCollectives',
-  'sendInvoiceByEmail',
   'style',
   'superCollectiveTag',
   'taxDeductibleDonations',


### PR DESCRIPTION
This option could not work as the endpoint `${config.host.website}/${backerCollective.slug}/invoices/${filename}` has been removed more than one year ago.