### PR TITLE
Host: Remove isTypeOf in favor of host field

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -23,7 +23,6 @@ export const Host = new GraphQLObjectType({
   name: 'Host',
   description: 'This represents an Host account',
   interfaces: () => [Account, AccountWithContributions],
-  isTypeOf: collective => collective.isHostAccount,
   fields: () => {
     return {
       ...AccountFields,

--- a/server/graphql/v2/object/Individual.js
+++ b/server/graphql/v2/object/Individual.js
@@ -5,6 +5,8 @@ import models from '../../../models';
 import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
 import { Account, AccountFields } from '../interface/Account';
 
+import { Host } from './Host';
+
 export const Individual = new GraphQLObjectType({
   name: 'Individual',
   description: 'This represents an Individual account',
@@ -93,6 +95,15 @@ export const Individual = new GraphQLObjectType({
             return true;
           } else {
             return false;
+          }
+        },
+      },
+      host: {
+        type: Host,
+        description: 'If the individual is a host account, this will return the matching Host object',
+        resolve(collective) {
+          if (collective.isHostAccount) {
+            return collective;
           }
         },
       },

--- a/server/graphql/v2/object/Organization.js
+++ b/server/graphql/v2/object/Organization.js
@@ -49,7 +49,7 @@ export const Organization = new GraphQLObjectType({
       },
       host: {
         type: Host,
-        description: 'If the organization if a host account, this will return the matchig Host object',
+        description: 'If the organization if a host account, this will return the matching Host object',
         resolve(collective) {
           if (collective.isHostAccount) {
             return collective;


### PR DESCRIPTION
Rollback on the approach taken in https://github.com/opencollective/opencollective-api/pull/5146.

Because an account can both be an `ORGANIZATION` and a `HOST`, `isTypeOf` was causing [some trouble](https://sentry.io/organizations/open-collective/issues/2164707214/?project=5199682&query=is%3Aunresolved+Expected+value+of+type+%22Host%22&statsPeriod=14d). I've changed the approach to instead use the workaround that we've been using until now: have a `host` field on organizations to retrieve the host fields if they're one. Also added this field on `INDIVIDUAL` to be able to do the same.