### PR TITLE
feat(paymentReceipts): add the number of total transactions to invoice query

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -146,6 +146,7 @@ const queries = {
         const totalAmount = invoicesByKey[slug]
           ? invoicesByKey[slug].totalAmount + transaction.amountInHostCurrency
           : transaction.amountInHostCurrency;
+        const totalTransactions = invoicesByKey[slug] ? invoicesByKey[slug].totalTransactions + 1 : 1;
 
         invoicesByKey[slug] = {
           HostCollectiveId,
@@ -154,6 +155,7 @@ const queries = {
           year,
           month,
           totalAmount,
+          totalTransactions,
           currency: transaction.hostCurrency,
         };
       });

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -698,6 +698,12 @@ export const InvoiceType = new GraphQLObjectType({
           return invoice.totalAmount;
         },
       },
+      totalTransactions: {
+        type: GraphQLInt,
+        resolve(invoice) {
+          return invoice.totalTransactions;
+        },
+      },
       currency: {
         type: GraphQLString,
         resolve(invoice) {


### PR DESCRIPTION
Following up https://github.com/opencollective/opencollective-frontend/pull/5201 in order to get the right number of transactions for a specific receipt, I'm adding `totalTransactions` to `InvoiceType` query, v1. 