### PR TITLE
Remove View All Expenses button from notification emails

### DIFF
--- a/templates/emails/collective.expense.error.hbs
+++ b/templates/emails/collective.expense.error.hbs
@@ -12,10 +12,6 @@ Subject: Payment from {{collective.name}} for {{expense.description}} expense fa
     We already notified the host and there's nothing you need to do right now, unless you're directly contacted by the
     host.
   </p>
-  <br /><br />
-  <a href="{{config.host.website}}/{{collective.slug}}/expenses" class="btn">
-    <div>View All Expenses</div>
-  </a>
 </center>
 
 {{> footer}}

--- a/templates/emails/collective.expense.processing.hbs
+++ b/templates/emails/collective.expense.processing.hbs
@@ -11,10 +11,6 @@ Subject: Expense from {{collective.name}} for {{expense.description}} is being P
       href="{{config.host.website}}/{{collective.slug}}">{{collective.name}} collective</a> is currently being processed
     by TransferWise and should be paid soon.
   </p>
-  <br /><br />
-  <a href="{{config.host.website}}/{{collective.slug}}/expenses" class="btn">
-    <div>View All Expenses</div>
-  </a>
 </center>
 
 {{> footer}}


### PR DESCRIPTION
This was requested by @piamancini due to privacy concerns.
I don't think these buttons are particularly useful since we're already linking the expense.