### PR TITLE
2FA login now works with one-time links enabled

### DIFF
--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -9,7 +9,10 @@ import pdf from 'html-pdf';
 import { cloneDeep, get, isEqual, padStart } from 'lodash';
 import sanitizeHtml from 'sanitize-html';
 
+import errors from './errors';
 import handlebars from './handlebars';
+
+const { BadRequest } = errors;
 
 export function addParamsToUrl(url, obj) {
   const u = new URL(url);
@@ -611,4 +614,20 @@ export const toIsoDateStr = date => {
   const month = date.getMonth() + 1;
   const day = date.getUTCDate();
   return `${year}-${padStart(month.toString(), 2, '0')}-${padStart(day.toString(), 2, '0')}`;
+};
+
+export const getTokenFromRequestHeaders = req => {
+  const header = req.headers && req.headers.authorization;
+  if (!header) {
+    return null;
+  }
+
+  const parts = header.split(' ');
+  const scheme = parts[0];
+  const token = parts[1];
+  if (!/^Bearer$/i.test(scheme) || !token) {
+    throw new BadRequest('Format is Authorization: Bearer [token]');
+  }
+
+  return token;
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -81,7 +81,10 @@ export default app => {
    * User reset password or new token flow (no jwt verification) or 2FA
    */
   app.post('/users/signin', required('user'), users.signin);
+  // check JWT and update token if no 2FA, but send back 2FA JWT if there is 2FA enabled
   app.post('/users/update-token', authentication.mustBeLoggedIn, users.updateToken);
+  // check the 2FA code against the token in the db to let 2FA-enabled users log in
+  app.post('/users/two-factor-auth', authentication.checkTwoFactorAuthJWT, users.twoFactorAuthAndUpdateToken);
 
   /**
    * Moving forward, all requests will try to authenticate the user if there is a JWT token provided


### PR DESCRIPTION
Addresses the issue the our login process and its one-time links did not work with our 2FA login flow.

This PR:

* adjusts the `/users/update-token` route so that it is only used for normal logins. It only checks if 2FA is enabled on the user's account, but doesn't handle the verification

* adds a new route `/users/two-factor-auth` to handle the verification code received from the front end and allow these users to log in