### PR TITLE
Follow up PR for 3D secure & host rolling limit

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -1657,6 +1657,26 @@ type Fund implements CollectiveInterface {
 }
 
 """
+Input type for guest contributions
+"""
+input GuestInfoInput {
+  """
+  Contributor's email
+  """
+  email: String
+
+  """
+  Full name of the user
+  """
+  name: String
+
+  """
+  The unique guest token
+  """
+  token: String
+}
+
+"""
 Properties by which hosts can be ordered.
 """
 enum HostCollectiveOrderFieldType {
@@ -1989,6 +2009,7 @@ type Mutation {
   """
   editPublicMessage(FromCollectiveId: Int!, CollectiveId: Int!, message: String): [Member]
   createOrder(order: OrderInputType!): OrderType
+    @deprecated(reason: "2020-10-13: This endpoint has been moved to GQLV2")
   confirmOrder(order: ConfirmOrderInputType!): OrderType
   addFundsToCollective(order: OrderInputType!): OrderType
   createUpdate(update: UpdateInputType!): UpdateType
@@ -2382,6 +2403,11 @@ input OrderInputType {
   tier: TierInputType
   customData: JSON
   recaptchaToken: String
+
+  """
+  Use this when fromAccount is null to pass the guest info
+  """
+  guestInfo: GuestInfoInput
 
   """
   The amount of taxes that were included in totalAmount

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -3727,7 +3727,7 @@ input GuestInfoInput {
   """
   Contributor's email
   """
-  email: EmailAddress
+  email: EmailAddress!
 
   """
   Full name of the user
@@ -3738,6 +3738,11 @@ input GuestInfoInput {
   The unique guest token
   """
   token: String
+
+  """
+  Address of the user, mandatory when amount is above $5000.
+  """
+  location: LocationInput
 }
 
 """
@@ -4765,7 +4770,14 @@ type Mutation {
     """
     amount: AmountInput
   ): Order
-  confirmOrder(order: OrderReferenceInput!): OrderWithPayment!
+  confirmOrder(
+    order: OrderReferenceInput!
+
+    """
+    If the order was made as a guest, you can use this field to authenticate
+    """
+    guestToken: String
+  ): OrderWithPayment!
 
   """
   Add a new payment method to be used with an Order
@@ -4797,15 +4809,25 @@ type Mutation {
   """
   addStripeCreditCard(
     """
-    A Payment Method to add to an Account
+    The credit card info
     """
-    paymentMethod: PaymentMethodCreateInput
+    creditCardInfo: CreditCardCreateInput!
 
     """
-    Account to add Payment Method to
+    Name associated to this credit card
     """
-    account: AccountReferenceInput
-  ): PaymentMethod
+    name: String!
+
+    """
+    Whether this credit card should be saved for future payments
+    """
+    isSavedForLater: Boolean = true
+
+    """
+    Account to add the credit card to
+    """
+    account: AccountReferenceInput!
+  ): CreditCardWithStripeError! @deprecated(reason: "2020-10-23: Use addCreditCard")
 
   """
   Confirm a credit card is ready for use after strong customer authentication
@@ -5040,6 +5062,11 @@ type OrderWithPayment {
   order: Order!
 
   """
+  If donating as a guest, this will contain your guest token to contribute again in the future
+  """
+  guestToken: String
+
+  """
   This field will be set if the order was created but there was an error with Stripe during the payment
   """
   stripeError: StripeError
@@ -5260,22 +5287,6 @@ type PaymentMethod {
   limitedToHosts: [Host]
   expiryDate: ISODateTime
   createdAt: ISODateTime
-}
-
-input PaymentMethodCreateInput {
-  data: PaymentMethodDataInput
-  name: String
-  token: String
-}
-
-input PaymentMethodDataInput {
-  brand: String!
-  country: String!
-  expMonth: Int!
-  expYear: Int!
-  fullName: String
-  funding: String
-  zip: String
 }
 
 """

--- a/server/lib/collectivelib.js
+++ b/server/lib/collectivelib.js
@@ -62,6 +62,7 @@ export const COLLECTIVE_SETTINGS_KEYS_LIST = [
   'matchingFund',
   'moderation',
   'paymentMethods',
+  'payoutsTwoFactorAuth',
   'recommendedCollectives',
   'style',
   'superCollectiveTag',


### PR DESCRIPTION
Follow up work for https://github.com/opencollective/opencollective-api/pull/4713

* Adds `payoutsTwoFactorAuth` to allowed collective settings keys

Follow up work for https://github.com/opencollective/opencollective-api/pull/4729

* Removes `addStripeCreditCard` mutation again since it's no longer needed for the changeover to `addCreditCard`