### PR TITLE
ExpensesQuery: Never return expenses for unapproved collectives

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -60,7 +60,11 @@ const isHostAdmin = async (req, expense): Promise<boolean> => {
     expense.collective = await req.loaders.Collective.byId.load(expense.CollectiveId);
   }
 
-  return req.remoteUser.isAdmin(expense.collective?.HostCollectiveId);
+  if (!expense.collective) {
+    return false;
+  }
+
+  return req.remoteUser.isAdmin(expense.collective.HostCollectiveId) && expense.collective.isActive;
 };
 
 /**

--- a/server/graphql/v2/query/ExpensesQuery.ts
+++ b/server/graphql/v2/query/ExpensesQuery.ts
@@ -153,7 +153,7 @@ const ExpensesQuery = {
         association: 'collective',
         attributes: [],
         required: true,
-        where: { HostCollectiveId: host.id },
+        where: { HostCollectiveId: host.id, approvedAt: { [Op.not]: null } },
       });
     }
 

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -89,6 +89,7 @@ export const fakeCollective = async (collectiveData = {}) => {
     hostFeePercent: 10,
     tags: [randStr(), randStr()],
     isActive: true,
+    approvedAt: collectiveData.HostCollectiveId ? new Date() : null,
     ...collectiveData,
   });
 


### PR DESCRIPTION
Before this PR, there was a chance of returning expenses from collectives not approved yet in the host dashboard.