### PR TITLE
parseInt on Amount value only if not null

### DIFF
--- a/server/graphql/v2/object/Amount.js
+++ b/server/graphql/v2/object/Amount.js
@@ -9,7 +9,11 @@ export const Amount = new GraphQLObjectType({
     value: {
       type: GraphQLFloat,
       resolve(amount) {
-        return parseInt(amount.value, 10) / 100;
+        if (amount.value === null) {
+          return null;
+        } else {
+          return parseInt(amount.value, 10) / 100;
+        }
       },
     },
     currency: {


### PR DESCRIPTION
From a support ticket: someone was trying to update their tier on a recurring contribution and it got hung up on loading the tiers:

<img width="414" alt="Screenshot 2020-08-26 at 13 24 27" src="https://user-images.githubusercontent.com/37520401/91303385-dc4be880-e79f-11ea-9087-8525ddb5669e.png">

Had a look at the tiers query for that Collective and found this error:

<img width="639" alt="Screenshot 2020-08-26 at 13 27 42" src="https://user-images.githubusercontent.com/37520401/91303442-f1c11280-e79f-11ea-8328-a23262e33bdb.png">

I was able to reproduce locally:

<img width="796" alt="Screenshot 2020-08-26 at 13 24 36" src="https://user-images.githubusercontent.com/37520401/91303977-af4c0580-e7a0-11ea-9f83-65c5e79f2b8a.png">

Looking into it, in the `Amount` object for v2, we parse the amount value as an integer without checking first whether it's `null`, which it could be.

```
export const Amount = new GraphQLObjectType({
  name: 'Amount',
  description: 'A financial amount.',
  fields: {
    value: {
      type: GraphQLFloat,
      resolve(amount) {
        return parseInt(amount.value, 10) / 100;
      },
    },
...
```

In order to fix this I added a check to see if the value is null before parsing it as an int

```
      resolve(amount) {
        if (amount.value === null) {
          return null;
        } else {
          return parseInt(amount.value, 10) / 100;
        }
      },
```

Running locally and setting the minimum amount to `null` on a tier for a recurring contribution I have fixed the issue.