### PR TITLE
Update 2FA test and remove unused package from repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6666,7 +6666,7 @@
     },
     "csv-stringify": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
         "lodash.get": "^4.0.0"
@@ -14398,12 +14398,6 @@
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
       }
-    },
-    "otpauth": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-6.0.7.tgz",
-      "integrity": "sha512-GStZHp76Jud1zKtkLeOOEFEcuJYCTYOjXdCNJ8veJlShCyzc4BK83fspQojoswuzy0TOH4R9dVJoHZ+zTIhmVA==",
-      "dev": true
     },
     "otplib": {
       "version": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "nodemon": "^2.0.4",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
-    "otpauth": "6.0.7",
     "prettier": "2.0.5",
     "sinon": "^9.0.3",
     "supertest": "^4.0.2",

--- a/test/server/routes/users.test.js
+++ b/test/server/routes/users.test.js
@@ -3,7 +3,6 @@ import config from 'config';
 import crypto from 'crypto-js';
 import moment from 'moment';
 import nodemailer from 'nodemailer';
-import { Secret, TOTP } from 'otpauth';
 import sinon from 'sinon';
 import speakeasy from 'speakeasy';
 import request from 'supertest';
@@ -145,12 +144,11 @@ describe('server/routes/users', () => {
       const encryptedToken = crypto[CIPHER].encrypt(secret.base32, SECRET_KEY).toString();
       const user = await models.User.create({ email: 'mopsa@mopsa.mopsa', twoFactorAuthToken: encryptedToken });
       const currentToken = user.jwt();
-      const twoFactorAuthenticatorCode = new TOTP({
+      const twoFactorAuthenticatorCode = speakeasy.totp({
         algorithm: 'SHA1',
-        digits: 6,
-        period: 30,
-        secret: Secret.fromB32(secret.base32),
-      }).generate();
+        encoding: 'base32',
+        secret: secret.base32,
+      });
 
       // When the endpoint is hit with a valid TOTP code
       const response = await request(expressApp)


### PR DESCRIPTION
Found in the frontend tests that I can just use `speakeasy` rather than `otpauth` for the tests, which is the only reason it was installed. So have updated the tests here and removed the package.