### PR TITLE
Platform tips refunds

### DIFF
--- a/migrations/20201016085526-add-platform-contribution-transaction-group.js
+++ b/migrations/20201016085526-add-platform-contribution-transaction-group.js
@@ -1,0 +1,44 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Transactions', 'PlatformTipForTransactionGroup', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    // Migrate all platform tips donated through Stripe
+    await queryInterface.sequelize.query(`
+      BEGIN;
+      with platformfees as (
+        select t.*
+        from "Transactions" t
+        where
+          t."deletedAt" is null
+          and t."data"->>'isFeesOnTop' = 'true'
+          and t."CollectiveId" = 1
+          and t."type" = 'CREDIT'
+        order by id desc
+      ), tgroups as (
+        select t."TransactionGroup" as "originalTransactionGroup", pf."TransactionGroup" as "platformTipTransactionGroup"
+        from "Transactions" t, platformfees pf
+        where pf."OrderId" = t."OrderId" 
+        and t."deletedAt" is null
+        and t."type" = 'CREDIT'
+        and t."CollectiveId" != 1
+        and age(t."createdAt", pf."createdAt") > interval '0'
+        and age(t."createdAt", pf."createdAt") < interval '1 minute'
+      )
+
+      UPDATE "Transactions"
+      SET "PlatformTipForTransactionGroup" = tg."originalTransactionGroup"
+      FROM "tgroups" tg
+      WHERE "TransactionGroup" = tg."platformTipTransactionGroup";
+      COMMIT;
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Transactions', 'PlatformTipForTransactionGroup');
+  },
+};

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -413,7 +413,7 @@ export default (Sequelize, DataTypes) => {
   Transaction.createDoubleEntry = async transaction => {
     transaction.type = transaction.amount > 0 ? TransactionTypes.CREDIT : TransactionTypes.DEBIT;
     transaction.netAmountInCollectiveCurrency = transaction.netAmountInCollectiveCurrency || transaction.amount;
-    transaction.TransactionGroup = uuid();
+    transaction.TransactionGroup = transaction.TransactionGroup || uuid();
     transaction.hostCurrencyFxRate = transaction.hostCurrencyFxRate || 1;
 
     if (!isUndefined(transaction.amountInHostCurrency)) {
@@ -529,6 +529,7 @@ export default (Sequelize, DataTypes) => {
         ),
         // This is always 1 because OpenCollective and OpenCollective Inc (Host) are in USD.
         hostCurrencyFxRate: 1,
+        PlatformTipForTransactionGroup: transaction.TransactionGroup,
         data: {
           hostToPlatformFxRate: await getFxRate(transaction.hostCurrency, FEES_ON_TOP_TRANSACTION_PROPERTIES.currency),
           feeOnTopPaymentProcessorFee,
@@ -573,6 +574,7 @@ export default (Sequelize, DataTypes) => {
     transaction.CreatedByUserId = CreatedByUserId;
     transaction.FromCollectiveId = FromCollectiveId;
     transaction.CollectiveId = CollectiveId;
+    transaction.TransactionGroup = uuid();
     transaction.PaymentMethodId = transaction.PaymentMethodId || PaymentMethodId;
     transaction.type = transaction.amount > 0 ? TransactionTypes.CREDIT : TransactionTypes.DEBIT;
     transaction.hostFeeInHostCurrency = toNegative(transaction.hostFeeInHostCurrency);

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -154,6 +154,11 @@ export default (Sequelize, DataTypes) => {
         references: { model: 'Transactions', key: 'id' },
       },
 
+      PlatformTipForTransactionGroup: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+
       isRefund: {
         type: DataTypes.BOOLEAN,
         defaultValue: false,

--- a/test/server/models/Transaction.test.js
+++ b/test/server/models/Transaction.test.js
@@ -222,7 +222,7 @@ describe('server/models/Transaction', () => {
         },
       };
 
-      await Transaction.createFromPayload({
+      const createdTransaction = await Transaction.createFromPayload({
         transaction,
         CreatedByUserId: user.id,
         FromCollectiveId: user.CollectiveId,
@@ -235,6 +235,9 @@ describe('server/models/Transaction', () => {
       const donationCredit = allTransactions.find(t => t.CollectiveId === oc.id);
       expect(donationCredit).to.have.property('type').equal('CREDIT');
       expect(donationCredit).to.have.property('amount').equal(1000);
+      expect(donationCredit)
+        .to.have.property('PlatformTipForTransactionGroup')
+        .equal(createdTransaction.TransactionGroup);
 
       const donationDebit = allTransactions.find(t => t.FromCollectiveId === oc.id);
       const partialPaymentProcessorFee = Math.round(200 * (1000 / 11000));
@@ -242,6 +245,9 @@ describe('server/models/Transaction', () => {
       expect(donationDebit)
         .to.have.property('amount')
         .equal(-1000 + partialPaymentProcessorFee);
+      expect(donationDebit)
+        .to.have.property('PlatformTipForTransactionGroup')
+        .equal(createdTransaction.TransactionGroup);
     });
 
     it('should convert the donation transaction to USD and store the FX rate', async () => {


### PR DESCRIPTION
Followup for another PR:
- Create a migration to mark tips as refunded (and create the opposite transaction) if the base transaction has been refunded