### PR TITLE
Remove guest tokens

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Check matching branch
         id: check-matching-branch
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v2.0.24
         with:
           route: GET /repos/:owner/:repo/git/:ref
           owner: opencollective

--- a/migrations/20210126110306-remove-guest-tokens.js
+++ b/migrations/20210126110306-remove-guest-tokens.js
@@ -1,24 +1,12 @@
-import { Model } from 'sequelize';
+'use strict';
 
-import restoreSequelizeAttributesOnClass from '../lib/restore-sequelize-attributes-on-class';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('GuestTokens');
+  },
 
-export class GuestToken extends Model<GuestToken> {
-  public readonly id!: number;
-  public CollectiveId!: number;
-  public value!: string;
-  public createdAt!: Date;
-  public updatedAt!: Date;
-
-  constructor(...args) {
-    super(...args);
-    restoreSequelizeAttributesOnClass(new.target, this);
-  }
-}
-
-export default (sequelize, DataTypes): typeof GuestToken => {
-  // Link the model to database fields
-  GuestToken.init(
-    {
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.createTable('GuestTokens', {
       id: {
         type: DataTypes.INTEGER,
         primaryKey: true,
@@ -57,13 +45,6 @@ export default (sequelize, DataTypes): typeof GuestToken => {
         type: DataTypes.DATE,
         allowNull: true,
       },
-    },
-    {
-      sequelize,
-      tableName: 'GuestTokens',
-      paranoid: true,
-    },
-  );
-
-  return GuestToken;
+    });
+  },
 };

--- a/server/graphql/v2/input/GuestInfoInput.ts
+++ b/server/graphql/v2/input/GuestInfoInput.ts
@@ -19,6 +19,7 @@ export const GuestInfoInput = new GraphQLInputObjectType({
     token: {
       type: GraphQLString,
       description: 'The unique guest token',
+      deprecationReason: '2021-01-26: Guest tokens are not used anymore',
     },
     location: {
       type: LocationInput,

--- a/server/graphql/v2/mutation/GuestMutations.ts
+++ b/server/graphql/v2/mutation/GuestMutations.ts
@@ -111,6 +111,7 @@ const guestMutations = {
       guestTokens: {
         type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
         description: 'This can be used to link the other guest contributions to the user',
+        deprecationReason: '2021-01-26: Guest tokens are not used anymore',
       },
     },
     async resolve(
@@ -129,15 +130,9 @@ const guestMutations = {
         throw new RateLimitExceeded();
       }
 
-      const guestTokens = <string[] | null>args.guestTokens;
-      if (guestTokens?.length > 30) {
-        throw new Error('Cannot link more than 30 profiles at the same time');
-      }
-
       const { user, collective } = await confirmGuestAccountByEmail(
         <string>args.email,
         <string>args.emailConfirmationToken,
-        <string[]>args.guestTokens,
       );
 
       const accessToken = user.jwt({}, TOKEN_EXPIRATION_SESSION);

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -34,7 +34,7 @@ const OrderWithPayment = new GraphQLObjectType({
     },
     guestToken: {
       type: GraphQLString,
-      description: 'If donating as a guest, this will contain your guest token to contribute again in the future',
+      description: 'If donating as a guest, this will contain your guest token to confirm your order',
     },
     stripeError: {
       type: StripeError,
@@ -95,7 +95,7 @@ const orderMutations = {
       };
 
       const result = await createOrderLegacy(legacyOrderObj, req.loaders, req.remoteUser, req.ip);
-      return { order: result.order, stripeError: result.stripeError, guestToken: result.guestToken?.value };
+      return { order: result.order, stripeError: result.stripeError, guestToken: result.order.data?.guestToken };
     },
   },
   cancelOrder: {

--- a/server/lib/guest-accounts.ts
+++ b/server/lib/guest-accounts.ts
@@ -5,17 +5,13 @@ import { v4 as uuid } from 'uuid';
 
 import { types as COLLECTIVE_TYPE } from '../constants/collectives';
 import { BadRequest, InvalidToken, NotFound, Unauthorized } from '../graphql/errors';
-import models, { Op, sequelize } from '../models';
-
-import { mergeCollectives } from './collectivelib';
+import models, { sequelize } from '../models';
 
 export const DEFAULT_GUEST_NAME = 'Guest';
-const INVALID_TOKEN_MSG = 'Your guest token is invalid. If you already have an account, please sign in.';
 
 type GuestProfileDetails = {
   user: typeof models.User;
   collective: typeof models.Collective;
-  token: typeof models.GuestToken;
 };
 
 type Location = {
@@ -24,35 +20,40 @@ type Location = {
 };
 
 /**
- * Load a `GuestToken` from its code, returns the user and collective associated
+ * If more recent info on the collective has been provided, update it. Otherwise do nothing.
  */
-export const loadGuestToken = async (guestToken: string): Promise<GuestProfileDetails> => {
-  const token = await models.GuestToken.findOne({
-    where: { value: guestToken },
-    include: [{ association: 'collective', required: true }],
-  });
+const updateCollective = async (collective, newInfo, transaction) => {
+  const fieldsToUpdate = {};
 
-  if (!token) {
-    throw new Error(INVALID_TOKEN_MSG);
+  if (newInfo.name && collective.name !== newInfo.name) {
+    fieldsToUpdate['name'] = newInfo.name;
   }
 
-  const user = await models.User.findOne({ where: { CollectiveId: token.collective.id } });
-  if (!user) {
-    // This can happen if trying to contribute with a guest token when the user
-    // associated has been removed (ie. if it's a spammer)
-    throw new Error(INVALID_TOKEN_MSG);
+  if (newInfo.location) {
+    if (newInfo.location.country && newInfo.location.country !== collective.countryISO) {
+      fieldsToUpdate['countryISO'] = newInfo.location.country;
+    }
+    if (newInfo.location.address && newInfo.location.address !== collective.address) {
+      fieldsToUpdate['address'] = newInfo.location.address;
+    }
   }
 
-  return { token, collective: token.collective, user };
+  return isEmpty(fieldsToUpdate) ? collective : collective.update(fieldsToUpdate, { transaction });
 };
 
-const createGuestProfile = (
-  email: string,
-  name: string | null,
-  location: Location | null,
-): Promise<GuestProfileDetails> => {
+/**
+ * Retrieves or create an guest profile by email.
+ */
+export const getOrCreateGuestProfile = async ({
+  email,
+  name,
+  location,
+}: {
+  email?: string | null;
+  name?: string | null;
+  location?: Location;
+}): Promise<GuestProfileDetails> => {
   const emailConfirmationToken = crypto.randomBytes(48).toString('hex');
-  const guestToken = crypto.randomBytes(48).toString('hex');
 
   if (!email) {
     throw new Error('An email is required to create a guest profile');
@@ -79,6 +80,7 @@ const createGuestProfile = (
       );
     } else if (user.CollectiveId) {
       collective = await models.Collective.findByPk(user.CollectiveId, { transaction });
+      collective = await updateCollective(collective, { name, location }, transaction);
     }
 
     // Create the public guest profile
@@ -101,89 +103,15 @@ const createGuestProfile = (
       await user.update({ CollectiveId: collective.id }, { transaction });
     }
 
-    // Create the token that will be used to authenticate future contributions for
-    // this guest profile
-    const guestTokenData = { CollectiveId: collective.id, UserId: user.id, value: guestToken };
-    const token = await models.GuestToken.create(guestTokenData, { transaction });
-
-    return { collective, user, token };
+    return { collective, user };
   });
 };
 
 /**
- * If more recent info on the collective has been provided, update it. Otherwise do nothing.
+ * Mark a guest account as "confirmed"
  */
-const updateCollective = async (collective, name: string, location: Location) => {
-  const fieldsToUpdate = {};
-
-  if (name && collective.name !== name) {
-    fieldsToUpdate['name'] = name;
-  }
-
-  if (location) {
-    if (location.country && location.country !== collective.countryISO) {
-      fieldsToUpdate['countryISO'] = location.country;
-    }
-    if (location.address && location.address !== collective.address) {
-      fieldsToUpdate['address'] = location.address;
-    }
-  }
-
-  return isEmpty(fieldsToUpdate) ? collective : collective.update(fieldsToUpdate);
-};
-
-/**
- * Returns the guest profile from a guest token
- */
-const getGuestProfileFromToken = async (tokenValue, { email, name, location }): Promise<GuestProfileDetails> => {
-  const { collective, user, token } = await loadGuestToken(tokenValue);
-
-  if (user.confirmedAt) {
-    // Account exists & user is confirmed => need to sign in
-    throw new Unauthorized('An account already exists for this email, please sign in.', 'ACCOUNT_EMAIL_ALREADY_EXISTS');
-  } else if (email && user.email !== email.trim()) {
-    // The user is making a new guest contribution from the same browser but with
-    // a different email. For now the behavior is to ignore the existing guest profile
-    // and to create a new one.
-    return createGuestProfile(email, name, location);
-  } else {
-    // Contributing again as guest using the same guest token, update profile info if needed
-    return {
-      collective: await updateCollective(collective, name, location),
-      user,
-      token,
-    };
-  }
-};
-
-/**
- * Retrieves or create an guest profile.
- */
-export const getOrCreateGuestProfile = async ({
-  email,
-  token,
-  name,
-  location,
-}: {
-  email?: string | null;
-  token?: string | null;
-  name?: string | null;
-  location?: Location;
-}): Promise<GuestProfileDetails> => {
-  if (token) {
-    // If there is a guest token, we try to fetch the profile from there
-    return getGuestProfileFromToken(token, { email, name, location });
-  } else {
-    // First time contributing as a guest or re-using an existing email with a different
-    // token. Note that a new Collective profile will be created for the contribution if the guest
-    // token don't match.
-    return createGuestProfile(email, name, location);
-  }
-};
-
 export const confirmGuestAccount = async (
   user: typeof models.User,
-  guestTokensValues?: string[] | null,
 ): Promise<{
   collective: typeof models.Collective;
   user: typeof models.User;
@@ -192,32 +120,23 @@ export const confirmGuestAccount = async (
   await user.update({ emailConfirmationToken: null, confirmedAt: new Date() });
 
   // 2. Update the profile (collective)
-  const userCollective = await user.getCollective();
+  let userCollective = await user.getCollective();
   const newName = userCollective.name !== DEFAULT_GUEST_NAME ? userCollective.name : 'Incognito';
-  await userCollective.update({
+  userCollective = await userCollective.update({
     name: newName,
     slug: newName === 'Incognito' ? `user-${uuid().split('-')[0]}` : await models.Collective.generateSlug([newName]),
     data: { ...userCollective.data, isGuest: false, wasGuest: true },
   });
 
-  // 3. Link the other guest profiles & contributions
-  await linkOtherGuestProfiles(user, userCollective, guestTokensValues);
-
-  // 4. If name was updated by the merge, update the slug
-  await userCollective.reload();
-  if (newName !== userCollective.name && userCollective.slug.startsWith('user-')) {
-    await userCollective.update({
-      slug: await models.Collective.generateSlug([userCollective.name]),
-    });
-  }
-
   return { user, collective: userCollective };
 };
 
+/**
+ * Mark a guest account as "confirmed" if the provided `emailConfirmationToken` is valid
+ */
 export const confirmGuestAccountByEmail = async (
   email: string,
   emailConfirmationToken: string,
-  guestTokensValues?: string[] | null,
 ): Promise<{
   collective: typeof models.Collective;
   user: typeof models.User;
@@ -235,43 +154,5 @@ export const confirmGuestAccountByEmail = async (
     });
   }
 
-  return confirmGuestAccount(user, guestTokensValues);
-};
-
-const linkOtherGuestProfiles = async (user, userCollective, guestTokensValues) => {
-  const guestTokensConditions: Record<string, unknown>[] = [
-    // User owns the email, so we can safely link all the contributions made with it
-    { UserId: user.id },
-    // User main profile
-    { CollectiveId: userCollective.id },
-  ];
-
-  if (guestTokensValues?.length) {
-    // If users have some guest tokens, not matter what the profiles are, it means they are the ones
-    // who made the contributions for the profiles so we can safely link them
-    guestTokensConditions.push({ value: { [Op.in]: guestTokensValues } });
-  }
-
-  const guestTokens = await models.GuestToken.findAll({
-    where: { [Op.or]: guestTokensConditions },
-    include: [
-      {
-        association: 'collective',
-        required: true,
-      },
-    ],
-  });
-
-  if (guestTokens.length > 0) {
-    await Promise.all(
-      guestTokens
-        .filter(token => token.collective.id !== userCollective.id && token.collective.data.isGuest)
-        .map(token => mergeCollectives(token.collective, userCollective)),
-    );
-
-    // Delete all guest tokens
-    await models.GuestToken.destroy({
-      where: { id: { [Op.in]: guestTokens.map(token => token.id) } },
-    });
-  }
+  return confirmGuestAccount(user);
 };

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -25,7 +25,6 @@ export function setupModels(client) {
     'Expense',
     'ExpenseAttachedFile',
     'ExpenseItem',
-    'GuestToken',
     'HostApplication',
     'LegalDocument',
     'Member',
@@ -72,10 +71,6 @@ export function setupModels(client) {
     foreignKey: 'CollectiveId',
     constraints: false,
   });
-
-  // GuestTokens
-  m.GuestToken.belongsTo(m.Collective, { as: 'collective', foreignKey: 'CollectiveId' });
-  m.GuestToken.belongsTo(m.User, { as: 'user', foreignKey: 'UserId' });
 
   // Members
   m.Member.belongsTo(m.User, {

--- a/test/server/graphql/v2/mutation/GuestMutations.test.ts
+++ b/test/server/graphql/v2/mutation/GuestMutations.test.ts
@@ -16,8 +16,8 @@ const sendConfirmationMutation = gqlV2/* GraphQL */ `
 `;
 
 const confirmGuestAccountMutation = gqlV2/* GraphQL */ `
-  mutation ConfirmGuestAccount($email: EmailAddress!, $emailConfirmationToken: String!, $guestTokens: [String!]) {
-    confirmGuestAccount(email: $email, emailConfirmationToken: $emailConfirmationToken, guestTokens: $guestTokens) {
+  mutation ConfirmGuestAccount($email: EmailAddress!, $emailConfirmationToken: String!) {
+    confirmGuestAccount(email: $email, emailConfirmationToken: $emailConfirmationToken) {
       accessToken
       account {
         id
@@ -32,8 +32,8 @@ const callSendConfirmation = (email, remoteUser = null) => {
   return graphqlQueryV2(sendConfirmationMutation, { email }, remoteUser);
 };
 
-const callConfirmGuestAccount = (email, emailConfirmationToken, guestTokens = [], remoteUser = null) => {
-  return graphqlQueryV2(confirmGuestAccountMutation, { email, emailConfirmationToken, guestTokens }, remoteUser);
+const callConfirmGuestAccount = (email, emailConfirmationToken, remoteUser = null) => {
+  return graphqlQueryV2(confirmGuestAccountMutation, { email, emailConfirmationToken }, remoteUser);
 };
 
 describe('server/graphql/v2/mutation/GuestMutations', () => {

--- a/test/server/lib/guest-accounts.test.ts
+++ b/test/server/lib/guest-accounts.test.ts
@@ -3,71 +3,44 @@ import { expect } from 'chai';
 import { confirmGuestAccountByEmail, getOrCreateGuestProfile } from '../../../server/lib/guest-accounts';
 import models from '../../../server/models';
 import { randEmail } from '../../stores';
-import { fakeOrder, fakeUser, randStr } from '../../test-helpers/fake-data';
+import { fakeUser, randStr } from '../../test-helpers/fake-data';
 import { resetTestDB } from '../../utils';
 
 describe('server/lib/guest-accounts.ts', () => {
   before(resetTestDB);
 
   describe('getOrCreateGuestProfile', () => {
-    describe('Without a guest token', () => {
-      it('Creates an account + user if an email is provided', async () => {
-        const email = randEmail();
-        const { collective } = await getOrCreateGuestProfile({ email });
-        const user = await models.User.findOne({ where: { CollectiveId: collective.id } });
-        const token = await models.GuestToken.findOne({ where: { CollectiveId: collective.id } });
+    it('Creates an account + user if an email is provided', async () => {
+      const email = randEmail();
+      const { collective } = await getOrCreateGuestProfile({ email });
+      const user = await models.User.findOne({ where: { CollectiveId: collective.id } });
 
-        expect(token).to.exist;
-        expect(collective).to.exist;
-        expect(user.email).to.eq(email);
-      });
-
-      it('Rejects if a verified account already exists for this email', async () => {
-        const user = await fakeUser();
-        const guestAccountPromise = getOrCreateGuestProfile({ email: user.email });
-        await expect(guestAccountPromise).to.be.rejectedWith(
-          'An account already exists for this email, please sign in',
-        );
-      });
-
-      it('Re-use the same profile if a non-verified account already exists', async () => {
-        const user = await fakeUser({ confirmedAt: null });
-        const { collective } = await getOrCreateGuestProfile({ email: user.email });
-        expect(collective).to.exist;
-        expect(collective.id).to.eq(user.CollectiveId);
-      });
+      expect(collective).to.exist;
+      expect(user.email).to.eq(email);
     });
 
-    describe('With a guest token', () => {
-      it('Returns the same guest account if no email or same email is provided', async () => {
-        const email = randEmail();
-        const { collective } = await getOrCreateGuestProfile({ email });
-        const token = await models.GuestToken.findOne({ where: { CollectiveId: collective.id } });
+    it('Rejects if a verified account already exists for this email', async () => {
+      const user = await fakeUser();
+      const guestAccountPromise = getOrCreateGuestProfile({ email: user.email });
+      await expect(guestAccountPromise).to.be.rejectedWith('An account already exists for this email, please sign in');
+    });
 
-        expect((await getOrCreateGuestProfile({ token: token.value })).collective.id).to.eq(collective.id);
-        expect((await getOrCreateGuestProfile({ token: token.value, email })).collective.id).to.eq(collective.id);
-      });
+    it('Re-use the same profile if a non-verified account already exists', async () => {
+      const user = await fakeUser({ confirmedAt: null });
+      const { collective } = await getOrCreateGuestProfile({ email: user.email });
+      expect(collective).to.exist;
+      expect(collective.id).to.eq(user.CollectiveId);
+    });
 
-      it('Returns a new guest account if a different email is provided', async () => {
-        const email = randEmail();
-        const { collective } = await getOrCreateGuestProfile({ email });
-        const token = await models.GuestToken.findOne({ where: { CollectiveId: collective.id } });
-        const otherProfile = await getOrCreateGuestProfile({ token: token.value, email: randEmail() });
-
-        expect(otherProfile.collective.id).to.not.eq(collective.id);
-      });
-
-      it('Throws if a verified account exists for this email', async () => {
-        const user = await fakeUser();
-        const guestAccountPromise = getOrCreateGuestProfile({
-          email: user.email,
-          token: user.collective.guestToken, // should not have any impact, just to make sure we can't bypass the validation
-        });
-
-        await expect(guestAccountPromise).to.be.rejectedWith(
-          'An account already exists for this email, please sign in',
-        );
-      });
+    it('Updates the profile with new info', async () => {
+      const email = randEmail();
+      const firstResult = await getOrCreateGuestProfile({ email });
+      const secondResult = await getOrCreateGuestProfile({ email, name: 'Updated name' });
+      expect(firstResult.collective).to.exist;
+      expect(secondResult.collective).to.exist;
+      expect(firstResult.collective.id).to.eq(secondResult.collective.id);
+      expect(firstResult.collective.name).to.eq('Guest');
+      expect(secondResult.collective.name).to.eq('Updated name');
     });
   });
 
@@ -118,43 +91,6 @@ describe('server/lib/guest-accounts.ts', () => {
       expect(user.confirmedAt).to.not.be.null;
       expect(user.collective.name).to.eq('Zappa');
       expect(user.collective.slug).to.include('zappa');
-    });
-
-    it('links all the other guest profiles (with the guest tokens) and removes them', async () => {
-      const email = randEmail();
-      const { user, collective: mainProfile, token: guestToken } = await getOrCreateGuestProfile({ email });
-      const { collective: otherGuestProfile, token: otherGuestToken } = await getOrCreateGuestProfile({ email });
-      expect(user.confirmedAt).to.be.null;
-
-      // Create some fake data
-      const orders = await Promise.all([
-        fakeOrder({ FromCollectiveId: mainProfile.id }, { withTransactions: true }),
-        fakeOrder({ FromCollectiveId: otherGuestProfile.id }, { withTransactions: true }),
-      ]);
-
-      await confirmGuestAccountByEmail(user.email, user.emailConfirmationToken, [otherGuestToken.value]);
-      await user.reload({ include: [{ association: 'collective' }] });
-      expect(user.confirmedAt).to.not.be.null;
-
-      // Has deleted tokens
-      expect((await guestToken.reload({ paranoid: false })).deletedAt).to.not.be.null;
-      expect((await otherGuestToken.reload({ paranoid: false })).deletedAt).to.not.be.null;
-
-      // Has moved orders and transactions
-      await Promise.all(
-        orders.map(async o => {
-          await Promise.all(o.transactions.map(t => t.reload()));
-          await o.reload();
-        }),
-      );
-
-      expect(orders[0].FromCollectiveId).to.eq(mainProfile.id);
-      expect(orders[1].FromCollectiveId).to.eq(mainProfile.id);
-
-      const findCredit = transactions => transactions.find(t => t.type === 'CREDIT');
-      const findDebit = transactions => transactions.find(t => t.type === 'DEBIT');
-      expect(findCredit(orders[1].transactions).FromCollectiveId).to.eq(mainProfile.id);
-      expect(findDebit(orders[1].transactions).CollectiveId).to.eq(mainProfile.id);
     });
   });
 });


### PR DESCRIPTION
These guest tokens used to be a way to prove that you owned a guest profile. With the latest changes changes on guest contributions, it doesn't make sense to keep them.

A notion of "guest token" still exists in this refactored code, but instead of storing it in the `GuestTokens` column we store it in `order.data.guestToken`. It's a way to prove that you own the **order** that was created. That is useful when users call `confirmOrder`, because we need to make sure they're the order creator without asking them to authenticate. It will also be used in the future for https://github.com/opencollective/opencollective/issues/3834, for the same reasons.