### PR TITLE
Automatically invoice Fixed Fee per Collective

### DIFF
--- a/cron/monthly/invoice-platform-fees.js
+++ b/cron/monthly/invoice-platform-fees.js
@@ -302,9 +302,9 @@ export async function run() {
       continue;
     }
 
-    const { HostName, currency, plan, chargedHostId } = hostTransactions[0];
+    const { HostName, currency, plan: planId, chargedHostId } = hostTransactions[0];
 
-    const hostFeeSharePercent = plans[plan]?.hostFeeSharePercent;
+    const hostFeeSharePercent = plans[planId]?.hostFeeSharePercent;
     const transactions = hostTransactions.map(t => {
       if (t.source === 'Shared Revenue') {
         t.amount = round(t.amount * (hostFeeSharePercent / 100));
@@ -319,11 +319,26 @@ export async function run() {
       return { incurredAt, amount, description };
     });
 
+    const host = await models.Collective.findByPk(hostId);
+    const plan = await host.getPlan();
+    if (plan.pricePerCollective) {
+      const activeHostedCollectives = await host.getHostedCollectivesCount();
+      const amount = (activeHostedCollectives || 0) * plan.pricePerCollective;
+      if (amount) {
+        items.push({
+          incurredAt: new Date(),
+          amount,
+          description: 'Fixed Fee per Hosted Collective',
+        });
+      }
+    }
+
     const transactionIds = transactions.map(t => t.TransactionId);
     const totalAmountCredited = sumBy(
       items
         .filter(i => i.description != 'Shared Revenue')
-        .filter(i => i.description != 'Reimburse: Payment Processor Fee for collected Platform Tips'),
+        .filter(i => i.description != 'Reimburse: Payment Processor Fee for collected Platform Tips')
+        .filter(i => i.description != 'Fixed Fee per Hosted Collective'),
       'amount',
     );
     const totalAmountCharged = sumBy(items, 'amount');
@@ -362,7 +377,6 @@ export async function run() {
         type: TransactionTypes.CREDIT,
       });
 
-      const host = await models.Collective.findByPk(hostId);
       const connectedAccounts = await host.getConnectedAccounts({
         where: { deletedAt: null },
       });

--- a/test/cron/monthly/invoice-platform-fees.test.js
+++ b/test/cron/monthly/invoice-platform-fees.test.js
@@ -30,7 +30,7 @@ describe('cron/monthly/invoice-platform-fees', () => {
       type: 'BANK_ACCOUNT',
     });
 
-    gbpHost = await fakeHost({ currency: 'GBP', plan: 'grow-plan-2021' });
+    gbpHost = await fakeHost({ currency: 'GBP', plan: 'grow-plan-2021', data: { plan: { pricePerCollective: 100 } } });
 
     const socialCollective = await fakeCollective({ HostCollectiveId: gbpHost.id });
     const transactionProps = {
@@ -137,5 +137,10 @@ describe('cron/monthly/invoice-platform-fees', () => {
       p => p.description == 'Reimburse: Payment Processor Fee for collected Platform Tips',
     );
     expect(reimburseItem).to.have.property('amount', Math.round(-100 / 1.23));
+  });
+
+  it('should consider fixed fee per host collective', async () => {
+    const reimburseItem = expense.items.find(p => p.description == 'Fixed Fee per Hosted Collective');
+    expect(reimburseItem).to.have.property('amount', 100);
   });
 });


### PR DESCRIPTION
The fixed fee per hosted collective can be set in `host.data.plan.pricePerCollective`.
Its value represents the **price in cents and in host currency** charged monthly per active hosted collective.