### PR TITLE
Implement graphql-cache POC

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -22,7 +22,11 @@
     }
   },
   "graphql": {
-    "apolloEngineAPIKey": "APOLLO_ENGINE_API_KEY"
+    "apolloEngineAPIKey": "APOLLO_ENGINE_API_KEY",
+    "cache": {
+      "enabled": "GRAPHQL_CACHE_ENABLED",
+      "ttl": "GRAPHQL_CACHE_TTL"
+    }
   },
   "memcache": {
     "servers": "MEMCACHE_SERVERS",
@@ -40,9 +44,6 @@
       "emailUnsubscribeSecret": "EMAIL_UNSUBSCRIBE_SECRET",
       "hashidSalt": "HASHID_SALT"
     }
-  },
-  "cache": {
-    "middleware": "CACHE_MIDDLEWARE"
   },
   "log": {
     "level": "LOG_LEVEL",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -23,6 +23,7 @@
   },
   "graphql": {
     "apolloEngineAPIKey": "APOLLO_ENGINE_API_KEY",
+    "apolloEngineAPIKeyV2": "APOLLO_ENGINE_API_KEY_V2",
     "cache": {
       "enabled": "GRAPHQL_CACHE_ENABLED",
       "ttl": "GRAPHQL_CACHE_TTL"

--- a/config/default.json
+++ b/config/default.json
@@ -142,5 +142,11 @@
   "dbEncryption": {
     "secretKey": "guineapigs",
     "cipher": "DES"
+  },
+  "graphql": {
+    "cache": {
+      "enabled": false,
+      "ttl": 300
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5815,11 +5815,6 @@
         }
       }
     },
-    "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -8686,68 +8681,6 @@
       "integrity": "sha512-iJ0h1Gk6fZRrFmO7tP9nIbxwNgCUJASfNj5fb0Hy15lGtbqqsxpt7609+wq+0XlByZjXmC/rslWQtnuSTVRIcg==",
       "requires": {
         "basic-auth": "^2.0.1"
-      }
-    },
-    "express-graphql": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.11.0.tgz",
-      "integrity": "sha512-IMYmF2aIBKKfo8c+EENBNR8FAy91QHboxfaHe1omCyb49GJXsToUgcjjIF/PfWJdzn0Ofp6JJvcsODQJrqpz2g==",
-      "requires": {
-        "accepts": "^1.3.7",
-        "content-type": "^1.0.4",
-        "http-errors": "1.8.0",
-        "raw-body": "^2.4.1"
-      },
-      "dependencies": {
-        "accepts": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-          "requires": {
-            "mime-types": "~2.1.24",
-            "negotiator": "0.6.2"
-          }
-        },
-        "http-errors": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-          "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "mime-db": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-        },
-        "mime-types": {
-          "version": "2.1.27",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-          "requires": {
-            "mime-db": "1.44.0"
-          }
-        },
-        "negotiator": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-        },
-        "setprototypeof": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-        }
       }
     },
     "express-jwt": {
@@ -15246,27 +15179,6 @@
       "requires": {
         "ip6": "0.0.4",
         "ipaddr.js": "1.2"
-      }
-    },
-    "raw-body": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
-      "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.3",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
       }
     },
     "rc": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "errorhandler": "1.5.1",
     "express": "4.17.1",
     "express-basic-auth": "1.2.0",
-    "express-graphql": "0.11.0",
     "express-limiter": "1.6.1",
     "express-session": "1.17.1",
     "express-ws": "4.0.0",

--- a/scripts/add_refund_transactions_from_collective.js
+++ b/scripts/add_refund_transactions_from_collective.js
@@ -13,7 +13,7 @@ import '../server/env';
 import Promise from 'bluebird';
 import debug from 'debug';
 
-import { purgeCacheForPage } from '../server/lib/cloudflare';
+import { purgeCacheForCollective } from '../server/lib/cache';
 import * as libPayments from '../server/lib/payments';
 import models from '../server/models';
 
@@ -78,10 +78,10 @@ async function refundTransaction(transaction) {
   const fromCollective = await transaction.getFromCollective();
   // purging cloudflare cache
   if (collective) {
-    purgeCacheForPage(`/${collective.slug}`);
+    purgeCacheForCollective(collective.slug);
   }
   if (fromCollective) {
-    purgeCacheForPage(`/${fromCollective.slug}`);
+    purgeCacheForCollective(fromCollective.slug);
   }
 
   return models.Transaction.findByPk(transaction.id);

--- a/server/graphql/cache.js
+++ b/server/graphql/cache.js
@@ -1,0 +1,101 @@
+import { difference } from 'lodash';
+
+export const purgeCacheForCollectiveOperationNames = [
+  'CollectivePage',
+  'BudgetSection',
+  'UpdatesSection',
+  'TransactionsSection',
+  'TransactionsPage',
+  'ExpensesPage',
+  'CollectiveBannerIframe',
+  'CollectiveCover',
+  'RecurringContributions',
+  'ContributionsSection',
+];
+
+export function checkSupportedVariables(req, variableNames) {
+  if (!req.body.variables) {
+    return false;
+  }
+  // Check missing variables
+  if (difference(variableNames, Object.keys(req.body.variables)).length > 0) {
+    return false;
+  }
+  // Check extra variables
+  if (difference(Object.keys(req.body.variables), variableNames).length > 0) {
+    return false;
+  }
+
+  return true;
+}
+
+export function getGraphqlCacheKey(req) {
+  if (req.remoteUser) {
+    return;
+  }
+  if (!req.body || !req.body.operationName) {
+    return;
+  }
+  switch (req.body.operationName) {
+    case 'CollectivePage':
+      if (!checkSupportedVariables(req, ['slug', 'nbContributorsPerContributeCard'])) {
+        return;
+      }
+      if (req.body.variables.nbContributorsPerContributeCard !== 4) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.slug}`;
+    case 'BudgetSection':
+      if (!checkSupportedVariables(req, ['slug', 'limit'])) {
+        return;
+      }
+      if (req.body.variables.limit !== 3) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.slug}`;
+    case 'UpdatesSection':
+      if (!checkSupportedVariables(req, ['slug', 'onlyPublishedUpdates'])) {
+        return;
+      }
+      if (req.body.variables.onlyPublishedUpdates !== true) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.slug}`;
+    case 'TransactionsSection':
+      if (!checkSupportedVariables(req, ['slug', 'limit'])) {
+        return;
+      }
+      if (req.body.variables.limit !== 10) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.slug}`;
+    case 'TransactionsPage':
+      if (!checkSupportedVariables(req, ['slug', 'offset', 'limit'])) {
+        return;
+      }
+      if (req.body.variables.offset !== 0 || req.body.variables.limit !== 15) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.slug}`;
+    case 'ExpensesPage':
+      if (!checkSupportedVariables(req, ['collectiveSlug', 'offset', 'limit'])) {
+        return;
+      }
+      if (req.body.variables.offset !== 0 || req.body.variables.limit !== 10) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.collectiveSlug}`;
+    case 'CollectiveBannerIframe':
+      if (!checkSupportedVariables(req, ['collectiveSlug'])) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.collectiveSlug}`;
+    case 'CollectiveCover':
+    case 'RecurringContributions':
+    case 'ContributionsSection':
+      if (!checkSupportedVariables(req, ['slug'])) {
+        return;
+      }
+      return `${req.body.operationName}_${req.body.variables.slug}`;
+  }
+}

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -10,7 +10,7 @@ import activities from '../../../constants/activities';
 import { types } from '../../../constants/collectives';
 import FEATURE from '../../../constants/feature';
 import roles from '../../../constants/roles';
-import { purgeCacheForPage } from '../../../lib/cloudflare';
+import { purgeCacheForCollective } from '../../../lib/cache';
 import emailLib from '../../../lib/email';
 import * as github from '../../../lib/github';
 import { handleHostCollectivesLimit } from '../../../lib/plans';
@@ -157,10 +157,10 @@ export async function createCollective(_, args, req) {
 
   // Purge cache for parent collective (for events) and hosts
   if (parentCollective) {
-    purgeCacheForPage(`/${parentCollective.slug}`);
+    purgeCacheForCollective(parentCollective.slug);
   }
   if (hostCollective) {
-    purgeCacheForPage(`/${hostCollective.slug}`);
+    purgeCacheForCollective(hostCollective.slug);
   }
 
   // Inherit fees from parent collective after setting its host (events)
@@ -420,7 +420,7 @@ export function editCollective(_, args, req) {
     })
     .then(() => {
       // Ask cloudflare to refresh the cache for this collective's page
-      purgeCacheForPage(`/${collective.slug}`);
+      purgeCacheForCollective(collective.slug);
       return collective;
     });
 }
@@ -474,7 +474,8 @@ export async function approveCollective(remoteUser, CollectiveId) {
     }),
   );
 
-  purgeCacheForPage(`/${collective.slug}`);
+  purgeCacheForCollective(collective.slug);
+
   // Approve the collective and return it
   return collective.update({ isActive: true, approvedAt: new Date() });
 }
@@ -900,7 +901,8 @@ export async function rejectCollective(_, args, req) {
     },
   });
 
-  purgeCacheForPage(`/${collective.slug}`);
+  purgeCacheForCollective(collective.slug);
+
   return collective.changeHost(null, req.remoteUser);
 }
 

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -12,8 +12,7 @@ import FEATURE from '../../../constants/feature';
 import status from '../../../constants/order_status';
 import roles from '../../../constants/roles';
 import { VAT_OPTIONS } from '../../../constants/vat';
-import cache from '../../../lib/cache';
-import { purgeCacheForPage } from '../../../lib/cloudflare';
+import cache, { purgeCacheForCollective } from '../../../lib/cache';
 import * as github from '../../../lib/github';
 import * as libPayments from '../../../lib/payments';
 import { handleHostPlanAddedFundsLimit, handleHostPlanBankTransfersLimit } from '../../../lib/plans';
@@ -503,7 +502,8 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     }
 
     // Invalidate Cloudflare cache for the collective pages
-    purgeCacheForPage([`/${collective.slug}`, `/${fromCollective.slug}`]);
+    purgeCacheForCollective(collective.slug);
+    purgeCacheForCollective(fromCollective.slug);
 
     order = await models.Order.findByPk(orderCreated.id);
     return order;

--- a/server/graphql/v1/mutations/updates.js
+++ b/server/graphql/v1/mutations/updates.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 
 import { mustHaveRole } from '../../../lib/auth';
-import { purgeCacheForPage } from '../../../lib/cloudflare';
+import { purgeCacheForCollective } from '../../../lib/cache';
 import { stripTags } from '../../../lib/utils';
 import models from '../../../models';
 import { NotFound, ValidationFailed } from '../../errors';
@@ -37,7 +37,7 @@ export async function createUpdate(_, args, req) {
     makePublicOn: args.update.makePublicOn,
   });
 
-  purgeCacheForPage(`/${collective.slug}`);
+  purgeCacheForCollective(collective.slug);
   return update;
 }
 
@@ -54,7 +54,7 @@ export async function editUpdate(_, args, req) {
   let update = await fetchUpdate(args.update.id);
   update = await update.edit(req.remoteUser, args.update);
   const collective = await models.Collective.findByPk(update.CollectiveId);
-  purgeCacheForPage(`/${collective.slug}`);
+  purgeCacheForCollective(collective.slug);
   return update;
 }
 
@@ -62,7 +62,7 @@ export async function publishUpdate(_, args, req) {
   let update = await fetchUpdate(args.id);
   update = await update.publish(req.remoteUser, args.notificationAudience);
   const collective = await models.Collective.findByPk(update.CollectiveId);
-  purgeCacheForPage(`/${collective.slug}`);
+  purgeCacheForCollective(collective.slug);
   return update;
 }
 
@@ -70,7 +70,7 @@ export async function unpublishUpdate(_, args, req) {
   let update = await fetchUpdate(args.id);
   update = await update.unpublish(req.remoteUser);
   const collective = await models.Collective.findByPk(update.CollectiveId);
-  purgeCacheForPage(`/${collective.slug}`);
+  purgeCacheForCollective(collective.slug);
   return update;
 }
 
@@ -78,6 +78,6 @@ export async function deleteUpdate(_, args, req) {
   let update = await fetchUpdate(args.id);
   update = await update.delete(req.remoteUser);
   const collective = await models.Collective.findByPk(update.CollectiveId);
-  purgeCacheForPage(`/${collective.slug}`);
+  purgeCacheForCollective(collective.slug);
   return update;
 }

--- a/server/graphql/v2/mutation/CreateCollectiveMutation.js
+++ b/server/graphql/v2/mutation/CreateCollectiveMutation.js
@@ -3,7 +3,7 @@ import { get, pick } from 'lodash';
 
 import activities from '../../../constants/activities';
 import roles from '../../../constants/roles';
-import { purgeCacheForPage } from '../../../lib/cloudflare';
+import { purgeCacheForCollective } from '../../../lib/cache';
 import { isCollectiveSlugReserved } from '../../../lib/collectivelib';
 import * as github from '../../../lib/github';
 import { defaultHostCollective } from '../../../lib/utils';
@@ -90,7 +90,7 @@ async function createCollective(_, args, req) {
   // Add the host if any
   if (host) {
     await collective.addHost(host, remoteUser, { shouldAutomaticallyApprove });
-    purgeCacheForPage(`/${host.slug}`);
+    purgeCacheForCollective(host.slug);
   }
 
   // Will send an email to the authenticated user

--- a/server/graphql/v2/mutation/CreateFundMutation.js
+++ b/server/graphql/v2/mutation/CreateFundMutation.js
@@ -3,7 +3,7 @@ import { get, pick } from 'lodash';
 
 import activities from '../../../constants/activities';
 import roles from '../../../constants/roles';
-import { purgeCacheForPage } from '../../../lib/cloudflare';
+import { purgeCacheForCollective } from '../../../lib/cache';
 import { isCollectiveSlugReserved } from '../../../lib/collectivelib';
 import models from '../../../models';
 import { Unauthorized, ValidationFailed } from '../../errors';
@@ -59,7 +59,7 @@ async function createFund(_, args, req) {
   // Add the host if any
   if (host) {
     await fund.addHost(host, remoteUser);
-    purgeCacheForPage(`/${host.slug}`);
+    purgeCacheForCollective(host.slug);
   }
 
   // Will send an email to the authenticated user

--- a/server/lib/cache/index.js
+++ b/server/lib/cache/index.js
@@ -2,7 +2,9 @@ import config from 'config';
 import debug from 'debug';
 import { get } from 'lodash';
 
+import { purgeCacheForCollectiveOperationNames } from '../../graphql/cache';
 import models from '../../models';
+import { purgeCacheForPage } from '../cloudflare';
 import logger from '../logger';
 import { md5 } from '../utils';
 
@@ -136,6 +138,14 @@ export function memoize(func, { key, maxAge = 0, serialize, unserialize }) {
   };
 
   return memoizedFunction;
+}
+
+export function purgeCacheForCollective(slug) {
+  purgeCacheForPage(`/${slug}`);
+  // GraphQL cache
+  for (const operationName of purgeCacheForCollectiveOperationNames) {
+    cache.del(`${operationName}_${slug}`);
+  }
 }
 
 export default cache;

--- a/server/lib/hyperwatch.js
+++ b/server/lib/hyperwatch.js
@@ -56,6 +56,9 @@ const load = async app => {
 
         if (req.body && req.body.query && req.body.variables) {
           log = log.set('graphql', req.body);
+          if (res.servedFromGraphqlCache) {
+            log = log.setIn(['graphql', 'servedFromCache'], true);
+          }
         }
 
         if (req.clientApp) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -100,6 +100,7 @@ export default app => {
   app.param('expenseid', params.expenseid);
 
   const isDevelopment = config.env === 'development';
+  const isProduction = config.env === 'production';
 
   /**
    * GraphQL caching
@@ -127,6 +128,8 @@ export default app => {
     introspection: true,
     playground: isDevelopment,
     engine: {
+      reportSchema: isProduction,
+      variant: 'current',
       apiKey: get(config, 'graphql.apolloEngineAPIKey'),
     },
     // Align with behavior from express-graphql
@@ -152,7 +155,9 @@ export default app => {
     introspection: true,
     playground: isDevelopment,
     engine: {
-      apiKey: get(config, 'graphql.apolloEngineAPIKey'),
+      reportSchema: isProduction,
+      variant: 'current',
+      apiKey: get(config, 'graphql.apolloEngineAPIKeyV2'),
     },
     // Align with behavior from express-graphql
     context: ({ req }) => {

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,6 +1,5 @@
 import { ApolloServer } from 'apollo-server-express';
 import config from 'config';
-import { graphqlHTTP } from 'express-graphql';
 import expressLimiter from 'express-limiter';
 import { get } from 'lodash';
 import multer from 'multer';
@@ -12,9 +11,11 @@ import uploadImage from './controllers/images';
 import * as email from './controllers/services/email';
 import * as users from './controllers/users';
 import { paypalWebhook, stripeWebhook, transferwiseWebhook } from './controllers/webhooks';
+import { getGraphqlCacheKey } from './graphql/cache';
 import graphqlSchemaV1 from './graphql/v1/schema';
 import graphqlSchemaV2 from './graphql/v2/schema';
-import logger from './lib/logger';
+import cache from './lib/cache';
+import { parseToBoolean } from './lib/utils';
 import * as authentication from './middleware/authentication';
 import errorHandler from './middleware/error_handler';
 import * as params from './middleware/params';
@@ -101,20 +102,47 @@ export default app => {
   const isDevelopment = config.env === 'development';
 
   /**
-   * GraphQL v1
+   * GraphQL caching
    */
-  const graphqlServerV1 = graphqlHTTP({
-    customFormatErrorFn: error => {
-      logger.error(`GraphQL v1 error: ${error.message}`);
-      logger.debug(error);
-      return error;
-    },
-    schema: graphqlSchemaV1,
-    pretty: isDevelopment,
-    graphiql: isDevelopment,
+  app.use('/graphql', async (req, res, next) => {
+    const cacheKey = getGraphqlCacheKey(req);
+    const enabled = parseToBoolean(config.graphql.cache.enabled);
+    if (cacheKey && enabled) {
+      const fromCache = await cache.get(cacheKey);
+      if (fromCache) {
+        res.servedFromGraphqlCache = true;
+        res.send(fromCache);
+        return;
+      }
+      req.cacheKey = cacheKey;
+    }
+    next();
   });
 
-  app.use('/graphql/v1', graphqlServerV1);
+  /**
+   * GraphQL v1
+   */
+  const graphqlServerV1 = new ApolloServer({
+    schema: graphqlSchemaV1,
+    introspection: true,
+    playground: isDevelopment,
+    engine: {
+      apiKey: get(config, 'graphql.apolloEngineAPIKey'),
+    },
+    // Align with behavior from express-graphql
+    context: ({ req }) => {
+      return req;
+    },
+    formatResponse: (response, ctx) => {
+      const req = ctx.context;
+      if (req.cacheKey) {
+        cache.set(req.cacheKey, response, Number(config.graphql.cache.ttl));
+      }
+      return response;
+    },
+  });
+
+  graphqlServerV1.applyMiddleware({ app, path: '/graphql/v1' });
 
   /**
    * GraphQL v2
@@ -130,6 +158,13 @@ export default app => {
     context: ({ req }) => {
       return req;
     },
+    formatResponse: (response, ctx) => {
+      const req = ctx.context;
+      if (req.cacheKey) {
+        cache.set(req.cacheKey, response, Number(config.graphql.cache.ttl));
+      }
+      return response;
+    },
   });
 
   graphqlServerV2.applyMiddleware({ app, path: '/graphql/v2' });
@@ -137,7 +172,7 @@ export default app => {
   /**
    * GraphQL default (v1)
    */
-  app.use('/graphql', graphqlServerV1);
+  graphqlServerV1.applyMiddleware({ app, path: '/graphql' });
 
   /**
    * Webhooks that should bypass api key check


### PR DESCRIPTION
I'm not familiar enough with Apollo Server, so rolling our own cache for this proof of concept.

- upgrade GraphQL v1 to Apollo Server (better middleware)
- replace `purgeCacheForPage` by a more generic `purgeCacheForCollective`
- introduce caching based on a specific list of GraphQL operation names
- use our caching layer: Redis in production
- disabled by default, opt in
- 5 minutes by default. configurable
- flushed whenever the previous Cloudflare flushing was implemented
- opt out for authenticated requests
