### PR TITLE
TaxForm for organization followup fixes

### DIFF
--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -941,6 +941,7 @@ const getTaxFormsRequiredForExpenses = expenseIds => {
       AND ld.year = date_part('year', all_expenses."incurredAt")
       AND ld."documentType" = 'US_TAX_FORM'
     WHERE analyzed_expenses.id IN (:expenseIds)
+    AND analyzed_expenses."FromCollectiveId" != d."HostCollectiveId"
     AND analyzed_expenses.type != 'RECEIPT'
     AND analyzed_expenses.status IN ('PENDING', 'APPROVED')
     AND analyzed_expenses."deletedAt" IS NULL
@@ -982,6 +983,7 @@ const getTaxFormsRequiredForAccounts = async (accountIds = [], date = new Date()
       AND ld."documentType" = 'US_TAX_FORM'
     WHERE all_expenses.type != 'RECEIPT'
     ${accountIds?.length ? 'AND account.id IN (:accountIds)' : ''}
+    AND account.id != d."HostCollectiveId"
     AND all_expenses.status NOT IN ('ERROR', 'REJECTED')
     AND all_expenses."deletedAt" IS NULL
     AND EXTRACT('year' FROM all_expenses."incurredAt") = :year

--- a/server/lib/tax-forms.js
+++ b/server/lib/tax-forms.js
@@ -22,6 +22,13 @@ export async function findAccountsThatNeedToBeSentTaxForm(year) {
   } else {
     return models.Collective.findAll({
       where: { id: { [Op.in]: results.map(result => result.collectiveId) } },
+      include: [{ association: 'legalDocuments', required: false }],
+    }).then(collectives => {
+      return collectives.filter(
+        collective =>
+          !collective.legalDocuments.length ||
+          collective.legalDocuments.some(legalDocument => legalDocument.shouldBeRequested()),
+      );
     });
   }
 }

--- a/server/models/LegalDocument.js
+++ b/server/models/LegalDocument.js
@@ -79,6 +79,10 @@ export default function (Sequelize, DataTypes) {
     });
   };
 
+  LegalDocument.prototype.shouldBeRequested = function () {
+    return this.requestStatus == NOT_REQUESTED || this.requestStatus == ERROR;
+  };
+
   LegalDocument.requestStatus = {
     REQUESTED,
     NOT_REQUESTED,

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -184,9 +184,13 @@ export function setupModels(client) {
   // m.Collective.hasMany(m.Order); // makes the test `mocha test/graphql.transaction.test.js -g "insensitive" fail
   m.Collective.hasMany(m.Member, { foreignKey: 'CollectiveId', as: 'members' });
   m.Collective.hasMany(m.Order, { foreignKey: 'CollectiveId', as: 'orders' });
+  m.Collective.hasMany(m.LegalDocument, { foreignKey: 'CollectiveId', as: 'legalDocuments' });
   m.Transaction.belongsTo(m.Order);
   m.Order.hasMany(m.Transaction);
   m.Tier.hasMany(m.Order);
+
+  // Legal documents
+  m.LegalDocument.belongsTo(m.Collective);
 
   // Subscription
   m.Order.belongsTo(m.Subscription); // adds SubscriptionId to the Orders table

--- a/test/server/lib/tax-forms.test.js
+++ b/test/server/lib/tax-forms.test.js
@@ -123,6 +123,15 @@ describe('server/lib/tax-forms', () => {
         incurredAt: moment(),
       }),
     );
+    // An expense from the host, should not be included
+    await Expense.create(
+      ExpenseOverThreshold({
+        UserId: hostCollective.CreatedByUserId,
+        FromCollectiveId: hostCollective.id,
+        CollectiveId: collectives[0].id,
+        incurredAt: moment(),
+      }),
+    );
     // An expense from this year over the threshold BUT it's of type receipt so it should not be counted
     await Expense.create(
       ExpenseOverThreshold({
@@ -208,6 +217,7 @@ describe('server/lib/tax-forms', () => {
       expect(accounts.length).to.be.eq(4);
       expect(accounts.some(account => account.id === organizationWithTaxForm.id)).to.be.true;
       expect(accounts.some(account => account.id === accountAlreadyNotified.id)).to.be.false;
+      expect(accounts.some(account => account.id === hostCollective.id)).to.be.false;
     });
   });
 


### PR DESCRIPTION
- [x] Don't send email if already sent
- [x] Don't send to hosts that required the legal documents

Also added a test to make sure we don't send requests to people below the threshold.