### PR TITLE
createOrder: Return error code when account already exists

### DIFF
--- a/migrations/20210114082711-remove-unique-guestoken-constraint.js
+++ b/migrations/20210114082711-remove-unique-guestoken-constraint.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "GuestTokens"
+      DROP CONSTRAINT "GuestTokens_UserId_key";
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2112154894

This error code will be handy for detecting & i18n the error.

Also fixed an error with "Unique UserId" that appeared when contributing from a second device with the same email.