### PR TITLE
Sentry: Add back GQL query to the report

### DIFF
--- a/server/lib/sentry.ts
+++ b/server/lib/sentry.ts
@@ -53,7 +53,7 @@ export const SentryGraphQLPlugin = {
             scope.setTag('kind', ctx.operation.operation);
 
             // Log query and variables as extras
-            scope.setExtra('query', ctx.context.query);
+            scope.setExtra('query', ctx.request.query);
             scope.setExtra('variables', ctx.request.variables);
 
             // Add logged in user (if any)


### PR DESCRIPTION
https://github.com/opencollective/opencollective-api/pull/5140 removed the GQL query from Sentry's tags. This PR adds it back.