### PR TITLE
Adjust Orders affected by the recurring contributions amount bug

### DIFF
--- a/migrations/20201013164008-adjust-erroneous-recurring-contributions.js
+++ b/migrations/20201013164008-adjust-erroneous-recurring-contributions.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(
+      `CREATE TEMPORARY TABLE "tmp_invalid_order_subscriptions" AS
+	  SELECT "Orders"."id" as "order_id", "Subscriptions".id as "sub_id", "Subscriptions".amount as "sub_amount", "Orders"."totalAmount" as "order_amount",  "Tiers".amount as "fixed_tier_amount", (COALESCE((("Orders".data ->> 'platformFee')::int), 0)) as "platform_fee" FROM "Orders"
+	  INNER JOIN "Subscriptions" ON "Orders"."SubscriptionId" = "Subscriptions".id
+	  INNER JOIN "Tiers" ON "Orders"."TierId"="Tiers".id
+	  WHERE ("Orders"."status" = 'ACTIVE') AND ("Subscriptions"."isActive" = true) AND ("Orders"."totalAmount" != "Subscriptions".amount) AND ("Orders"."totalAmount" != "Tiers".amount) AND ("Orders"."TierId" IS NOT NULL) AND ("Tiers"."amountType" = 'FIXED');
+	  
+	  UPDATE "Orders" o
+	  SET "totalAmount" = t.fixed_tier_amount + platform_fee
+	  FROM "tmp_invalid_order_subscriptions" t
+	  WHERE (o.id = t.order_id);
+	  
+	  UPDATE "Subscriptions" s
+	  SET "amount" = t.fixed_tier_amount + platform_fee
+	  FROM "tmp_invalid_order_subscriptions" t
+	  WHERE (s.id = t.sub_id);
+	  
+	  DROP TABLE "tmp_invalid_order_subscriptions";`,
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};


### PR DESCRIPTION
After discovering the bug in https://github.com/opencollective/opencollective-frontend/pull/5222 and having a user get in touch via support for a similar reason, I looked in the database to find how many orders had been affected.

There are 10 orders where:

* The Order `totalAmount` doesn't match the Subscription `amount`, meaning it has likely been updated via the new recurring contribution menu (we did not implement updating the subscription attached to the order - this will also soon be fixed)
* The Tier was `FIXED` and the Order amount did not match the fixed Tier amount (this is directly related to the bug)

This attempts to remedy that by looking at the selected Tier's amount (and whether there are any platform fees to consider) and then adjusting the Subscription amount and Order amount to match this.