### PR TITLE
deleteCollective: Delete associated memberships

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -602,7 +602,9 @@ export async function deleteCollective(_, args, req) {
   }
 
   return models.Member.findAll({
-    where: { CollectiveId: collective.id },
+    where: {
+      [Op.or]: [{ CollectiveId: collective.id }, { MemberCollectiveId: collective.id }],
+    },
   })
     .then(members => {
       return map(

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1115,7 +1115,7 @@ export default function (Sequelize, DataTypes) {
     debug('getUsers for ', this.id);
     return models.Member.findAll({
       where: { CollectiveId: this.id },
-      include: [{ model: models.Collective, as: 'memberCollective' }],
+      include: [{ model: models.Collective, as: 'memberCollective', required: true }],
     })
       .tap(memberships => debug('>>> members found', memberships.length))
       .map(membership => membership.memberCollective)


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2152287370/

Only members of the collective were deleted when deleting the collective, not its memberships. Also added a check on `getUsers` to make it more resilient against this.