### PR TITLE
Collective: Allow empty names

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -190,8 +190,7 @@ export default function (Sequelize, DataTypes) {
           this.setDataValue('name', name.replace(/\s+/g, ' ').trim());
         },
         validate: {
-          notEmpty: true,
-          len: [1, 255],
+          len: [0, 255],
         },
       },
 


### PR DESCRIPTION
Related to https://opencollective.freshdesk.com/a/tickets/11328

We enforced `name` to not be empty (while still allowing `null`) but some users are facing issues because of that.