### PR TITLE
Remove deprecated stripTags and replace it with lib/sanitize-html

### DIFF
--- a/server/graphql/common/comment.js
+++ b/server/graphql/common/comment.js
@@ -1,7 +1,7 @@
 import { pick } from 'lodash';
 
 import { mustBeLoggedInTo } from '../../lib/auth';
-import { stripTags } from '../../lib/utils';
+import { sanitizeHTML } from '../../lib/sanitize-html';
 import models from '../../models';
 import { NotFound, Unauthorized, ValidationFailed } from '../errors';
 
@@ -126,7 +126,7 @@ function fromCollectiveResolver({ FromCollectiveId }, _, { loaders }) {
  * Returns a resolver function that strip tags from the object prop.
  * @param {string} prop - prop to look in the object of the resolver first argument.
  */
-const getStripTagsResolver = prop => obj => stripTags(obj[prop] || '');
+const getStripTagsResolver = prop => obj => sanitizeHTML(obj[prop] || '');
 
 export {
   editComment,

--- a/server/graphql/v1/mutations/updates.js
+++ b/server/graphql/v1/mutations/updates.js
@@ -2,7 +2,7 @@ import { get } from 'lodash';
 
 import { mustHaveRole } from '../../../lib/auth';
 import { purgeCacheForCollective } from '../../../lib/cache';
-import { stripTags } from '../../../lib/utils';
+import { stripHTML } from '../../../lib/sanitize-html';
 import models from '../../../models';
 import { NotFound, ValidationFailed } from '../../errors';
 
@@ -23,12 +23,12 @@ export async function createUpdate(_, args, req) {
     throw new Error('This collective does not exist');
   }
 
-  const markdown = args.update.markdown ? stripTags(args.update.markdown) : '';
+  const markdown = args.update.markdown ? stripHTML(args.update.markdown) : '';
 
   const update = await models.Update.create({
     title: args.update.title,
     markdown,
-    html: stripTags(args.update.html),
+    html: stripHTML(args.update.html),
     CollectiveId,
     isPrivate: args.update.isPrivate,
     TierId: get(args, 'update.tier.id'),

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -24,7 +24,7 @@ import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPES } from '../../constants/pa
 import roles from '../../constants/roles';
 import { getCollectiveAvatarUrl } from '../../lib/collectivelib';
 import { getContributorsForTier } from '../../lib/contributors';
-import { stripTags } from '../../lib/utils';
+import { stripHTML } from '../../lib/sanitize-html';
 import models, { Op, sequelize } from '../../models';
 import { PayoutMethodTypes } from '../../models/PayoutMethod';
 import * as commonComment from '../common/comment';
@@ -1104,7 +1104,7 @@ export const UpdateType = new GraphQLObjectType({
             return null;
           }
 
-          return stripTags(update.html || '');
+          return stripHTML(update.html || '');
         },
       },
       markdown: {
@@ -1114,7 +1114,7 @@ export const UpdateType = new GraphQLObjectType({
             return null;
           }
 
-          return stripTags(update.markdown || '');
+          return stripHTML(update.markdown || '');
         },
       },
       tags: {

--- a/server/graphql/v2/object/Update.js
+++ b/server/graphql/v2/object/Update.js
@@ -1,7 +1,7 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-iso-date';
 
-import { stripTags } from '../../../lib/utils';
+import { stripHTML } from '../../../lib/sanitize-html';
 import { UpdateAudienceType } from '../enum/UpdateAudienceType';
 import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';
 import { Account } from '../interface/Account';
@@ -51,7 +51,7 @@ const Update = new GraphQLObjectType({
             return null;
           }
 
-          return stripTags(update.html || '');
+          return stripHTML(update.html || '');
         },
       },
       tags: { type: new GraphQLList(GraphQLString) },

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -7,10 +7,10 @@ import Promise from 'bluebird';
 import config from 'config';
 import pdf from 'html-pdf';
 import { cloneDeep, get, isEqual, padStart } from 'lodash';
-import sanitizeHtml from 'sanitize-html';
 
 import errors from './errors';
 import handlebars from './handlebars';
+import { sanitizeHTML } from './sanitize-html';
 
 const { BadRequest } = errors;
 
@@ -59,35 +59,8 @@ export function getDomain(url = '') {
   return domain;
 }
 
-/**
- * @deprecated Please use the functions in `server/lib/sanitize-html.js`
- */
-export function stripTags(str, allowedTags) {
-  return sanitizeHtml(str, {
-    allowedTags: allowedTags || sanitizeHtml.defaults.allowedTags.concat(['img', 'h1', 'h2', 'h3']),
-    allowedAttributes: {
-      a: ['href', 'name', 'target'],
-      img: ['src'],
-      iframe: [
-        'src',
-        'allowfullscreen',
-        'frameborder',
-        'autoplay',
-        'width',
-        'height',
-        {
-          name: 'allow',
-          multiple: true,
-          values: ['autoplay', 'encrypted-media', 'gyroscope'],
-        },
-      ],
-    },
-    allowedIframeHostnames: ['www.youtube.com', 'www.youtube-nocookie.com', 'player.vimeo.com'],
-  });
-}
-
 export const sanitizeObject = (obj, attributes, sanitizerFn) => {
-  const sanitizer = typeof sanitizerFn === 'function' ? sanitizerFn : stripTags;
+  const sanitizer = typeof sanitizerFn === 'function' ? sanitizerFn : sanitizeHTML;
 
   attributes.forEach(attr => {
     if (!obj[attr]) {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -49,6 +49,7 @@ import emailLib from '../lib/email';
 import logger from '../lib/logger';
 import { handleHostCollectivesLimit } from '../lib/plans';
 import queries from '../lib/queries';
+import { stripHTML } from '../lib/sanitize-html';
 import {
   collectiveSpamCheck,
   notifyTeamAboutPreventedCollectiveCreate,
@@ -56,7 +57,7 @@ import {
 } from '../lib/spam';
 import { canUseFeature } from '../lib/user-permissions';
 import userlib from '../lib/userlib';
-import { capitalize, cleanTags, flattenArray, formatCurrency, getDomain, md5, stripTags } from '../lib/utils';
+import { capitalize, cleanTags, flattenArray, formatCurrency, getDomain, md5 } from '../lib/utils';
 
 import CustomDataTypes from './DataTypes';
 import { PayoutMethodTypes } from './PayoutMethod';
@@ -264,7 +265,7 @@ export default function (Sequelize, DataTypes) {
         type: DataTypes.TEXT,
         set(longDescription) {
           if (longDescription) {
-            this.setDataValue('longDescription', stripTags(longDescription));
+            this.setDataValue('longDescription', stripHTML(longDescription));
           } else {
             this.setDataValue('longDescription', null);
           }

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -6,7 +6,8 @@ import { Op } from 'sequelize';
 import Temporal from 'sequelize-temporal';
 
 import { maxInteger } from '../constants/math';
-import { capitalize, days, formatCurrency, stripTags } from '../lib/utils';
+import { stripHTML } from '../lib/sanitize-html';
+import { capitalize, days, formatCurrency } from '../lib/utils';
 import { isSupportedVideoProvider, supportedVideoProviders } from '../lib/validators';
 
 import CustomDataTypes from './DataTypes';
@@ -98,7 +99,7 @@ export default function (Sequelize, DataTypes) {
           if (!content) {
             this.setDataValue('longDescription', null);
           } else {
-            this.setDataValue('longDescription', stripTags(content));
+            this.setDataValue('longDescription', stripHTML(content));
           }
         },
       },


### PR DESCRIPTION
We weren't using deprecated `stripTags` in many places so replaced it with the favoured `strip-html` (for stripping all tags) or `sanitize-html` where certain tags are allowed