### PR TITLE
Spam: Don't prevent collective creation

### DIFF
--- a/server/lib/spam.ts
+++ b/server/lib/spam.ts
@@ -461,23 +461,3 @@ export const notifyTeamAboutSuspiciousCollective = async (report: SpamAnalysisRe
   message = addLine(domains.length > 0 && `Domains: \`${domains.toString()}\``);
   return slackLib.postMessageToOpenCollectiveSlack(message, OPEN_COLLECTIVE_SLACK_CHANNEL.ABUSE);
 };
-
-/**
- * Post a message on Slack if the collective is suspicious
- */
-export const notifyTeamAboutPreventedCollectiveCreate = async (
-  report: SpamAnalysisReport,
-  user: any | null,
-): Promise<void> => {
-  const { keywords, domains } = report;
-  let message = `A collective creation was prevented and the user has been put in limited mode.`;
-  const addLine = (line: string): string => (line ? `${message}\n${line}` : message);
-  if (user) {
-    message = addLine(`UserId: ${user.id}`);
-  }
-  message = addLine(keywords.length > 0 && `Keywords: \`${keywords.toString()}\``);
-  message = addLine(domains.length > 0 && `Domains: \`${domains.toString()}\``);
-  message = addLine(`Collective data:`);
-  message = addLine(`> ${JSON.stringify(report.data)}`);
-  return slackLib.postMessageToOpenCollectiveSlack(message, OPEN_COLLECTIVE_SLACK_CHANNEL.ABUSE);
-};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -398,7 +398,7 @@ export default (Sequelize, DataTypes) => {
    * Limit the user account, preventing most actions on the platoform
    * @param spamReport: an optional spam report to attach to the account limitation. See `server/lib/spam.ts`.
    */
-  User.prototype.limitAcount = async function (spamReport = null) {
+  User.prototype.limitAccount = async function (spamReport = null) {
     const newData = { ...this.data, features: { ...get(this.data, 'features'), ALL: false } };
     if (spamReport) {
       newData.spamReports = [...get(this.data, 'spamReports', []), spamReport];

--- a/test/server/lib/spam.test.js
+++ b/test/server/lib/spam.test.js
@@ -3,11 +3,7 @@ import config from 'config';
 import sinon from 'sinon';
 
 import slackLib from '../../../server/lib/slack';
-import {
-  collectiveSpamCheck,
-  notifyTeamAboutPreventedCollectiveCreate,
-  notifyTeamAboutSuspiciousCollective,
-} from '../../../server/lib/spam';
+import { collectiveSpamCheck, notifyTeamAboutSuspiciousCollective } from '../../../server/lib/spam';
 import { fakeCollective } from '../../test-helpers/fake-data';
 
 describe('server/lib/spam', () => {
@@ -102,30 +98,6 @@ describe('server/lib/spam', () => {
       const args = slackPostMessageStub.getCall(0).args;
       expect(args[0]).to.eq(
         '*Suspicious collective data was submitted for collective:* https://opencollective.com/ketoooo\nScore: 0.3\nKeywords: `keto`',
-      );
-      expect(args[1]).to.eq(config.slack.webhooks.abuse);
-    });
-  });
-
-  describe('notifyTeamAboutPreventedCollectiveCreate', () => {
-    let slackPostMessageStub = null;
-
-    before(() => {
-      slackPostMessageStub = sinon.stub(slackLib, 'postMessage');
-    });
-
-    after(() => {
-      slackPostMessageStub.restore();
-    });
-
-    it('notifies Slack with the report info', async () => {
-      const report = await collectiveSpamCheck({ name: 'Keto stuff', slug: 'ketoooo' });
-      await notifyTeamAboutPreventedCollectiveCreate(report);
-      expect(slackPostMessageStub.calledOnce).to.be.true;
-
-      const args = slackPostMessageStub.getCall(0).args;
-      expect(args[0]).to.eq(
-        'A collective creation was prevented and the user has been put in limited mode.\nKeywords: `keto`\nCollective data:\n> {"name":"Keto stuff","slug":"ketoooo"}',
       );
       expect(args[1]).to.eq(config.slack.webhooks.abuse);
     });

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -261,32 +261,6 @@ describe('server/models/Collective', () => {
     expect(/-\d+$/.test(collective.slug)).to.be.true;
   });
 
-  it('prevents collective creation and limit user if spam is detected', async () => {
-    const user = await fakeUser();
-    const spamCollectiveData = {
-      name: 'BUY MY KETO',
-      website: 'https://supplementslove.com/buy-stuff',
-      CreatedByUserId: user.id,
-    };
-
-    // Should prevent collective creation
-    await expect(models.Collective.create(spamCollectiveData)).to.be.eventually.rejectedWith(
-      Error,
-      'Collective creation failed',
-    );
-
-    // Should limit user account
-    await user.reload();
-    expect(user.data.features.ALL).to.be.false;
-
-    // User should not be able to create any new collectives
-    const legitCollectiveData = { name: 'Legit project', CreatedByUserId: user.id };
-    await expect(models.Collective.create(legitCollectiveData)).to.be.eventually.rejectedWith(
-      Error,
-      "You're not authorized to create new collectives at the moment.",
-    );
-  });
-
   it('does not create collective with a blocked slug', () => {
     return Collective.create({ name: 'learn more' }).then(collective => {
       // `https://host/learn-more` is a protected page.


### PR DESCRIPTION
Drawback of the current fix: there will be more spammy profiles created.

Alternatives:
1. Have a special flag to "whitelist" user, collective creation will not be prevented if flag is set
2. Only limit user and block account creation if using a domain from block list (`spam.scrore === 1 && spam.usesBlockedDomain`)
3. Don't limit the user, but still block collective creation