### PR TITLE
Event: Never return null for isApproved

### DIFF
--- a/server/graphql/v2/object/Event.js
+++ b/server/graphql/v2/object/Event.js
@@ -35,7 +35,7 @@ export const Event = new GraphQLObjectType({
             return false;
           } else {
             const parent = await req.loaders.Collective.byId.load(event.ParentCollectiveId);
-            return parent && parent.isApproved();
+            return Boolean(parent && parent.isApproved());
           }
         },
       },


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3556

Happens when we try to access the page of an event whose parent has been deleted.