### PR TITLE
Emails: Improve button sizing

### DIFF
--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -93,6 +93,7 @@
       padding-right: 24px;
       padding-top: 14px;
       border-radius: 100px;
+      min-height: 47px;
     }
     .btn div {
       font-family: 'Inter', sans-serif;


### PR DESCRIPTION
On some clients the padding Y of the button is not respected, which can make it smaller.