### PR TITLE
LoginEmail: Show login link as plain text

### DIFF
--- a/templates/emails/user.new.token.hbs
+++ b/templates/emails/user.new.token.hbs
@@ -7,6 +7,15 @@ Subject: Open Collective: Login
 <center>
   <h3>You are one click away from logging into your Open Collective account.</h3>
   <a href="{{{loginLink}}}" class="btn blue"><div>One-click login</div></a>
+  <br/>
+  <br/>
+  <br/>
+  <hr/>
+  <br/>
+  <p>
+    Link not working? Try this:<br/>
+    <a href="{{loginLink}}" style="word-break: break-all; font-size: 12px;">{{loginLink}}</a>
+  </p>
 </center>
 
 <div itemscope itemtype="http://schema.org/EmailMessage">


### PR DESCRIPTION
Some users are having troubles to login with Outlook because of their redirect. By looking at what the industry is doing, it seems very frequent to attach the link as clear text so users can copy paste them if needed.

# Preview

![2020-10-22_16-13](https://user-images.githubusercontent.com/1556356/96886426-dca4ef00-1483-11eb-82c7-fbd488ecf5b4.png)
