### PR TITLE
Implement rolling host payout limit with 2FA

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -5,6 +5,7 @@ import emailLib from '../lib/email';
 import errors from '../lib/errors';
 import logger from '../lib/logger';
 import RateLimit, { ONE_HOUR_IN_SECONDS } from '../lib/rate-limit';
+import { verifyTwoFactorAuthenticatorCode } from '../lib/two-factor-authentication';
 import { isValidEmail } from '../lib/utils';
 import models from '../models';
 
@@ -106,7 +107,7 @@ export const twoFactorAuthAndUpdateToken = async (req, res, next) => {
   }
 
   // we need to verify the 2FA code before returning the token
-  const verified = auth.verifyTwoFactorAuthenticatorCode(user.twoFactorAuthToken, twoFactorAuthenticatorCode);
+  const verified = verifyTwoFactorAuthenticatorCode(user.twoFactorAuthToken, twoFactorAuthenticatorCode);
   if (!verified) {
     return next(new Unauthorized('Two-factor authentication code failed. Please try again'));
   }

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -343,7 +343,7 @@ const mutations = {
       },
       twoFactorAuthenticatorCode: {
         type: GraphQLString,
-        description: '2FA code for if the host account has it turned on and the transaction is large.',
+        description: '2FA code for if the host account has 2FA for payouts turned on.',
       },
     },
     resolve(_, args, req) {

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -177,7 +177,7 @@ const expenseMutations = {
             },
             twoFactorAuthenticatorCode: {
               type: GraphQLString,
-              description: '2FA code for if the host account has it turned on and the transaction is large.',
+              description: '2FA code for if the host account has 2FA for payouts turned on.',
             },
           },
         }),

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -1,15 +1,10 @@
 import Promise from 'bluebird';
 import config from 'config';
 import jwt from 'jsonwebtoken';
-import { isNil } from 'lodash';
 import moment from 'moment';
-import speakeasy from 'speakeasy';
 
 import * as errors from '../graphql/errors';
 import models, { Op } from '../models';
-
-import cache from './cache';
-import { crypto } from './encryption';
 
 // Helper
 const daysToSeconds = days => moment.duration({ days }).asSeconds();
@@ -76,74 +71,5 @@ export function mustHaveRole(remoteUser, roles, CollectiveId, action = 'perform 
   mustBeLoggedInTo(remoteUser, action);
   if (!CollectiveId || !remoteUser.hasRole(roles, CollectiveId)) {
     throw new errors.Unauthorized(`You don't have sufficient permissions to ${action}`);
-  }
-}
-
-/**
- * Verifies a TOTP against a user's 2FA token saved in the DB
- * encryptedTwoFactorAuthToken = token saved for a User in the DB
- * twoFactorAuthenticatorCode = 6-digit TOTP
- */
-export function verifyTwoFactorAuthenticatorCode(encryptedTwoFactorAuthToken, twoFactorAuthenticatorCode) {
-  const decryptedTwoFactorAuthToken = crypto.decrypt(encryptedTwoFactorAuthToken);
-  const verified = speakeasy.totp.verify({
-    secret: decryptedTwoFactorAuthToken,
-    encoding: 'base32',
-    token: twoFactorAuthenticatorCode,
-    window: 2,
-  });
-  return verified;
-}
-
-const getCacheKey = userId => {
-  return `${userId}_2fa_payment_limit`;
-};
-
-export async function rollingPayoutLimitTwoFactorAuthentication(
-  req,
-  twoFactorAuthenticatorCode,
-  hostRollingLimit,
-  expenseAmount,
-) {
-  if (req.remoteUser.twoFactorAuthToken !== null) {
-    // 1. we check the 'cache' if the key exists: cacheKey=${user.id}_2fa_payment_limit
-    const userId = req.remoteUser.id;
-    const cacheKey = getCacheKey(userId);
-    const keyInCache = await cache.get(cacheKey);
-
-    if (twoFactorAuthenticatorCode) {
-      const verified = verifyTwoFactorAuthenticatorCode(req.remoteUser.twoFactorAuthToken, twoFactorAuthenticatorCode);
-      if (!verified) {
-        throw new Error('Two-factor authentication failed: invalid code. Please try again.');
-      }
-      // With 2FA code
-      // 2. if limit key exists, reset the limit; if limit key doesn't exist, initialise the limit
-      return {
-        cacheKey,
-        cacheValue: 0,
-      };
-    } else {
-      // Without 2FA code
-      // 2. if the limit key does exist, check the value
-      // 3. if the payment fits the limit, process the payment, decrease the limit
-      // 4. if it doesn't fit the limit, prompt 2FA again
-      if (isNil(keyInCache)) {
-        // 5. if the limit key doesn't exist, ask for 2FA
-        throw new Error('Two-factor authentication enabled: please enter your code.');
-      } else {
-        const runningTotal = keyInCache + expenseAmount;
-        const expenseExceedsRollingLimit = runningTotal > hostRollingLimit;
-        if (expenseExceedsRollingLimit) {
-          throw new Error('Two-factor authentication payout limit exceeded: please re-enter your code.');
-        } else {
-          return {
-            cacheKey,
-            cacheValue: runningTotal,
-          };
-        }
-      }
-    }
-  } else {
-    throw new Error('Host has two-factor authentication enabled for large payouts.');
   }
 }

--- a/server/lib/two-factor-authentication.js
+++ b/server/lib/two-factor-authentication.js
@@ -1,0 +1,87 @@
+import { get, isNil } from 'lodash';
+import speakeasy from 'speakeasy';
+
+import cache from './cache';
+import { crypto } from './encryption';
+
+export const ROLLING_LIMIT_CACHE_VALIDITY = 3600; // 1h in secs for cache to expire
+
+/**
+ * Verifies a TOTP against a user's 2FA token saved in the DB
+ * encryptedTwoFactorAuthToken = token saved for a User in the DB
+ * twoFactorAuthenticatorCode = 6-digit TOTP
+ */
+export function verifyTwoFactorAuthenticatorCode(encryptedTwoFactorAuthToken, twoFactorAuthenticatorCode) {
+  const decryptedTwoFactorAuthToken = crypto.decrypt(encryptedTwoFactorAuthToken);
+  const verified = speakeasy.totp.verify({
+    secret: decryptedTwoFactorAuthToken,
+    encoding: 'base32',
+    token: twoFactorAuthenticatorCode,
+    window: 2,
+  });
+  return verified;
+}
+
+const getTwoFactorAuthenticationLimitKey = userId => {
+  return `${userId}_2fa_payment_limit`;
+};
+
+export async function handleTwoFactorAuthenticationPayoutLimit(user, twoFactorAuthenticatorCode, expense) {
+  if (user.twoFactorAuthToken !== null) {
+    const host = await expense.collective.getHostCollective();
+    const hostPayoutTwoFactorAuthenticationRollingLimit = get(
+      host,
+      'settings.payoutsTwoFactorAuth.rollingLimit',
+      1000000,
+    );
+    // 1. we check the 'cache' if the key exists: cacheKey=${user.id}_2fa_payment_limit
+    const twoFactorAuthenticationLimitKey = getTwoFactorAuthenticationLimitKey(user.id);
+    const twoFactorAuthenticationLimitAmountForUser = await cache.get(twoFactorAuthenticationLimitKey);
+
+    if (twoFactorAuthenticatorCode) {
+      const verified = verifyTwoFactorAuthenticatorCode(user.twoFactorAuthToken, twoFactorAuthenticatorCode);
+      if (!verified) {
+        throw new Error('Two-factor authentication failed: invalid code. Please try again.');
+      }
+      // With 2FA code
+      // 2. if limit key exists, reset the limit; if limit key doesn't exist, initialise the limit
+      cache.set(twoFactorAuthenticationLimitKey, 0, ROLLING_LIMIT_CACHE_VALIDITY);
+      return;
+    } else {
+      // Without 2FA code
+      // 2. if the limit key does exist, check the value
+      // 3. if the payment fits the limit, process the payment, decrease the limit
+      // 4. if it doesn't fit the limit, prompt 2FA again
+      if (isNil(twoFactorAuthenticationLimitAmountForUser)) {
+        // 5. if the limit key doesn't exist, ask for 2FA
+        throw new Error('Two-factor authentication enabled: please enter your code.');
+      } else {
+        const runningTotal = twoFactorAuthenticationLimitAmountForUser + expense.amount;
+        const expenseExceedsRollingLimit = runningTotal > hostPayoutTwoFactorAuthenticationRollingLimit;
+        if (expenseExceedsRollingLimit) {
+          throw new Error('Two-factor authentication payout limit exceeded: please re-enter your code.');
+        } else {
+          cache.set(twoFactorAuthenticationLimitKey, runningTotal, ROLLING_LIMIT_CACHE_VALIDITY);
+          return;
+        }
+      }
+    }
+  } else {
+    throw new Error('Host has two-factor authentication enabled for large payouts.');
+  }
+}
+
+export async function resetRollingPayoutLimitOnFailure(user, expense) {
+  const twoFactorAuthenticationLimitKey = getTwoFactorAuthenticationLimitKey(user.id);
+  const twoFactorAuthenticationLimitAmountForUser = await cache.get(twoFactorAuthenticationLimitKey);
+
+  if (!isNil(twoFactorAuthenticationLimitAmountForUser) && twoFactorAuthenticationLimitAmountForUser !== 0) {
+    cache.set(
+      twoFactorAuthenticationLimitKey,
+      twoFactorAuthenticationLimitAmountForUser - expense.amount,
+      ROLLING_LIMIT_CACHE_VALIDITY,
+    );
+  }
+
+  return;
+}


### PR DESCRIPTION
Limit right now is hard coded at $1000.

This implements a rolling limit for each host admin user doing payouts once they're authenticated with 2FA.

```
When processing a payment (without the 2FA code passed as parameter)
 - Check in the "cache" if the key exists. cacheKey=`${user.id}_2fa_payment_limit`;
  - If it doesn't -> 2FA
  - If it does, check its value.
    - If the payment fits in the limit -> process and decrease the limit
    - If the payment doesn't fit in the limit -> 2FA
When processing a payment (with a valid 2FA code passed as parameter):
 - Check in the "cache" if the key exists. cacheKey=`${user.id}_2fa_payment_limit`;
   - If it exists -> reset the limit
   - If it doesn't -> initialize the limit
```