### PR TITLE
Search: deprecate Algolia

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -129,7 +129,8 @@
   "algolia": {
     "appId": "ALGOLIA_APP_ID",
     "appKey": "ALGOLIA_KEY",
-    "index": "ALGOLIA_INDEX"
+    "index": "ALGOLIA_INDEX",
+    "useAsDefault": "ALGOLIA_USE_DEFAULT"
   },
   "fixer": {
     "accessKey": "FIXER_ACCESS_KEY"

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -40,6 +40,7 @@
 | ALGOLIA_APP_ID                      | .algolia.appId                              | algolia APP id                                                                 |
 | ALGOLIA_KEY                         | .algolia.appKey                             | algolia key                                                                    |
 | ALGOLIA_INDEX                       | .algolia.index                              | algolia index                                                                  |
+| ALGOLIA_USE_DEFAULT                 | .algolia.useAsDefault                       | whether to use Algolia as the default engine for search                        |
 | FOREST_AUTH_SECRET                  |                                             | forest auth secret                                                             |
 | FOREST_ENV_SECRET                   |                                             | forest environment secret                                                      |
 |                                     | .stripe.redirectUri                         |                                                                                |

--- a/migrations/20201119100223-update-collectives-search-index.js
+++ b/migrations/20201119100223-update-collectives-search-index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  up: async function (queryInterface) {
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "collective_search_index";`);
+    await queryInterface.sequelize.query(`
+      CREATE INDEX
+        collective_search_index
+      ON
+        "Collectives"
+      USING
+        gin((
+          to_tsvector('simple', name)
+          || to_tsvector('simple', slug)
+          || to_tsvector('simple', COALESCE(description, ''))
+          || COALESCE(array_to_tsvector(tags), '')
+          || to_tsvector('simple', COALESCE("longDescription", ''))
+        ))
+    `);
+  },
+
+  down: async function (queryInterface) {
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "collective_search_index";`);
+  },
+};

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -1,4 +1,5 @@
 import Promise from 'bluebird';
+import config from 'config';
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
 import { get, pick, uniq } from 'lodash';
 import { isEmail } from 'validator';
@@ -10,7 +11,7 @@ import { fetchCollectiveId } from '../../lib/cache';
 import { getConsolidatedInvoicesData } from '../../lib/pdf';
 import rawQueries from '../../lib/queries';
 import { searchCollectivesByEmail, searchCollectivesInDB, searchCollectivesOnAlgolia } from '../../lib/search';
-import { toIsoDateStr } from '../../lib/utils';
+import { parseToBoolean, toIsoDateStr } from '../../lib/utils';
 import models, { Op, sequelize } from '../../models';
 import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../errors';
 
@@ -1387,10 +1388,7 @@ const queries = {
    */
   search: {
     type: CollectiveSearchResultsType,
-    description: `
-      Search for collectives. Uses Algolia, except if searching for users or if using flag to opt-out.
-      Results are returned with best matches first.
-    `,
+    description: `Search for collectives. Results are returned with best matches first.`,
     args: {
       term: {
         type: GraphQLString,
@@ -1419,7 +1417,8 @@ const queries = {
       },
       useAlgolia: {
         type: GraphQLBoolean,
-        defaultValue: true,
+        deprecationReason: '2020-11-18: Algolia is intended to be removed in a near future',
+        defaultValue: parseToBoolean(config.algolia.useAsDefault),
         description: `
           If set to false, an internal query will be used to search the collective rather than Algolia.
           You **must** set this to false when searching for users/organizations.


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/3688, https://github.com/opencollective/opencollective/issues/3247, https://github.com/opencollective/opencollective/issues/3233, https://github.com/opencollective/opencollective/issues/2605

This PR:
- Deprecates the `useAlgolia` param on `seach`
- Makes it default to `false`, with a feature flag to re-enable it quickly if needed

@znarf do you think we should add more metrics to keep track of the performances?