### PR TITLE
GQLV2/Update: Fetch with slug + account

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -6805,6 +6805,16 @@ type Query {
     The update slug identifying the update
     """
     updateSlug: String
+
+    """
+    The update slug identifying the update
+    """
+    slug: String
+
+    """
+    When fetching by slug, an account must be provided
+    """
+    account: AccountReferenceInput
   ): Update
   loggedInAccount: Account
 }
@@ -7071,7 +7081,7 @@ type Update {
   """
   List the comments for this update. Not backed by a loader, don't use this in lists.
   """
-  comments(limit: Int, offset: Int): CommentCollection!
+  comments(limit: Int, offset: Int): CommentCollection
 }
 
 """

--- a/server/graphql/v2/query/UpdateQuery.js
+++ b/server/graphql/v2/query/UpdateQuery.js
@@ -2,6 +2,7 @@ import { GraphQLString } from 'graphql';
 
 import models from '../../../models';
 import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
+import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import Update from '../object/Update';
 
 const UpdateQuery = {
@@ -14,13 +15,33 @@ const UpdateQuery = {
     updateSlug: {
       type: GraphQLString,
       description: 'The update slug identifying the update',
+      deprecationReason: '2020-01-19: Please use `slug`',
+    },
+    slug: {
+      type: GraphQLString,
+      description: 'The update slug identifying the update',
+    },
+    account: {
+      type: AccountReferenceInput,
+      description: 'When fetching by slug, an account must be provided',
     },
   },
   async resolve(_, args) {
     if (args.id) {
       return models.Update.findByPk(idDecode(args.id, IDENTIFIER_TYPES.UPDATE));
     } else if (args.updateSlug) {
-      return models.Update.findBySlug(args.updateSlug);
+      // @deprecated This doesn't work since update's slugs are not unique
+      return models.Update.findOne({ where: { slug: args.updateSlug.toLowerCase() } });
+    } else if (args.account && args.slug) {
+      const account = await fetchAccountWithReference(args.account, { throwIfMissing: true });
+      return models.Update.findOne({
+        where: {
+          slug: args.slug.toLowerCase(),
+          CollectiveId: account.id,
+        },
+      });
+    } else {
+      throw new Error('You must either provide an ID or an account + slug to retrieve an update');
     }
   },
 };

--- a/server/models/Update.js
+++ b/server/models/Update.js
@@ -368,21 +368,6 @@ export default function (Sequelize, DataTypes) {
     );
   };
 
-  Update.findBySlug = (slug, options = {}) => {
-    if (!slug || slug.length < 1) {
-      return Promise.resolve(null);
-    }
-    return Update.findOne({
-      where: { slug: slug.toLowerCase() },
-      ...options,
-    }).then(Update => {
-      if (!Update) {
-        throw new Error(`No update found with slug ${slug}`);
-      }
-      return Update;
-    });
-  };
-
   Update.associate = m => {
     Update.belongsTo(m.Collective, {
       foreignKey: 'CollectiveId',


### PR DESCRIPTION
Fix for https://opencollective.freshdesk.com/a/tickets/12465

On https://opencollective.com/zinc-community/updates, if you click on the first update in the list you will notice that it is actually not from zinc community. The reason is that in the latest version of the update page, we fetch the update solely by its slug, but update's slugs are not unique. In this specific case, the slug `august-2020-update` is also used by another collective.

The solution is to fetch by specifying an account in addition to the update slug. This is what we use to do in GQLV1: https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v1/queries.js#L449