### PR TITLE
Refactor PENDING status and introduce more precise statuses

### DIFF
--- a/cron/daily/60-clean-orders.js
+++ b/cron/daily/60-clean-orders.js
@@ -7,11 +7,12 @@ import { sequelize } from '../../server/models';
 // https://github.com/sequelize/sequelize/issues/3957
 
 Promise.all([
-  // Mark all Manual Payments as ERROR after 2 months
+  // Mark all Manual Payments as EXPIRED after 2 months
+  // (Until August 2020, it used to be ERROR instead of EXPIRED)
   // Make sure to not include pledges
   sequelize.query(
     `UPDATE "Orders"
-  SET "status" = 'ERROR', "updatedAt" = NOW()
+  SET "status" = 'EXPIRED', "updatedAt" = NOW()
   FROM "Collectives"
   WHERE "Orders"."status" = 'PENDING'
   AND "Orders"."PaymentMethodId" IS NULL

--- a/migrations/20200824143059-new-order-statuses.js
+++ b/migrations/20200824143059-new-order-statuses.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `UPDATE "Orders"
+  SET "status" = 'PLEDGED'
+  FROM "Collectives"
+  WHERE "Orders"."status" = 'PENDING'
+  AND "Orders"."PaymentMethodId" IS NULL
+  AND "Collectives"."id" = "Orders"."CollectiveId"
+  AND "Collectives"."isActive" = FALSE
+  AND "Collectives"."isPledged" = TRUE`,
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `UPDATE "Orders"
+  SET "status" = 'PENDING'
+  WHERE "status" = 'PLEDGED'`,
+    );
+  },
+};

--- a/server/constants/order_status.js
+++ b/server/constants/order_status.js
@@ -5,16 +5,20 @@
  * pending -> active (subscription)
  * pending -> active -> cancelled (subscription)
  * pending -> cancelled
- * pending -> rejected
  * pending -> expired
  */
 
 export default {
-  PENDING: 'PENDING',
-  PAID: 'PAID',
-  ACTIVE: 'ACTIVE',
-  CANCELLED: 'CANCELLED',
-  REJECTED: 'REJECTED',
-  ERROR: 'ERROR',
-  EXPIRED: 'EXPIRED',
+  NEW: 'NEW', // New default state since August 2020
+  REQUIRE_ACTION: 'REQUIRE_ACTION', // For Strong Customer Authentication ("3D Secure")
+  PAID: 'PAID', // For One Time Contributions
+  ERROR: 'ERROR', // For One Time and Recurring Contribution
+  // This is only for "Recurring Contributions"
+  ACTIVE: 'ACTIVE', // Active Recurring contribution with up to date payments
+  CANCELLED: 'CANCELLED', // When it's Cancelled by contributors or automatically after X failures
+  // This is only for "Manual" payments
+  PENDING: 'PENDING', // Initial state
+  EXPIRED: 'EXPIRED', // When it's marked as such by Admins
+  // For Pledges
+  PLEDGED: 'PLEDGED',
 };

--- a/server/constants/order_status.js
+++ b/server/constants/order_status.js
@@ -10,7 +10,7 @@
 
 export default {
   NEW: 'NEW', // New default state since August 2020
-  REQUIRE_ACTION: 'REQUIRE_ACTION', // For Strong Customer Authentication ("3D Secure")
+  REQUIRE_CLIENT_CONFIRMATION: 'REQUIRE_CLIENT_CONFIRMATION', // For Strong Customer Authentication ("3D Secure")
   PAID: 'PAID', // For One Time Contributions
   ERROR: 'ERROR', // For One Time and Recurring Contribution
   // This is only for "Recurring Contributions"

--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -465,12 +465,12 @@ export const loaders = req => {
     }).then(results => sortResults(combinedKeys, results, 'CollectiveId:FromCollectiveId', [])),
   );
 
-  // Order - findPendingOrdersForCollective
-  context.loaders.Order.findPendingOrdersForCollective = new DataLoader(CollectiveIds =>
+  // Order - findPledgedOrdersForCollective
+  context.loaders.Order.findPledgedOrdersForCollective = new DataLoader(CollectiveIds =>
     models.Order.findAll({
       where: {
         CollectiveId: { [Op.in]: CollectiveIds },
-        status: 'PENDING',
+        status: 'PLEDGED',
       },
       order: [['createdAt', 'DESC']],
     }).then(results => sortResults(CollectiveIds, results, 'CollectiveId', [])),

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1447,8 +1447,8 @@ const CollectiveFields = () => {
       resolve(collective, args = {}, req) {
         const where = {};
 
-        if (args.status === 'PENDING') {
-          return req.loaders.Order.findPendingOrdersForCollective.load(collective.id);
+        if (args.status === 'PLEDGED') {
+          return req.loaders.Order.findPledgedOrdersForCollective.load(collective.id);
         } else if (args.status) {
           where.status = args.status;
         } else {

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -404,7 +404,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     let orderStatus = status.NEW;
     // Special cases
     if (collective.isPledged) {
-      orderStatus = status.PLEDGE;
+      orderStatus = status.PLEDGED;
     }
     if (get(order, 'paymentMethod.type') === 'manual') {
       orderStatus = status.PENDING;
@@ -511,7 +511,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     if (orderCreated) {
       if (!orderCreated.processedAt) {
         if (error.stripeResponse) {
-          orderCreated.status = status.REQUIRE_ACTION;
+          orderCreated.status = status.REQUIRE_CLIENT_CONFIRMATION;
         } else {
           orderCreated.status = status.ERROR;
         }
@@ -564,10 +564,10 @@ export async function confirmOrder(order, remoteUser) {
   if (!remoteUser.isAdmin(order.FromCollectiveId)) {
     throw new Unauthorized("You don't have permission to confirm this order");
   }
-  if (![status.ERROR, status.PENDING, status.REQUIRE_ACTION].includes(order.status)) {
-    // As August 2020, we're transitionning from PENDING to REQUIRE_ACTION
+  if (![status.ERROR, status.PENDING, status.REQUIRE_CLIENT_CONFIRMATION].includes(order.status)) {
+    // As August 2020, we're transitionning from PENDING to REQUIRE_CLIENT_CONFIRMATION
     // PENDING can be safely removed after a few days (it will be dedicated for "Manual" payments)
-    throw new Error('Order can only be confirmed if its status is ERROR, PENDING or REQUIRE_ACTION.');
+    throw new Error('Order can only be confirmed if its status is ERROR, PENDING or REQUIRE_CLIENT_CONFIRMATION.');
   }
 
   try {

--- a/server/graphql/v2/enum/OrderStatus.js
+++ b/server/graphql/v2/enum/OrderStatus.js
@@ -6,9 +6,12 @@ export const OrderStatus = new GraphQLEnumType({
   values: {
     ACTIVE: {},
     CANCELLED: {},
-    PENDING: {},
-    PAID: {},
     ERROR: {},
     EXPIRED: {},
+    NEW: {},
+    PAID: {},
+    PENDING: {},
+    PLEDGED: {},
+    REQUIRE_ACTION: {},
   },
 });

--- a/server/graphql/v2/enum/OrderStatus.js
+++ b/server/graphql/v2/enum/OrderStatus.js
@@ -12,6 +12,6 @@ export const OrderStatus = new GraphQLEnumType({
     PAID: {},
     PENDING: {},
     PLEDGED: {},
-    REQUIRE_ACTION: {},
+    REQUIRE_CLIENT_CONFIRMATION: {},
   },
 });

--- a/server/lib/backyourstack/dispatcher.js
+++ b/server/lib/backyourstack/dispatcher.js
@@ -125,7 +125,7 @@ export async function dispatchFunds(order) {
         description: `Monthly financial contribution to ${collective.name} through BackYourStack`,
         totalAmount,
         currency: order.currency,
-        status: status.PENDING,
+        status: status.NEW,
       };
       const orderCreated = await models.Order.create(orderData);
 

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -120,7 +120,7 @@ export default function (Sequelize, DataTypes) {
 
       status: {
         type: DataTypes.STRING,
-        defaultValue: status.PENDING,
+        defaultValue: status.NEW,
         allowNull: false,
         validate: {
           isIn: {

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -145,6 +145,7 @@ describe('server/graphql/v1/createOrder', () => {
       slug: 'test',
       name: 'test',
       isActive: false,
+      isPledged: true,
       website: 'https://github.com/opencollective/frontend',
     });
     const thisOrder = cloneDeep(baseOrder);
@@ -169,7 +170,7 @@ describe('server/graphql/v1/createOrder', () => {
     res.errors && console.error(res.errors);
     expect(res.errors).to.not.exist;
 
-    expect(res.data.createOrder.status).to.equal('PENDING');
+    expect(res.data.createOrder.status).to.equal('PLEDGED');
   });
 
   it('creates a pending order (pledge) with inactive subscription if interval is included and collective is not active', async () => {
@@ -177,6 +178,7 @@ describe('server/graphql/v1/createOrder', () => {
       slug: 'test',
       name: 'test',
       isActive: false,
+      isPledged: true,
       website: 'https://github.com/opencollective/frontend',
     });
     const thisOrder = cloneDeep(baseOrder);
@@ -202,7 +204,7 @@ describe('server/graphql/v1/createOrder', () => {
     res.errors && console.error(res.errors);
     expect(res.errors).to.not.exist;
 
-    expect(res.data.createOrder.status).to.equal('PENDING');
+    expect(res.data.createOrder.status).to.equal('PLEDGED');
     expect(res.data.createOrder.subscription.interval).to.equal('month');
   });
 


### PR DESCRIPTION
`PENDING` status for Orders is currently ambiguous. In this PR, I'm introducing new statuses to lift the ambiguity and only use the `PENDING` status for "Manual" payments. For that matter, I'm introducing 3 new types:

- `NEW` for the initial default state of an Order, only application crashes will lead having this type in the database. Entries should be soft deleted after some time has passed.
- `REQUIRE_ACTION` for Payments that requires confirmation through Stripe (Strong Customer Authentication / "3D Secure").
- `PLEDGED` for "Pledge" contributions to Pledged Collectives.

Requires matching Frontend PR: https://github.com/opencollective/opencollective-frontend/pull/4917
