### PR TITLE
Emails: Apply colors from design system to buttons

### DIFF
--- a/templates/emails/collective.expense.created.hbs
+++ b/templates/emails/collective.expense.created.hbs
@@ -54,7 +54,7 @@ Subject: New expense on {{collective.name}}: {{currency expense.amount currency=
   <br />
   <br />
   <a class="btn blue" href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">
-    <div style="font-size: 15px;">View expense on Open Collective</div>
+    <div>View expense on Open Collective</div>
   </a>
 
   <br /><br />

--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -29,6 +29,7 @@
     }
     a {
       text-decoration: none;
+      color: #297EFF;
     }
     h1 {
       color: #3399FF;
@@ -84,12 +85,21 @@
       border-radius: 16px;
       display: inline-block;
       color: #3399FF;
+      font-weight: 600;
+      font-size: 14px;
+      line-height: 17px;
+      padding-bottom: 14px;
+      padding-left: 24px;
+      padding-right: 24px;
+      padding-top: 14px;
+      border-radius: 100px;
     }
     .btn div {
-      font-family: "Helvetica Neue";
+      font-family: 'Inter', sans-serif;
+      font-weight: 600;
+      font-size: 14px;
+      line-height: 17px;
       font-size: 12px;
-      font-weight: bold;
-      line-height: 15px;
       text-align: center;
     }
     .btn.green {
@@ -104,6 +114,16 @@
     }
     .btn.blue {
     	background-color: #3399FF;
+      background: linear-gradient(180deg,#1869F5 0%,#1258e2 100%);
+      background-color: #1869F5;
+      border-color: #1869F5;
+      color: #FFFFFF;
+    }
+    .btn.blue:hover {
+      background: linear-gradient(180deg,#297EFF 0%,#1869F5 100%);
+      background-color: #297EFF;
+      border-color: #297EFF;
+      color: #FFFFFF;
     }
     .btn.blue div {
       color: white;


### PR DESCRIPTION
A tiny change to use the current colors from the design system for emails buttons. Also uses the default link colors from website.

# Context

![image](https://user-images.githubusercontent.com/1556356/96886957-5f2dae80-1484-11eb-81cf-d424bc614831.png)


# Preview

## Signin

![image](https://user-images.githubusercontent.com/1556356/96887069-7f5d6d80-1484-11eb-9bac-ee814190ade8.png)


## New expense

![image](https://user-images.githubusercontent.com/1556356/96887123-8e442000-1484-11eb-95b3-300f8132ade3.png)

