### PR TITLE
Tiers: Store flag for enabling tier page

### DIFF
--- a/migrations/20201224083644-add-tiers-standalone-page.js
+++ b/migrations/20201224083644-add-tiers-standalone-page.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Tiers', 'useStandalonePage', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('TierHistories', 'useStandalonePage', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+
+    await queryInterface.sequelize.query(`
+      UPDATE "Tiers"
+      SET "useStandalonePage" = TRUE
+      WHERE "longDescription" IS NOT NULL
+      AND length("longDescription") > 0
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Tiers', 'useStandalonePage');
+  },
+};

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -270,6 +270,10 @@ export const TierInputType = new GraphQLInputObjectType({
       type: GraphQLString,
       description: 'A long, html-formatted description.',
     },
+    useStandalonePage: {
+      type: GraphQLBoolean,
+      description: 'Whether this tier has a standalone page',
+    },
     videoUrl: {
       type: GraphQLString,
       description: 'Link to a video (YouTube, Vimeo).',

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1495,9 +1495,14 @@ export const TierType = new GraphQLObjectType({
       hasLongDescription: {
         type: GraphQLBoolean,
         description: 'Returns true if the tier has a long description',
+        deprecationReason: '2020-12-24: This field is being deprecated in favor of useStandalonePage',
         resolve(tier) {
           return Boolean(tier.longDescription);
         },
+      },
+      useStandalonePage: {
+        type: GraphQLBoolean,
+        description: 'Returns true if the tier has its standalone page activated',
       },
       videoUrl: {
         type: GraphQLString,

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -103,6 +103,12 @@ export default function (Sequelize, DataTypes) {
         },
       },
 
+      useStandalonePage: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+
       videoUrl: {
         type: DataTypes.STRING,
         validate: {


### PR DESCRIPTION
- Add a `useStandalonePage` flag for tiers (defaults to false)
- Set `useStandalonePage` to true for all tiers with a long description
- Allow users to edit `useStandalonePage`