### PR TITLE
Add longDescription to expense model

### DIFF
--- a/migrations/20200813085021-add-expense-longDescription.js
+++ b/migrations/20200813085021-add-expense-longDescription.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Expenses', 'longDescription', {
+      type: Sequelize.TEXT,
+    });
+    await queryInterface.addColumn('ExpenseHistories', 'longDescription', {
+      type: Sequelize.TEXT,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Expenses', 'longDescription');
+    await queryInterface.removeColumn('ExpenseHistories', 'longDescription');
+  },
+};

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -126,6 +126,7 @@ const checkExpenseItems = (expenseData, items) => {
 const EXPENSE_EDITABLE_FIELDS = [
   'amount',
   'description',
+  'longDescription',
   'category',
   'type',
   'tags',

--- a/server/graphql/v2/input/ExpenseCreateInput.ts
+++ b/server/graphql/v2/input/ExpenseCreateInput.ts
@@ -18,6 +18,10 @@ export const ExpenseCreateInput = new GraphQLInputObjectType({
       type: new GraphQLNonNull(GraphQLString),
       description: 'Main title of the expense',
     },
+    longDescription: {
+      type: GraphQLString,
+      description: 'Longer text to attach to the expense',
+    },
     tags: {
       type: new GraphQLList(GraphQLString),
       description: 'Tags associated to the expense (ie. Food, Engineering...)',

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -57,6 +57,7 @@ const expenseMutations = {
       return createExpenseLegacy(req.remoteUser, {
         ...pick(args.expense, [
           'description',
+          'longDescription',
           'tags',
           'type',
           'privateMessage',

--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -41,6 +41,10 @@ const Expense = new GraphQLObjectType({
         type: new GraphQLNonNull(GraphQLString),
         description: 'Title/main description for this expense',
       },
+      longDescription: {
+        type: GraphQLString,
+        description: 'Longer description for this expense',
+      },
       amount: {
         type: new GraphQLNonNull(GraphQLInt),
         description: "Total amount of the expense (sum of the item's amounts).",

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -100,6 +100,18 @@ export default function (Sequelize, DataTypes) {
         allowNull: false,
       },
 
+      longDescription: {
+        type: DataTypes.TEXT,
+        set(value) {
+          if (value) {
+            const cleanHtml = sanitizeHTML(value, PRIVATE_MESSAGE_SANITIZE_OPTS).trim();
+            this.setDataValue('longDescription', cleanHtml || null);
+          } else {
+            this.setDataValue('longDescription', null);
+          }
+        },
+      },
+
       /**
        * @deprecated Now using PaymentMethodId. The reason why this hadn't been removed yet
        * is because we'd need to migrate the legacy `donation` payout types that exist in the


### PR DESCRIPTION
The idea is to have a clean generic column to contain a longer description, in the case of "Funding Request" the message sent while sending the request.