### PR TITLE
Include reference on transactions to RUB

### DIFF
--- a/server/lib/transferwise.ts
+++ b/server/lib/transferwise.ts
@@ -154,7 +154,7 @@ export const createRecipientAccount = async (
   };
 };
 
-interface CreateTransfer {
+export interface CreateTransfer {
   accountId: number;
   quoteId: number;
   uuid: string;

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -13,6 +13,7 @@ import { Balance, Quote, RecipientAccount, Transfer } from '../../types/transfer
 const hashObject = obj => crypto.createHash('sha1').update(JSON.stringify(obj)).digest('hex').slice(0, 7);
 
 export const blockedCurrenciesForBusinesProfiles = ['BRL', 'PKR'];
+export const currenciesThatRequireReference = ['RUB'];
 
 async function populateProfileId(connectedAccount): Promise<void> {
   if (!connectedAccount.data?.id) {
@@ -85,11 +86,16 @@ async function payExpense(
     ...payoutMethod.data,
   });
 
-  const transfer = await transferwise.createTransfer(connectedAccount.token, {
+  const transferOptions: transferwise.CreateTransfer = {
     accountId: recipient.id,
     quoteId: quote.id,
     uuid: uuid(),
-  });
+  };
+  // Append reference to currencies that require it.
+  if (currenciesThatRequireReference.includes(payoutMethod.data.currency)) {
+    transferOptions.details = { reference: `${expense.id}` };
+  }
+  const transfer = await transferwise.createTransfer(connectedAccount.token, transferOptions);
 
   let fund;
   try {


### PR DESCRIPTION
TransferWise requires a reference for transactions to particular currencies.
We're facing some issues with a transaction to RUB complaining about this, although their documentation suggests being incapable of transferring from USD to RUB, their API returns USD -> RUB as a valid transaction.
This should fix this error and implement the base code to include reference when needed, if despite this refactor the transaction still doesn't work, I'll start blacklisting currency pairs internally.