### PR TITLE
Make ExpenseItem.incurredAt optional

### DIFF
--- a/migrations/20200917190000-expense-item-allow-null-incurredAt.js
+++ b/migrations/20200917190000-expense-item-allow-null-incurredAt.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query(`
+    ALTER TABLE "ExpenseItems" ALTER COLUMN "incurredAt" DROP NOT NULL
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query(`
+    ALTER TABLE "ExpenseItems" ALTER COLUMN "incurredAt" SET NOT NULL
+    `);
+  },
+};

--- a/server/graphql/v1/mutations/expenses.js
+++ b/server/graphql/v1/mutations/expenses.js
@@ -122,6 +122,14 @@ const checkExpenseItems = (expenseData, items) => {
       throw new ValidationFailed('Some items are missing a file');
     }
   }
+
+  // If expense is not a grant request then incurredAt must be set
+  if (expenseData.type !== expenseType.FUNDING_REQUEST) {
+    const hasMissingDate = items.some(a => !a.incurredAt);
+    if (hasMissingDate) {
+      throw new ValidationFailed('Some items are missing a date');
+    }
+  }
 };
 
 const EXPENSE_EDITABLE_FIELDS = [

--- a/server/models/ExpenseItem.ts
+++ b/server/models/ExpenseItem.ts
@@ -123,7 +123,7 @@ export default (sequelize, DataTypes): typeof ExpenseItem => {
       incurredAt: {
         type: DataTypes.DATE,
         defaultValue: DataTypes.NOW,
-        allowNull: false,
+        allowNull: true,
       },
       ExpenseId: {
         type: DataTypes.INTEGER,

--- a/test/stores/index.js
+++ b/test/stores/index.js
@@ -222,6 +222,9 @@ export async function newCollectiveInHost(name, currency, hostCollective, user =
  * @return {models.Expense} newly created expense instance.
  */
 export async function createExpense(user, expenseData) {
+  if (expenseData.items) {
+    expenseData.items.forEach(i => (i.incurredAt = i.incurredAt || new Date()));
+  }
   return expenses.createExpense(user, expenseData);
 }
 


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/3512

Not required, but technically, grant items do not have an incurred date.