### PR TITLE
GraphQL: Remove Update deprecations

### DIFF
--- a/server/graphql/common/update.js
+++ b/server/graphql/common/update.js
@@ -47,75 +47,52 @@ export async function createUpdate(_, args, req) {
   return update;
 }
 
-async function fetchUpdate(id) {
-  const update = await models.Update.findByPk(idDecode(id, IDENTIFIER_TYPES.UPDATE));
+/**
+ * Fetches the update. Throws if the update does not exists or if user is not allowed to edit it.
+ */
+async function fetchUpdateForEdit(id, remoteUser) {
+  if (!remoteUser) {
+    throw new Unauthorized('You must be logged in to edit this update');
+  } else if (!id) {
+    throw new ValidationFailed(`Update ID is required`);
+  }
+
+  const update = await models.Update.findByPk(idDecode(id, IDENTIFIER_TYPES.UPDATE), {
+    include: { association: 'collective' },
+  });
   if (!update) {
     throw new NotFound(`Update with id ${id} not found`);
+  } else if (!remoteUser.isAdminOfCollective(update.collective)) {
+    throw new Forbidden("You don't have sufficient permissions to edit this update");
   }
+
   return update;
 }
 
 export async function editUpdate(_, args, req) {
-  if (!req.remoteUser) {
-    throw new Unauthorized('You must be logged in to edit this update');
-  }
-
-  requireArgs(args, ['update.id']);
-  let update = await fetchUpdate(args.update.id);
-  const collective = await models.Collective.findByPk(update.CollectiveId);
-  if (!req.remoteUser.isAdminOfCollective(collective)) {
-    throw new Forbidden("You don't have sufficient permissions to edit this update");
-  }
-
+  let update = await fetchUpdateForEdit(args.update.id, req.remoteUser);
   update = await update.edit(req.remoteUser, args.update);
-  purgeCacheForCollective(collective.slug);
+  purgeCacheForCollective(update.collective.slug);
   return update;
 }
 
 export async function publishUpdate(_, args, req) {
-  if (!req.remoteUser) {
-    throw new Unauthorized('You must be logged in to publish this update');
-  }
-
-  let update = await fetchUpdate(args.id);
-  const collective = await models.Collective.findByPk(update.CollectiveId);
-  if (!req.remoteUser.isAdminOfCollective(collective)) {
-    throw new Forbidden("You don't have sufficient permissions to publish this update");
-  }
-
+  let update = await fetchUpdateForEdit(args.id, req.remoteUser);
   update = await update.publish(req.remoteUser, args.notificationAudience);
-  purgeCacheForCollective(collective.slug);
+  purgeCacheForCollective(update.collective.slug);
   return update;
 }
 
 export async function unpublishUpdate(_, args, req) {
-  if (!req.remoteUser) {
-    throw new Unauthorized('You must be logged in to unpublish this update');
-  }
-
-  let update = await fetchUpdate(args.id);
-  const collective = await models.Collective.findByPk(update.CollectiveId);
-  if (!req.remoteUser.isAdminOfCollective(collective)) {
-    throw new Forbidden("You don't have sufficient permissions to unpublish this update");
-  }
-
+  let update = await fetchUpdateForEdit(args.id, req.remoteUser);
   update = await update.unpublish(req.remoteUser);
-  purgeCacheForCollective(collective.slug);
+  purgeCacheForCollective(update.collective.slug);
   return update;
 }
 
 export async function deleteUpdate(_, args, req) {
-  if (!req.remoteUser) {
-    throw new Unauthorized('You must be logged in to delete this update');
-  }
-
-  let update = await fetchUpdate(args.id);
-  const collective = await models.Collective.findByPk(update.CollectiveId);
-  if (!req.remoteUser.isAdminOfCollective(collective)) {
-    throw new Forbidden("You don't have sufficient permissions to delete this update");
-  }
-
+  let update = await fetchUpdateForEdit(args.id, req.remoteUser);
   update = await update.delete(req.remoteUser);
-  purgeCacheForCollective(collective.slug);
+  purgeCacheForCollective(update.collective.slug);
   return update;
 }

--- a/server/graphql/common/update.js
+++ b/server/graphql/common/update.js
@@ -48,12 +48,7 @@ export async function createUpdate(_, args, req) {
 }
 
 async function fetchUpdate(id) {
-  let update;
-  if (typeof id == 'string') {
-    update = await models.Update.findByPk(idDecode(id, IDENTIFIER_TYPES.UPDATE));
-  } else {
-    update = await models.Update.findByPk(id);
-  }
+  const update = await models.Update.findByPk(idDecode(id, IDENTIFIER_TYPES.UPDATE));
   if (!update) {
     throw new NotFound(`Update with id ${id} not found`);
   }

--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -303,6 +303,7 @@ type Collective implements CollectiveInterface {
   stats: CollectiveStatsType
   contributionPolicy: String
   categories: [String]!
+  hasVirtualCards: Boolean!
 }
 
 """
@@ -488,6 +489,7 @@ interface CollectiveInterface {
   isArchived: Boolean
   isApproved: Boolean
   isDeletable: Boolean
+  hasVirtualCards: Boolean
   host: CollectiveInterface
   hostCollective: CollectiveInterface
 
@@ -1288,6 +1290,7 @@ type Event implements CollectiveInterface {
   stats: CollectiveStatsType
   contributionPolicy: String
   categories: [String]!
+  hasVirtualCards: Boolean!
 }
 
 """
@@ -1660,6 +1663,7 @@ type Fund implements CollectiveInterface {
   stats: CollectiveStatsType
   contributionPolicy: String
   categories: [String]!
+  hasVirtualCards: Boolean!
 }
 
 """
@@ -2685,6 +2689,7 @@ type Organization implements CollectiveInterface {
   stats: CollectiveStatsType
   contributionPolicy: String
   categories: [String]!
+  hasVirtualCards: Boolean!
   email: String
 }
 
@@ -3069,6 +3074,7 @@ type Project implements CollectiveInterface {
   stats: CollectiveStatsType
   contributionPolicy: String
   categories: [String]!
+  hasVirtualCards: Boolean!
 }
 
 """
@@ -3888,6 +3894,7 @@ type User implements CollectiveInterface {
   stats: CollectiveStatsType
   contributionPolicy: String
   categories: [String]!
+  hasVirtualCards: Boolean!
   firstName: String @deprecated(reason: "2020-03-27: These field are now deprecated in favor of collective.name")
   lastName: String @deprecated(reason: "2020-03-27: These field are now deprecated in favor of collective.name")
   email: String
@@ -4176,4 +4183,5 @@ type Vendor implements CollectiveInterface {
   stats: CollectiveStatsType
   contributionPolicy: String
   categories: [String]!
+  hasVirtualCards: Boolean!
 }

--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -1984,13 +1984,6 @@ type Mutation {
   createOrder(order: OrderInputType!): OrderType
     @deprecated(reason: "2020-10-13: This endpoint has been moved to GQLV2")
   confirmOrder(order: ConfirmOrderInputType!): OrderType
-  createUpdate(update: UpdateInputType!): UpdateType
-    @deprecated(reason: "2021-01-29: This endpoint has been moved to GQLV2")
-  editUpdate(update: UpdateAttributesInputType!): UpdateType @deprecated(reason: "2021-01-29: Not used anymore")
-  publishUpdate(id: Int!, notificationAudience: UpdateAudienceTypeEnum!): UpdateType
-    @deprecated(reason: "2021-01-29: Not used anymore")
-  unpublishUpdate(id: Int!): UpdateType @deprecated(reason: "2021-01-29: Not used anymore")
-  deleteUpdate(id: Int!): UpdateType @deprecated(reason: "2021-01-29: Not used anymore")
   createComment(comment: CommentInputType!): CommentType @deprecated(reason: "2021-01-29: Not used anymore")
   editComment(comment: CommentAttributesInputType!): CommentType @deprecated(reason: "2021-01-29: Not used anymore")
   deleteComment(id: Int!): CommentType @deprecated(reason: "2021-01-29: Not used anymore")
@@ -3131,8 +3124,6 @@ type Query {
     fetchDataFromLedger: Boolean
     includeHostedCollectivesTransactions: Boolean
   ): [Transaction]
-  Update(collectiveSlug: String, updateSlug: String, id: Int): UpdateType
-    @deprecated(reason: "2021-01-29: Not used anymore")
   Application(id: Int): Application
   allUpdates(CollectiveId: Int!, includeHostedCollectives: Boolean, limit: Int, offset: Int): [UpdateType]
   allOrders(
@@ -3617,23 +3608,6 @@ enum TypeOfCollective {
 }
 
 """
-Input type for UpdateType
-"""
-input UpdateAttributesInputType {
-  id: Int
-  views: Int
-  slug: String
-  title: String
-  image: String
-  isPrivate: Boolean
-  makePublicOn: IsoDateString
-  markdown: String
-  html: String
-  fromCollective: CollectiveAttributesInputType
-  tier: TierInputType
-}
-
-"""
 Defines targets for an update
 """
 enum UpdateAudienceTypeEnum {
@@ -3651,24 +3625,6 @@ enum UpdateAudienceTypeEnum {
   Will be sent to financial contributors
   """
   FINANCIAL_CONTRIBUTORS
-}
-
-"""
-Input type for UpdateType
-"""
-input UpdateInputType {
-  id: Int
-  views: Int
-  slug: String
-  title: String
-  image: String
-  isPrivate: Boolean
-  makePublicOn: IsoDateString
-  markdown: String
-  html: String
-  fromCollective: CollectiveAttributesInputType
-  collective: CollectiveAttributesInputType!
-  tier: TierInputType
 }
 
 """

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -471,6 +471,7 @@ enum ActivityType {
   COLLECTIVE_EXPENSE_SCHEDULED_FOR_PAYMENT
   COLLECTIVE_EXPENSE_ERROR
   COLLECTIVE_EXPENSE_INVITE_DRAFTED
+  COLLECTIVE_EXPENSE_MISSING_RECEIPT
   COLLECTIVE_MEMBER_CREATED
   COLLECTIVE_TRANSACTION_CREATED
   COLLECTIVE_UPDATE_CREATED
@@ -7932,20 +7933,14 @@ VirtualCard related properties.
 """
 type VirtualCard {
   id: String
-<<<<<<< HEAD
   account: Account
   host: Account
-=======
-  CollectiveId: Int
-  HostCollectiveId: Int
->>>>>>> debt(Updates): Further deprecation removal & refactors
   name: String
   last4: String
   data: JSONObject
   privateData: JSONObject
   createdAt: DateTime
   updatedAt: DateTime
-<<<<<<< HEAD
 }
 
 input VirtualCardInput {
@@ -7958,7 +7953,4 @@ input VirtualCardInput {
 
 input VirtualCardReferenceInput {
   id: String
-=======
-  deletedAt: DateTime
->>>>>>> debt(Updates): Further deprecation removal & refactors
 }

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -7230,11 +7230,6 @@ type Query {
     """
     The update slug identifying the update
     """
-    updateSlug: String
-
-    """
-    The update slug identifying the update
-    """
     slug: String
 
     """
@@ -7937,14 +7932,20 @@ VirtualCard related properties.
 """
 type VirtualCard {
   id: String
+<<<<<<< HEAD
   account: Account
   host: Account
+=======
+  CollectiveId: Int
+  HostCollectiveId: Int
+>>>>>>> debt(Updates): Further deprecation removal & refactors
   name: String
   last4: String
   data: JSONObject
   privateData: JSONObject
   createdAt: DateTime
   updatedAt: DateTime
+<<<<<<< HEAD
 }
 
 input VirtualCardInput {
@@ -7957,4 +7958,7 @@ input VirtualCardInput {
 
 input VirtualCardReferenceInput {
   id: String
+=======
+  deletedAt: DateTime
+>>>>>>> debt(Updates): Further deprecation removal & refactors
 }

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -424,43 +424,6 @@ export const CommentAttributesInputType = new GraphQLInputObjectType({
   }),
 });
 
-export const UpdateInputType = new GraphQLInputObjectType({
-  name: 'UpdateInputType',
-  description: 'Input type for UpdateType',
-  fields: () => ({
-    id: { type: GraphQLInt },
-    views: { type: GraphQLInt },
-    slug: { type: GraphQLString },
-    title: { type: GraphQLString },
-    image: { type: GraphQLString },
-    isPrivate: { type: GraphQLBoolean },
-    makePublicOn: { type: IsoDateString },
-    markdown: { type: GraphQLString, deprecationReason: '2021-01-25: Please use html' },
-    html: { type: GraphQLString },
-    fromCollective: { type: CollectiveAttributesInputType },
-    collective: { type: new GraphQLNonNull(CollectiveAttributesInputType) },
-    tier: { type: TierInputType },
-  }),
-});
-
-export const UpdateAttributesInputType = new GraphQLInputObjectType({
-  name: 'UpdateAttributesInputType',
-  description: 'Input type for UpdateType',
-  fields: () => ({
-    id: { type: GraphQLInt },
-    views: { type: GraphQLInt },
-    slug: { type: GraphQLString },
-    title: { type: GraphQLString },
-    image: { type: GraphQLString },
-    isPrivate: { type: GraphQLBoolean },
-    makePublicOn: { type: IsoDateString },
-    markdown: { type: GraphQLString, deprecationReason: '2021-01-25: Please use html' },
-    html: { type: GraphQLString },
-    fromCollective: { type: CollectiveAttributesInputType },
-    tier: { type: TierInputType },
-  }),
-});
-
 export const InvoiceInputType = new GraphQLInputObjectType({
   name: 'InvoiceInputType',
   description: 'Input dates and collectives for Invoice',

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -3,7 +3,6 @@ import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectT
 import models from '../../models';
 import { bulkCreateGiftCards, createGiftCardsForEmails } from '../../paymentProviders/opencollective/giftcard';
 import { editPublicMessage } from '../common/members';
-import * as updateMutations from '../common/update';
 import { createUser } from '../common/user';
 import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../errors';
 
@@ -50,8 +49,6 @@ import {
   OrderInputType,
   StripeCreditCardDataInputType,
   TierInputType,
-  UpdateAttributesInputType,
-  UpdateInputType,
   UserInputType,
 } from './inputTypes';
 import { TransactionInterfaceType } from './TransactionInterface';
@@ -63,8 +60,6 @@ import {
   OrderType,
   PaymentMethodType,
   TierType,
-  UpdateAudienceTypeEnum,
-  UpdateType,
   UserType,
 } from './types';
 
@@ -332,69 +327,6 @@ const mutations = {
     },
     resolve(_, args, req) {
       return confirmOrder(args.order, req.remoteUser);
-    },
-  },
-  createUpdate: {
-    type: UpdateType,
-    deprecationReason: '2021-01-29: This endpoint has been moved to GQLV2',
-    args: {
-      update: {
-        type: new GraphQLNonNull(UpdateInputType),
-      },
-    },
-    resolve(_, args, req) {
-      return updateMutations.createUpdate(_, args, req);
-    },
-  },
-  editUpdate: {
-    type: UpdateType,
-    deprecationReason: '2021-01-29: Not used anymore',
-    args: {
-      update: {
-        type: new GraphQLNonNull(UpdateAttributesInputType),
-      },
-    },
-    resolve(_, args, req) {
-      return updateMutations.editUpdate(_, args, req);
-    },
-  },
-  publishUpdate: {
-    type: UpdateType,
-    deprecationReason: '2021-01-29: Not used anymore',
-    args: {
-      id: {
-        type: new GraphQLNonNull(GraphQLInt),
-      },
-      notificationAudience: {
-        type: new GraphQLNonNull(UpdateAudienceTypeEnum),
-      },
-    },
-    resolve(_, args, req) {
-      return updateMutations.publishUpdate(_, args, req);
-    },
-  },
-  unpublishUpdate: {
-    type: UpdateType,
-    deprecationReason: '2021-01-29: Not used anymore',
-    args: {
-      id: {
-        type: new GraphQLNonNull(GraphQLInt),
-      },
-    },
-    resolve(_, args, req) {
-      return updateMutations.unpublishUpdate(_, args, req);
-    },
-  },
-  deleteUpdate: {
-    type: UpdateType,
-    deprecationReason: '2021-01-29: Not used anymore',
-    args: {
-      id: {
-        type: new GraphQLNonNull(GraphQLInt),
-      },
-    },
-    resolve(_, args, req) {
-      return updateMutations.deleteUpdate(_, args, req);
     },
   },
   createComment: {

--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -299,25 +299,6 @@ const queries = {
     },
   },
 
-  Update: {
-    type: UpdateType,
-    deprecationReason: '2021-01-29: Not used anymore',
-    args: {
-      collectiveSlug: { type: GraphQLString },
-      updateSlug: { type: GraphQLString },
-      id: { type: GraphQLInt },
-    },
-    async resolve(_, args) {
-      if (args.id) {
-        return models.Update.findByPk(args.id);
-      }
-      const CollectiveId = await fetchCollectiveId(args.collectiveSlug);
-      return models.Update.findOne({
-        where: { CollectiveId, slug: args.updateSlug },
-      });
-    },
-  },
-
   Application: {
     type: ApplicationType,
     args: {

--- a/server/graphql/v2/query/UpdateQuery.js
+++ b/server/graphql/v2/query/UpdateQuery.js
@@ -12,11 +12,6 @@ const UpdateQuery = {
       type: GraphQLString,
       description: 'Public identifier',
     },
-    updateSlug: {
-      type: GraphQLString,
-      description: 'The update slug identifying the update',
-      deprecationReason: '2020-01-19: Please use `slug`',
-    },
     slug: {
       type: GraphQLString,
       description: 'The update slug identifying the update',
@@ -29,9 +24,6 @@ const UpdateQuery = {
   async resolve(_, args) {
     if (args.id) {
       return models.Update.findByPk(idDecode(args.id, IDENTIFIER_TYPES.UPDATE));
-    } else if (args.updateSlug) {
-      // @deprecated This doesn't work since update's slugs are not unique
-      return models.Update.findOne({ where: { slug: args.updateSlug.toLowerCase() } });
     } else if (args.account && args.slug) {
       const account = await fetchAccountWithReference(args.account, { throwIfMissing: true });
       return models.Update.findOne({

--- a/test/server/graphql/v2/mutation/UpdateMutations.test.js
+++ b/test/server/graphql/v2/mutation/UpdateMutations.test.js
@@ -126,7 +126,7 @@ describe('server/graphql/v2/mutation/UpdateMutations', () => {
         notificationAudience: update1.notificationAudience,
       });
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal('You must be logged in to publish this update');
+      expect(result.errors[0].message).to.equal('You must be logged in to edit this update');
     });
 
     it('fails if not authenticated as admin of collective', async () => {
@@ -136,7 +136,7 @@ describe('server/graphql/v2/mutation/UpdateMutations', () => {
         user2,
       );
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal("You don't have sufficient permissions to publish this update");
+      expect(result.errors[0].message).to.equal("You don't have sufficient permissions to edit this update");
     });
 
     it('unpublishes an update successfully', async () => {
@@ -296,7 +296,7 @@ describe('server/graphql/v2/mutation/UpdateMutations', () => {
         id: idEncode(update1.id, IDENTIFIER_TYPES.UPDATE),
       });
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal('You must be logged in to delete this update');
+      expect(result.errors[0].message).to.equal('You must be logged in to edit this update');
       return models.Update.findByPk(update1.id).then(updateFound => {
         expect(updateFound).to.not.be.null;
       });
@@ -309,7 +309,7 @@ describe('server/graphql/v2/mutation/UpdateMutations', () => {
         user2,
       );
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal("You don't have sufficient permissions to delete this update");
+      expect(result.errors[0].message).to.equal("You don't have sufficient permissions to edit this update");
       return models.Update.findByPk(update1.id).then(updateFound => {
         expect(updateFound).to.not.be.null;
       });


### PR DESCRIPTION
This removes the v1 mutations related to the update now that both https://github.com/opencollective/opencollective-frontend/pull/5669 and https://github.com/opencollective/opencollective-api/pull/5082 are merged.

Related to https://github.com/opencollective/opencollective/issues/3053