### PR TITLE
ThankYouEmail: Don't add PDF receipt for gift cards

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -6,7 +6,7 @@ import { find, get, includes, isNumber, omit, pick } from 'lodash';
 
 import activities from '../constants/activities';
 import status from '../constants/order_status';
-import { PAYMENT_METHOD_TYPES } from '../constants/paymentMethods';
+import { PAYMENT_METHOD_TYPE } from '../constants/paymentMethods';
 import roles from '../constants/roles';
 import tiers from '../constants/tiers';
 import { FEES_ON_TOP_TRANSACTION_PROPERTIES } from '../constants/transactions';
@@ -431,7 +431,7 @@ const sendOrderConfirmedEmail = async (order, transaction) => {
     };
 
     // hit PDF service and get PDF (unless payment method type is gift card)
-    if (paymentMethod?.type !== PAYMENT_METHOD_TYPES.VIRTUALCARD) {
+    if (paymentMethod?.type !== PAYMENT_METHOD_TYPE.VIRTUALCARD) {
       pdf = await getTransactionPdf(transaction, user);
     }
 

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -5,7 +5,7 @@ import { Op } from 'sequelize';
 
 import intervals from '../constants/intervals';
 import status from '../constants/order_status';
-import { PAYMENT_METHOD_TYPES } from '../constants/paymentMethods';
+import { PAYMENT_METHOD_TYPE } from '../constants/paymentMethods';
 import models from '../models';
 
 import emailLib from './email';
@@ -393,7 +393,7 @@ export async function sendThankYouEmail(order, transaction) {
   }
 
   // hit PDF service and get PDF (unless payment method type is gift card)
-  if (paymentMethod?.type !== PAYMENT_METHOD_TYPES.VIRTUALCARD) {
+  if (paymentMethod?.type !== PAYMENT_METHOD_TYPE.VIRTUALCARD) {
     pdf = await getTransactionPdf(transaction, user);
   }
 


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3750

On a side note, typescript would have detected this error automatically if `payments.js` was a typescript file.