### PR TITLE
Fix inconsistent 2FA sign-in test

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -100,6 +100,7 @@ export const updateToken = async (req, res, next) => {
       secret: decryptedTwoFactorAuthToken,
       encoding: 'base32',
       token: twoFactorAuthenticatorCode,
+      window: 2,
     });
     if (!verified) {
       return next(new Unauthorized('Two-factor authentication code failed. Please try again'));


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/3347

I increase the time-frame our 2FA validator considers to make sure it still works when the time-frame moves 2 steps.
It is common to consider more than one window when using TOTP.