### PR TITLE
fix: typo in 'oneThousandBackers' tweet

### DIFF
--- a/server/lib/twitter.js
+++ b/server/lib/twitter.js
@@ -128,7 +128,7 @@ Support them too!`,
 Support them too!`,
       oneHundred: `🎉 {collective} just reached 100 backers!! 🙌
 Support them too!`,
-      oneThousandBackers: `🎉 {collective} just reached 1,0000 backers!!! 🙌
+      oneThousandBackers: `🎉 {collective} just reached 1,000 backers!!! 🙌
 Support them too!`,
       updatePublished: 'Latest update from the collective: {title}',
       monthlyStats: `In {month}, {totalNewBackers, select,


### PR DESCRIPTION
Will likely want a test from someone more familiar with the project as a follow-on.

Came across this in the source, looked obviously incorrect.