### PR TITLE
Dedicated type for Host payment method

### DIFF
--- a/migrations/20200819082531-rename-host-payment-method.js
+++ b/migrations/20200819082531-rename-host-payment-method.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      UPDATE "PaymentMethods" as pm
+      SET "name" = CONCAT(c."name", ' (Host)'), "type" = 'host'
+      FROM "Collectives" AS c
+      WHERE pm."service" = 'opencollective' AND pm."type" = 'collective'
+      AND pm."CollectiveId" = c."id"
+      AND c."type" IN ('ORGANIZATION', 'USER')
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/server/constants/paymentMethods.ts
+++ b/server/constants/paymentMethods.ts
@@ -11,6 +11,7 @@ export enum PAYMENT_METHOD_TYPE {
   PREPAID = 'prepaid',
   PAYMENT = 'payment',
   COLLECTIVE = 'collective',
+  HOST = 'host',
   ADAPTIVE = 'adaptive',
   VIRTUALCARD = 'virtualcard',
 }

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -951,7 +951,7 @@ export default function (Sequelize, DataTypes) {
 
   Collective.prototype.getOrCreateHostPaymentMethod = async function () {
     const hostPaymentMethod = await models.PaymentMethod.findOne({
-      where: { service: 'opencollective', type: 'collective', CollectiveId: this.id },
+      where: { service: 'opencollective', type: 'host', CollectiveId: this.id },
     });
 
     if (hostPaymentMethod) {
@@ -961,7 +961,7 @@ export default function (Sequelize, DataTypes) {
     return models.PaymentMethod.create({
       CollectiveId: this.id,
       service: 'opencollective',
-      type: 'collective',
+      type: 'host',
       name: `${this.name} (Host)`,
       primary: true,
       currency: this.currency,

--- a/server/paymentProviders/opencollective/host.js
+++ b/server/paymentProviders/opencollective/host.js
@@ -1,0 +1,69 @@
+import { get } from 'lodash';
+
+import { maxInteger } from '../../constants/math';
+import { TransactionTypes } from '../../constants/transactions';
+import { getFxRate } from '../../lib/currency';
+import * as paymentsLib from '../../lib/payments';
+import models from '../../models';
+
+const paymentMethodProvider = {};
+
+paymentMethodProvider.features = {
+  recurring: false,
+  waitToCharge: false,
+};
+
+// We don't check balance for "Added Funds"
+paymentMethodProvider.getBalance = () => {
+  return Promise.resolve(maxInteger);
+};
+
+paymentMethodProvider.processOrder = async order => {
+  const collectiveHost = await order.collective.getHostCollective();
+
+  if (order.paymentMethod.CollectiveId !== order.collective.HostCollectiveId) {
+    throw new Error('Can only use the Host payment method to Add Funds to an hosted Collective.');
+  }
+
+  const hostFeePercent = get(order, 'data.hostFeePercent', 0);
+  const platformFeePercent = get(order, 'data.platformFeePercent', 0);
+
+  const payload = {
+    CreatedByUserId: order.CreatedByUserId,
+    FromCollectiveId: order.FromCollectiveId,
+    CollectiveId: order.CollectiveId,
+    PaymentMethodId: order.PaymentMethodId,
+  };
+
+  // Different collectives on the same host may have different currencies
+  // That's bad design. We should always keep the same host currency everywhere and only use the currency
+  // of the collective for display purposes (using the fxrate at the time of display)
+  // Anyway, until we change that, when we give money to a collective that has a different currency
+  // we need to compute the equivalent using the fxrate of the day
+  const fxrate = await getFxRate(order.currency, order.paymentMethod.currency);
+  const totalAmountInPaymentMethodCurrency = order.totalAmount * fxrate;
+
+  const hostFeeInHostCurrency = paymentsLib.calcFee(order.totalAmount * fxrate, hostFeePercent);
+  const platformFeeInHostCurrency = paymentsLib.calcFee(order.totalAmount * fxrate, platformFeePercent);
+
+  payload.transaction = {
+    type: TransactionTypes.CREDIT,
+    OrderId: order.id,
+    amount: order.totalAmount,
+    currency: order.currency,
+    hostCurrency: collectiveHost.currency,
+    hostCurrencyFxRate: fxrate,
+    netAmountInCollectiveCurrency: order.totalAmount * (1 - hostFeePercent / 100),
+    amountInHostCurrency: totalAmountInPaymentMethodCurrency,
+    hostFeeInHostCurrency,
+    platformFeeInHostCurrency,
+    paymentProcessorFeeInHostCurrency: 0,
+    description: order.description,
+  };
+
+  const transactions = await models.Transaction.createFromPayload(payload);
+
+  return transactions;
+};
+
+export default paymentMethodProvider;

--- a/server/paymentProviders/opencollective/index.js
+++ b/server/paymentProviders/opencollective/index.js
@@ -1,6 +1,5 @@
-/** @module paymentProviders/opencollective */
-
 import collective from './collective';
+import host from './host';
 import manual from './manual';
 import prepaid from './prepaid';
 import virtualcard from './virtualcard';
@@ -14,6 +13,8 @@ async function processOrder(order) {
       return virtualcard.processOrder(order);
     case 'manual':
       return manual.processOrder(order);
+    case 'host':
+      return collective.processOrder(order);
     case 'collective': // Fall through
     default:
       return collective.processOrder(order);
@@ -27,6 +28,7 @@ export default {
   types: {
     default: collective,
     collective,
+    host,
     manual,
     prepaid,
     virtualcard,

--- a/test/server/graphql/v1/paymentMethods.test.js
+++ b/test/server/graphql/v1/paymentMethods.test.js
@@ -118,7 +118,7 @@ describe('server/graphql/v1/paymentMethods', () => {
         where: {
           service: 'opencollective',
           CollectiveId: host.id,
-          type: 'collective',
+          type: 'host',
         },
       }).then(pm => {
         paymentMethod = pm;


### PR DESCRIPTION
It's a bit complicated to follow what happens in the "collective" payment method when it has 2 different purposes, one for Hosts (Added Funds) and one for Collectives (and Events, Funds, Projects) (Collective to Collective transactions).

Adding a dedicated payment method type for Hosts / Added Funds will simplify that.

Frontend should be unimpacted because of the work in https://github.com/opencollective/opencollective-api/pull/3767 and https://github.com/opencollective/opencollective-frontend/pull/4036

I would even argue that we should not even need a Payment Method for that but I don't want to tackle this kind of refactoring yet.