### PR TITLE
Refund feesOnTop

### DIFF
--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -772,13 +772,7 @@ export async function markExpenseAsUnpaid(req, ExpenseId, processorFeeRefunded) 
   });
 
   const paymentProcessorFeeInHostCurrency = processorFeeRefunded ? transaction.paymentProcessorFeeInHostCurrency : 0;
-  const refundedTransaction = await libPayments.createRefundTransaction(
-    transaction,
-    paymentProcessorFeeInHostCurrency,
-    null,
-    expense.User,
-  );
-  await libPayments.associateTransactionRefundId(transaction, refundedTransaction);
+  await libPayments.createRefundTransaction(transaction, paymentProcessorFeeInHostCurrency, null, expense.User);
 
   const updatedExpense = await expense.update({ status: statuses.APPROVED, lastEditedById: remoteUser.id });
   await updatedExpense.createActivity(activities.COLLECTIVE_EXPENSE_MARKED_AS_UNPAID, remoteUser);

--- a/server/paymentProviders/opencollective/collective.js
+++ b/server/paymentProviders/opencollective/collective.js
@@ -135,8 +135,7 @@ paymentMethodProvider.refundTransaction = async (transaction, user) => {
 
   // Use 0 for processor fees because there's no fees for collective to collective
   // transactions within the same host.
-  const refundTransaction = await paymentsLib.createRefundTransaction(transaction, 0, null, user);
-  return paymentsLib.associateTransactionRefundId(transaction, refundTransaction);
+  return await paymentsLib.createRefundTransaction(transaction, 0, null, user);
 };
 
 export default paymentMethodProvider;

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -2,7 +2,7 @@ import { isNumber, pick } from 'lodash';
 
 import { maxInteger } from '../../constants/math';
 import { HOST_FEE_PERCENT, TransactionTypes } from '../../constants/transactions';
-import { associateTransactionRefundId, createRefundTransaction } from '../../lib/payments';
+import { createRefundTransaction } from '../../lib/payments';
 import models from '../../models';
 /**
  * Manual Payment method
@@ -110,8 +110,7 @@ async function processOrder(order) {
  * they want to actually refund the money.
  */
 const refundTransaction = async (transaction, user) => {
-  const refundTransaction = await createRefundTransaction(transaction, 0, null, user);
-  return associateTransactionRefundId(transaction, refundTransaction);
+  return await createRefundTransaction(transaction, 0, null, user);
 };
 
 /* Expected API of a Payment Method Type */

--- a/server/paymentProviders/opencollective/prepaid.js
+++ b/server/paymentProviders/opencollective/prepaid.js
@@ -122,10 +122,7 @@ async function processOrder(order) {
 
 async function refundTransaction(transaction, user) {
   /* Create negative transactions for the received transaction */
-  const refundTransaction = await libpayments.createRefundTransaction(transaction, 0, null, user);
-
-  /* Associate RefundTransactionId to all the transactions created */
-  return libpayments.associateTransactionRefundId(transaction, refundTransaction);
+  return await libpayments.createRefundTransaction(transaction, 0, null, user);
 }
 
 /* Expected API of a Payment Method Type */

--- a/server/paymentProviders/opencollective/virtualcard.js
+++ b/server/paymentProviders/opencollective/virtualcard.js
@@ -528,10 +528,7 @@ async function registerCreateInCache(collectiveId, count) {
 
 async function refundTransaction(transaction, user) {
   /* Create negative transactions for the received transaction */
-  const refundTransaction = await libpayments.createRefundTransaction(transaction, 0, null, user);
-
-  /* Associate RefundTransactionId to all the transactions created */
-  return libpayments.associateTransactionRefundId(transaction, refundTransaction);
+  return await libpayments.createRefundTransaction(transaction, 0, null, user);
 }
 
 /* Expected API of a Payment Method Type */

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -330,21 +330,17 @@ export default {
     const fees = extractFees(refundBalance);
 
     /* Create negative transactions for the received transaction */
-    const refundTransaction = await paymentsLib.createRefundTransaction(
+    return await paymentsLib.createRefundTransaction(
       transaction,
       fees.stripeFee,
       {
+        ...transaction.data,
         refund,
         balanceTransaction: refundBalance,
+        charge,
       },
       user,
     );
-
-    /* Associate RefundTransactionId to all the transactions created */
-    return paymentsLib.associateTransactionRefundId(transaction, refundTransaction, {
-      ...transaction.data,
-      charge,
-    });
   },
 
   /** Refund a given transaction that was already refunded
@@ -371,21 +367,12 @@ export default {
     const fees = extractFees(refundBalance);
 
     /* Create negative transactions for the received transaction */
-    const refundTransaction = await paymentsLib.createRefundTransaction(
+    return await paymentsLib.createRefundTransaction(
       transaction,
       fees.stripeFee,
-      {
-        refund,
-        balanceTransaction: refundBalance,
-      },
+      { ...transaction.data, charge, refund, balanceTransaction: refundBalance },
       user,
     );
-
-    /* Associate RefundTransactionId to all the transactions created */
-    return paymentsLib.associateTransactionRefundId(transaction, refundTransaction, {
-      ...transaction.data,
-      charge,
-    });
   },
 
   webhook: (/* requestBody, event */) => {


### PR DESCRIPTION
Also refacts createRefundTransaction to include `associateTransactionRefundId`.

Since the stripe charge carries the full amount and the transaction split is something that exists only on our side, refunding the feeOnTop transaction works fine.
I suggest using https://github.com/opencollective/opencollective-frontend/pull/4897 when testing.