### PR TITLE
GuestAccount: Always return the same collective

### DIFF
--- a/migrations/20210119082711-remove-unique-guestoken-collective-constraint.js
+++ b/migrations/20210119082711-remove-unique-guestoken-collective-constraint.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "GuestTokens"
+      DROP CONSTRAINT "GuestTokens_CollectiveId_key";
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};

--- a/server/models/GuestToken.ts
+++ b/server/models/GuestToken.ts
@@ -37,7 +37,6 @@ export default (sequelize, DataTypes): typeof GuestToken => {
         onDelete: 'CASCADE',
         onUpdate: 'CASCADE',
         allowNull: false,
-        unique: true,
       },
       value: {
         type: DataTypes.STRING,

--- a/test/server/lib/guest-accounts.test.ts
+++ b/test/server/lib/guest-accounts.test.ts
@@ -30,11 +30,11 @@ describe('server/lib/guest-accounts.ts', () => {
         );
       });
 
-      it('Creates a new profile if a non-verified account already exists for this profile', async () => {
+      it('Re-use the same profile if a non-verified account already exists', async () => {
         const user = await fakeUser({ confirmedAt: null });
         const { collective } = await getOrCreateGuestProfile({ email: user.email });
         expect(collective).to.exist;
-        expect(collective.id).to.not.eq(user.CollectiveId);
+        expect(collective.id).to.eq(user.CollectiveId);
       });
     });
 
@@ -135,10 +135,6 @@ describe('server/lib/guest-accounts.ts', () => {
       await confirmGuestAccountByEmail(user.email, user.emailConfirmationToken, [otherGuestToken.value]);
       await user.reload({ include: [{ association: 'collective' }] });
       expect(user.confirmedAt).to.not.be.null;
-
-      // Has deleted other profiles (but not the main one)
-      expect((await otherGuestProfile.reload({ paranoid: false })).deletedAt).to.not.be.null;
-      expect((await mainProfile.reload({ paranoid: false })).deletedAt).to.be.null;
 
       // Has deleted tokens
       expect((await guestToken.reload({ paranoid: false })).deletedAt).to.not.be.null;


### PR DESCRIPTION
This was causing permissions issues with the payment methods. After this PR, anyone will be able to contribute as an existing guest profile given that they submit their order with the same email.