### PR TITLE
Generate and store 2FA recovery codes on setup

### DIFF
--- a/migrations/20210208130000-add-2fa-recovery-codes-to-user.js
+++ b/migrations/20210208130000-add-2fa-recovery-codes-to-user.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Users', 'twoFactorAuthRecoveryCodes', {
+      type: Sequelize.ARRAY(Sequelize.STRING),
+      allowNull: true,
+      defaultValue: null,
+    });
+    await queryInterface.addColumn('UserHistories', 'twoFactorAuthRecoveryCodes', {
+      type: Sequelize.ARRAY(Sequelize.STRING),
+      allowNull: true,
+      defaultValue: null,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Users', 'twoFactorAuthRecoveryCodes');
+    await queryInterface.removeColumn('UserHistories', 'twoFactorAuthRecoveryCodes');
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8720,10 +8720,12 @@
       "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.0.tgz",
+      "integrity": "sha512-teWAwfMb1d6brahYyKqcBEb5Yp8PJPvPOdOonXDnvaKOTmKDFNVE8E3Y2XQuzjNV/3XMwHbrX9fHWvrhRKt4Gg==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "css-select": {
       "version": "1.2.0",
@@ -8748,7 +8750,7 @@
     },
     "csv-stringify": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
         "lodash.get": "^4.0.0"
@@ -20009,8 +20011,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.16",
@@ -20142,6 +20143,14 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"
+      },
+      "dependencies": {
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+          "dev": true
+        }
       }
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cookie-parser": "1.4.5",
     "cors": "2.8.5",
     "crypto-js": "4.0.0",
+    "crypto-random-string": "3.3.0",
     "dataloader": "2.0.0",
     "dataloader-sequelize": "2.3.1",
     "debug": "4.3.1",

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -477,6 +477,21 @@ enum ActivityType {
 }
 
 """
+Response for the addTwoFactorAuthTokenToIndividual mutation
+"""
+type AddTwoFactorAuthTokenToIndividualResponse {
+  """
+  The Individual that the 2FA has been enabled for
+  """
+  account: Individual!
+
+  """
+  The recovery codes for the Individual to write down
+  """
+  recoveryCodes: [String]
+}
+
+"""
 A financial amount.
 """
 type Amount {
@@ -5247,22 +5262,22 @@ type Mutation {
   ): Account!
 
   """
-  Add 2FA to the Account if it does not have it
+  Add 2FA to the Individual if it does not have it
   """
   addTwoFactorAuthTokenToIndividual(
     """
-    Account that will have 2FA added to it
+    Individual that will have 2FA added to it
     """
     account: AccountReferenceInput!
 
     """
-    The generated secret to save to the Account
+    The generated secret to save to the Individual
     """
     token: String!
-  ): Individual!
+  ): AddTwoFactorAuthTokenToIndividualResponse!
 
   """
-  Remove 2FA from the Account if it has been enabled
+  Remove 2FA from the Individual if it has been enabled
   """
   removeTwoFactorAuthTokenFromIndividual(
     """
@@ -5710,7 +5725,7 @@ input OrderTaxInput {
   """
   Country of the account ordering, to know from where to apply the tax
   """
-  country: CountryISO!
+  country: CountryISO
 
   """
   Tax identification number, if any

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -103,6 +103,11 @@ export default (Sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: true,
       },
+
+      twoFactorAuthRecoveryCodes: {
+        type: DataTypes.ARRAY(DataTypes.STRING),
+        allowNull: true,
+      },
     },
     {
       paranoid: true,

--- a/test/server/graphql/v2/mutation/AccountMutations.test.js
+++ b/test/server/graphql/v2/mutation/AccountMutations.test.js
@@ -17,12 +17,15 @@ const editSettingsMutation = gqlV2/* GraphQL */ `
 `;
 
 const addTwoFactorAuthTokenMutation = gqlV2/* GraphQL */ `
-  mutation AddTwoFactorAuthToAccount($account: AccountReferenceInput!, $token: String!) {
+  mutation AddTwoFactorAuthToIndividual($account: AccountReferenceInput!, $token: String!) {
     addTwoFactorAuthTokenToIndividual(account: $account, token: $token) {
-      id
-      ... on Individual {
-        hasTwoFactorAuth
+      account {
+        id
+        ... on Individual {
+          hasTwoFactorAuth
+        }
       }
+      recoveryCodes
     }
   }
 `;
@@ -197,7 +200,8 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
         adminUser,
       );
       expect(result.errors).to.not.exist;
-      expect(result.data.addTwoFactorAuthTokenToIndividual.hasTwoFactorAuth).to.eq(true);
+      expect(result.data.addTwoFactorAuthTokenToIndividual.account.hasTwoFactorAuth).to.eq(true);
+      expect(result.data.addTwoFactorAuthTokenToIndividual.recoveryCodes).to.have.lengthOf(6);
     });
 
     it('fails if user already enabled 2FA', async () => {


### PR DESCRIPTION
Relates https://github.com/opencollective/opencollective/issues/3709

Frontend PR: https://github.com/opencollective/opencollective-frontend/pull/5588

* When the user sets up 2FA on their account, generates recovery codes, returns them to the frontend to be displayed once during the setup process, then they are stored securely (encrypted with the 2FA token and also hashed) in the Users table
* When the user removes 2FA from their account, it removes the recovery codes