### PR TITLE
Add Sentry

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -169,5 +169,8 @@
   },
   "pdfService": {
     "fetchTransactionsReceipts": "FETCH_TRANSACTIONS_RECEIPTS"
+  },
+  "sentry": {
+    "dsn": "SENTRY_DSN"
   }
 }

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -15,6 +15,7 @@
 | STRIPE_CLIENT_ID                    | .stripe.client_id                           | Stripe Client id                                                               |
 | STRIPE_KEY                          | .stripe.key                                 | Stripe key                                                                     |
 | STRIPE_SECRET                       | .stripe.secret                              | Stripe secret                                                                  |
+| SENTRY_DSN                          | .sentry.dsn                                 | Sentry DSN                                                                     |
 | AWS_KEY                             | .aws.s3.key                                 | AWS key                                                                        |
 | AWS_SECRET                          | .aws.s3.secret                              | AWS secret                                                                     |
 | AWS_S3_BUCKET                       | .aws.s3.bucket                              | AWS s3 bucket to send files                                                    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3793,6 +3793,104 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sentry/core": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.29.2.tgz",
+      "integrity": "sha512-7WYkoxB5IdlNEbwOwqSU64erUKH4laavPsM0/yQ+jojM76ErxlgEF0u//p5WaLPRzh3iDSt6BH+9TL45oNZeZw==",
+      "requires": {
+        "@sentry/hub": "5.29.2",
+        "@sentry/minimal": "5.29.2",
+        "@sentry/types": "5.29.2",
+        "@sentry/utils": "5.29.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.29.2.tgz",
+      "integrity": "sha512-LaAIo2hwUk9ykeh9RF0cwLy6IRw+DjEee8l1HfEaDFUM6TPGlNNGObMJNXb9/95jzWp7jWwOpQjoIE3jepdQJQ==",
+      "requires": {
+        "@sentry/types": "5.29.2",
+        "@sentry/utils": "5.29.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.29.2.tgz",
+      "integrity": "sha512-0aINSm8fGA1KyM7PavOBe1GDZDxrvnKt+oFnU0L+bTcw8Lr+of+v6Kwd97rkLRNOLw621xP076dL/7LSIzMuhw==",
+      "requires": {
+        "@sentry/hub": "5.29.2",
+        "@sentry/types": "5.29.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.29.2.tgz",
+      "integrity": "sha512-98m1ZejmJgA+eiz6jEFyYYfp6kJZQnx6d6KrJDMxGfss4YTmmJY57bE4xStnjjk7WINDGzlCiHuk+wJFMBjuoA==",
+      "requires": {
+        "@sentry/core": "5.29.2",
+        "@sentry/hub": "5.29.2",
+        "@sentry/tracing": "5.29.2",
+        "@sentry/types": "5.29.2",
+        "@sentry/utils": "5.29.2",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.29.2.tgz",
+      "integrity": "sha512-iumYbVRpvoU3BUuIooxibydeaOOjl5ysc+mzsqhRs2NGW/C3uKAsFXdvyNfqt3bxtRQwJEhwJByLP2u3pLThpw==",
+      "requires": {
+        "@sentry/hub": "5.29.2",
+        "@sentry/minimal": "5.29.2",
+        "@sentry/types": "5.29.2",
+        "@sentry/utils": "5.29.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.29.2.tgz",
+      "integrity": "sha512-dM9wgt8wy4WRty75QkqQgrw9FV9F+BOMfmc0iaX13Qos7i6Qs2Q0dxtJ83SoR4YGtW8URaHzlDtWlGs5egBiMA=="
+    },
+    "@sentry/utils": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.29.2.tgz",
+      "integrity": "sha512-nEwQIDjtFkeE4k6yIk4Ka5XjGRklNLThWLs2xfXlL7uwrYOH2B9UBBOOIRUraBm/g/Xrra3xsam/kRxuiwtXZQ==",
+      "requires": {
+        "@sentry/types": "5.29.2",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -12302,6 +12400,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "macos-release": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@octokit/rest": "18.0.12",
     "@opencollective/taxes": "3.1.0",
     "@paypal/payouts-sdk": "^1.0.0",
+    "@sentry/node": "5.29.2",
+    "@sentry/tracing": "5.29.2",
     "apollo-server-express": "2.19.1",
     "argparse": "2.0.1",
     "aws-sdk": "2.816.0",

--- a/server/index.js
+++ b/server/index.js
@@ -8,12 +8,14 @@ import throng from 'throng';
 
 import expressLib from './lib/express';
 import logger from './lib/logger';
+import { plugSentryToApp } from './lib/sentry';
 import routes from './routes';
 
 const workers = process.env.WEB_CONCURRENCY || 1;
 
 async function start(i) {
   const expressApp = express();
+  plugSentryToApp(expressApp); // Sentry request handler must be the first middleware on the app
 
   await expressLib(expressApp);
 

--- a/server/lib/sentry.ts
+++ b/server/lib/sentry.ts
@@ -1,0 +1,80 @@
+import * as Sentry from '@sentry/node';
+import * as Tracing from '@sentry/tracing';
+import config from 'config';
+import * as express from 'express';
+
+export const plugSentryToApp = (app: express.Express): void => {
+  if (!config.sentry?.dsn) {
+    return;
+  }
+
+  Sentry.init({
+    dsn: config.sentry.dsn,
+    environment: config.env,
+    attachStacktrace: true,
+    enabled: config.env !== 'test',
+    integrations: [
+      // enable HTTP calls tracing
+      new Sentry.Integrations.Http({ tracing: true }),
+      // enable Express.js middleware tracing
+      new Tracing.Integrations.Express({ app }),
+    ],
+  });
+
+  // ---- Add request handlers ----
+  // RequestHandler creates a separate execution context using domains, so that every
+  // transaction/span/breadcrumb is attached to its own Hub instance
+  app.use(Sentry.Handlers.requestHandler({ ip: true }));
+
+  // TracingHandler creates a trace for every incoming request
+  app.use(Sentry.Handlers.tracingHandler());
+};
+
+export const SentryGraphQLPlugin = {
+  requestDidStart(_): object {
+    return {
+      didEncounterErrors(ctx): void {
+        // If we couldn't parse the operation, don't do anything here
+        if (!ctx.operation) {
+          return;
+        }
+
+        for (const err of ctx.errors) {
+          // Only report internal server errors, all errors extending ApolloError should be user-facing
+          if (err.extensions?.code) {
+            continue;
+          }
+
+          // Add scoped report details and send to Sentry
+          Sentry.withScope(scope => {
+            // Annotate whether failing operation was query/mutation/subscription
+            scope.setTag('kind', ctx.operation.operation);
+
+            // Log query and variables as extras
+            scope.setExtra('query', ctx.context.query);
+            scope.setExtra('variables', ctx.request.variables);
+
+            // Add logged in user (if any)
+            if (ctx.context.remoteUser) {
+              scope.setUser({
+                id: ctx.context.remoteUser.id,
+                CollectiveId: ctx.context.remoteUser.CollectiveId,
+              });
+            }
+
+            if (err.path) {
+              // We can also add the path as breadcrumb
+              scope.addBreadcrumb({
+                category: 'query-path',
+                message: err.path.join(' > '),
+                level: Sentry.Severity.Debug,
+              });
+            }
+
+            Sentry.captureException(err);
+          });
+        }
+      },
+    };
+  },
+};

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,4 +1,4 @@
-import { ApolloServer } from 'apollo-server-express';
+import { ApolloError, ApolloServer } from 'apollo-server-express';
 import config from 'config';
 import expressLimiter from 'express-limiter';
 import { get, pick } from 'lodash';
@@ -16,6 +16,7 @@ import graphqlSchemaV1 from './graphql/v1/schema';
 import graphqlSchemaV2 from './graphql/v2/schema';
 import cache from './lib/cache';
 import logger from './lib/logger';
+import { SentryGraphQLPlugin } from './lib/sentry';
 import { parseToBoolean } from './lib/utils';
 import * as authentication from './middleware/authentication';
 import errorHandler from './middleware/error_handler';
@@ -138,6 +139,7 @@ export default app => {
   const graphqlServerOptions = {
     introspection: true,
     playground: isDevelopment,
+    plugins: config.sentry?.dsn ? [SentryGraphQLPlugin] : undefined,
     // Align with behavior from express-graphql
     context: ({ req }) => {
       return req;


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2997
Example: https://sentry.io/organizations/open-collective/issues/2110469501/

Adds Sentry with basic defaults. Currently:
- Ignore errors generated from [server/graphql/errors.ts](https://github.com/opencollective/opencollective-api/blob/master/server/graphql/errors.ts) (these are user-facing)
- Attach stacktrace
- Attach user ID
- Attach query name and variables

**Release plan:** merge this PR and enable on staging. Only enable on prod when we have enough data to confirm it's safe to do so.

**Todo:** configure the `release` field to help investigate the date an error was introduced.