### PR TITLE
Emails: Disable BCC on non-prod

### DIFF
--- a/test/server/routes/email.test.js
+++ b/test/server/routes/email.test.js
@@ -12,12 +12,17 @@ import models from '../../../server/models';
 import webhookBodyApprove from '../../mocks/mailgun.webhook.approve';
 import webhookBodyPayload from '../../mocks/mailgun.webhook.payload';
 import initNock from '../../nocks/email.routes.test.nock.js';
+import { randEmail } from '../../stores';
 import { fakeCollective, fakeUser } from '../../test-helpers/fake-data';
 import * as utils from '../../utils';
 
 const generateToken = (email, slug, template) => {
   const uid = `${email}.${slug}.${template}.${config.keys.opencollective.jwtSecret}`;
   return md5(uid);
+};
+
+const fakeIntervalUser = () => {
+  return fakeUser({ email: randEmail('test@opencollective.com') });
 };
 
 const { Collective } = models;
@@ -33,13 +38,13 @@ const usersData = [
   {
     firstName: 'Aseem',
     lastName: 'Sood',
-    email: 'asood123+test@gmail.com',
+    email: randEmail('test@opencollective.com'),
     role: 'ADMIN',
   },
   {
     firstName: 'Pia',
     lastName: 'Mancini',
-    email: 'pia+test@opencollective.com',
+    email: randEmail('test@opencollective.com'),
     role: 'BACKER',
   },
   {
@@ -113,7 +118,7 @@ describe('server/routes/email', () => {
   it('forwards emails sent to info@:slug.opencollective.com if enabled', async () => {
     const spy = sandbox.spy(emailLib, 'sendMessage');
     const collective = await fakeCollective({ settings: { features: { forwardEmails: true } } });
-    const users = await Promise.all([fakeUser(), fakeUser(), fakeUser()]);
+    const users = await Promise.all([fakeIntervalUser(), fakeIntervalUser(), fakeIntervalUser()]);
     await Promise.all(users.map(user => collective.addUserWithRole(user, 'ADMIN')));
 
     return request(expressApp)
@@ -134,7 +139,7 @@ describe('server/routes/email', () => {
   it('do not forwards emails sent to info@:slug.opencollective.com', async () => {
     const spy = sandbox.spy(emailLib, 'sendMessage');
     const collective = await fakeCollective();
-    const user = await fakeUser();
+    const user = await fakeIntervalUser();
     await collective.addUserWithRole(user, 'ADMIN');
     const endpoint = request(expressApp).post('/webhooks/mailgun');
     const res = await endpoint.send(


### PR DESCRIPTION
Though I didn't find anything in mailgun logs proving that we sent emails to external BCCs, I don't see anything preventing that in the code. Adding some defensive checks.