### PR TITLE
Reject transaction

### DIFF
--- a/server/constants/order_status.js
+++ b/server/constants/order_status.js
@@ -21,4 +21,5 @@ export default {
   EXPIRED: 'EXPIRED', // When it's marked as such by Admins
   // For Pledges
   PLEDGED: 'PLEDGED',
+  REJECTED: 'REJECTED',
 };

--- a/server/graphql/v1/TransactionInterface.js
+++ b/server/graphql/v1/TransactionInterface.js
@@ -84,12 +84,7 @@ const TransactionFields = () => {
     refundTransaction: {
       type: TransactionInterfaceType,
       resolve(transaction) {
-        // If it's a sequelize model transaction, it means it has the method getRefundTransaction
-        // otherwise we just null
-        if (transaction && transaction.getRefundTransaction) {
-          return transaction.getRefundTransaction();
-        }
-        return null;
+        return transaction.getRefundTransaction();
       },
     },
     uuid: {

--- a/server/graphql/v2/enum/OrderStatus.js
+++ b/server/graphql/v2/enum/OrderStatus.js
@@ -12,6 +12,7 @@ export const OrderStatus = new GraphQLEnumType({
     PAID: {},
     PENDING: {},
     PLEDGED: {},
+    REJECTED: {},
     REQUIRE_CLIENT_CONFIRMATION: {},
   },
 });

--- a/server/graphql/v2/input/AccountReferenceInput.js
+++ b/server/graphql/v2/input/AccountReferenceInput.js
@@ -26,7 +26,7 @@ export const AccountReferenceInput = new GraphQLInputObjectType({
 /**
  * Retrieves an account
  *
- * @param {string|number} input - slug or id of the collective
+ * @param {object} input - object containing slug or id of the collective
  * @param {object} params
  *    - dbTransaction: An SQL transaction to run the query. Will skip `loaders`
  *    - lock: If true and `dbTransaction` is set, the row will be locked

--- a/server/lib/emailTemplates.js
+++ b/server/lib/emailTemplates.js
@@ -113,6 +113,7 @@ export const templateNames = [
   'hostplan.renewal.thankyou',
   'hostplan.first.subscription.confirmation',
   'hostplan.upgrade.subscription.confirmation',
+  'contribution.rejected',
 ];
 
 const templatesPath = `${__dirname}/../../templates`;

--- a/templates/emails/contribution.rejected.hbs
+++ b/templates/emails/contribution.rejected.hbs
@@ -1,0 +1,19 @@
+Subject: Your contribution to {{collective.name}}
+
+{{> header}}
+
+<h1>Hello,</h1>
+
+<p>Thank you for your contribution to {{collective.name}}. Unfortunately, your contribution has been rejected.</p>
+
+{{#if rejectionReason}}
+<p>Note from {{collective.name}}:</p>
+<blockquote
+	style="color:#6a737d;font-size: 16px;text-align: left;padding: 0.5em 0.75em;margin: 1em 0;border-left: 3px solid #e4e4e4;white-space: pre-line;">
+	{{rejectionReason}}</blockquote>
+{{/if}}
+
+<p>
+	We're sorry this has happened. If you have questions, contact <a
+		href="mailto:support@opencollective.com">support@opencollective.com</a>.</p>
+{{> footer}}

--- a/test/server/graphql/common/transactions.test.js
+++ b/test/server/graphql/common/transactions.test.js
@@ -74,11 +74,11 @@ describe('server/graphql/common/transactions', () => {
     it('can refund if root or host admin of the collective receiving the contribution', async () => {
       expect(await canRefund(transaction, undefined, publicReq)).to.be.false;
       expect(await canRefund(transaction, undefined, randomUserReq)).to.be.false;
-      expect(await canRefund(transaction, undefined, collectiveAdminReq)).to.be.false;
       expect(await canRefund(transaction, undefined, collectiveAccountantReq)).to.be.false;
       expect(await canRefund(transaction, undefined, hostAccountantReq)).to.be.false;
       expect(await canRefund(transaction, undefined, contributorReq)).to.be.false;
       expect(await canRefund(transaction, undefined, fromCollectiveAccountantReq)).to.be.false;
+      expect(await canRefund(transaction, undefined, collectiveAdminReq)).to.be.true;
       expect(await canRefund(transaction, undefined, hostAdminReq)).to.be.true;
       expect(await canRefund(transaction, undefined, rootAdminReq)).to.be.true;
     });

--- a/test/server/graphql/v1/refundTransaction.test.js
+++ b/test/server/graphql/v1/refundTransaction.test.js
@@ -161,7 +161,7 @@ describe('server/graphql/v1/refundTransaction', () => {
 
     // Then it should error out with the right error
     const [{ message }] = result.errors;
-    expect(message).to.equal('Not a site admin or host collective admin');
+    expect(message).to.equal('Cannot refund this transaction');
   });
 
   describe('Save CreatedByUserId', () => {


### PR DESCRIPTION
Frontend PR https://github.com/opencollective/opencollective-frontend/pull/5070

Relates https://github.com/opencollective/opencollective/issues/3484

* Adds capability for Collective admins to refund transactions
* Adds 'isRejected' field to `Transaction` v2 object
* Adds `rejectTransaction` mutation which:
    * refunds the transaction
    * changes the related `Order` status to `REJECTED`
    * destroys the membership with the role `BACKER`