### PR TITLE
Remove limitedToCollectiveIds from PaymentMethods

### DIFF
--- a/migrations/20200811082357-remove-limitedToCollectiveIds.js
+++ b/migrations/20200811082357-remove-limitedToCollectiveIds.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    // As the behavior for `limitedToCollectiveIds` was similar to `limitedToHostCollectiveIds`,
+    // we migrate the value of the first to the second if there's not one already
+    await queryInterface.sequelize.query(`
+      UPDATE  "PaymentMethods" pm
+      SET     "limitedToHostCollectiveIds" = "limitedToCollectiveIds"
+      WHERE   "limitedToHostCollectiveIds" IS NULL
+      AND     "limitedToCollectiveIds" IS NOT NULL
+    `);
+
+    return queryInterface.removeColumn('PaymentMethods', 'limitedToCollectiveIds');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('PaymentMethods', 'limitedToCollectiveIds', {
+      type: Sequelize.ARRAY(Sequelize.INTEGER),
+    });
+  },
+};

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -653,6 +653,7 @@ const mutations = {
       limitedToCollectiveIds: {
         type: new GraphQLList(GraphQLInt),
         description: 'Limit this payment method to make donations to those collectives',
+        deprecationReason: '2020-08-11: This field does not exist anymore',
       },
       limitedToHostCollectiveIds: {
         type: new GraphQLList(GraphQLInt),
@@ -744,6 +745,7 @@ const mutations = {
       limitedToCollectiveIds: {
         type: new GraphQLList(GraphQLInt),
         description: 'Limit this payment method to make donations to those collectives',
+        deprecationReason: '2020-08-11: This field does not exist anymore',
       },
       limitedToHostCollectiveIds: {
         type: new GraphQLList(GraphQLInt),

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -2082,8 +2082,9 @@ export const PaymentMethodType = new GraphQLObjectType({
       },
       limitedToCollectiveIds: {
         type: new GraphQLList(GraphQLInt),
-        resolve(paymentMethod) {
-          return paymentMethod.limitedToCollectiveIds;
+        deprecationReason: '2020-08-11: This field does not exist anymore',
+        resolve() {
+          return null;
         },
       },
       limitedToHostCollectiveIds: {

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -150,11 +150,6 @@ export default function (Sequelize, DataTypes) {
         },
       },
 
-      limitedToCollectiveIds: {
-        type: DataTypes.ARRAY(DataTypes.INTEGER),
-        description: 'if not null, this payment method can only be used for collectives listed by their id',
-      },
-
       limitedToHostCollectiveIds: {
         type: DataTypes.ARRAY(DataTypes.INTEGER),
         description: 'if not null, this payment method can only be used for collectives hosted by these collective ids',
@@ -279,16 +274,6 @@ export default function (Sequelize, DataTypes) {
         }).then(r => r && r.name)
       );
     };
-
-    if (this.limitedToCollectiveIds) {
-      const collective = order.collective || (await order.getCollective());
-      if (!this.limitedToCollectiveIds.includes(collective.HostCollectiveId)) {
-        const collectives = await Promise.map(this.limitedToCollectiveIds, fetchCollectiveName);
-        throw new Error(
-          `This payment method can only be used for the following collectives ${formatArrayToString(collectives)}`,
-        );
-      }
-    }
 
     if (this.limitedToHostCollectiveIds) {
       const collective = order.collective || (await order.getCollective());

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -152,7 +152,6 @@ async function processOrder(order) {
  *                 organization wants to use
  * @param {Date} [args.expiryDate] The expiry date of the payment method
  * @param {[limitedToTags]} [args.limitedToTags] Limit this payment method to donate to collectives having those tags
- * @param {[limitedToCollectiveIds]} [args.limitedToCollectiveIds] Limit this payment method to those collective ids
  * @param {[limitedToHostCollectiveIds]} [args.limitedToHostCollectiveIds] Limit this payment method to collectives hosted by those collective ids
  * @param {boolean} sendEmailAsync if true, emails will be sent in background
  *  and we won't check if it has properly been sent to confirm
@@ -414,7 +413,6 @@ function getCreateParams(args, collective, sourcePaymentMethod, remoteUser) {
     CollectiveId: args.CollectiveId,
     expiryDate: expiryDate,
     limitedToTags: args.limitedToTags,
-    limitedToCollectiveIds: isEmpty(args.limitedToCollectiveIds) ? null : args.limitedToCollectiveIds,
     limitedToHostCollectiveIds: isEmpty(args.limitedToHostCollectiveIds) ? null : args.limitedToHostCollectiveIds,
     uuid: uuid(),
     service: 'opencollective',

--- a/test/server/paymentProviders/opencollective/virtualcard.test.js
+++ b/test/server/paymentProviders/opencollective/virtualcard.test.js
@@ -27,7 +27,6 @@ const createPaymentMethodQuery = /* GraphQL */ `
     $type: String!
     $currency: String!
     $limitedToTags: [String]
-    $limitedToCollectiveIds: [Int]
     $limitedToHostCollectiveIds: [Int]
   ) {
     createPaymentMethod(
@@ -40,7 +39,6 @@ const createPaymentMethodQuery = /* GraphQL */ `
       type: $type
       currency: $currency
       limitedToTags: $limitedToTags
-      limitedToCollectiveIds: $limitedToCollectiveIds
       limitedToHostCollectiveIds: $limitedToHostCollectiveIds
     ) {
       id
@@ -55,7 +53,6 @@ const createPaymentMethodQuery = /* GraphQL */ `
       expiryDate
       currency
       limitedToTags
-      limitedToCollectiveIds
       limitedToHostCollectiveIds
     }
   }


### PR DESCRIPTION
Better to deploy https://github.com/opencollective/opencollective-frontend/pull/4797 first as it removes the input on the frontend, but it won't break if we don't.