### PR TITLE
Sentry: Remove requests handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@opencollective/taxes": "3.1.0",
     "@paypal/payouts-sdk": "^1.0.0",
     "@sentry/node": "5.30.0",
-    "@sentry/tracing": "5.30.0",
     "apollo-server-express": "2.19.2",
     "argparse": "2.0.1",
     "aws-sdk": "2.828.0",

--- a/server/lib/sentry.ts
+++ b/server/lib/sentry.ts
@@ -1,10 +1,8 @@
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import config from 'config';
-import * as express from 'express';
 import { isEqual } from 'lodash';
 
-export const plugSentryToApp = (app: express.Express): void => {
+export const plugSentryToApp = (): void => {
   if (!config.sentry?.dsn) {
     return;
   }
@@ -14,21 +12,7 @@ export const plugSentryToApp = (app: express.Express): void => {
     environment: config.env,
     attachStacktrace: true,
     enabled: config.env !== 'test',
-    integrations: [
-      // enable HTTP calls tracing
-      new Sentry.Integrations.Http({ tracing: true }),
-      // enable Express.js middleware tracing
-      new Tracing.Integrations.Express({ app }),
-    ],
   });
-
-  // ---- Add request handlers ----
-  // RequestHandler creates a separate execution context using domains, so that every
-  // transaction/span/breadcrumb is attached to its own Hub instance
-  app.use(Sentry.Handlers.requestHandler({ ip: true }));
-
-  // TracingHandler creates a trace for every incoming request
-  app.use(Sentry.Handlers.tracingHandler());
 };
 
 const IGNORED_GQL_ERRORS = [


### PR DESCRIPTION
Adding sentry created an issue where some IPs were corrupted in `req.ip`. This PR removes the request handlers, which will prevent us from catching errors on the REST endpoints but should fix the IP issue. Since GQL requests are the most important to track, it's worth it.