### PR TITLE
New Backer email: Display amount in title

### DIFF
--- a/scripts/compile-email.js
+++ b/scripts/compile-email.js
@@ -485,6 +485,24 @@ data['user.monthlyreport'] = {
     },
   ],
 };
+data['collective.member.created'] = {
+  member: {
+    memberCollective: {
+      name: 'John Doe',
+    },
+    role: 'contributor',
+  },
+  collective: {
+    name: 'TheCollective',
+  },
+  order: {
+    currency: 'USD',
+    totalAmount: 64 * 100,
+    subscription: {
+      interval: 'month',
+    },
+  },
+};
 
 const defaultData = {
   config: {

--- a/server/lib/handlebars.js
+++ b/server/lib/handlebars.js
@@ -2,7 +2,7 @@ import handlebars from 'handlebars';
 import { lowercase } from 'lodash';
 import moment from 'moment-timezone';
 
-import { capitalize, formatCurrencyObject, pluralize, resizeImage } from './utils';
+import { capitalize, formatCurrency, formatCurrencyObject, pluralize, resizeImage } from './utils';
 
 // from https://stackoverflow.com/questions/8853396/logical-operator-in-a-handlebars-js-if-conditional
 handlebars.registerHelper('ifCond', function (v1, operator, v2, options) {
@@ -159,6 +159,26 @@ handlebars.registerHelper('encodeURIComponent', str => {
 });
 
 handlebars.registerHelper('formatCurrencyObject', (obj, props) => formatCurrencyObject(obj, props.hash));
+
+handlebars.registerHelper('formatOrderAmountWithInterval', order => {
+  if (!order.currency || !order.totalAmount) {
+    return null;
+  }
+
+  const formattedAmount = formatCurrency(order.totalAmount, order.currency);
+  const subscription = order.subscription;
+  const interval = subscription?.interval || order.interval;
+
+  if (interval !== null) {
+    if (interval === 'month') {
+      return `(${formattedAmount}/m)`;
+    } else if (interval === 'year') {
+      return `(${formattedAmount}/y)`;
+    }
+  } else {
+    return `(${formattedAmount})`;
+  }
+});
 
 handlebars.registerHelper('debug', console.log);
 

--- a/templates/emails/collective.member.created.hbs
+++ b/templates/emails/collective.member.created.hbs
@@ -1,4 +1,4 @@
-Subject: {{member.memberCollective.name}} joined {{{collective.name}}} as {{toLowerCase member.role}}
+Subject: {{member.memberCollective.name}} joined {{{collective.name}}} as {{toLowerCase member.role}} {{#if order}}{{formatOrderAmountWithInterval order}}{{/if}}
 
 {{> header}}
 

--- a/test/server/graphql/v1/mutation.test.js
+++ b/test/server/graphql/v1/mutation.test.js
@@ -576,7 +576,7 @@ describe('server/graphql/v1/mutation', () => {
           expect(emailSendMessageSpy.firstCall.args[0]).to.equal('user2@opencollective.com');
           expect(emailSendMessageSpy.firstCall.args[1]).to.equal('Your Organization on Open Collective');
           expect(emailSendMessageSpy.secondCall.args[0]).to.equal('user1@opencollective.com');
-          expect(emailSendMessageSpy.secondCall.args[1]).to.equal("Google joined Scouts d'Arlon as backer");
+          expect(emailSendMessageSpy.secondCall.args[1]).to.equal("Google joined Scouts d'Arlon as backer ($20/m)");
           expect(emailSendMessageSpy.secondCall.args[2]).to.contain('Looking forward!'); // publicMessage
           expect(emailSendMessageSpy.secondCall.args[2]).to.contain(
             '@google thanks for your financial contribution to @scouts',


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/3823

Besides adding the suffix described in the issue this PR also adds some mock data for the email template in `compile-email.js`
I used the mock data for testing, but since there was no other previous data I thought I might as well leave it in the commit.

Used MailDev for testing: 
![MailDev_Screenshot](https://user-images.githubusercontent.com/43905913/105638016-2b926400-5e79-11eb-83de-376126b7df01.png)