### PR TITLE
PayExpense Concurency

### DIFF
--- a/migrations/20200922100646-double-expense-transactions.js
+++ b/migrations/20200922100646-double-expense-transactions.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const destroyDuplicatesQuery = `
+  UPDATE "Transactions" t
+  SET
+    "deletedAt" = NOW(),
+    data = (
+      CASE WHEN t.data IS NULL 
+      THEN '{"isDuplicateExpenseTransaction": true}'::jsonb
+      ELSE t.data::jsonb || '{"isDuplicateExpenseTransaction": true}'::jsonb
+    END)
+  WHERE t.id IN (
+    SELECT
+      max(id)
+    FROM
+      "Transactions"
+    WHERE
+      "ExpenseId" IS NOT NULL
+      AND "type" = :transactionType
+      AND "PaymentMethodId" IS NULL
+      AND "RefundTransactionId" IS NULL
+      AND "deletedAt" IS NULL
+    GROUP BY
+      "ExpenseId"
+    HAVING
+      COUNT(id) = 2
+  )
+`;
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(destroyDuplicatesQuery, { replacements: { transactionType: 'CREDIT' } });
+    await queryInterface.sequelize.query(destroyDuplicatesQuery, { replacements: { transactionType: 'DEBIT' } });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      UPDATE "Transactions" 
+      SET "deletedAt" = NULL
+      WHERE ("data" ->> 'isDuplicateExpenseTransaction')::boolean = TRUE
+    `);
+  },
+};


### PR DESCRIPTION
An alternative approach to https://github.com/opencollective/opencollective-api/pull/4598, that is simpler as we don't need to pass the SQL transaction down. It's a "soft" lock, where we only use a transaction + SQL lock to actually set a flag in the expense `data`, then we rely on this flag to check whether the expense is locked.

I came up with that because https://github.com/opencollective/opencollective-api/pull/4598 gave me a really hard time to make sure all SQL queries get the SQL transaction (including the ones in subqueries and models methods) and it added a lot of complexity to the code. A potential way to do it properly would be through https://github.com/Jeff-Lewis/cls-hooked, but last time I tried it was pretty unstable and there was some incompatibilities in our codebase.

Also protected the "mark as unpaid" endpoint, because it also creates transactions in the DB.