### PR TITLE
Update subscriptions handling

### DIFF
--- a/cron/disabled/00-charge-subscriptions.js
+++ b/cron/disabled/00-charge-subscriptions.js
@@ -5,6 +5,7 @@ import fs from 'fs';
 
 import { ArgumentParser } from 'argparse';
 import { parse as json2csv } from 'json2csv';
+import PQueue from 'p-queue';
 
 import emailLib from '../../server/lib/email';
 import {
@@ -12,7 +13,6 @@ import {
   ordersWithPendingCharges,
   processOrderWithSubscription,
 } from '../../server/lib/subscriptions';
-import { promiseSeq } from '../../server/lib/utils';
 import { sequelize } from '../../server/models';
 
 const REPORT_EMAIL = 'ops@opencollective.com';
@@ -35,73 +35,74 @@ const csvFields = [
   'nextPeriodStartAfter',
 ];
 
+/** Print `message` to console if `options.verbose` is true */
+function vprint(options, message) {
+  if (options.verbose) {
+    console.log(message);
+  }
+}
+
+const startTime = new Date();
+
 /** Run the script with parameters read from the command line */
 async function run(options) {
-  const start = new Date();
-  const { count, rows: orders } = await ordersWithPendingCharges({ limit: options.limit });
+  options.startDate = process.env.START_DATE ? new Date(process.env.START_DATE) : new Date();
+
+  const queue = new PQueue({ concurrency: options.concurrency });
+
+  const { count, rows: orders } = await ordersWithPendingCharges({
+    limit: options.limit,
+    startDate: options.startDate,
+  });
   vprint(
     options,
     `${count} subscriptions pending charges. Charging ${orders.length} subscriptions right now. dryRun: ${options.dryRun}`,
   );
   const data = [];
-  await promiseSeq(
-    orders,
-    async order => {
-      vprint(
-        options,
-        `order: ${order.id}, subscription: ${order.Subscription.id}, ` +
-          `attempt: #${order.Subscription.chargeRetryCount}, ` +
-          `due: ${order.Subscription.nextChargeDate}`,
-      );
-      data.push(await processOrderWithSubscription(options, order));
-    },
-    options.batchSize,
-  );
 
-  if (data.length > 0) {
+  for (const order of orders) {
+    queue.add(() =>
+      processOrderWithSubscription(order, options).then(csvEntry => {
+        if (csvEntry) {
+          data.push(csvEntry);
+        }
+      }),
+    );
+  }
+
+  queue.onIdle().then(async () => {
+    if (data.length === 0) {
+      vprint(options, 'Not generating CSV file');
+      // We used to send a "ReportNoCharges" here but we're stopping this while moving to an Hourly schedule
+      return;
+    }
     vprint(options, 'Writing the output to a CSV file');
     try {
       const csv = json2csv(data, { fields: csvFields });
       if (options.dryRun) {
         fs.writeFileSync('charge_subscriptions.output.csv', csv);
-      } else {
-        if (!options.dryRun) {
-          vprint(options, 'Sending email report');
-          const attachments = [
-            {
-              filename: `${new Date().toLocaleDateString()}.csv`,
-              content: csv,
-            },
-          ];
-          await emailReport(start, orders, groupProcessedOrders(data), attachments);
-        }
+      }
+      if (!options.dryRun) {
+        vprint(options, 'Sending email report');
+        const attachments = [
+          {
+            filename: `${new Date().toLocaleDateString()}.csv`,
+            content: csv,
+          },
+        ];
+        await emailReport(orders, groupProcessedOrders(data), attachments);
       }
     } catch (err) {
       console.log(err);
     }
-  } else {
-    vprint(options, 'Not generating CSV file');
-    if (!options.dryRun) {
-      await emailReportNoCharges(start);
-    }
-  }
-}
 
-/** Send an email with a message just notifying that there were no
- subscriptions to charge. */
-
-async function emailReportNoCharges(start) {
-  // Time we spent running the whole script
-  const now = new Date(),
-    end = now - start;
-  // Build & send message
-  const text = `No subscriptions pending charges found\n\nTotal time taken: ${end}ms`;
-  const subject = `Ø Daily Subscription Report - ${now.toLocaleDateString()}`;
-  return emailLib.sendMessage(REPORT_EMAIL, subject, '', { text });
+    await sequelize.close();
+    vprint(options, 'Finished running charge subscriptions');
+  });
 }
 
 /** Send an email with details of the subscriptions processed */
-async function emailReport(start, orders, data, attachments) {
+async function emailReport(orders, data, attachments) {
   const icon = err => (err ? '❌' : '✅');
   let result = [`Total Subscriptions pending charges found: ${orders.length}`, ''];
 
@@ -131,8 +132,8 @@ async function emailReport(start, orders, data, attachments) {
   }
 
   // Time we spent running the whole script
-  const now = new Date(),
-    end = now - start;
+  const now = new Date();
+  const end = now - startTime;
   result.push(`\n\nTotal time taken: ${end}ms`);
 
   // Subject line of the email
@@ -145,13 +146,6 @@ async function emailReport(start, orders, data, attachments) {
     text: result.join('\n'),
     attachments,
   });
-}
-
-/** Print `message` to console if `options.verbose` is true */
-function vprint(options, message) {
-  if (options.verbose) {
-    console.log(message);
-  }
 }
 
 /** Return the options passed by the user to run the script */
@@ -174,30 +168,31 @@ export function parseCommandLineArguments() {
   });
   parser.addArgument(['-l', '--limit'], {
     help: 'total subscriptions to process',
-    defaultValue: 2500,
+    defaultValue: 500,
   });
-  parser.addArgument(['-b', '--batch-size'], {
-    help: 'batch size to fetch at a time',
-    defaultValue: 10,
+  parser.addArgument(['-c', '--concurrency'], {
+    help: 'concurrency',
+    defaultValue: 3,
+  });
+  parser.addArgument(['-s', '--simulate'], {
+    help: 'concurrency',
+    defaultValue: false,
+    action: 'storeConst',
+    constant: true,
   });
   const args = parser.parseArgs();
   return {
     dryRun: args.dryrun,
     verbose: !args.quiet,
     limit: args.limit,
-    batchSize: args.batch_size,
+    concurrency: args.concurrency,
+    simulate: args.simulate,
   };
 }
 
 /** Kick off the script with all the user selected options */
 export async function entryPoint(options) {
-  vprint(options, 'Starting to charge subscriptions');
-  try {
-    await run(options);
-  } finally {
-    await sequelize.close();
-  }
-  vprint(options, 'Finished running charge subscriptions');
+  await run(options);
 }
 
 /* Entry point */

--- a/migrations/20200828123457-missing-order-interval.js
+++ b/migrations/20200828123457-missing-order-interval.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `UPDATE "Orders"
+  SET "interval" = "Subscriptions"."interval"
+  FROM "Subscriptions"
+  WHERE "Subscriptions"."id" = "Orders"."SubscriptionId"
+  AND "SubscriptionId" IS NOT NULL
+  AND "Orders"."interval" IS NULL`,
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/test/server/lib/subscriptions.test.js
+++ b/test/server/lib/subscriptions.test.js
@@ -319,7 +319,7 @@ describe('server/lib/subscriptions', () => {
       emailMock.expects('send').never();
 
       // When the order above is processed
-      const entry = await processOrderWithSubscription({ dryRun: true }, order);
+      const entry = await processOrderWithSubscription(order, { dryRun: true });
 
       // Then nothing was attempted
       expect(entry.status).to.equal('unattempted');
@@ -357,7 +357,7 @@ describe('server/lib/subscriptions', () => {
         paymentsStub.resolves({ info: 'Transaction' });
 
         // When the order is processed
-        const entry = await processOrderWithSubscription({ dryRun: false }, order);
+        const entry = await processOrderWithSubscription(order, { dryRun: false });
 
         // Expect the mock expectations to be verified. The right
         // email was sent.
@@ -385,7 +385,7 @@ describe('server/lib/subscriptions', () => {
         paymentsStub.resolves({ info: 'Transaction' });
 
         // When the order is processed
-        const entry = await processOrderWithSubscription({ dryRun: false }, order);
+        const entry = await processOrderWithSubscription(order, { dryRun: false });
 
         // Expect the mock expectations to be verified. The right
         // email was sent.
@@ -412,7 +412,7 @@ describe('server/lib/subscriptions', () => {
         paymentsStub.rejects('TypeError -- Whatever');
 
         // When the order is processed
-        const entry = await processOrderWithSubscription({ dryRun: false }, order);
+        const entry = await processOrderWithSubscription(order, { dryRun: false });
 
         // Expect the mock expectations to be verified. The right
         // email was sent.
@@ -439,7 +439,7 @@ describe('server/lib/subscriptions', () => {
         paymentsStub.resolves({});
 
         // When the order is processed
-        const entry = await processOrderWithSubscription({ dryRun: false }, order);
+        const entry = await processOrderWithSubscription(order, { dryRun: false });
 
         // Then expect the stub of the payment lib to be called
         expect(paymentsStub.called).to.be.true;
@@ -459,7 +459,7 @@ describe('server/lib/subscriptions', () => {
         paymentsStub.rejects('TypeError -- Whatever');
 
         // When the order is processed
-        const entry = await processOrderWithSubscription({ dryRun: false }, order);
+        const entry = await processOrderWithSubscription(order, { dryRun: false });
 
         // Then expect the stub of the payment lib to be called
         expect(paymentsStub.called).to.be.true;
@@ -482,7 +482,7 @@ describe('server/lib/subscriptions', () => {
         await subscription.update({ chargeNumber: 2 });
 
         // When the order is processed
-        const entry = await processOrderWithSubscription({ dryRun: false }, order);
+        const entry = await processOrderWithSubscription(order, { dryRun: false });
 
         // Then expect the stub of the payment lib to NOT be called!
         // No charge should happen!!!


### PR DESCRIPTION
- ability to configure START_DATE / startDate
- temporary move out of CRON schedule (will be moved to `hourly` later)
- use `p-queue` for simpler concurency
- default to 500 per batch
- refetch order to protect against duplicate handling

