### PR TITLE
Fix FXRate on Fees On Top transactions

### DIFF
--- a/migrations/20200729160000-fix-fees-on-top-fxrate.js
+++ b/migrations/20200729160000-fix-fees-on-top-fxrate.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const [, debitResult] = await queryInterface.sequelize.query(`
+      UPDATE "Transactions"
+      SET "amountInHostCurrency" = "netAmountInCollectiveCurrency"
+      WHERE "OrderId" IS NOT NULL
+      AND "hostCurrencyFxRate" != 1
+      AND "data"->>'isFeesOnTop' = 'true'
+      AND "type" = 'DEBIT'
+      AND ("CollectiveId" = 1 OR "FromCollectiveId" = 1);
+    `);
+
+    console.info(`Updated ${debitResult.rowCount} DEBIT transactions`);
+
+    // FX Rate
+    const [, fxResult] = await queryInterface.sequelize.query(`
+      UPDATE "Transactions"
+      SET "hostCurrencyFxRate" = 1
+      WHERE "OrderId" IS NOT NULL
+      AND "hostCurrencyFxRate" != 1
+      AND "data"->>'isFeesOnTop' = 'true'
+      AND ("CollectiveId" = 1 OR "FromCollectiveId" = 1);
+    `);
+
+    console.info(`Updated ${fxResult.rowCount} FXRate transactions`);
+  },
+
+  down: async () => {
+    /**
+     * They'd be a risk of corrupting other data if we allow rollback on this one.
+     */
+  },
+};

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -462,7 +462,8 @@ export default (Sequelize, DataTypes) => {
         netAmountInCollectiveCurrency: Math.round(
           Math.abs(transaction.platformFeeInHostCurrency) * platformCurrencyFxRate,
         ),
-        hostCurrencyFxRate: platformCurrencyFxRate,
+        // This is always 1 because OpenCollective and OpenCollective Inc (Host) are in USD.
+        hostCurrencyFxRate: 1,
         data: {
           hostToPlatformFxRate: await getFxRate(transaction.hostCurrency, FEES_ON_TOP_TRANSACTION_PROPERTIES.currency),
         },


### PR DESCRIPTION
Uncovered a second bug while investigating https://github.com/opencollective/opencollective/issues/3370
This bug causes the `amountInHostCurrency` of the DEBIT transaction to be multiplied by the `hostCurrencyFxRate` twice.

**Why only in the debit transaction?**
The problem is that we already set the correct values in `Transaction.createFeesOnTopTransaction` and we are wrongly setting `hostCurrencyFxRate` to the same FXRate we're using to convert the fees to USD.
This will cause `Transaction.createDoubleEntry` to recalculate `amountInHostCurrency` for the DEBIT transaction and multiply it by the FX rate again.