### PR TITLE
Consolidated monthly transaction PDFs for users and orgs

### DIFF
--- a/cron/monthly/collective-report.js
+++ b/cron/monthly/collective-report.js
@@ -4,10 +4,11 @@ import '../../server/env';
 import Promise from 'bluebird';
 import config from 'config';
 import debugLib from 'debug';
-import { filter, pick, without } from 'lodash';
+import { filter, isEmpty, pick, without } from 'lodash';
 import moment from 'moment';
 
 import { notifyAdminsOfCollective } from '../../server/lib/notifications';
+import { getConsolidatedInvoicePdfs } from '../../server/lib/pdf';
 import { getTiersStats } from '../../server/lib/utils';
 import models, { Op } from '../../server/models';
 
@@ -241,7 +242,15 @@ const processCollective = collective => {
         return collective;
       });
     })
-    .then(collective => {
+    .then(async collective => {
+      if (collective.type === 'ORGANIZATION') {
+        const monthlyConsolidatedInvoices = await getConsolidatedInvoicePdfs(collective);
+
+        if (!isEmpty(monthlyConsolidatedInvoices)) {
+          options.attachments.push(...monthlyConsolidatedInvoices);
+          emailData.consolidatedPdfs = true;
+        }
+      }
       const activity = {
         type: 'collective.monthlyreport',
         data: emailData,

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -14,6 +14,7 @@ const minutesToSeconds = minutes => moment.duration({ minutes }).asSeconds();
 export const TOKEN_EXPIRATION_LOGIN = minutesToSeconds(75);
 export const TOKEN_EXPIRATION_CONNECTED_ACCOUNT = daysToSeconds(1);
 export const TOKEN_EXPIRATION_SESSION = daysToSeconds(90);
+export const TOKEN_EXPIRATION_PDF = minutesToSeconds(75);
 
 const ALGORITHM = 'HS256';
 const KID = 'HS256-2019-09-02';

--- a/server/lib/pdf.js
+++ b/server/lib/pdf.js
@@ -1,6 +1,10 @@
 import config from 'config';
+import { get } from 'lodash';
+import moment from 'moment';
 
-import { TOKEN_EXPIRATION_LOGIN } from './auth';
+import models, { Op } from '../models';
+
+import { TOKEN_EXPIRATION_PDF } from './auth';
 import { fetchWithTimeout } from './fetch';
 import logger from './logger';
 
@@ -9,7 +13,7 @@ export const getTransactionPdf = async (transaction, user) => {
     return;
   }
   const pdfUrl = `${config.host.pdf}/transactions/${transaction.uuid}/invoice.pdf`;
-  const accessToken = user.jwt({}, TOKEN_EXPIRATION_LOGIN);
+  const accessToken = user.jwt({}, TOKEN_EXPIRATION_PDF);
   const headers = {
     Authorization: `Bearer ${accessToken}`,
   };
@@ -27,4 +31,122 @@ export const getTransactionPdf = async (transaction, user) => {
     .catch(error => {
       logger.error(`Error fetching PDF: ${error.message}`);
     });
+};
+
+export const getConsolidatedInvoicesData = async fromCollective => {
+  const transactions = await models.Transaction.findAll({
+    attributes: ['createdAt', 'HostCollectiveId', 'amountInHostCurrency', 'hostCurrency'],
+    where: {
+      type: 'CREDIT',
+      [Op.or]: [
+        { FromCollectiveId: fromCollective.id, UsingVirtualCardFromCollectiveId: null },
+        { UsingVirtualCardFromCollectiveId: fromCollective.id },
+      ],
+    },
+  });
+
+  const hostsById = {};
+  const invoicesByKey = {};
+  let invoices = [];
+
+  for (const transaction of transactions) {
+    const HostCollectiveId = transaction.HostCollectiveId;
+    if (!HostCollectiveId) {
+      continue;
+    }
+    if (!hostsById[HostCollectiveId]) {
+      hostsById[HostCollectiveId] = await models.Collective.findByPk(HostCollectiveId, {
+        attributes: ['id', 'slug'],
+      });
+    }
+
+    const createdAt = new Date(transaction.createdAt);
+    const year = createdAt.getFullYear();
+    const month = createdAt.getMonth() + 1;
+    const monthToDigit = month < 10 ? `0${month}` : `${month}`;
+    const slug = `${year}${monthToDigit}.${hostsById[HostCollectiveId].slug}.${fromCollective.slug}`;
+    const totalAmount = invoicesByKey[slug]
+      ? invoicesByKey[slug].totalAmount + transaction.amountInHostCurrency
+      : transaction.amountInHostCurrency;
+    const totalTransactions = invoicesByKey[slug] ? invoicesByKey[slug].totalTransactions + 1 : 1;
+
+    invoicesByKey[slug] = {
+      HostCollectiveId,
+      FromCollectiveId: fromCollective.id,
+      slug,
+      year,
+      month,
+      totalAmount,
+      totalTransactions,
+      currency: transaction.hostCurrency,
+    };
+  }
+
+  invoices = Object.values(invoicesByKey);
+  invoices.sort((a, b) => {
+    return b.slug.localeCompare(a.slug);
+  });
+
+  return invoices;
+};
+
+export const getConsolidatedInvoicePdfs = async fromCollective => {
+  if (config.pdfService.fetchTransactionsReceipts === false) {
+    return;
+  }
+
+  // Get invoices
+  const invoices = await getConsolidatedInvoicesData(fromCollective);
+
+  const pdfAttachments = [];
+
+  // Get URL info from invoices
+  for (const invoice of invoices) {
+    const invoiceInfo = get(invoice, 'slug').split('.');
+    const dateYYYYMM = invoiceInfo[0];
+    const month = dateYYYYMM.slice(-2);
+    const year = dateYYYYMM.slice(0, 4);
+    const startDate = moment([year, month]);
+    const endDate = moment(startDate).endOf('month');
+    const startOfMonth = startDate.toISOString();
+    const endOfMonth = endDate.toISOString();
+    const toOrgCollectiveSlug = invoiceInfo[1];
+    const fromCollectiveSlug = invoiceInfo[2];
+
+    // Get user so we can generate access token
+    const fromCollectiveUser = await models.User.findOne({
+      where: { CollectiveId: invoice.FromCollectiveId },
+    });
+
+    // Call PDF service for the invoice
+    const pdfUrl = `${config.host.pdf}/collectives/${fromCollectiveSlug}/${toOrgCollectiveSlug}/${startOfMonth}/${endOfMonth}.pdf`;
+    const accessToken = fromCollectiveUser.jwt({}, TOKEN_EXPIRATION_PDF);
+    const headers = {
+      Authorization: `Bearer ${accessToken}`,
+    };
+
+    let invoicePdf;
+    try {
+      const response = await fetchWithTimeout(pdfUrl, { method: 'get', headers, timeoutInMs: 10000 });
+
+      const { status } = response;
+      if (status >= 200 && status < 300) {
+        invoicePdf = response.body;
+      } else {
+        logger.warn('Failed to fetch PDF');
+      }
+    } catch (error) {
+      logger.error(`Error fetching PDF: ${error.message}`);
+    }
+
+    // Push invoice to attachments if fetch is successful
+    if (invoicePdf) {
+      pdfAttachments.push({
+        filename: `${fromCollectiveSlug}_${toOrgCollectiveSlug}_${startOfMonth}_${endOfMonth}.pdf`,
+        content: invoicePdf,
+      });
+    }
+  }
+
+  return pdfAttachments;
 };

--- a/templates/emails/collective.monthlyreport.hbs
+++ b/templates/emails/collective.monthlyreport.hbs
@@ -136,6 +136,10 @@ Subject: {{collective.name}} Collective {{month}} {{year}} Report
       <td><div class="action"><a href="{{@root.collective.publicUrl}}/edit/goals?utm_source=opencollective&utm_campaign=monthlyreport&utm_medium=email">Edit goals</a></div></td>
     </tr>
   </table>
+
+  {{#if consolidatedPdfs}}
+  <br /><p>We've also attached PDFs of all your contributions, organized by fiscal host, to this email 👇</p>{{/if}}
+
   {{#if collective.nextGoal}}
   {{collective.nextGoal.title}}<br />
   <div class="progress-track">

--- a/templates/emails/user.monthlyreport.hbs
+++ b/templates/emails/user.monthlyreport.hbs
@@ -222,7 +222,8 @@ Subject: {{capitalize month}} Report
         <h2>Hi {{fromCollective.name}} 👋</h2>
         <ul class="intro">
           <li>In {{month}}, you have backed {{stats.collectives}} {{pluralize "collective" n=stats.collectives}} for a total of {{stats.totalDonatedString}}. Thank you for your {{pluralize "contribution" n=stats.collectives}}! 🙌
-          {{#if stats.expenses}}<br />They've spent a total of {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}</li>
+          {{#if stats.expenses}}<br />They've spent a total of {{stats.totalSpentString}}{{stats.expensesBreakdownString}}.{{/if}}
+          {{#if consolidatedPdfs}}<br />You can find PDFs of all your contributions, organized by fiscal host, attached to this email.{{/if}}</li>
           {{#each collectives}}
             {{#if nextGoal}}
               <li><a href="{{../config.host.website}}/{{slug}}">{{name}}</a> needs {{currency nextGoal.missing.amount currency=currency}} more {{#if nextGoal.missing.interval}}per {{nextGoal.missing.interval}}{{/if}} to reach their next goal of {{nextGoal.title}} ({{nextGoal.percentage}} there). 


### PR DESCRIPTION
This PR:

* moves consolidated PDF functionality out of GraphQL v1 queries and into `lib/pdf`
* adds call for consolidated PDFs of contributions per host for a user collective to the `cron/monthly/user-report`
* attaches PDFs to user monthly report if any, and adds a line in the email about it
* adds to org monthly report