### PR TITLE
Fix missing manual transfer feesOnTop

### DIFF
--- a/reports/platform-report.js
+++ b/reports/platform-report.js
@@ -152,6 +152,7 @@ async function PlatformReport(year, month) {
           max((CASE WHEN pm."service" = 'paypal' AND t."CollectiveId" = 1 THEN t."amount" ELSE 0 END)::float) as "feeOnTopPaypal",
           max((CASE WHEN (pm."service" = 'stripe' OR spm.service = 'stripe') AND t."CollectiveId" = 1 THEN t."amount" ELSE 0 END)::float) as "feeOnTopStripe",
           max((CASE WHEN t."PaymentMethodId" is NULL AND t."CollectiveId" = 1 THEN t."amount" ELSE 0 END)::float) as "feeOnTopBankTransfers",
+          max(CASE WHEN t."CollectiveId" = 1 and pm."service" != 'stripe' AND pm."service" != 'paypal' AND (spm.service IS NULL OR spm.service != 'stripe') THEN t."amount" ELSE 0 END)::float as "feeOnTopManual",
           max((CASE WHEN (t."PaymentMethodId" is NULL OR ((pm."service" != 'stripe' OR pm.service IS NULL) AND (spm.service IS NULL OR spm.service != 'stripe'))) AND t."CollectiveId" = 1 THEN t."amount" ELSE 0 END)::float) as "feeOnTopDue",
           max((CASE WHEN t."CollectiveId" != 1 THEN t."HostCollectiveId" ELSE 0 END)) AS "HostCollectiveId",
           t."OrderId"
@@ -169,9 +170,10 @@ async function PlatformReport(year, month) {
           "HostCollectiveId",
           sum("feeOnTopPaypal") AS "feesOnTopPaypal",
           sum("feeOnTopBankTransfers") AS "feesOnTopBankTransfers",
+          sum("feeOnTopManual") AS "feesOnTopManual",
           sum("feeOnTopStripe") AS "feesOnTopStripe",
           sum("feeOnTopDue") AS "feesOnTopDue",
-          COALESCE(sum("feeOnTopPaypal"), 0) + COALESCE(sum("feeOnTopBankTransfers"), 0) + COALESCE(sum("feeOnTopStripe"), 0) as "feesOnTop"
+          COALESCE(sum("feeOnTopPaypal"), 0) + COALESCE(sum("feeOnTopBankTransfers"), 0) + COALESCE(sum("feeOnTopStripe"), 0) + COALESCE(sum("feeOnTopManual"), 0) as "feesOnTop"
         FROM "feesOnTopTransactions"
         GROUP BY "HostCollectiveId"
       )

--- a/templates/emails/report.platform.hbs
+++ b/templates/emails/report.platform.hbs
@@ -157,6 +157,12 @@ Subject: {{month}} {{year}} Platform Report
       </tr>
       <tr>
         <td></td>
+        <td>Balance Based and Manual Transactions:</td>
+        <td></td>
+        <td align="right">{{currency feesOnTopManual currency='USD'}}</td>
+      </tr>
+      <tr>
+        <td></td>
         <td>PayPal:</td>
         <td></td>
         <td align="right">{{currency feesOnTopPaypal currency='USD'}}</td>


### PR DESCRIPTION
We had a case where the report was pointing out a higher value on total fees that were being displayed in the details.
Turns out, a collective tipped a donation to another collective using its balance (`pm.service = 'opencollective'`).