### PR TITLE
Fix Slack notifications

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -25,6 +25,11 @@
       "bucket": "opencollective-test"
     }
   },
+  "slack": {
+    "webhooks": {
+      "abuse": "SLACK_ABUSE_TEST_URL"
+    }
+  },
   "mailgun": {
     "user": "",
     "password": ""

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -105,7 +105,9 @@
     }
   },
   "slack": {
-    "webhookUrl": "SLACK_HOOK_URL"
+    "webhooks": {
+      "abuse": "SLACK_WEBHOOK_ABUSE"
+    }
   },
   "github": {
     "clientID": "GITHUB_CLIENT_ID",

--- a/config/default.json
+++ b/config/default.json
@@ -103,9 +103,9 @@
     "redirectUri": "http://localhost:3060/connected-accounts/stripe/callback"
   },
   "slack": {
-    "privateActivityChannel": "#activity-private-test",
-    "publicActivityChannel": "#activity-public-test",
-    "abuseChannel": "#abuse"
+    "webhooks": {
+      "abuse": null
+    }
   },
   "recaptcha": {
     "siteKey": "6LcyeXoUAAAAAFtdHDZfsxncFUkD9NqydqbIFcCK",

--- a/config/production.json
+++ b/config/production.json
@@ -28,10 +28,6 @@
   "stripe": {
     "redirectUri": "https://api.opencollective.com/connected-accounts/stripe/callback"
   },
-  "slack": {
-    "privateActivityChannel": "#activity-private",
-    "publicActivityChannel": "#activity-public"
-  },
   "paypal": {
     "rest": {
       "mode": "live"

--- a/config/test.json
+++ b/config/test.json
@@ -10,6 +10,11 @@
       "bucket": "opencollective-test"
     }
   },
+  "slack": {
+    "webhooks": {
+      "abuse": "SLACK_ABUSE_TEST_URL"
+    }
+  },
   "mailgun": {
     "user": "",
     "password": ""

--- a/cron/10mn/milestones.js
+++ b/cron/10mn/milestones.js
@@ -4,7 +4,6 @@ import '../../server/env';
 process.env.PORT = 3066;
 
 import Promise from 'bluebird';
-import config from 'config';
 import debugLib from 'debug';
 import _, { get, pick, set } from 'lodash';
 
@@ -180,19 +179,11 @@ const postSlackMessage = async (message, webhookUrl, options = {}) => {
 };
 
 const postToSlack = async (message, slackAccount) => {
-  // post to slack.opencollective.com (bug: we send it twice if both `collective` and `host` have set up a Slack webhook)
-  await postSlackMessage(message, config.slack.webhookUrl, {
-    channel: config.slack.publicActivityChannel,
-    linkTwitterMentions: true,
-  });
-
   if (!slackAccount) {
     return console.warn(`No slack account to post ${message}`);
   }
 
-  await postSlackMessage(message, slackAccount.webhookUrl, {
-    linkTwitterMentions: true,
-  });
+  await postSlackMessage(message, slackAccount.webhookUrl, { linkTwitterMentions: true });
 };
 
 const sendTweet = async (tweet, twitterAccount, template) => {

--- a/cron/monthly/collective-tweet.js
+++ b/cron/monthly/collective-tweet.js
@@ -11,12 +11,10 @@ if (process.env.NODE_ENV === 'production' && today.getDate() !== 1) {
 process.env.PORT = 3066;
 
 import Promise from 'bluebird';
-import config from 'config';
 import debugLib from 'debug';
 import _, { get, pick, set } from 'lodash';
 import moment from 'moment';
 
-import slackLib from '../../server/lib/slack';
 import twitter from '../../server/lib/twitter';
 import models from '../../server/models';
 const d = new Date();
@@ -29,14 +27,6 @@ const endDate = new Date(d.getFullYear(), d.getMonth() + 1, 1);
 console.log('startDate', startDate, 'endDate', endDate);
 
 const debug = debugLib('monthlyreport');
-
-async function publishToSlack(message, webhookUrl, options) {
-  try {
-    return slackLib.postMessage(message, webhookUrl, options);
-  } catch (e) {
-    console.warn('Unable to post to slack', e);
-  }
-}
 
 const init = () => {
   const startTime = new Date();
@@ -188,12 +178,6 @@ const sendTweet = async (twitterAccount, data) => {
       // eslint-disable-next-line camelcase
       in_reply_to_status_id: get(twitterAccount, 'settings.monthlyStats.lastTweetId'),
     });
-    const tweetUrl = `https://twitter.com/${res.user.screen_name}/status/${res.id_str}`;
-    // publish to slack.opencollective.com
-    await publishToSlack(tweetUrl, config.slack.webhookUrl, {
-      channel: config.slack.publicActivityChannel,
-    });
-
     set(twitterAccount, 'settings.monthlyStats.lastTweetId', res.id_str);
     set(twitterAccount, 'settings.monthlyStats.lastTweetSentAt', new Date(res.created_at));
     twitterAccount.save();

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -30,7 +30,7 @@
 | API_URL                             | .host.api                                   | API exposed url                                                                |
 | WEBSITE_URL                         | .host.website                               | UI URL                                                                         |
 | FRONTEND_URL                        | .host.frontend                              | URL of the frontend service (for caching)                                      |
-| SLACK_HOOK_URL                      | .slack.webhookUrl                           | slack hook url                                                                 |
+| SLACK_WEBHOOK_ABUSE                 | .slack.webhooks.abuse                       | slack abuse webhook url                                                        |
 | GITHUB_CLIENT_ID                    | .github.clientId                            | github client ID                                                               |
 | GITHUB_CLIENT_SECRET                | .github.clientSecret                        | github client secret                                                           |
 | MEETUP_CLIENT_ID                    | .meetup.clientId                            | meetup client ID                                                               |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9449,11 +9449,6 @@
         "resolve-dir": "^1.0.1"
       }
     },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "express-server-status": "1.0.3",
     "express-session": "1.17.1",
     "express-ws": "4.0.0",
-    "flat": "5.0.2",
     "forest-express-sequelize": "6.3.6",
     "fs-extra": "9.0.1",
     "graphql": "15.3.0",

--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -1,5 +1,3 @@
-import flatten from 'flat';
-
 import activities from '../constants/activities';
 import { TransactionTypes } from '../constants/transactions';
 
@@ -286,14 +284,6 @@ export default {
       default:
         return '';
     }
-  },
-
-  formatAttachment: attachment => {
-    const flattenedData = flatten(attachment);
-    const rows = Object.keys(flattenedData)
-      .filter(key => flattenedData[key])
-      .map(key => `${key}: ${flattenedData[key]}`);
-    return rows.join('\n');
   },
 };
 

--- a/server/lib/slack.js
+++ b/server/lib/slack.js
@@ -3,37 +3,36 @@
  */
 
 import config from 'config';
-import debug from 'debug';
 import Slack from 'node-slack';
 
-import constants from '../constants/activities';
 import activitiesLib from '../lib/activities';
 
-const debugSlack = debug('slack');
+import logger from './logger';
+
+export const OPEN_COLLECTIVE_SLACK_CHANNEL = {
+  ABUSE: 'abuse',
+};
 
 export default {
   /*
-   * Post a given activity to OpenCollective private channel
-   * This method can only publish to our webhookUrl and our private channel, so we don't leak info by mistake
-   */
-  postActivityOnPrivateChannel(activity) {
-    const message = activitiesLib.formatMessageForPrivateChannel(activity, 'slack');
-    const options = {
-      attachments: formatAttachment(activity),
-      channel: config.slack.privateActivityChannel,
-    };
-    return this.postMessage(message, config.slack.webhookUrl, options);
-  },
-
-  /*
    * Post a given activity to a public channel (meaning scrubbed info only)
    */
-  postActivityOnPublicChannel(activity, webhookUrl, options) {
-    if (!options) {
-      options = {};
-    }
+  postActivityOnPublicChannel(activity, webhookUrl) {
     const message = activitiesLib.formatMessageForPublicChannel(activity, 'slack');
-    return this.postMessage(message, webhookUrl, options);
+    return this.postMessage(message, webhookUrl);
+  },
+
+  /**
+   * Post a message on Open Collective's Slack. Channel must be a valid key of
+   * `config.slack.webhooks`. Use the `OPEN_COLLECTIVE_SLACK_CHANNEL` helper.
+   */
+  postMessageToOpenCollectiveSlack(message, channel) {
+    const webhookUrl = config.slack.webhooks[channel];
+    if (webhookUrl) {
+      this.postMessage(message, webhookUrl);
+    } else if (typeof webhookUrl === 'undefined') {
+      logger.warn(`Unknown slack channel ${channel}`);
+    }
   },
 
   /*
@@ -50,15 +49,10 @@ export default {
 
     const slackOptions = {
       text: msg,
-      username: 'OpenCollective Activity Bot',
+      username: 'OpenCollective',
       icon_url: 'https://opencollective.com/favicon.ico', // eslint-disable-line camelcase
       attachments: options.attachments || [],
     };
-
-    // note that channel is optional on slack, as every webhook has a default channel
-    if (options.channel) {
-      slackOptions.channel = options.channel;
-    }
 
     return new Promise((resolve, reject) => {
       // production check
@@ -72,24 +66,11 @@ export default {
 
       return new Slack(webhookUrl, {}).send(slackOptions, err => {
         if (err) {
-          debugSlack(err);
+          logger.warn(`SlackLib.postMessage failed for ${webhookUrl}:`, err);
           return reject(err);
         }
         return resolve();
       });
     });
   },
-};
-
-const formatAttachment = activity => {
-  if (activity.type === constants.WEBHOOK_STRIPE_RECEIVED) {
-    return [
-      {
-        title: 'Data',
-        color: 'good',
-        text: activitiesLib.formatAttachment(activity.data),
-      },
-    ];
-  }
-  return [];
 };

--- a/server/lib/spam.ts
+++ b/server/lib/spam.ts
@@ -1,7 +1,6 @@
-import config from 'config';
 import { clamp } from 'lodash';
 
-import slackLib from '../lib/slack';
+import slackLib, { OPEN_COLLECTIVE_SLACK_CHANNEL } from '../lib/slack';
 
 /** Return type when running a spam analysis */
 export type SpamAnalysisReport = {
@@ -226,9 +225,7 @@ export const notifyTeamAboutSuspiciousCollective = async (report: SpamAnalysisRe
   message = addLine(`Score: ${score}`);
   message = addLine(keywords.length > 0 && `Keywords: \`${keywords.toString()}\``);
   message = addLine(domains.length > 0 && `Domains: \`${domains.toString()}\``);
-  return slackLib.postMessage(message, config.slack.webhookUrl, {
-    channel: config.slack.abuseChannel,
-  });
+  return slackLib.postMessageToOpenCollectiveSlack(message, OPEN_COLLECTIVE_SLACK_CHANNEL.ABUSE);
 };
 
 /**
@@ -248,7 +245,5 @@ export const notifyTeamAboutPreventedCollectiveCreate = async (
   message = addLine(domains.length > 0 && `Domains: \`${domains.toString()}\``);
   message = addLine(`Collective data:`);
   message = addLine(`> ${JSON.stringify(report.data)}`);
-  return slackLib.postMessage(message, config.slack.webhookUrl, {
-    channel: config.slack.abuseChannel,
-  });
+  return slackLib.postMessageToOpenCollectiveSlack(message, OPEN_COLLECTIVE_SLACK_CHANNEL.ABUSE);
 };

--- a/test/server/lib/slack.test.js
+++ b/test/server/lib/slack.test.js
@@ -59,22 +59,9 @@ describe('server/lib/slack', () => {
     it('with activity succeeds', done => {
       formatMessageStub.withArgs(activity, 'slack').returns(formattedMessage);
 
-      const expected = postMessageStub.withArgs(formattedMessage, webhookUrl, {});
+      const expected = postMessageStub.withArgs(formattedMessage, webhookUrl);
 
-      slackLib.postActivityOnPublicChannel(activity, webhookUrl, {});
-
-      expect(expected.called).to.be.ok;
-      done();
-    });
-
-    it('with options keeps the options', done => {
-      const options = { option1: 'option1', attachments: [] };
-
-      formatMessageStub.withArgs(activity, 'slack').returns(formattedMessage);
-
-      const expected = postMessageStub.withArgs(formattedMessage, webhookUrl, options);
-
-      slackLib.postActivityOnPublicChannel(activity, webhookUrl, options);
+      slackLib.postActivityOnPublicChannel(activity, webhookUrl);
 
       expect(expected.called).to.be.ok;
       done();

--- a/test/server/lib/spam.test.js
+++ b/test/server/lib/spam.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import config from 'config';
 import sinon from 'sinon';
 
 import slackLib from '../../../server/lib/slack';
@@ -97,7 +98,7 @@ describe('server/lib/spam', () => {
       expect(args[0]).to.eq(
         '*Suspicious collective data was submitted for collective:* https://opencollective.com/ketoooo\nScore: 0.3\nKeywords: `keto`',
       );
-      expect(args[2].channel).to.eq('#abuse');
+      expect(args[1]).to.eq(config.slack.webhooks.abuse);
     });
   });
 
@@ -121,7 +122,7 @@ describe('server/lib/spam', () => {
       expect(args[0]).to.eq(
         'A collective creation was prevented and the user has been put in limited mode.\nKeywords: `keto`\nCollective data:\n> {"name":"Keto stuff","slug":"ketoooo"}',
       );
-      expect(args[2].channel).to.eq('#abuse');
+      expect(args[1]).to.eq(config.slack.webhooks.abuse);
     });
   });
 });


### PR DESCRIPTION
- No change to user webhooks. If their `webhookUrl` is configured with a proper app, it should continue working flawlessly.
- Remove all messages sent to our `#activity-public` (was broken for a month, after Slack deprecated legacy API)
- Remove all messages sent to our `#activity-private` (couldn't find the channel on our Slack)
- Changed the config structure so that we can now configure one webhook per channel, migrated `#abuse` to this system
- Added a `logger.warn` when webhook fails (so that we can remove the deprecated ones, if any)
- Removed the `flat` library (was not used anymore)