### PR TITLE
fix(paymentReceipts): remove consolidated receipts for current month

### DIFF
--- a/server/lib/pdf.js
+++ b/server/lib/pdf.js
@@ -36,7 +36,7 @@ export const getTransactionPdf = async (transaction, user) => {
 
 export const getConsolidatedInvoicesData = async fromCollective => {
   const transactions = await models.Transaction.findAll({
-    attributes: ['createdAt', 'HostCollectiveId', 'amountInHostCurrency', 'hostCurrency'],
+    attributes: ['createdAt', 'HostCollectiveId', 'amountInHostCurrency', 'hostCurrency', 'CollectiveId'],
     where: {
       type: 'CREDIT',
       [Op.or]: [
@@ -55,6 +55,15 @@ export const getConsolidatedInvoicesData = async fromCollective => {
     if (!HostCollectiveId) {
       continue;
     }
+
+    if (fromCollective.id === transaction.CollectiveId) {
+      continue;
+    }
+
+    if (moment(transaction.createdAt).isSame(new Date(), 'month')) {
+      continue;
+    }
+
     if (!hostsById[HostCollectiveId]) {
       hostsById[HostCollectiveId] = await models.Collective.findByPk(HostCollectiveId, {
         attributes: ['id', 'slug'],

--- a/server/lib/pdf.js
+++ b/server/lib/pdf.js
@@ -40,7 +40,7 @@ export const getConsolidatedInvoicesData = async fromCollective => {
     where: {
       CollectiveId: { [Op.not]: fromCollective.id },
       ExpenseId: { [Op.eq]: null },
-      // createdAt: { [Op.lt]: moment().startOf('month') },
+      createdAt: { [Op.lt]: moment().startOf('month') },
       [Op.or]: [
         { FromCollectiveId: fromCollective.id, type: 'DEBIT', isRefund: true },
         { FromCollectiveId: fromCollective.id, type: 'CREDIT' },
@@ -53,8 +53,6 @@ export const getConsolidatedInvoicesData = async fromCollective => {
   const hostsById = {};
   const invoicesByKey = {};
   let invoices = [];
-
-  console.log(JSON.stringify(transactions, null, 2));
 
   for (const transaction of transactions) {
     const HostCollectiveId = transaction.HostCollectiveId;

--- a/server/lib/pdf.js
+++ b/server/lib/pdf.js
@@ -60,10 +60,6 @@ export const getConsolidatedInvoicesData = async fromCollective => {
       continue;
     }
 
-    // if (moment(transaction.createdAt).isSame(new Date(), 'month')) {
-    //   continue;
-    // }
-
     if (!hostsById[HostCollectiveId]) {
       hostsById[HostCollectiveId] = await models.Collective.findByPk(HostCollectiveId, {
         attributes: ['id', 'slug'],

--- a/server/lib/pdf.js
+++ b/server/lib/pdf.js
@@ -39,6 +39,7 @@ export const getConsolidatedInvoicesData = async fromCollective => {
     attributes: ['createdAt', 'HostCollectiveId', 'amountInHostCurrency', 'hostCurrency', 'CollectiveId'],
     where: {
       type: 'CREDIT',
+      CollectiveId: { [Op.not]: fromCollective.id },
       [Op.or]: [
         { FromCollectiveId: fromCollective.id, UsingGiftCardFromCollectiveId: null },
         { UsingGiftCardFromCollectiveId: fromCollective.id },
@@ -53,10 +54,6 @@ export const getConsolidatedInvoicesData = async fromCollective => {
   for (const transaction of transactions) {
     const HostCollectiveId = transaction.HostCollectiveId;
     if (!HostCollectiveId) {
-      continue;
-    }
-
-    if (fromCollective.id === transaction.CollectiveId) {
       continue;
     }
 


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/3684

- Removes transactions from current months in consolidated reciepts
- Removes transactions to self. i.e where `transaction.fromCollectiveId !== transaction.collectiveId`