### PR TITLE
Fix small errors in reject contributions cron

### DIFF
--- a/cron/disabled/reject-contributions.js
+++ b/cron/disabled/reject-contributions.js
@@ -23,7 +23,7 @@ const query = `SELECT "Orders"."id"
 
 const getContributorRejectedCategories = (fromCollective, collective) => {
   const rejectedCategories = get(collective, 'settings.moderation.rejectedCategories', []);
-  const contributorCategories = get(fromCollective, 'categories', []);
+  const contributorCategories = get(fromCollective, 'data.categories', []);
 
   if (rejectedCategories.length === 0 || contributorCategories.length === 0) {
     return [];
@@ -103,7 +103,7 @@ async function run({ dryRun = false } = {}) {
           await subscription.deactivate();
         }
       } else {
-        logger.info(`  - Subsription not found`);
+        logger.info(`  - Subscription not found`);
       }
     } else {
       logger.info(`  - No subscription to deactivate`);

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -173,7 +173,7 @@ export async function createRefundTransaction(transaction, refundedPaymentProces
       'paymentProcessorFeeInHostCurrency',
       'data.isFeesOnTop',
     ]);
-    refund.CreatedByUserId = user.id;
+    refund.CreatedByUserId = user?.id || null;
     refund.description = `Refund of "${t.description}"`;
     refund.data = data;
 

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -1,6 +1,6 @@
 import Promise from 'bluebird';
 import debugLib from 'debug';
-import { defaultsDeep, get, isUndefined } from 'lodash';
+import { defaultsDeep, get, isNull, isUndefined } from 'lodash';
 import moment from 'moment';
 import { v4 as uuid } from 'uuid';
 
@@ -47,7 +47,14 @@ export default (Sequelize, DataTypes) => {
         },
         onDelete: 'SET NULL',
         onUpdate: 'CASCADE',
-        allowNull: false,
+        allowNull: true, // we allow CreatedByUserId to be null but only on refund transactions
+        validate: {
+          isValid(value) {
+            if (isNull(value) && this.isRefund === false) {
+              throw new Error('Only refund transactions can have null user.');
+            }
+          },
+        },
       },
 
       // Source of the money for a DEBIT


### PR DESCRIPTION
* Adds second argument for `user` to `libPayments.refundTransaction` so it executes
* Adds full path for contributor rejected categories (`collective.data.categories` instead of `collective.categories`)