### PR TITLE
Allow transferwise.availableCurrencies blocklist to be bypassed

### DIFF
--- a/server/graphql/v2/object/TransferWise.ts
+++ b/server/graphql/v2/object/TransferWise.ts
@@ -71,10 +71,16 @@ export const TransferWise = new GraphQLObjectType({
       },
     },
     availableCurrencies: {
+      args: {
+        ignoreBlockedCurrencies: {
+          type: GraphQLBoolean,
+          description: 'Ignores blocklisted currencies, used to generate the bank information form for manual payments',
+        },
+      },
       type: new GraphQLList(GraphQLJSONObject),
-      async resolve(host) {
+      async resolve(host, args) {
         if (host) {
-          return await transferwise.getAvailableCurrencies(host);
+          return await transferwise.getAvailableCurrencies(host, args?.ignoreBlockedCurrencies);
         } else {
           return null;
         }

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -111,7 +111,10 @@ async function payExpense(
   return { quote, recipient, transfer, fund };
 }
 
-async function getAvailableCurrencies(host: any): Promise<{ code: string; minInvoiceAmount: number }[]> {
+async function getAvailableCurrencies(
+  host: any,
+  ignoreBlockedCurrencies = false,
+): Promise<{ code: string; minInvoiceAmount: number }[]> {
   const cacheKey = `transferwise_available_currencies_${host.id}`;
   const fromCache = await cache.get(cacheKey);
   if (fromCache) {
@@ -125,7 +128,8 @@ async function getAvailableCurrencies(host: any): Promise<{ code: string; minInv
     throw new TransferwiseError('Host is not connected to Transferwise', 'transferwise.error.notConnected');
   }
   await populateProfileId(connectedAccount);
-  const currencyBlockList = connectedAccount.data?.type === 'business' ? blockedCurrenciesForBusinesProfiles : [];
+  const currencyBlockList =
+    connectedAccount.data?.type === 'business' && !ignoreBlockedCurrencies ? blockedCurrenciesForBusinesProfiles : [];
 
   const pairs = await transferwise.getCurrencyPairs(connectedAccount.token);
   const source = pairs.sourceCurrencies.find(sc => sc.currencyCode === host.currency);


### PR DESCRIPTION
This is useful to generate a generic bank account form without the intent to be used in TransferWise.