### PR TITLE
PayPal payouts checking race-condition

### DIFF
--- a/cron/hourly/11-check-pending-paypal-expenses.js
+++ b/cron/hourly/11-check-pending-paypal-expenses.js
@@ -20,10 +20,13 @@ export async function run() {
         {
           status: { [Op.notIn]: [status.PAID, status.ERROR] },
           updatedAt: {
-            [Op.gte]: moment().subtract(15, 'days').toDate(),
+            // 40 so we can cover the 30 day limit
+            [Op.gte]: moment().subtract(40, 'days').toDate(),
           },
         },
       ],
+      // 30 minutes window to avoid race conditions with the webhook interface
+      updatedAt: { [Op.lte]: moment().subtract(30, 'minutes').toDate() },
       'data.payout_batch_id': { [Op.not]: null },
     },
     include: [

--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -74,6 +74,9 @@ export const payExpensesBatch = async (expenses: any[]): Promise<any[]> => {
 };
 
 export const checkBatchItemStatus = async (item: PayoutItemDetails, expense: any, host: any) => {
+  // Reload up-to-date values to avoid race conditions when processing batches.
+  await expense.reload();
+
   if (expense.data.payout_batch_id !== item.payout_batch_id) {
     throw new Error(`Item does not belongs to expense it claims it does.`);
   }


### PR DESCRIPTION
There were two episodes where a batch was processed twice: September 28, 2020, 4:04 AM, and September 7, 2020, 9:34 PM.
I'm implementing some updates here, including delaying the transaction check worker to give 30 minutes so the webhook can have priority over it.
Duplicated transactions were manually soft-deleted.