### PR TITLE
fix yearly report for hosts

### DIFF
--- a/reports/host-report.js
+++ b/reports/host-report.js
@@ -248,8 +248,7 @@ async function HostReport(year, month, hostId) {
       data.transactions = transactions;
       // Don't generate PDF in email if it's the yearly report
       let pdf;
-      if (yearlyReport || process.env.SKIP_PDF) {
-      } else {
+      if (!yearlyReport && !process.env.SKIP_PDF) {
         pdf = await exportToPDF('expenses', data, {
           paper: host.currency === 'USD' ? 'Letter' : 'A4',
         }).catch(error => {


### PR DESCRIPTION
I tried to run the yearly report for the allforclimate host and it wasn't working.
Took me a bit of time to figure out what was going on because it was not returning any error.

Turns out if SKIP_PDF is true or if the host report is the yearly report, you are returning before the end of the function instead of simply skipping PDF generation.

This fixes it. You may want to merge this before Jan 1 (but if I'm not mistaken you need to manually trigger this yearly report).