### PR TITLE
addFunds: Allow for all hosts if source has no budget

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -880,7 +880,10 @@ export async function addFundsToCollective(order, remoteUser) {
     fromCollective = await models.Collective.findByPk(order.fromCollective.id);
     if (!fromCollective) {
       throw new Error(`From collective id ${order.fromCollective.id} not found`);
-    } else {
+    } else if (fromCollective.hasBudget()) {
+      // Make sure logged in user is admin of the source profile, unless it doesn't have a budget (user
+      // or host organization without budget activated). It's not an ideal solution though, as spammy
+      // hosts could still use this to pollute user's ledgers.
       const isAdminOfFromCollective = remoteUser.isRoot() || remoteUser.isAdmin(fromCollective.id);
       if (!isAdminOfFromCollective && fromCollective.HostCollectiveId !== host.id) {
         const fromCollectiveHostId = await fromCollective.getHostCollectiveId();

--- a/server/graphql/v2/interface/AccountWithContributions.ts
+++ b/server/graphql/v2/interface/AccountWithContributions.ts
@@ -2,7 +2,6 @@ import config from 'config';
 import { GraphQLBoolean, GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
 import { isNil } from 'lodash';
 
-import { types } from '../../../constants/collectives';
 import { getPaginatedContributorsForCollective } from '../../../lib/contributors';
 import models from '../../../models';
 import { ContributorCollection } from '../collection/ContributorCollection';
@@ -10,10 +9,6 @@ import { TierCollection } from '../collection/TierCollection';
 import { AccountType, MemberRole } from '../enum';
 
 import { CollectionArgs } from './Collection';
-
-const hasBudget = account => {
-  return account.type !== types.ORGANIZATION || (account.isHostAccount && account.isActive);
-};
 
 export const AccountWithContributionsFields = {
   totalFinancialContributors: {
@@ -26,7 +21,7 @@ export const AccountWithContributionsFields = {
       },
     },
     async resolve(account, args, req): Promise<number> {
-      if (!hasBudget(account)) {
+      if (!account.hasBudget()) {
         return 0;
       }
 
@@ -43,7 +38,7 @@ export const AccountWithContributionsFields = {
   tiers: {
     type: new GraphQLNonNull(TierCollection),
     async resolve(account): Promise<object> {
-      if (!hasBudget(account)) {
+      if (!account.hasBudget()) {
         return [];
       }
 

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -968,6 +968,16 @@ export default function (Sequelize, DataTypes) {
     return this;
   };
 
+  Collective.prototype.hasBudget = () => {
+    if ([types.COLLECTIVE, types.EVENT, types.PROJECT, types.FUND].includes(this.type)) {
+      return true;
+    } else if (this.type === types.ORGANIZATION) {
+      return this.isHostAccount && this.isActive;
+    } else {
+      return false;
+    }
+  };
+
   /**
    * Activate Budget (so the "Host Organization" can receive financial contributions and manage expenses)
    */


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3837

Followup on https://github.com/opencollective/opencollective-api/pull/5103 by relaxing the condition if the `source` doesn't have a budget (users or hosts orgs without a budget activated).