### PR TITLE
Add Collective.data key to disable platform tips

### DIFF
--- a/server/graphql/v2/interface/AccountWithContributions.ts
+++ b/server/graphql/v2/interface/AccountWithContributions.ts
@@ -70,7 +70,7 @@ export const AccountWithContributionsFields = {
     description:
       'Returns true if a custom contribution to Open Collective can be submitted for contributions made to this account',
     resolve(account): boolean {
-      return account.platformFeePercent === 0;
+      return account.platformFeePercent === 0 && Boolean(account.data?.disablePlatformTips) !== true;
     },
   },
   balance: {


### PR DESCRIPTION
This is a workaround for disabling the platform tips on a collective basis.
My original intent is to disable the platform tip of BRL collectives due to stripe limitation until someone can properly spec out this issue.