### PR TITLE
fix:undefine expenses category bug in user monthly report

### DIFF
--- a/cron/monthly/user-report.js
+++ b/cron/monthly/user-report.js
@@ -448,7 +448,9 @@ const computeStats = async (collectives, currency = 'USD') => {
   stats.totalDonatedString = formatCurrencyObject(stats.totalDonatedPerCurrency);
   const ar = [];
   stats.topCategories.map(category => {
-    ar.push(`${category} (${formatCurrencyObject(categories[category].totalAmountPerCurrency)})`);
+    ar.push(
+      `${category || 'unclassified expenses'} (${formatCurrencyObject(categories[category].totalAmountPerCurrency)})`,
+    );
   });
   stats.expensesBreakdownString = `${Object.keys(categories).length > 3 ? ', mostly in' : ' in'} ${formatArrayToString(
     ar,


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/3450
i added "unclassified expenses" as expense category when category is undefined just like @znarf suggested. 

---
_Edit by @Betree: fix issue link_