### PR TITLE
emails: Don't escape sanitized HTML content

### DIFF
--- a/templates/emails/collective.comment.created.hbs
+++ b/templates/emails/collective.comment.created.hbs
@@ -29,7 +29,7 @@ Subject: {{collective.name}}: New comment
   <tbody>
     <tr>
       <td style="border: 1px solid #e8edee; border-radius: 6px; padding: 2em 1em;">
-        <blockquote style="color: #798088;font-size: 13px;text-align: left;padding: 0px 1em;margin: 0em 0;white-space: pre-line;">{{comment.html}}</blockquote>
+        <blockquote style="color: #798088;font-size: 13px;text-align: left;padding: 0px 1em;margin: 0em 0;white-space: pre-line;">{{{comment.html}}}</blockquote>
       </td>
     </tr>
   </tbody>

--- a/templates/emails/collective.conversation.created.hbs
+++ b/templates/emails/collective.conversation.created.hbs
@@ -13,7 +13,7 @@ Subject: New conversation on {{collective.name}}: "{{conversation.title}}"
   <tbody>
     <tr>
       <td style="border: 1px solid #e8edee; border-radius: 6px; padding: 2em 1em;">
-        <blockquote style="color: #798088;font-size: 13px;text-align: left;padding: 0px 1em;margin: 0em 0;white-space: pre-line;">{{rootComment.html}}</blockquote>
+        <blockquote style="color: #798088;font-size: 13px;text-align: left;padding: 0px 1em;margin: 0em 0;white-space: pre-line;">{{{rootComment.html}}}</blockquote>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
- Fix https://github.com/opencollective/opencollective/issues/3554
- Also fix the same issue for expense's comments

I assume this was introduced in https://github.com/opencollective/opencollective-api/pull/3693 (because handlebars changed the way it sanitizes content).