### PR TITLE
Fixes on GQLV2 Updates object

### DIFF
--- a/server/graphql/v2/interface/AccountWithContributions.ts
+++ b/server/graphql/v2/interface/AccountWithContributions.ts
@@ -100,7 +100,7 @@ export const AccountWithContributionsFields = {
       const query = {
         where: {
           CollectiveId: collective.id,
-          publishedAt: onlyPublishedUpdates ? { [Op.ne]: null } : null,
+          publishedAt: onlyPublishedUpdates ? { [Op.ne]: null } : undefined,
         },
         order: [['createdAt', 'DESC']],
         limit,

--- a/server/graphql/v2/object/Update.js
+++ b/server/graphql/v2/object/Update.js
@@ -1,7 +1,7 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
 
-import { stripHTML } from '../../../lib/sanitize-html';
+import { stripTags } from '../../../lib/utils';
 import { UpdateAudienceType } from '../enum/UpdateAudienceType';
 import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';
 import { Account } from '../interface/Account';
@@ -51,7 +51,7 @@ const Update = new GraphQLObjectType({
             return null;
           }
 
-          return stripHTML(update.html || '');
+          return stripTags(update.html || '');
         },
       },
       tags: { type: new GraphQLList(GraphQLString) },


### PR DESCRIPTION
- **Return all updates by default**
Using `null` meant that by default, the query returned only unpublished updates (that have a `null` value for `publishedAt`).

- **Don't stripe HTML**
HTML was completely stripped in the `html` field