### PR TITLE
Update default fee percents

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -6,6 +6,12 @@
       "benchmark": true
     }
   },
+  "fees": {
+    "default": {
+      "hostPercent": 5,
+      "platformPercent": 5
+    }
+  },
   "maintenancedb": {
     "url": "postgres://postgres@localhost:5432/postgres"
   },

--- a/config/default.json
+++ b/config/default.json
@@ -34,6 +34,12 @@
     "images": "https://images-staging.opencollective.com",
     "invoices": "https://invoices-staging.opencollective.com"
   },
+  "fees": {
+    "default": {
+      "hostPercent": 0,
+      "platformPercent": 0
+    }
+  },
   "limits": {
     "ordersPerHour": {
       "perAccount": 10,

--- a/config/test.json
+++ b/config/test.json
@@ -2,6 +2,12 @@
   "database": {
     "url": "postgres://opencollective@127.0.0.1:5432/opencollective_test"
   },
+  "fees": {
+    "default": {
+      "hostPercent": 5,
+      "platformPercent": 5
+    }
+  },
   "log": {
     "level": "warn"
   },

--- a/migrations/20201020153732-update-default-feePercent.js
+++ b/migrations/20201020153732-update-default-feePercent.js
@@ -1,0 +1,49 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Update Current Hosts to the previous default which was platformFeePercent=5
+    await queryInterface.sequelize.query(`
+      UPDATE "Collectives"
+      SET "platformFeePercent" = 5
+      WHERE "isHostAccount" IS TRUE
+      AND "platformFeePercent" IS NULL
+    `);
+
+    // Update Collectives with unset platformFeePercent to their Host platformFeePercent
+    await queryInterface.sequelize.query(`
+      UPDATE "Collectives"
+      SET "platformFeePercent" = "HostCollectives"."platformFeePercent"
+      FROM "Collectives" as "HostCollectives"
+      WHERE "HostCollectives"."id" = "Collectives"."HostCollectiveId"
+      AND "Collectives"."platformFeePercent" IS NULL
+    `);
+
+    // Update Current Hosts to hostFeePercent=0 if they have a bogus value
+    await queryInterface.sequelize.query(`
+      UPDATE "Collectives"
+      SET "hostFeePercent" = 0
+      WHERE "isHostAccount" IS TRUE
+      AND "hostFeePercent" IS NULL
+    `);
+
+    // Update Collectives with unset hostFeePercent to their Host hostFeePercent
+    await queryInterface.sequelize.query(`
+      UPDATE "Collectives"
+      SET "hostFeePercent" = "HostCollectives"."hostFeePercent"
+      FROM "Collectives" as "HostCollectives"
+      WHERE "HostCollectives"."id" = "Collectives"."HostCollectiveId"
+      AND "Collectives"."hostFeePercent" IS NULL
+    `);
+
+    // Update all unhosted collectives to hostFeePercent=null platformFeePercent=null
+    await queryInterface.sequelize.query(`
+      UPDATE "Collectives"
+      SET "platformFeePercent" = NULL, "hostFeePercent" = NULL
+      WHERE "HostCollectiveId" IS NULL
+      AND "type" IN ('COLLECTIVE', 'FUND', 'EVENT", "PROJECT')
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/migrations/20201020153732-update-default-feePercent.js
+++ b/migrations/20201020153732-update-default-feePercent.js
@@ -41,7 +41,7 @@ module.exports = {
       UPDATE "Collectives"
       SET "platformFeePercent" = NULL, "hostFeePercent" = NULL
       WHERE "HostCollectiveId" IS NULL
-      AND "type" IN ('COLLECTIVE', 'FUND', 'EVENT", "PROJECT')
+      AND "type" IN ('COLLECTIVE', 'FUND', 'EVENT', 'PROJECT')
     `);
   },
 

--- a/server/constants/transactions.js
+++ b/server/constants/transactions.js
@@ -1,10 +1,10 @@
 /** @module constants/transactions */
 
 /** Percentage that Open Collective charges per transaction: 5% */
-export const OC_FEE_PERCENT = 5;
+export const PLATFORM_FEE_PERCENT = 0;
 
 /** Default per transaction host fee percentage */
-export const HOST_FEE_PERCENT = 5;
+export const HOST_FEE_PERCENT = 0;
 
 /** Types of Transactions */
 export const TransactionTypes = {

--- a/server/constants/transactions.js
+++ b/server/constants/transactions.js
@@ -1,11 +1,3 @@
-/** @module constants/transactions */
-
-/** Percentage that Open Collective charges per transaction: 5% */
-export const PLATFORM_FEE_PERCENT = 0;
-
-/** Default per transaction host fee percentage */
-export const HOST_FEE_PERCENT = 0;
-
 /** Types of Transactions */
 export const TransactionTypes = {
   CREDIT: 'CREDIT',

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -466,11 +466,17 @@ export async function approveCollective(remoteUser, CollectiveId) {
     },
   });
 
-  // Approve all events created by this collective
+  // Approve all events and projects created by this collective
   const events = await collective.getEvents();
   await Promise.all(
     events.map(event => {
       event.update({ isActive: true, approvedAt: new Date() });
+    }),
+  );
+  const projects = await collective.getProjects();
+  await Promise.all(
+    projects.map(project => {
+      project.update({ isActive: true, approvedAt: new Date() });
     }),
   );
 
@@ -518,9 +524,11 @@ export async function archiveCollective(_, args, req) {
     membership.destroy();
   }
 
-  if (collective.type === types.EVENT) {
+  if (collective.type === types.EVENT || collective.type === types.PROJECT) {
     return collective.update({ isActive: false, deactivatedAt: Date.now() });
   }
+
+  // TODO: cascade deactivation to EVENTs and PROJECTs?
 
   return collective.update({ isActive: false, deactivatedAt: Date.now(), approvedAt: null, HostCollectiveId: null });
 }

--- a/server/graphql/v2/interface/AccountWithContributions.ts
+++ b/server/graphql/v2/interface/AccountWithContributions.ts
@@ -2,7 +2,7 @@ import { GraphQLBoolean, GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLN
 import { isNil } from 'lodash';
 
 import { types } from '../../../constants/collectives';
-import { OC_FEE_PERCENT } from '../../../constants/transactions';
+import { PLATFORM_FEE_PERCENT } from '../../../constants/transactions';
 import { getPaginatedContributorsForCollective } from '../../../lib/contributors';
 import models from '../../../models';
 import { ContributorCollection } from '../collection/ContributorCollection';
@@ -67,7 +67,7 @@ export const AccountWithContributionsFields = {
     type: new GraphQLNonNull(GraphQLInt),
     description: 'How much platform fees are charged for this account',
     resolve(account): number {
-      return isNil(account.platformFeePercent) ? OC_FEE_PERCENT : account.platformFeePercent;
+      return isNil(account.platformFeePercent) ? PLATFORM_FEE_PERCENT : account.platformFeePercent;
     },
   },
   platformContributionAvailable: {

--- a/server/graphql/v2/interface/AccountWithContributions.ts
+++ b/server/graphql/v2/interface/AccountWithContributions.ts
@@ -1,8 +1,8 @@
+import config from 'config';
 import { GraphQLBoolean, GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
 import { isNil } from 'lodash';
 
 import { types } from '../../../constants/collectives';
-import { PLATFORM_FEE_PERCENT } from '../../../constants/transactions';
 import { getPaginatedContributorsForCollective } from '../../../lib/contributors';
 import models from '../../../models';
 import { ContributorCollection } from '../collection/ContributorCollection';
@@ -67,7 +67,7 @@ export const AccountWithContributionsFields = {
     type: new GraphQLNonNull(GraphQLInt),
     description: 'How much platform fees are charged for this account',
     resolve(account): number {
-      return isNil(account.platformFeePercent) ? PLATFORM_FEE_PERCENT : account.platformFeePercent;
+      return isNil(account.platformFeePercent) ? config.fees.default.platformPercent : account.platformFeePercent;
     },
   },
   platformContributionAvailable: {

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -8,7 +8,7 @@ import activities from '../constants/activities';
 import status from '../constants/order_status';
 import roles from '../constants/roles';
 import tiers from '../constants/tiers';
-import { FEES_ON_TOP_TRANSACTION_PROPERTIES, PLATFORM_FEE_PERCENT } from '../constants/transactions';
+import { FEES_ON_TOP_TRANSACTION_PROPERTIES } from '../constants/transactions';
 import { createPrepaidPaymentMethod, isPrepaidBudgetOrder } from '../lib/prepaid-budget';
 import { formatAccountDetails } from '../lib/transferwise';
 import { formatCurrency, toIsoDateStr } from '../lib/utils';
@@ -552,7 +552,9 @@ export const getPlatformFee = order => {
   }
 
   const defaultPlatformFeePercent =
-    order.collective.platformFeePercent === null ? PLATFORM_FEE_PERCENT : order.collective.platformFeePercent;
+    order.collective.platformFeePercent === null
+      ? config.fees.default.platformPercent
+      : order.collective.platformFeePercent;
 
   const platformFeePercent = get(order, 'data.platformFeePercent', defaultPlatformFeePercent);
 

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -8,7 +8,7 @@ import activities from '../constants/activities';
 import status from '../constants/order_status';
 import roles from '../constants/roles';
 import tiers from '../constants/tiers';
-import { FEES_ON_TOP_TRANSACTION_PROPERTIES, OC_FEE_PERCENT } from '../constants/transactions';
+import { FEES_ON_TOP_TRANSACTION_PROPERTIES, PLATFORM_FEE_PERCENT } from '../constants/transactions';
 import { createPrepaidPaymentMethod, isPrepaidBudgetOrder } from '../lib/prepaid-budget';
 import { formatAccountDetails } from '../lib/transferwise';
 import { formatCurrency, toIsoDateStr } from '../lib/utils';
@@ -552,7 +552,7 @@ export const getPlatformFee = order => {
   }
 
   const defaultPlatformFeePercent =
-    order.collective.platformFeePercent === null ? OC_FEE_PERCENT : order.collective.platformFeePercent;
+    order.collective.platformFeePercent === null ? PLATFORM_FEE_PERCENT : order.collective.platformFeePercent;
 
   const platformFeePercent = get(order, 'data.platformFeePercent', defaultPlatformFeePercent);
 

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -1,10 +1,12 @@
+import config from 'config';
 import { isNumber, pick } from 'lodash';
 
 import { maxInteger } from '../../constants/math';
-import { HOST_FEE_PERCENT, TransactionTypes } from '../../constants/transactions';
+import { TransactionTypes } from '../../constants/transactions';
 import { FEATURE, hasOptedInForFeature } from '../../lib/allowed-features';
 import { createRefundTransaction } from '../../lib/payments';
 import models from '../../models';
+
 /**
  * Manual Payment method
  * This payment method enables a host to manually receive donations (e.g. by wire directly to the host's bank account)
@@ -63,7 +65,7 @@ async function processOrder(order) {
     // Default for Collective
     order.collective.hostFeePercent,
     // Just in case, default on the platform
-    HOST_FEE_PERCENT,
+    config.fees.default.hostPercent,
   ].find(isNumber);
 
   const isFeesOnTop = order.data?.isFeesOnTop || false;

--- a/server/paymentProviders/opencollective/prepaid.js
+++ b/server/paymentProviders/opencollective/prepaid.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 
-import { OC_FEE_PERCENT, TransactionTypes } from '../../constants/transactions';
+import { PLATFORM_FEE_PERCENT, TransactionTypes } from '../../constants/transactions';
 import * as currency from '../../lib/currency';
 import * as libpayments from '../../lib/payments';
 import models, { Op } from '../../models';
@@ -85,7 +85,7 @@ async function processOrder(order) {
 
   const feeOnTop = order.data?.platformFee || 0;
   const defaultPlatformFee =
-    order.collective.platformFeePercent === null ? OC_FEE_PERCENT : order.collective.platformFeePercent;
+    order.collective.platformFeePercent === null ? PLATFORM_FEE_PERCENT : order.collective.platformFeePercent;
   const platformFeePercent = get(order, 'data.platformFeePercent', defaultPlatformFee);
   const platformFeeInHostCurrency = feeOnTop || libpayments.calcFee(order.totalAmount, platformFeePercent);
 

--- a/server/paymentProviders/opencollective/prepaid.js
+++ b/server/paymentProviders/opencollective/prepaid.js
@@ -1,6 +1,7 @@
+import config from 'config';
 import { get } from 'lodash';
 
-import { PLATFORM_FEE_PERCENT, TransactionTypes } from '../../constants/transactions';
+import { TransactionTypes } from '../../constants/transactions';
 import * as currency from '../../lib/currency';
 import * as libpayments from '../../lib/payments';
 import models, { Op } from '../../models';
@@ -85,7 +86,9 @@ async function processOrder(order) {
 
   const feeOnTop = order.data?.platformFee || 0;
   const defaultPlatformFee =
-    order.collective.platformFeePercent === null ? PLATFORM_FEE_PERCENT : order.collective.platformFeePercent;
+    order.collective.platformFeePercent === null
+      ? config.fees.default.platformPercent
+      : order.collective.platformFeePercent;
   const platformFeePercent = get(order, 'data.platformFeePercent', defaultPlatformFee);
   const platformFeeInHostCurrency = feeOnTop || libpayments.calcFee(order.totalAmount, platformFeePercent);
 


### PR DESCRIPTION
- Host always with hostFeePercent and platformFeePercent set (if missing hostFeePercent=0, platformFeePercent=5)
- new Hosts will start with  hostFeePercent=0, platformFeePercent=0. 
- Collectives always starts with hostFeePercent=null, platformFeePercent=null
- When applying to an Host they inherit its hostFeePercent and platformFeePercent
- On Rejection or when they reset the Host, they're moved back to hostFeePercent=null, platformFeePercent=null
- Remove "covid-19" exception