### PR TITLE
ThankYouEmail: link CTA to collective's main page 

### DIFF
--- a/templates/emails/thankyou.hbs
+++ b/templates/emails/thankyou.hbs
@@ -34,7 +34,7 @@ Subject: Thank you for your {{currency order.totalAmount currency=order.currency
 </p>
 
 <h2>Help us raise more money!</h2>
-<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}/donate">https://opencollective.com/{{collective.slug}}/donate</a>
+<p>Share this URL: <a href="https://opencollective.com/{{collective.slug}}">https://opencollective.com/{{collective.slug}}</a>
 </p>
 
 {{#if transactionPdf}}


### PR DESCRIPTION
change call-to-action to collective's main page 

Resolve https://github.com/opencollective/opencollective/issues/3733