### PR TITLE
Deprecate collective.user.added activity

### DIFF
--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -28,7 +28,6 @@ export default {
   COLLECTIVE_TRANSACTION_CREATED: 'collective.transaction.created',
   COLLECTIVE_UPDATE_CREATED: 'collective.update.created',
   COLLECTIVE_UPDATE_PUBLISHED: 'collective.update.published',
-  COLLECTIVE_USER_ADDED: 'collective.user.added',
   COLLECTIVE_CONTACT: 'collective.contact',
   ORGANIZATION_COLLECTIVE_CREATED: 'organization.collective.created',
   SUBSCRIPTION_ACTIVATED: 'subscription.activated',
@@ -47,4 +46,5 @@ export default {
 
   // Not used anymore, leaving for historical reference
   COLLECTIVE_TRANSACTION_PAID: 'collective.transaction.paid', // replaced with COLLECTIVE_EXPENSE_PAID
+  COLLECTIVE_USER_ADDED: 'collective.user.added',
 };

--- a/server/models/Activity.js
+++ b/server/models/Activity.js
@@ -87,9 +87,6 @@ Types:
   - collective.deleted
       data: collective.name, user.info
 
-  + collective.user.added
-      data: collective, user (caller), target (the new user), collectiveuser
-      2* Userid: the new user + the caller
   - collective.user.updated
       data: collective, user (caller), target (the updated user), collectiveuser (updated values)
       2* Userid: the updated user + the caller

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -258,9 +258,6 @@ Types:
   - collective.deleted
       data: collective.name, user.info
 
-  + collective.user.added
-      data: collective, user (caller), target (the new user), collectiveuser
-      2* Userid: the new user + the caller
   - collective.user.updated
       data: collective, user (caller), target (the updated user), collectiveuser (updated values)
       2* Userid: the updated user + the caller

--- a/test/mocks/data.js
+++ b/test/mocks/data.js
@@ -212,8 +212,6 @@ export default {
       },
       { type: 'user.created', UserId: 3, data: {} },
       { type: 'collective.created', UserId: 1, CollectiveId: 1, data: {} },
-      { type: 'collective.user.added', UserId: 1, CollectiveId: 1, data: {} },
-      { type: 'collective.user.added', UserId: 3, CollectiveId: 1, data: {} },
       { type: 'collective.updated', UserId: 1, CollectiveId: 1, data: {} },
       { type: 'collective.updated', UserId: 3, CollectiveId: 1, data: {} },
       { type: 'collective.updated', UserId: 1, CollectiveId: 1, data: {} },
@@ -367,20 +365,6 @@ export default {
         data: {
           user: {
             email: 'jussi@kuohujoki.fi',
-          },
-          collective: {
-            name: 'Blah',
-            slug: 'blah',
-            publicUrl: 'https://opencollective.com/blah',
-          },
-        },
-      },
-      {
-        type: 'collective.user.added',
-        data: {
-          user: {
-            image: 'http://image.githubusercontent.com/asood123',
-            id: 2,
           },
           collective: {
             name: 'Blah',

--- a/test/server/lib/activities.test.js
+++ b/test/server/lib/activities.test.js
@@ -9,60 +9,60 @@ const activitiesData = utils.data('activities1').activities;
 describe('server/lib/activities', () => {
   describe('formatMessageForPublicChannel', () => {
     it(`${constants.COLLECTIVE_TRANSACTION_CREATED} donation`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[12], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[10], 'slack');
       expect(actual).to.equal('New Donation: someone gave USD 10.42 to <https://opencollective.com/pubquiz|Pub quiz>!');
     });
 
     it(`${constants.COLLECTIVE_TRANSACTION_CREATED} expense`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[13], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[11], 'slack');
       expect(actual).to.equal(
         'New Expense: someone submitted an expense to <https://opencollective.com/pubquiz|Pub quiz>: USD -12.98 for pizza!',
       );
     });
 
     it(`${constants.COLLECTIVE_EXPENSE_PAID} expense paid`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[14], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[12], 'slack');
       expect(actual).to.equal("Expense paid on <https://opencollective.com/pubquiz|Pub quiz>: USD -12.98 for 'pizza'");
     });
 
     it(constants.SUBSCRIPTION_CONFIRMED, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[16], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[14], 'slack');
       expect(actual).to.equal(
         'New subscription confirmed: EUR 12.34 from someone to <https://opencollective.com/blah|Blah>!',
       );
     });
 
     it(`${constants.SUBSCRIPTION_CONFIRMED} with month interval`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[17], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[15], 'slack');
       expect(actual).to.equal(
         'New subscription confirmed: EUR 12.34/month from <https://twitter.com/xdamman|xdamman> to <https://opencollective.com/yeoman|Yeoman>! [<https://twitter.com/intent/tweet?text=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20contribution%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman|Thank that person on Twitter>]',
       );
     });
 
     it(constants.COLLECTIVE_CREATED, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[19], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[17], 'slack');
       expect(actual).to.equal('New collective created by someone: <https://opencollective.com/blah|Blah>');
     });
 
     it(`${constants.COLLECTIVE_EXPENSE_CREATED}`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[21], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[18], 'slack');
       expect(actual).to.equal('New Expense: someone submitted an expense to <blah.com|Blah>: EUR 12.34 for for pizza!');
     });
 
     it(`${constants.COLLECTIVE_EXPENSE_REJECTED}`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[22], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[19], 'slack');
       expect(actual).to.equal('Expense rejected: EUR 12.34 for for pizza in <blah.com|Blah>!');
     });
 
     it(`${constants.COLLECTIVE_EXPENSE_APPROVED}`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[23], 'slack');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[20], 'slack');
       expect(actual).to.equal('Expense approved: EUR 12.34 for for pizza in <blah.com|Blah>!');
     });
   });
 
   describe('formatMessageForPublicChannel gitter format', () => {
     it(`${constants.SUBSCRIPTION_CONFIRMED} with month interval for Gitter`, () => {
-      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[17], 'markdown');
+      const actual = activitiesLib.formatMessageForPublicChannel(activitiesData[15], 'markdown');
       expect(actual).to.equal(
         'New subscription confirmed: EUR 12.34/month from [xdamman](https://twitter.com/xdamman) to [Yeoman](https://opencollective.com/yeoman)! [[Thank that person on Twitter](https://twitter.com/intent/tweet?text=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20contribution%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman)]',
       );


### PR DESCRIPTION
That was not triggered anywhere and someone was recently confused while using it for a webhook.