### PR TITLE
Add more tests to sanitizeHtml and fix length issue

### DIFF
--- a/server/lib/sanitize-html.ts
+++ b/server/lib/sanitize-html.ts
@@ -147,19 +147,26 @@ export const generateSummaryForHTML = (content: string, maxLength = 255): string
   // Trim: `<strong> Test with   spaces </strong>` ==> <strong>Test with spaces</strong>
   const trimmed = sanitized.trim().replace('\n', ' ').replace(/\s+/g, ' ');
 
-  // Truncate
-  const truncated = truncate(trimmed, { length: maxLength, omission: '' });
-
-  // Second sanitize pass: an additional precaution in case someones finds a way to play with the trimmed version
-  const secondSanitized = sanitizeHTML(truncated, optsSanitizeSummary);
-
   const isTruncated = trimmed.length > maxLength;
+
+  let cutLength = maxLength;
+  let summary = trimmed;
+
+  while (summary.length > maxLength) {
+    // Truncate
+    summary = truncate(summary, { length: cutLength, omission: '' });
+
+    // Second sanitize pass: an additional precaution in case someones finds a way to play with the trimmed version
+    summary = sanitizeHTML(summary, optsSanitizeSummary);
+
+    cutLength--;
+  }
 
   // Check to see if the second sanitization cuts a html tag in the middle
   if (isTruncated) {
-    return `${secondSanitized.trim()}...`;
+    return `${summary.trim()}...`;
   } else {
-    return secondSanitized;
+    return summary;
   }
 };
 

--- a/test/server/lib/sanitize-html.test.js
+++ b/test/server/lib/sanitize-html.test.js
@@ -174,9 +174,13 @@ describe('server/lib/sanitize-html', () => {
     });
 
     it("Doesn't cut anchors", () => {
-      expect(generateSummaryForHTML("I'd like to say <strong>Hello World</strong>", 30)).to.to.eq(
-        "I'd like to say <strong>Hello </strong>...",
+      expect(generateSummaryForHTML('Hey, Hi <strong>Hello World</strong>', 30)).to.to.eq(
+        'Hey, Hi <strong>Hello</strong>...',
       );
+    });
+
+    it('Handle length properly with anchors', () => {
+      expect(generateSummaryForHTML("I'd like to say <strong>Hello World</strong>", 30)).to.have.lengthOf.at.most(33);
     });
 
     it('Adds separator after titles', () => {
@@ -198,6 +202,13 @@ describe('server/lib/sanitize-html', () => {
       ).to.eq(
         `After a much ado, we created an easy way to donate to <a href="${config.host.website}/redirect?url=https%3A%2F%2Fsagemath.org" target="_blank">SageMath</a> project. Donations are US tax (IRC 501(c)(6)) deductible.`,
       );
+    });
+
+    it('Handles utf-8 strings properly', () => {
+      const frenchSample = `Une communauté, c'est de la confiance et du partage. Open Collective vous permet de gérer vos finances pour que tout le monde puisse voir d'où vient l'argent et où il va. Collectez et dépensez de l'argent de manière transparente. Recevez des fonds par carte de crédit, Paypal ou virement bancaire et enregistrez tout dans votre budget transparent. Définissez différentes façons de contribuer avec des niveaux et des récompenses personnalisables.`;
+      for (const sampleLength of [40, 100, 240]) {
+        expect(generateSummaryForHTML(frenchSample, sampleLength)).to.have.lengthOf.at.most(sampleLength + 3);
+      }
     });
 
     it('Truncating tags in middle works as expected', () => {


### PR DESCRIPTION
Problem with `generateSummaryForHTML("I'd like to say <strong>Hello World</strong>", 30)`.

Expected length < 33

Got `I'd like to say <strong>Hello </strong>` length = 39

```
{
  content: "I'd like to say <strong>Hello World</strong>",
  sanitized: "I'd like to say <strong>Hello World</strong>",
  trimmed: "I'd like to say <strong>Hello World</strong>",
  truncated: "I'd like to say <strong>Hello ",
  secondSanitized: "I'd like to say <strong>Hello </strong>",
  isTruncated: true
}
```
