### PR TITLE
Guest contributions

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -106,6 +106,9 @@
       "perIp": "ORDERS_LIMIT_IP"
     }
   },
+  "guestContributions": {
+    "enable": "ENABLE_GUEST_CONTRIBUTIONS"
+  },
   "slack": {
     "webhooks": {
       "abuse": "SLACK_WEBHOOK_ABUSE"

--- a/config/default.json
+++ b/config/default.json
@@ -62,6 +62,9 @@
     "collectiveEmailMessagePerHour": 5,
     "maxMemberInvitationsPerCollective": 50
   },
+  "guestContributions": {
+    "enable": true
+  },
   "email": {
     "from": "Open Collective <info@opencollective.com>"
   },

--- a/config/production.json
+++ b/config/production.json
@@ -22,6 +22,9 @@
     "images": "https://images.opencollective.com",
     "pdf": "https://pdf.opencollective.com"
   },
+  "guestContributions": {
+    "enable": false
+  },
   "log": {
     "slowRequest": true
   },

--- a/migrations/20201008134841-add-guest-tokens.js
+++ b/migrations/20201008134841-add-guest-tokens.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, DataTypes) => {
+    await queryInterface.createTable('GuestTokens', {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      CollectiveId: {
+        type: DataTypes.INTEGER,
+        references: { key: 'id', model: 'Collectives' },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false,
+        unique: true,
+      },
+      value: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    });
+
+    await queryInterface.addIndex('GuestTokens', ['CollectiveId']);
+  },
+
+  down: async (queryInterface, DataTypes) => {
+    await queryInterface.dropTable('GuestTokens');
+  },
+};

--- a/migrations/20201008142518-add-confirmedAt-to-users.js
+++ b/migrations/20201008142518-add-confirmedAt-to-users.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Users', 'confirmedAt', {
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.NOW,
+      allowNull: true,
+    });
+
+    // Mark all existing users as confirmed
+    await queryInterface.sequelize.query(`
+      UPDATE "Users" SET "confirmedAt" = "createdAt"
+    `);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('Users', 'confirmedAt');
+  },
+};

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -2683,6 +2683,12 @@ type Debit implements Transaction {
 }
 
 """
+A field whose value conforms to the standard internet email address format as
+specified in RFC822: https://www.w3.org/Protocols/rfc822/.
+"""
+scalar EmailAddress
+
+"""
 This represents an Event account
 """
 type Event implements Account & AccountWithHost & AccountWithContributions {
@@ -3703,6 +3709,26 @@ input FundCreateInput {
 }
 
 """
+Input type for guest contributions
+"""
+input GuestInfoInput {
+  """
+  Contributor's email
+  """
+  email: EmailAddress
+
+  """
+  Full name of the user
+  """
+  name: String
+
+  """
+  The unique guest token
+  """
+  token: String
+}
+
+"""
 This represents an Host account
 """
 type Host implements Account & AccountWithContributions {
@@ -4215,9 +4241,10 @@ type Individual implements Account {
   location: Location
   categories: [String]!
   stats: AccountStats
-  firstName: String
-  lastName: String
+  firstName: String @deprecated(reason: "2020-10-12: Use the name field")
+  lastName: String @deprecated(reason: "2020-10-12: Use the name field")
   email: String
+  isGuest: Boolean!
   isFollowingConversation(id: String!): Boolean!
   hasTwoFactorAuth: Boolean
 }
@@ -4910,14 +4937,19 @@ input OrderCreateInput {
   frequency: ContributionFrequency!
 
   """
-  The profile making the order
+  The profile making the order. Can be null for guest contributions.
   """
-  fromAccount: AccountReferenceInput!
+  fromAccount: AccountReferenceInput
 
   """
   The profile you want to contribute to
   """
   toAccount: AccountReferenceInput!
+
+  """
+  Use this when fromAccount is null to pass the guest info
+  """
+  guestInfo: GuestInfoInput
 
   """
   The payment method used for this order

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -304,6 +304,25 @@ export const TierInputType = new GraphQLInputObjectType({
   }),
 });
 
+export const GuestInfoInput = new GraphQLInputObjectType({
+  name: 'GuestInfoInput',
+  description: 'Input type for guest contributions',
+  fields: {
+    email: {
+      type: GraphQLString,
+      description: "Contributor's email",
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Full name of the user',
+    },
+    token: {
+      type: GraphQLString,
+      description: 'The unique guest token',
+    },
+  },
+});
+
 export const OrderInputType = new GraphQLInputObjectType({
   name: 'OrderInputType',
   description: 'Input type for OrderType',
@@ -324,12 +343,16 @@ export const OrderInputType = new GraphQLInputObjectType({
     publicMessage: { type: GraphQLString },
     privateMessage: { type: GraphQLString },
     paymentMethod: { type: PaymentMethodInputType },
-    user: { type: UserInputType },
+    user: { type: UserInputType, deprecationReason: '2020-10-13: This field is now ignored' },
     fromCollective: { type: CollectiveAttributesInputType },
     collective: { type: new GraphQLNonNull(CollectiveAttributesInputType) },
     tier: { type: TierInputType },
     customData: { type: GraphQLJSON },
     recaptchaToken: { type: GraphQLString },
+    guestInfo: {
+      type: GuestInfoInput,
+      description: 'Use this when fromAccount is null to pass the guest info',
+    },
     // For taxes
     taxAmount: {
       type: GraphQLInt,

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -469,8 +469,9 @@ const mutations = {
         type: new GraphQLNonNull(OrderInputType),
       },
     },
-    resolve(_, args, req) {
-      return createOrder(args.order, req.loaders, req.remoteUser, req.ip);
+    async resolve(_, args, req) {
+      const { order } = await createOrder(args.order, req.loaders, req.remoteUser, req.ip);
+      return order;
     },
   },
   confirmOrder: {

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -463,6 +463,7 @@ const mutations = {
   },
   createOrder: {
     type: OrderType,
+    deprecationReason: '2020-10-13: This endpoint has been moved to GQLV2',
     args: {
       order: {
         type: new GraphQLNonNull(OrderInputType),

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -23,7 +23,7 @@ import { handleHostPlanAddedFundsLimit, handleHostPlanBankTransfersLimit } from 
 import recaptcha from '../../../lib/recaptcha';
 import { getChargeRetryCount, getNextChargeAndPeriodStartDates } from '../../../lib/recurring-contributions';
 import { canUseFeature } from '../../../lib/user-permissions';
-import { capitalize, formatCurrency, md5 } from '../../../lib/utils';
+import { capitalize, formatCurrency, md5, parseToBoolean } from '../../../lib/utils';
 import models from '../../../models';
 import { setupCreditCard } from '../../../paymentProviders/stripe/creditcard';
 import { FeatureNotAllowedForUser, Forbidden, NotFound, Unauthorized, ValidationFailed } from '../../errors';
@@ -100,7 +100,9 @@ async function checkOrdersLimit(order, reqIp) {
 }
 
 const checkGuestContribution = order => {
-  if (order.interval) {
+  if (!parseToBoolean(config.guestContributions.enable)) {
+    throw new Error('Guest contributions are not enabled yet');
+  } else if (order.interval) {
     throw new Error('You need to sign up to create a recurring contribution');
   } else if (order.guestInfo?.email && !isEmail(order.guestInfo.email)) {
     throw new Error('You need to provide a valid email');

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -112,7 +112,8 @@ const checkGuestContribution = order => {
 };
 
 async function checkRecaptcha(order, remoteUser, reqIp) {
-  if (['ci', 'test'].includes(config.env)) {
+  // Disabled for all environments
+  if (['ci', 'test', 'development', 'production'].includes(config.env)) {
     return;
   }
 

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -2,9 +2,10 @@ import * as LibTaxes from '@opencollective/taxes';
 import Promise from 'bluebird';
 import config from 'config';
 import debugLib from 'debug';
-import { get, isNil, omit, pick } from 'lodash';
+import { get, isNil, omit, pick, set } from 'lodash';
 import moment from 'moment';
 import { v4 as uuid } from 'uuid';
+import { isEmail } from 'validator';
 
 import activities from '../../../constants/activities';
 import { types } from '../../../constants/collectives';
@@ -15,6 +16,8 @@ import { VAT_OPTIONS } from '../../../constants/vat';
 import { canRefund } from '../../../graphql/common/transactions';
 import cache, { purgeCacheForCollective } from '../../../lib/cache';
 import * as github from '../../../lib/github';
+import { getOrCreateGuestProfile } from '../../../lib/guest-accounts';
+import logger from '../../../lib/logger';
 import * as libPayments from '../../../lib/payments';
 import { handleHostPlanAddedFundsLimit, handleHostPlanBankTransfersLimit } from '../../../lib/plans';
 import recaptcha from '../../../lib/recaptcha';
@@ -29,7 +32,7 @@ const oneHourInSeconds = 60 * 60;
 
 const debug = debugLib('orders');
 
-async function checkOrdersLimit(order, remoteUser, reqIp) {
+async function checkOrdersLimit(order, reqIp) {
   if (['ci', 'test'].includes(config.env)) {
     return;
   }
@@ -95,6 +98,16 @@ async function checkOrdersLimit(order, remoteUser, reqIp) {
     }
   }
 }
+
+const checkGuestContribution = order => {
+  if (order.interval) {
+    throw new Error('You need to sign up to create a recurring contribution');
+  } else if (order.guestInfo?.email && !isEmail(order.guestInfo.email)) {
+    throw new Error('You need to provide a valid email');
+  } else if (!order.guestInfo?.email && !order.guestInfo?.token) {
+    throw new Error('When contributing as a guest, you either need to provide an email or a token');
+  }
+};
 
 async function checkRecaptcha(order, remoteUser, reqIp) {
   if (['ci', 'test'].includes(config.env)) {
@@ -190,23 +203,25 @@ const getTaxInfo = async (order, collective, host, tier, loaders) => {
 
 export async function createOrder(order, loaders, remoteUser, reqIp) {
   debug('Beginning creation of order', order);
-  if (!remoteUser) {
-    throw new Unauthorized();
-  }
-  await checkOrdersLimit(order, remoteUser, reqIp);
-  const recaptchaResponse = await checkRecaptcha(order, remoteUser, reqIp);
+
   if (remoteUser && !canUseFeature(remoteUser, FEATURE.ORDER)) {
     return new FeatureNotAllowedForUser();
+  } else if (!remoteUser) {
+    checkGuestContribution(order);
   }
 
-  let orderCreated;
+  await checkOrdersLimit(order, reqIp);
+  const recaptchaResponse = await checkRecaptcha(order, remoteUser, reqIp);
+
+  let orderCreated, isGuest;
   try {
     // ---- Set defaults ----
     order.quantity = order.quantity || 1;
     order.taxAmount = order.taxAmount || 0;
 
-    if (order.paymentMethod && order.paymentMethod.service === 'stripe' && order.paymentMethod.uuid && !remoteUser) {
-      throw new Error('You need to be logged in to be able to use a payment method on file');
+    const isExistingPaymentMethod = Boolean(order.paymentMethod?.id || order.paymentMethod?.uuid);
+    if (isExistingPaymentMethod && !remoteUser) {
+      throw new Error('You need to be logged in to be able to use an existing payment method');
     }
 
     if (!order.collective || (!order.collective.id && !order.collective.website && !order.collective.githubHandle)) {
@@ -233,7 +248,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
     // Some tests are relying on this check being done at that point
     // Could be moved below at some point (see commented code)
-    if (order.platformFeePercent && !remoteUser.isRoot()) {
+    if (order.platformFeePercent && !remoteUser?.isRoot()) {
       throw new Error('Only a root can change the platformFeePercent');
     }
 
@@ -269,23 +284,15 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
       throw new Error('Orders cannot be created for a collective by that same collective.');
     }
 
-    /*
-    if (order.platformFeePercent && collective.platformFeePercent) {
-      if (order.platformFeePercent < collective.platformFeePercent && !remoteUser.isRoot()) {
-        throw new Error('Only a root can set a lower platformFeePercent');
-      }
-    }
-    */
-
     if (order.platformFee) {
-      if (collective.platformFeePercent && !remoteUser.isRoot()) {
+      if (collective.platformFeePercent && !remoteUser?.isRoot()) {
         throw new Error('Only a root can set a platformFee on a collective with non-zero platformFee');
       }
     }
 
     const host = await collective.getHostCollective();
     if (order.hostFeePercent) {
-      if (!remoteUser.isAdmin(host.id)) {
+      if (!remoteUser?.isAdmin(host.id)) {
         throw new Error('Only an admin of the host can change the hostFeePercent');
       }
     }
@@ -326,7 +333,7 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
 
     // find or create user, check permissions to set `fromCollective`
     let fromCollective;
-    if (!order.fromCollective || (!order.fromCollective.id && !order.fromCollective.name)) {
+    if (remoteUser && (!order.fromCollective || (!order.fromCollective.id && !order.fromCollective.name))) {
       fromCollective = await loaders.Collective.byId.load(remoteUser.CollectiveId);
     }
 
@@ -342,10 +349,10 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
         possibleRoles.push(roles.MEMBER);
       }
 
-      if (!remoteUser.hasRole(possibleRoles, order.fromCollective.id)) {
+      if (!remoteUser?.hasRole(possibleRoles, order.fromCollective.id)) {
         // We only allow to add funds on behalf of a collective if the user is an admin of that collective or an admin of the host of the collective that receives the money
         const HostId = await collective.getHostCollectiveId();
-        if (!remoteUser.isAdmin(HostId)) {
+        if (!remoteUser?.isAdmin(HostId)) {
           throw new Error(
             `You don't have sufficient permissions to create an order on behalf of the ${
               fromCollective.name
@@ -356,7 +363,17 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
     }
 
     if (!fromCollective) {
-      fromCollective = await models.Collective.createOrganization(order.fromCollective, remoteUser, remoteUser);
+      if (remoteUser) {
+        // @deprecated - Creating organizations inline from this endpoint should not be suoported anymore
+        logger.warn('createOrder: Inline org creation should not be used anymore');
+        fromCollective = await models.Collective.createOrganization(order.fromCollective, remoteUser, remoteUser);
+      } else {
+        // Create or retrieve guest profile from GUEST_TOKEN
+        const guestProfile = await getOrCreateGuestProfile(order.guestInfo);
+        remoteUser = guestProfile.user;
+        fromCollective = guestProfile.collective;
+        isGuest = true;
+      }
     }
 
     const currency = (tier && tier.currency) || collective.currency;
@@ -491,7 +508,13 @@ export async function createOrder(order, loaders, remoteUser, reqIp) {
         // but this is breaking some conventions elsewhere
         if (orderCreated.data.savePaymentMethod) {
           order.paymentMethod.CollectiveId = orderCreated.FromCollectiveId;
+        } else if (isGuest) {
+          // Always link the payment method to the collective for guests but make sure `save` is false
+          order.paymentMethod.CollectiveId = orderCreated.FromCollectiveId;
+          order.paymentMethod.save = false;
+          set(order.paymentMethod, 'data.isGuest', true);
         }
+
         await orderCreated.setPaymentMethod(order.paymentMethod);
       }
       // also adds the user as a BACKER of collective
@@ -861,7 +884,9 @@ export async function addFundsToCollective(order, remoteUser) {
   order.collective = collective;
   let fromCollective, user;
 
+  // @deprecated Users are normally not created inline anymore
   if (order.user && order.user.email) {
+    logger.warn('addFundsToCollective: Inline user creation should not be used anymore');
     user = await models.User.findByEmail(order.user.email);
     if (!user) {
       user = await models.User.createUserWithCollective({

--- a/server/graphql/v2/input/GuestInfoInput.ts
+++ b/server/graphql/v2/input/GuestInfoInput.ts
@@ -1,0 +1,22 @@
+import { GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from 'graphql';
+
+import EmailAddress from '../scalar/EmailAddress';
+
+export const GuestInfoInput = new GraphQLInputObjectType({
+  name: 'GuestInfoInput',
+  description: 'Input type for guest contributions',
+  fields: {
+    email: {
+      type: GraphQLNonNull(EmailAddress),
+      description: "Contributor's email",
+    },
+    name: {
+      type: GraphQLString,
+      description: 'Full name of the user',
+    },
+    token: {
+      type: GraphQLString,
+      description: 'The unique guest token',
+    },
+  },
+});

--- a/server/graphql/v2/input/GuestInfoInput.ts
+++ b/server/graphql/v2/input/GuestInfoInput.ts
@@ -2,6 +2,8 @@ import { GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from 'graphql';
 
 import EmailAddress from '../scalar/EmailAddress';
 
+import { LocationInput } from './LocationInput';
+
 export const GuestInfoInput = new GraphQLInputObjectType({
   name: 'GuestInfoInput',
   description: 'Input type for guest contributions',
@@ -17,6 +19,10 @@ export const GuestInfoInput = new GraphQLInputObjectType({
     token: {
       type: GraphQLString,
       description: 'The unique guest token',
+    },
+    location: {
+      type: LocationInput,
+      description: 'Address of the user, mandatory when amount is above $5000.',
     },
   },
 });

--- a/server/graphql/v2/input/OrderCreateInput.ts
+++ b/server/graphql/v2/input/OrderCreateInput.ts
@@ -5,6 +5,7 @@ import { ContributionFrequency } from '../enum/ContributionFrequency';
 
 import { AccountReferenceInput } from './AccountReferenceInput';
 import { AmountInput } from './AmountInput';
+import { GuestInfoInput } from './GuestInfoInput';
 import { OrderTaxInput } from './OrderTaxInput';
 import { PaymentMethodInput } from './PaymentMethodInput';
 import { TierReferenceInput } from './TierReferenceInput';
@@ -25,12 +26,16 @@ export const OrderCreateInput = new GraphQLInputObjectType({
       type: new GraphQLNonNull(ContributionFrequency),
     },
     fromAccount: {
-      type: new GraphQLNonNull(AccountReferenceInput),
-      description: 'The profile making the order',
+      type: AccountReferenceInput,
+      description: 'The profile making the order. Can be null for guest contributions.',
     },
     toAccount: {
       type: new GraphQLNonNull(AccountReferenceInput),
       description: 'The profile you want to contribute to',
+    },
+    guestInfo: {
+      type: GuestInfoInput,
+      description: 'Use this when fromAccount is null to pass the guest info',
     },
     paymentMethod: {
       description: 'The payment method used for this order',

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -263,13 +263,18 @@ const orderMutations = {
       order: {
         type: new GraphQLNonNull(OrderReferenceInput),
       },
+      guestToken: {
+        type: GraphQLString,
+        description: 'If the order was made as a guest, you can use this field to authenticate',
+      },
     },
     async resolve(_, args, req) {
       const baseOrder = await fetchOrderWithReference(args.order);
-      const updatedOrder = await confirmOrderLegacy(baseOrder, req.remoteUser);
+      const updatedOrder = await confirmOrderLegacy(baseOrder, req.remoteUser, args.guestToken);
       return {
         order: updatedOrder,
         stripeError: updatedOrder.stripeError,
+        guestToken: args.guestToken,
       };
     },
   },

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -1,4 +1,4 @@
-import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { isNil, isNull, isUndefined } from 'lodash';
 
 import activities from '../../../constants/activities';
@@ -30,6 +30,10 @@ const OrderWithPayment = new GraphQLObjectType({
     order: {
       type: new GraphQLNonNull(Order),
       description: 'The order created',
+    },
+    guestToken: {
+      type: GraphQLString,
+      description: 'If donating as a guest, this will contain your guest token to contribute again in the future',
     },
     stripeError: {
       type: StripeError,
@@ -89,8 +93,8 @@ const orderMutations = {
         platformFee,
       };
 
-      const orderCreated = await createOrderLegacy(legacyOrderObj, req.loaders, req.remoteUser, req.ip);
-      return { order: orderCreated, stripeError: orderCreated.stripeError };
+      const result = await createOrderLegacy(legacyOrderObj, req.loaders, req.remoteUser, req.ip);
+      return { order: result.order, stripeError: result.stripeError, guestToken: result.guestToken?.value };
     },
   },
   cancelOrder: {

--- a/server/graphql/v2/object/Individual.js
+++ b/server/graphql/v2/object/Individual.js
@@ -15,6 +15,7 @@ export const Individual = new GraphQLObjectType({
       ...AccountFields,
       firstName: {
         type: GraphQLString,
+        deprecationReason: '2020-10-12: Use the name field',
         resolve(userCollective, args, req) {
           return (
             userCollective && req.loaders.getUserDetailsByCollectiveId.load(userCollective.id).then(u => u.firstName)
@@ -23,6 +24,7 @@ export const Individual = new GraphQLObjectType({
       },
       lastName: {
         type: GraphQLString,
+        deprecationReason: '2020-10-12: Use the name field',
         resolve(userCollective, args, req) {
           return (
             userCollective && req.loaders.getUserDetailsByCollectiveId.load(userCollective.id).then(u => u.lastName)
@@ -38,6 +40,12 @@ export const Individual = new GraphQLObjectType({
           return (
             userCollective && req.loaders.getUserDetailsByCollectiveId.load(userCollective.id).then(user => user.email)
           );
+        },
+      },
+      isGuest: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve(account) {
+          return Boolean(account.data?.isGuest);
         },
       },
       isFollowingConversation: {

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -64,7 +64,9 @@ export const PaymentMethod = new GraphQLObjectType({
       account: {
         type: Account,
         resolve(paymentMethod, _, req) {
-          return req.loaders.Collective.byId.load(paymentMethod.CollectiveId);
+          if (paymentMethod.CollectiveId) {
+            return req.loaders.Collective.byId.load(paymentMethod.CollectiveId);
+          }
         },
       },
       sourcePaymentMethod: {

--- a/server/graphql/v2/scalar/EmailAddress.ts
+++ b/server/graphql/v2/scalar/EmailAddress.ts
@@ -1,0 +1,36 @@
+import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
+import { isEmail } from 'validator';
+
+const validate = (value: unknown) => {
+  if (typeof value !== 'string') {
+    throw new TypeError(`Value is not string: ${value}`);
+  }
+
+  if (!isEmail(value)) {
+    throw new TypeError(`Value is not a valid email address: ${value}`);
+  }
+
+  return value;
+};
+
+/**
+ * A field whose value conforms to the standard internet email address format as specified in RFC822: https://www.w3.org/Protocols/rfc822/.
+ * Inspired by https://github.com/Urigo/graphql-scalars/blob/master/src/scalars/EmailAddress.ts
+ */
+const EmailAddress = new GraphQLScalarType({
+  name: 'EmailAddress',
+  description:
+    'A field whose value conforms to the standard internet email address format as specified in RFC822: https://www.w3.org/Protocols/rfc822/.',
+
+  serialize: validate,
+  parseValue: validate,
+  parseLiteral(ast) {
+    if (ast.kind !== Kind.STRING) {
+      throw new GraphQLError(`Can only validate strings as email addresses but got a: ${ast.kind}`);
+    }
+
+    return validate(ast.value);
+  },
+});
+
+export default EmailAddress;

--- a/server/lib/guest-accounts.ts
+++ b/server/lib/guest-accounts.ts
@@ -1,0 +1,128 @@
+import crypto from 'crypto';
+
+import { v4 as uuid } from 'uuid';
+
+import { types as COLLECTIVE_TYPE } from '../constants/collectives';
+import models, { sequelize } from '../models';
+
+const INVALID_TOKEN_MSG = 'Your guest token is invalid. If you already have an account, please sign in.';
+
+type GuestProfileDetails = {
+  user: typeof models.User;
+  collective: typeof models.Collective;
+  token: typeof models.GuestToken;
+};
+
+/**
+ * Load a `GuestToken` from its code, returns the user and collective associated
+ */
+const loadGuestToken = async (guestToken: string): Promise<GuestProfileDetails> => {
+  const token = await models.GuestToken.findOne({
+    where: { value: guestToken },
+    include: [{ association: 'collective', required: true }],
+  });
+
+  if (!token) {
+    throw new Error(INVALID_TOKEN_MSG);
+  }
+
+  const user = await models.User.findOne({ where: { CollectiveId: token.collective.id } });
+  if (!user) {
+    // This can happen if trying to contribute with a guest token when the user
+    // associated has been removed (ie. if it's a spammer)
+    throw new Error(INVALID_TOKEN_MSG);
+  }
+
+  return { token, collective: token.collective, user };
+};
+
+const createGuestProfile = (email: string, name: string | null): Promise<GuestProfileDetails> => {
+  const emailConfirmationToken = crypto.randomBytes(48).toString('hex');
+  const guestToken = crypto.randomBytes(48).toString('hex');
+
+  if (!email) {
+    throw new Error('An email is required to create a guest profile');
+  }
+
+  return sequelize.transaction(async transaction => {
+    // Create the public guest profile
+    const collective = await models.Collective.create(
+      {
+        type: COLLECTIVE_TYPE.USER,
+        slug: `guest-${uuid().split('-')[0]}`,
+        name: name ?? 'Guest',
+        data: { isGuest: true },
+      },
+      { transaction },
+    );
+
+    // Create (or fetch) the user associated with the email
+    let user = await models.User.findOne({ where: { email } }, { transaction });
+    if (!user) {
+      user = await models.User.create(
+        {
+          email,
+          confirmedAt: null,
+          CollectiveId: collective.id,
+          emailConfirmationToken,
+        },
+        { transaction },
+      );
+    } else if (user.confirmedAt) {
+      // We only allow to re-use the same User without token if it's not verified.
+      throw new Error('An account already exists for this email, please sign in.');
+    }
+
+    collective.update({ CreatedByUserId: user.id });
+
+    // Create the token that will be used to authenticate future contributions for
+    // this guest profile
+    const guestTokenData = { CollectiveId: collective.id, value: guestToken };
+    const token = await models.GuestToken.create(guestTokenData, { transaction });
+
+    return { collective, user, token };
+  });
+};
+
+/**
+ * Returns the guest profile from a guest token
+ */
+const getGuestProfileFromToken = async (token, { email, name }): Promise<GuestProfileDetails> => {
+  const { collective, user } = await loadGuestToken(token);
+
+  if (user.confirmedAt) {
+    // Account exists & user is confirmed => need to sign in
+    throw new Error('An account already exists for this email, please sign in.');
+  } else if (email && user.email !== email.trim()) {
+    // The user is making a new guest contribution from the same browser but with
+    // a different email. For now the behavior is to ignore the existing guest profile
+    // and to create a new one.
+    return createGuestProfile(email, name);
+  } else {
+    // Contributing again as guest using the same guest token
+    return { collective, user, token };
+  }
+};
+
+/**
+ * Retrieves or create an guest profile.
+ */
+export const getOrCreateGuestProfile = async ({
+  email,
+  token,
+  name,
+}: {
+  email?: string | null;
+  token?: string | null;
+  name?: string | null;
+}): Promise<GuestProfileDetails> => {
+  if (token) {
+    // If there is a guest token, we try to fetch the profile from there
+    return getGuestProfileFromToken(token, { email, name });
+  } else {
+    // First time contributing as a guest or re-using an existing email with a different
+    // token. Note that a new Collective profile will be created for the contribution if the guest
+    // token don't match.
+    return createGuestProfile(email, name);
+  }
+};

--- a/server/lib/guest-accounts.ts
+++ b/server/lib/guest-accounts.ts
@@ -16,7 +16,7 @@ type GuestProfileDetails = {
 /**
  * Load a `GuestToken` from its code, returns the user and collective associated
  */
-const loadGuestToken = async (guestToken: string): Promise<GuestProfileDetails> => {
+export const loadGuestToken = async (guestToken: string): Promise<GuestProfileDetails> => {
   const token = await models.GuestToken.findOne({
     where: { value: guestToken },
     include: [{ association: 'collective', required: true }],
@@ -87,8 +87,8 @@ const createGuestProfile = (email: string, name: string | null): Promise<GuestPr
 /**
  * Returns the guest profile from a guest token
  */
-const getGuestProfileFromToken = async (token, { email, name }): Promise<GuestProfileDetails> => {
-  const { collective, user } = await loadGuestToken(token);
+const getGuestProfileFromToken = async (tokenValue, { email, name }): Promise<GuestProfileDetails> => {
+  const { collective, user, token } = await loadGuestToken(tokenValue);
 
   if (user.confirmedAt) {
     // Account exists & user is confirmed => need to sign in

--- a/server/lib/guest-accounts.ts
+++ b/server/lib/guest-accounts.ts
@@ -73,7 +73,7 @@ const createGuestProfile = (email: string, name: string | null): Promise<GuestPr
       throw new Error('An account already exists for this email, please sign in.');
     }
 
-    collective.update({ CreatedByUserId: user.id });
+    await collective.update({ CreatedByUserId: user.id }, { transaction });
 
     // Create the token that will be used to authenticate future contributions for
     // this guest profile

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -547,6 +547,11 @@ export function promiseSeq(arr, predicate, consecutive = 100) {
 }
 
 export function parseToBoolean(value) {
+  // If value is already a boolean, don't bother converting it
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
   let lowerValue = value;
   // check whether it's string
   if (lowerValue && (typeof lowerValue === 'string' || lowerValue instanceof String)) {

--- a/server/models/GuestToken.ts
+++ b/server/models/GuestToken.ts
@@ -1,0 +1,62 @@
+import { Model } from 'sequelize';
+
+import restoreSequelizeAttributesOnClass from '../lib/restore-sequelize-attributes-on-class';
+
+export class GuestToken extends Model<GuestToken> {
+  public readonly id!: number;
+  public CollectiveId!: number;
+  public value!: string;
+  public createdAt!: Date;
+  public updatedAt!: Date;
+
+  constructor(...args) {
+    super(...args);
+    restoreSequelizeAttributesOnClass(new.target, this);
+  }
+}
+
+export default (sequelize, DataTypes): typeof GuestToken => {
+  // Link the model to database fields
+  GuestToken.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      CollectiveId: {
+        type: DataTypes.INTEGER,
+        references: { key: 'id', model: 'Collectives' },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false,
+        unique: true,
+      },
+      value: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'GuestTokens',
+    },
+  );
+
+  return GuestToken;
+};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -77,6 +77,12 @@ export default (Sequelize, DataTypes) => {
         defaultValue: Sequelize.NOW,
       },
 
+      confirmedAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: true,
+      },
+
       lastLoginAt: {
         type: DataTypes.DATE,
       },

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -25,6 +25,7 @@ export function setupModels(client) {
     'Expense',
     'ExpenseAttachedFile',
     'ExpenseItem',
+    'GuestToken',
     'LegalDocument',
     'Member',
     'MemberInvitation',
@@ -70,6 +71,9 @@ export function setupModels(client) {
     foreignKey: 'CollectiveId',
     constraints: false,
   });
+
+  // GuestTokens
+  m.GuestToken.belongsTo(m.Collective, { as: 'collective', foreignKey: 'CollectiveId' });
 
   // Members
   m.Member.belongsTo(m.User, {

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -446,7 +446,9 @@ describe('server/graphql/v1/createOrder', () => {
 
     // Then there should be errors
     expect(res.errors).to.exist;
-    expect(res.errors[0].message).to.equal('You need to be authenticated to perform this action');
+    expect(res.errors[0].message).to.equal(
+      'When contributing as a guest, you either need to provide an email or a token',
+    );
   });
 
   it("doesn't store the payment method for user if order fail", async () => {

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -447,7 +447,7 @@ describe('server/graphql/v1/createOrder', () => {
     // Then there should be errors
     expect(res.errors).to.exist;
     expect(res.errors[0].message).to.equal(
-      'When contributing as a guest, you either need to provide an email or a token',
+      'You need to provide a guest profile with an email for logged out contributions',
     );
   });
 

--- a/test/server/graphql/v1/mutation.test.js
+++ b/test/server/graphql/v1/mutation.test.js
@@ -857,6 +857,7 @@ describe('server/graphql/v1/mutation', () => {
             email: 'newuser@email.com',
           });
           const result = await utils.graphqlQuery(createOrderMutation, { order }, remoteUser);
+          result.errors && console.error(result.errors);
           expect(result).to.deep.equal({
             data: {
               createOrder: {
@@ -1010,14 +1011,14 @@ describe('server/graphql/v1/mutation', () => {
             collective: { id: event1.id },
             tier: { id: 4 },
             quantity: 2,
-            user: { email: user2.email },
+            guestInfo: { email: user2.email },
           };
 
           const loggedInUser = null;
           const result = await utils.graphqlQuery(createOrderMutation, { order }, loggedInUser);
           // result.errors && console.error(result.errors[0]);
           expect(result.errors).to.exist;
-          expect(result.errors[0].message).to.equal('You need to be authenticated to perform this action');
+          expect(result.errors[0].message).to.equal('An account already exists for this email, please sign in.');
         });
 
         it('from a new user', async () => {

--- a/test/server/graphql/v1/tiers.test.js
+++ b/test/server/graphql/v1/tiers.test.js
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import { VAT_OPTIONS } from '../../../../server/constants/vat';
 import stripe from '../../../../server/lib/stripe';
 import models from '../../../../server/models';
+import { randEmail } from '../../../stores';
 import { fakeHost, fakeUser } from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
@@ -258,9 +259,13 @@ describe('server/graphql/v1/tiers', () => {
         const order = generateLoggedOutOrder(user1.email);
         order.paymentMethod = { uuid: paymentMethod1.uuid, service: 'stripe' };
 
-        const result = await utils.graphqlQuery(createOrderMutation, { order });
+        const result = await utils.graphqlQuery(createOrderMutation, {
+          order: { ...order, guestInfo: { email: randEmail() } },
+        });
         expect(result.errors).to.exist;
-        expect(result.errors[0].message).to.equal('You need to be authenticated to perform this action');
+        expect(result.errors[0].message).to.equal(
+          'You need to be logged in to be able to use an existing payment method',
+        );
       });
 
       it('fails to use a payment method on file if not logged in as the owner', async () => {

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -1,0 +1,217 @@
+import { expect } from 'chai';
+import gqlV2 from 'fake-tag';
+import sinon from 'sinon';
+
+import * as payments from '../../../../../server/lib/payments';
+import models from '../../../../../server/models';
+import { randEmail } from '../../../../stores';
+import { fakeCollective, fakeHost, fakeTier, fakeUser } from '../../../../test-helpers/fake-data';
+import { graphqlQueryV2 } from '../../../../utils';
+
+const CREATE_ORDER_MUTATION = gqlV2/* GraphQL */ `
+  mutation CreateOrder($order: OrderCreateInput!) {
+    createOrder(order: $order) {
+      order {
+        id
+        status
+        quantity
+        frequency
+        tier {
+          legacyId
+        }
+        amount {
+          valueInCents
+        }
+        platformContributionAmount {
+          valueInCents
+        }
+        fromAccount {
+          id
+          legacyId
+          slug
+          name
+          ... on Individual {
+            isGuest
+          }
+        }
+        paymentMethod {
+          account {
+            id
+            legacyId
+          }
+        }
+        toAccount {
+          legacyId
+        }
+      }
+    }
+  }
+`;
+
+const callCreateOrder = (params, remoteUser = null) => {
+  return graphqlQueryV2(CREATE_ORDER_MUTATION, params, remoteUser);
+};
+
+const stubExecuteOrderFn = async (user, order) => {
+  let subscription;
+  if (order.interval) {
+    subscription = await models.Subscription.create({
+      amount: order.amount,
+      currency: order.currency,
+      interval: order.interval,
+      isActive: true,
+    });
+  }
+
+  return order.update({ SubscriptionId: subscription?.id, processedAt: new Date(), status: 'PAID' });
+};
+
+describe('server/graphql/v2/mutation/OrderMutations', () => {
+  let fromUser, toCollective, host, validOrderParams, sandbox;
+
+  before(async () => {
+    fromUser = await fakeUser();
+
+    // Stub the payment
+    sandbox = sinon.createSandbox();
+    sandbox.stub(payments, 'executeOrder').callsFake(stubExecuteOrderFn);
+
+    // Add Stripe to host
+    host = await fakeHost();
+    toCollective = await fakeCollective({ HostCollectiveId: host.id });
+    await models.ConnectedAccount.create({ service: 'stripe', token: 'abc', CollectiveId: host.id });
+
+    // Some default params to create a valid order
+    validOrderParams = {
+      fromAccount: { legacyId: fromUser.CollectiveId },
+      toAccount: { legacyId: toCollective.id },
+      frequency: 'ONETIME',
+      paymentMethod: {
+        type: 'CREDIT_CARD',
+        name: '4242',
+        creditCardInfo: {
+          token: 'tok_123456781234567812345678',
+          brand: 'VISA',
+          country: 'US',
+          expMonth: 11,
+          expYear: 2024,
+        },
+      },
+      amount: {
+        valueInCents: 5000,
+      },
+    };
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  describe('createOrder', () => {
+    describe('Logged in', () => {
+      it('works with basic params', async () => {
+        const result = await callCreateOrder({ order: validOrderParams }, fromUser);
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+
+        const order = result.data.createOrder.order;
+        expect(order.amount.valueInCents).to.eq(5000);
+        expect(order.frequency).to.eq('ONETIME');
+        expect(order.fromAccount.legacyId).to.eq(fromUser.CollectiveId);
+        expect(order.toAccount.legacyId).to.eq(toCollective.id);
+      });
+
+      it('supports additional params', async () => {
+        const tier = await fakeTier({
+          CollectiveId: toCollective.id,
+          amount: 5000,
+          amountType: 'FIXED',
+          interval: 'month',
+        });
+        const result = await callCreateOrder(
+          {
+            order: {
+              ...validOrderParams,
+              frequency: 'MONTHLY',
+              tier: { legacyId: tier.id },
+              quantity: 3,
+            },
+          },
+          fromUser,
+        );
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+
+        const order = result.data.createOrder.order;
+        expect(order.amount.valueInCents).to.eq(5000 * 3);
+        expect(order.frequency).to.eq('MONTHLY');
+        expect(order.fromAccount.legacyId).to.eq(fromUser.CollectiveId);
+        expect(order.toAccount.legacyId).to.eq(toCollective.id);
+        expect(order.quantity).to.eq(3);
+        expect(order.tier.legacyId).to.eq(tier.id);
+      });
+
+      it('can add platform contribution', async () => {
+        const collectiveWithoutPlaformFee = await fakeCollective({ platformFeePercent: 0, HostCollectiveId: host.id });
+        const result = await callCreateOrder(
+          {
+            order: {
+              ...validOrderParams,
+              toAccount: { legacyId: collectiveWithoutPlaformFee.id },
+              platformContributionAmount: {
+                valueInCents: 2500,
+              },
+            },
+          },
+          fromUser,
+        );
+
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        const order = result.data.createOrder.order;
+        expect(order.amount.valueInCents).to.eq(7500);
+        expect(order.platformContributionAmount.valueInCents).to.eq(2500);
+      });
+
+      it('can add taxes', async () => {
+        // TODO
+      });
+
+      it('respects the isSavedForLater param', async () => {
+        // TODO
+      });
+    });
+
+    describe('Guest', () => {
+      it('Needs to provide an email', async () => {
+        const result = await callCreateOrder({ order: { ...validOrderParams, fromAccount: null } });
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.include(
+          'When contributing as a guest, you either need to provide an email or a token',
+        );
+      });
+
+      it('Works with a small order', async () => {
+        const email = randEmail();
+        const orderData = { ...validOrderParams, fromAccount: null, guestInfo: { email } };
+        const result = await callCreateOrder({ order: orderData });
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+
+        const order = result.data.createOrder.order;
+        expect(order.fromAccount.isGuest).to.eq(true);
+        expect(order.paymentMethod.account.id).to.eq(order.fromAccount.id);
+        expect(order.status).to.eq('PAID');
+      });
+
+      it('Rejects if no email/guest token is provided and amount requires it', async () => {
+        // TODO
+        // expect(result.errors).to.exist;
+      });
+
+      it('requires you to confirm your email when the sum of your contributions is > $250', async () => {
+        // TODO
+      });
+    });
+  });
+});

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -187,7 +187,7 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
         const result = await callCreateOrder({ order: { ...validOrderParams, fromAccount: null } });
         expect(result.errors).to.exist;
         expect(result.errors[0].message).to.include(
-          'When contributing as a guest, you either need to provide an email or a token',
+          'You need to provide a guest profile with an email for logged out contributions',
         );
       });
 

--- a/test/server/lib/guest-accounts.test.ts
+++ b/test/server/lib/guest-accounts.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+
+import { getOrCreateGuestProfile } from '../../../server/lib/guest-accounts';
+import models from '../../../server/models';
+import { randEmail } from '../../stores';
+import { fakeUser } from '../../test-helpers/fake-data';
+import { resetTestDB } from '../../utils';
+
+describe('server/lib/guest-accounts.ts', () => {
+  before(resetTestDB);
+
+  describe('getOrCreateGuestProfile', () => {
+    describe('Without a guest token', () => {
+      it('Creates an account + user if an email is provided', async () => {
+        const email = randEmail();
+        const { collective } = await getOrCreateGuestProfile({ email });
+        const user = await models.User.findOne({ where: { CollectiveId: collective.id } });
+        const token = await models.GuestToken.findOne({ where: { CollectiveId: collective.id } });
+
+        expect(token).to.exist;
+        expect(collective).to.exist;
+        expect(user.email).to.eq(email);
+      });
+
+      it('Rejects if a verified account already exists for this email', async () => {
+        const user = await fakeUser();
+        const guestAccountPromise = getOrCreateGuestProfile({ email: user.email });
+        expect(guestAccountPromise).to.be.rejectedWith('An account already exists for this email, please sign in');
+      });
+
+      it('Creates a new profile if a non-verified account already exists for this profile', async () => {
+        const user = await fakeUser({ confirmedAt: null });
+        const { collective } = await getOrCreateGuestProfile({ email: user.email });
+        expect(collective).to.exist;
+        expect(collective.id).to.not.eq(user.CollectiveId);
+      });
+    });
+
+    describe('With a guest token', () => {
+      it('Returns the same guest account if no email or same email is provided', async () => {
+        const email = randEmail();
+        const { collective } = await getOrCreateGuestProfile({ email });
+        const token = await models.GuestToken.findOne({ where: { CollectiveId: collective.id } });
+
+        expect((await getOrCreateGuestProfile({ token: token.value })).collective.id).to.eq(collective.id);
+        expect((await getOrCreateGuestProfile({ token: token.value, email })).collective.id).to.eq(collective.id);
+      });
+
+      it('Returns a new guest account if a different email is provided', async () => {
+        const email = randEmail();
+        const { collective } = await getOrCreateGuestProfile({ email });
+        const token = await models.GuestToken.findOne({ where: { CollectiveId: collective.id } });
+        const otherProfile = await getOrCreateGuestProfile({ token: token.value, email: randEmail() });
+
+        expect(otherProfile.collective.id).to.not.eq(collective.id);
+      });
+
+      it('Throws if a verified account exists for this email', async () => {
+        const user = await fakeUser();
+        const guestAccountPromise = getOrCreateGuestProfile({
+          email: user.email,
+          token: user.collective.guestToken, // should not have any impact, just to make sure we can't bypass the validation
+        });
+
+        expect(guestAccountPromise).to.be.rejectedWith('An account already exists for this email, please sign in');
+      });
+    });
+  });
+});

--- a/test/server/paymentProviders/opencollective/collective.test.js
+++ b/test/server/paymentProviders/opencollective/collective.test.js
@@ -232,13 +232,15 @@ describe('server/paymentProviders/opencollective/collective', () => {
         totalAmount: ocPaymentMethodBalance.amount,
       };
       // Executing queries
-      const res = await utils.graphqlQuery(createOrderMutation, { order });
+      const res = await utils.graphqlQuery(createOrderMutation, {
+        order: { ...order, guestInfo: { email: store.randEmail() } },
+      });
       const resWithUserParam = await utils.graphqlQuery(createOrderMutation, { order }, user2);
 
       // Then there should be Errors for the Result of the query without any user defined as param
       expect(res.errors).to.exist;
       expect(res.errors).to.not.be.empty;
-      expect(res.errors[0].message).to.contain('You need to be authenticated to perform this action');
+      expect(res.errors[0].message).to.contain('You need to be logged in to be able to use an existing payment method');
 
       // Then there should also be Errors for the Result of the query through user2
       expect(resWithUserParam.errors).to.exist;

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -14,7 +14,6 @@ import { types as CollectiveType } from '../../server/constants/collectives';
 import { PAYMENT_METHOD_SERVICES, PAYMENT_METHOD_TYPES } from '../../server/constants/paymentMethods';
 import { REACTION_EMOJI } from '../../server/constants/reaction-emoji';
 import models from '../../server/models';
-import { LEGAL_DOCUMENT_TYPE } from '../../server/models/LegalDocument';
 import { PayoutMethodTypes } from '../../server/models/PayoutMethod';
 import { randEmail, randUrl } from '../stores';
 


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/3443

A first draft of the work for guest contributions that:
- Removes support for passing a `user` in `createOrder` V1. Shouldn't break anything as we deprecated this behavior a long time ago.
- Implements the basis for guest contributions

*Todo*
- [x] Frontend
- [x] Return the guest tokens from `createOrder` mutation
- [x] Make sure 3D secure works with guest accounts