### PR TITLE
Wording changes for rejectedCategories

### DIFF
--- a/server/lib/collectivelib.js
+++ b/server/lib/collectivelib.js
@@ -123,8 +123,8 @@ export function validateSettings(settings) {
     }
   }
 
-  if (settings.moderation?.rejectedContributionCategories) {
-    const categories = get(settings, 'moderation.rejectedContributionCategories');
+  if (settings.moderation?.rejectedCategories) {
+    const categories = get(settings, 'moderation.rejectedCategories');
     for (const category of categories) {
       if (!MODERATION_CATEGORIES.includes(category)) {
         return 'Invalid filtering category';


### PR DESCRIPTION
Changes `rejectedContributionCategories` to `rejectedCategories` as requested [here](https://github.com/opencollective/opencollective-frontend/pull/5183#discussion_r498780446) 