### PR TITLE
fix(Reject contribution): Fix permissions

### DIFF
--- a/server/graphql/common/transactions.ts
+++ b/server/graphql/common/transactions.ts
@@ -131,5 +131,12 @@ export const canReject = async (transaction, _, req): Promise<boolean> => {
   if (transaction.type !== TransactionTypes.CREDIT || transaction.OrderId === null) {
     return false;
   }
-  return remoteUserMeetsOneCondition(req, transaction, [isPayeeCollectiveAdmin]);
+  const timeLimit = moment().subtract(30, 'd');
+  const createdAtMoment = moment(transaction.createdAt);
+  const transactionIsOlderThanThirtyDays = createdAtMoment < timeLimit;
+  if (transactionIsOlderThanThirtyDays) {
+    return remoteUserMeetsOneCondition(req, transaction, [isRoot, isPayeeHostAdmin]);
+  } else {
+    return remoteUserMeetsOneCondition(req, transaction, [isRoot, isPayeeHostAdmin, isPayeeCollectiveAdmin]);
+  }
 };


### PR DESCRIPTION
Add same permissions to `canReject` as `canRefund`, because `canReject` was only allowing Collective admins to reject and we want it to have the same permissions as `canRefund`