### PR TITLE
GQLV1: Mark some endpoints as deprecated

### DIFF
--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -371,6 +371,7 @@ const mutations = {
   },
   createExpense: {
     type: ExpenseType,
+    deprecationReason: '2020-09-17: Now using GQLV2 for that',
     args: {
       expense: { type: new GraphQLNonNull(ExpenseInputType) },
     },

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -242,6 +242,7 @@ const queries = {
 
   InvoiceByDateRange: {
     type: InvoiceType,
+    deprecationReason: '2020-09-17: PDF service is now using the GQLV2 transactions endpoint',
     args: {
       invoiceInputType: {
         type: new GraphQLNonNull(InvoiceInputType),


### PR DESCRIPTION
Since we're now using GQLV2's `transactions` with https://github.com/opencollective/opencollective-pdf/pull/486, this endpoint is not needed anymore