### PR TITLE
Add dependency status in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Open Collective API
 
+[![Dependency Status](https://david-dm.org/opencollective/opencollective-api.svg)](https://david-dm.org/opencollective/opencollective-api)
 ![CI](https://github.com/opencollective/opencollective-api/workflows/CI/badge.svg)
 ![E2E](https://github.com/opencollective/opencollective-api/workflows/E2E/badge.svg)
 


### PR DESCRIPTION
I removed it because I thought the service was not maintained anymore. It was a temporary issue.