### PR TITLE
Fix GraphQL schema issue preventing playground docs/schema to load

### DIFF
--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -143,6 +143,10 @@ const accountFieldsDefinition = () => ({
         type: new GraphQLList(AccountType),
         description: 'Type of accounts (BOT/COLLECTIVE/EVENT/ORGANIZATION/INDIVIDUAL)',
       },
+      orderBy: {
+        type: new GraphQLNonNull(ChronologicalOrderInput),
+        defaultValue: ChronologicalOrderInput.defaultValue,
+      },
     },
   },
   transactions: {


### PR DESCRIPTION
![Screenshot 2020-08-24 at 15 26 31](https://user-images.githubusercontent.com/37520401/91059121-3a05f680-e621-11ea-9f77-d64a596b32cf.png)

My GraphQL v2 playground would not load the docs or schema. There were no errors in the terminal. However opening the browsers I found this.

![Screenshot 2020-08-24 at 15 46 06](https://user-images.githubusercontent.com/37520401/91059129-3c685080-e621-11ea-90da-3f3b6df6e27a.png)

So I added the `orderBy` field to `Account.memberOf` and now it's fixed.