### PR TITLE
GQLV2/Order: Add legacyId and transactions

### DIFF
--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -520,6 +520,12 @@ export const loaders = req => {
 
   /** *** Transaction *****/
   context.loaders.Transaction = {
+    byOrderId: new DataLoader(async keys => {
+      const where = { OrderId: { [Op.in]: keys } };
+      const order = [['createdAt', 'ASC']];
+      const transactions = await models.Transaction.findAll({ where, order });
+      return sortResults(keys, transactions, 'OrderId', []);
+    }),
     findByOrderId: options =>
       createDataLoaderWithOptions(
         (OrderIds, options) => {


### PR DESCRIPTION
To build feature parity with the legacy contribution flow (redirect requires to include the legacy order ID and the transaction ID).