### PR TITLE
enhancement(Update): free up slug before deletion

### DIFF
--- a/server/models/Update.js
+++ b/server/models/Update.js
@@ -216,6 +216,11 @@ export default function (Sequelize, DataTypes) {
             return instance.generateSlug();
           }
         },
+        beforeDestroy: async instance => {
+          const newSlug = `${instance.slug}-${Date.now()}`;
+          instance.slug = newSlug;
+          await instance.save({ paranoid: false, hooks: false });
+        },
         afterCreate: instance => {
           models.Activity.create({
             type: activities.COLLECTIVE_UPDATE_CREATED,

--- a/test/server/models/Update.test.js
+++ b/test/server/models/Update.test.js
@@ -27,6 +27,7 @@ describe('server/models/Update', () => {
         { id: 2, title: 'update 2 - today', isPrivate: true, makePublicOn: today },
         { id: 3, title: 'update 3 - tomorrow', isPrivate: true, makePublicOn: tomorrow },
         { id: 4, title: 'update 4', isPrivate: true, makePublicOn: null },
+        { id: 5, title: 'unique-slug', isPrivate: false, makePublicOn: null },
       ],
       { CreatedByUserId: user.id, CollectiveId: collective.id },
     );
@@ -56,6 +57,18 @@ describe('server/models/Update', () => {
     it('update.makePublicOn is null', async () => {
       const update = await models.Update.findByPk(4);
       expect(update.dataValues.isPrivate).to.equal(true);
+    });
+  });
+
+  describe('delete update', () => {
+    it('frees up current slug when deleted', async () => {
+      const uniqueSlug = 'unique-slug';
+      const update = await models.Update.findOne({ where: { slug: uniqueSlug } });
+      expect(update.slug).to.equal('unique-slug');
+      await update.destroy();
+      // free up slug after deletion
+      expect(uniqueSlug).to.not.be.equal(update.slug);
+      expect(/-\d+$/.test(update.slug)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3876

- [x] When deleting an update, add a `-${Date.now()}` suffix to the existing slug (ideally in an `beforeDestroy` sequelize hook)
- [x] Add a test in `test/server/models/Update.test.js` to make sure the slug is freed up