### PR TITLE
Collectives: Make data private

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -624,7 +624,10 @@ export const CollectiveInterfaceType = new GraphQLInterfaceType({
         description: 'Defines if a collective is pledged',
         type: GraphQLBoolean,
       },
-      data: { type: GraphQLJSON },
+      data: {
+        type: GraphQLJSON,
+        deprecationReason: '2020-10-08: This field is not provided anymore and will return an empty object',
+      },
       githubContributors: { type: new GraphQLNonNull(GraphQLJSON) },
       slug: { type: GraphQLString },
       path: { type: GraphQLString },
@@ -1068,8 +1071,9 @@ const CollectiveFields = () => {
     },
     data: {
       type: GraphQLJSON,
-      resolve(collective) {
-        return collective.data || {};
+      deprecationReason: '2020-10-08: This field is not provided anymore and will return an empty object',
+      resolve() {
+        return {};
       },
     },
     githubContributors: {

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -176,7 +176,7 @@ export const CollectiveInputType = new GraphQLInputObjectType({
     tags: { type: new GraphQLList(GraphQLString) },
     tiers: { type: new GraphQLList(TierInputType) },
     settings: { type: GraphQLJSON },
-    data: { type: GraphQLJSON },
+    data: { type: GraphQLJSON, deprecationReason: '2020-10-08: data cannot be edited. This field will be ignored.' },
     members: { type: new GraphQLList(MemberInputType) },
     notifications: { type: new GraphQLList(NotificationInputType) },
     HostCollectiveId: { type: GraphQLInt },

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -317,7 +317,7 @@ export function editCollective(_, args, req) {
   }
 
   const newCollectiveData = {
-    ...omit(args.collective, ['location', 'type', 'ParentCollectiveId']),
+    ...omit(args.collective, ['location', 'type', 'ParentCollectiveId', 'data']),
     LastEditedByUserId: req.remoteUser.id,
   };
 


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/4681 + https://github.com/opencollective/opencollective-images/pull/324 to be merged & deployed first for a smooth migration.

In https://github.com/opencollective/opencollective/issues/3443 I plan to store the `GUEST_TOKEN` in `data`, so we needed to make sure data is private - following the pattern implemented for `Expenses`.