### PR TITLE
GQLV1: Deprecate legacy expense fields

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -744,7 +744,7 @@ type CollectiveStatsType {
   ): Int
   yearlyBudget: Int
   yearlyBudgetManaged: Int
-  topExpenses: JSON
+  topExpenses: JSON @deprecated(reason: "[LegacyExpenseFlow] 2020-11-17: Not used anymore")
   topFundingSources: JSON
   activeRecurringContributions: JSON
 }
@@ -1428,7 +1428,7 @@ type ExpenseType {
   attachments: [ExpenseItem] @deprecated(reason: "2020-04-09 - Please use items")
   items: [ExpenseItem]
   attachedFiles: [ExpenseAttachedFile!]
-  userTaxFormRequiredBeforePayment: Boolean
+  userTaxFormRequiredBeforePayment: Boolean @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Please use API V2")
   user: UserDetails
   fromCollective: CollectiveInterface
 
@@ -1436,6 +1436,7 @@ type ExpenseType {
   Returns the list of comments for this expense, or `null` if user is not allowed to see them
   """
   comments(limit: Int, offset: Int): CommentListType
+    @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that")
   collective: CollectiveInterface
 
   """
@@ -1986,8 +1987,9 @@ type Mutation {
     token: String!
   ): UserDetails
   editConnectedAccount(connectedAccount: ConnectedAccountInputType!): ConnectedAccountType
-  approveExpense(id: Int!): ExpenseType
+  approveExpense(id: Int!): ExpenseType @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that")
   unapproveExpense(id: Int!): ExpenseType
+    @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that")
   rejectExpense(id: Int!): ExpenseType
   payExpense(
     id: Int!
@@ -2004,13 +2006,16 @@ type Mutation {
     2FA code for if the host account has 2FA for payouts turned on.
     """
     twoFactorAuthenticatorCode: String
-  ): ExpenseType
+  ): ExpenseType @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that")
   markOrderAsPaid(id: Int!): OrderType
   markPendingOrderAsExpired(id: Int!): OrderType
-  createExpense(expense: ExpenseInputType!): ExpenseType @deprecated(reason: "2020-09-17: Now using GQLV2 for that")
+  createExpense(expense: ExpenseInputType!): ExpenseType
+    @deprecated(reason: "2020-09-17: [LegacyExpenseFlow] Now using GQLV2 for that")
   editExpense(expense: ExpenseInputType!): ExpenseType
-  deleteExpense(id: Int!): ExpenseType
+    @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that")
+  deleteExpense(id: Int!): ExpenseType @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that")
   markExpenseAsUnpaid(id: Int!, processorFeeRefunded: Boolean!): ExpenseType
+    @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that")
 
   """
   Update a single tier
@@ -3319,7 +3324,7 @@ type Query {
     fromCollectiveSlug: String
     limit: Int
     offset: Int
-  ): [ExpenseType]
+  ): [ExpenseType] @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Please use API V2")
   expenses(
     CollectiveId: Int
     CollectiveSlug: String
@@ -3479,6 +3484,11 @@ type Query {
     Only return collectives of this type
     """
     types: [TypeOfCollective]
+
+    """
+    Filter on wether account is a host
+    """
+    isHost: Boolean
 
     """
     Limit the amount of results. Defaults to 20

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -505,6 +505,7 @@ export const CollectiveStatsType = new GraphQLObjectType({
       },
       topExpenses: {
         type: GraphQLJSON,
+        deprecationReason: '[LegacyExpenseFlow] 2020-11-17: Not used anymore',
         resolve(collective) {
           return Promise.all([
             queries.getTopExpenseCategories(collective.id),

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -281,6 +281,7 @@ const mutations = {
   },
   approveExpense: {
     type: ExpenseType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that',
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
@@ -290,6 +291,7 @@ const mutations = {
   },
   unapproveExpense: {
     type: ExpenseType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that',
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
@@ -308,6 +310,7 @@ const mutations = {
   },
   payExpense: {
     type: ExpenseType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that',
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
       paymentProcessorFeeInCollectiveCurrency: { type: GraphQLInt },
@@ -346,7 +349,7 @@ const mutations = {
   },
   createExpense: {
     type: ExpenseType,
-    deprecationReason: '2020-09-17: Now using GQLV2 for that',
+    deprecationReason: '2020-09-17: [LegacyExpenseFlow] Now using GQLV2 for that',
     args: {
       expense: { type: new GraphQLNonNull(ExpenseInputType) },
     },
@@ -356,6 +359,7 @@ const mutations = {
   },
   editExpense: {
     type: ExpenseType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that',
     args: {
       expense: { type: new GraphQLNonNull(ExpenseInputType) },
     },
@@ -365,6 +369,7 @@ const mutations = {
   },
   deleteExpense: {
     type: ExpenseType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that',
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
@@ -374,6 +379,7 @@ const mutations = {
   },
   markExpenseAsUnpaid: {
     type: ExpenseType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that',
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
       processorFeeRefunded: { type: new GraphQLNonNull(GraphQLBoolean) },

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -470,6 +470,7 @@ const queries = {
    */
   allComments: {
     type: new GraphQLList(UpdateType),
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Please use API V2',
     args: {
       ExpenseId: { type: GraphQLInt },
       UpdateId: { type: GraphQLInt },
@@ -610,6 +611,7 @@ const queries = {
    */
   allExpenses: {
     type: new GraphQLList(ExpenseType),
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Please use API V2',
     args: {
       CollectiveId: { type: new GraphQLNonNull(GraphQLInt) },
       includeHostedCollectives: { type: GraphQLBoolean },
@@ -679,6 +681,7 @@ const queries = {
    */
   expenses: {
     type: PaginatedExpensesType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Please use API V2',
     args: {
       CollectiveId: { type: GraphQLInt },
       CollectiveSlug: { type: GraphQLString },
@@ -750,6 +753,7 @@ const queries = {
    */
   Expense: {
     type: ExpenseType,
+    deprecationReason: '2020-11-17: [LegacyExpenseFlow] Please use API V2',
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -948,6 +948,7 @@ export const ExpenseType = new GraphQLObjectType({
       },
       userTaxFormRequiredBeforePayment: {
         type: GraphQLBoolean,
+        deprecationReason: '2020-11-17: [LegacyExpenseFlow] Please use API V2',
         async resolve(expense, _, req) {
           return req.loaders.Expense.userTaxFormRequiredBeforePayment.load(expense.id);
         },
@@ -967,6 +968,7 @@ export const ExpenseType = new GraphQLObjectType({
       comments: {
         type: CommentListType,
         description: 'Returns the list of comments for this expense, or `null` if user is not allowed to see them',
+        deprecationReason: '2020-11-17: [LegacyExpenseFlow] Now using GQLV2 for that',
         args: {
           limit: { type: GraphQLInt },
           offset: { type: GraphQLInt },


### PR DESCRIPTION
Goes with https://github.com/opencollective/opencollective-frontend/pull/5422

A followup PR will soon come to remove all those fields and refactor a bit the code to optimize for V2 (stop supporting legacy behaviors like expense `categories`).