### PR TITLE
Improve setCurrency

### DIFF
--- a/server/graphql/v2/input/AccountUpdateInput.js
+++ b/server/graphql/v2/input/AccountUpdateInput.js
@@ -1,0 +1,14 @@
+import { GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from 'graphql';
+
+import { Currency } from '../enum/Currency';
+
+export const AccountUpdateInput = new GraphQLInputObjectType({
+  name: 'AccountUpdateInput',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The public id identifying the account (ie: dgm9bnk8-0437xqry-ejpvzeol-jdayw5re)',
+    },
+    currency: { type: Currency },
+  }),
+});

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -9,7 +9,9 @@ import { verifyTwoFactorAuthenticatorCode } from '../../../lib/two-factor-authen
 import models, { sequelize } from '../../../models';
 import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../../errors';
 import { AccountTypeToModelMapping } from '../enum/AccountType';
+import { idDecode } from '../identifiers';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
+import { AccountUpdateInput } from '../input/AccountUpdateInput';
 import { Account } from '../interface/Account';
 import { Host } from '../object/Host';
 import { Individual } from '../object/Individual';
@@ -213,7 +215,7 @@ const accountMutations = {
     args: {
       account: {
         type: new GraphQLNonNull(AccountReferenceInput),
-        description: 'Account that will have 2FA added to it',
+        description: 'Account where the host plan will be edited.',
       },
       plan: {
         type: new GraphQLNonNull(GraphQLString),
@@ -251,6 +253,40 @@ const accountMutations = {
       }
 
       await cache.del(`plan_${account.id}`);
+
+      return account;
+    },
+  },
+  editAccount: {
+    type: new GraphQLNonNull(Host),
+    description: 'Edit key properties of an account.',
+    args: {
+      account: {
+        type: new GraphQLNonNull(AccountUpdateInput),
+        description: 'Account to edit.',
+      },
+    },
+    async resolve(_, args, req): Promise<object> {
+      if (!req.remoteUser) {
+        throw new Unauthorized();
+      }
+
+      const id = idDecode(args.account.id, 'account');
+      const account = await req.loaders.Collective.byId.load(id);
+      if (!account) {
+        throw new NotFound('Account Not Found');
+      }
+
+      if (!req.remoteUser.isAdminOfCollective(account) && !req.remoteUser.isRoot()) {
+        throw new Forbidden();
+      }
+
+      for (const key of Object.keys(args.account)) {
+        switch (key) {
+          case 'currency':
+            await account.setCurrency(args.account[key]);
+        }
+      }
 
       return account;
     },

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1835,7 +1835,10 @@ export default function (Sequelize, DataTypes) {
     const isHost = await this.isHost();
     if (isHost) {
       // We only expect currency change at the beginning of the history of the Host
-      const transactionCount = await models.Transaction.count({ where: { HostCollectiveId: this.id } });
+      // We're however good with it if currency is already recorded as hostCurrency in the ledger
+      const transactionCount = await models.Transaction.count({
+        where: { HostCollectiveId: this.id, hostCurrency: { [Op.not]: currency } },
+      });
       if (transactionCount > 0) {
         throw new Error(
           'You cannot change the currency of an Host with transactions. Please contact support@opencollective.com.',
@@ -1844,22 +1847,53 @@ export default function (Sequelize, DataTypes) {
       let collectives = await this.getHostedCollectives();
       collectives = collectives.filter(collective => collective.id !== this.id);
       // We use setCurrency so that it will cascade to Tiers
-      await Promise.map(collectives, collective => collective.setCurrency(currency), { concurrency: 3 });
+      if (collectives.length > 0) {
+        await Promise.map(
+          collectives,
+          async collective => {
+            const collectiveTransactionCount = await models.Transaction.count({
+              where: { CollectiveId: collective.id },
+            });
+            // We only proceed with Collectives without Transactions
+            if (collectiveTransactionCount === 0) {
+              return collective.setCurrency(currency);
+            }
+          },
+          { concurrency: 3 },
+        );
+      }
     }
 
-    // This is currently for COLLECTIVE and EVENTS but we make it generic
+    // Update all transactions
+    // Ensure consistency between collective.currency and transaction.currency
+    const transactions = await models.Transaction.findAll({ where: { CollectiveId: this.id } });
+    if (transactions.length > 0) {
+      await Promise.map(transactions, transaction => transaction.setCurrency(currency), { concurrency: 3 });
+    }
+
+    // Update tiers, skip or delete when they are already used?
     const tiers = await this.getTiers();
     if (tiers.length > 0) {
-      await Promise.map(tiers, tier => tier.update({ currency }), { concurrency: 3 });
+      await Promise.map(
+        tiers,
+        async tier => {
+          // We only proceed with Tiers without Orders
+          const orderCount = await models.Order.count({ where: { TierId: tier.id } });
+          if (orderCount === 0) {
+            return tier.setCurrency(currency);
+          }
+        },
+        { concurrency: 3 },
+      );
     }
 
     // Cascade currency to events and projects
     const events = await this.getEvents();
-    if (events?.length > 0) {
+    if (events.length > 0) {
       await Promise.map(events, event => event.setCurrency(currency), { concurrency: 3 });
     }
     const projects = await this.getProjects();
-    if (projects?.length > 0) {
+    if (projects.length > 0) {
       await Promise.map(projects, project => project.setCurrency(currency), { concurrency: 3 });
     }
 

--- a/server/models/Tier.js
+++ b/server/models/Tier.js
@@ -6,6 +6,7 @@ import { Op } from 'sequelize';
 import Temporal from 'sequelize-temporal';
 
 import { maxInteger } from '../constants/math';
+import logger from '../lib/logger';
 import { buildSanitizerOptions, sanitizeHTML } from '../lib/sanitize-html';
 import { capitalize, days, formatCurrency } from '../lib/utils';
 import { isSupportedVideoProvider, supportedVideoProviders } from '../lib/validators';
@@ -376,6 +377,15 @@ export default function (Sequelize, DataTypes) {
 
   Tier.prototype.checkAvailableQuantity = function (quantityNeeded = 1) {
     return this.availableQuantity().then(available => available - quantityNeeded >= 0);
+  };
+
+  Tier.prototype.setCurrency = async function (currency) {
+    // Nothing to do
+    if (currency === this.currency) {
+      return this;
+    }
+
+    return this.update({ currency });
   };
 
   /**

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import Promise from 'bluebird';
 import debugLib from 'debug';
 import { defaultsDeep, get, isNull, isUndefined, pick } from 'lodash';
@@ -321,6 +323,29 @@ export default (Sequelize, DataTypes) => {
     }
   };
 
+  Transaction.prototype.getOppositeTransaction = async function () {
+    return models.Transaction.findOne({
+      where: {
+        type: this.type === 'CREDIT' ? 'DEBIT' : 'CREDIT',
+        CollectiveId: this.FromCollectiveId,
+        FromCollectiveId: this.CollectiveId,
+        TransactionGroup: this.TransactionGroup,
+        PlatformTipForTransactionGroup: this.PlatformTipForTransactionGroup,
+      },
+    });
+  };
+
+  Transaction.prototype.setCurrency = async function (currency) {
+    // Nothing to do
+    if (currency === this.currency) {
+      return this;
+    }
+
+    await Transaction.updateCurrency(currency, this);
+
+    return this.save();
+  };
+
   /**
    * Class Methods
    */
@@ -450,7 +475,7 @@ export default (Sequelize, DataTypes) => {
       transaction.amountInHostCurrency = Math.round(transaction.amountInHostCurrency);
     }
 
-    // Is the target "collective" (account) "Active" (has an host, manage its own budget)
+    const collective = await models.Collective.findByPk(transaction.CollectiveId);
     const fromCollective = await models.Collective.findByPk(transaction.FromCollectiveId);
     const fromCollectiveHost = await fromCollective.getHostCollective();
 
@@ -468,20 +493,26 @@ export default (Sequelize, DataTypes) => {
         amount: -transaction.netAmountInCollectiveCurrency,
         netAmountInCollectiveCurrency: -transaction.amount,
         amountInHostCurrency: Math.round(-transaction.netAmountInCollectiveCurrency * transaction.hostCurrencyFxRate),
+
         hostFeeInHostCurrency: transaction.hostFeeInHostCurrency,
         platformFeeInHostCurrency: transaction.platformFeeInHostCurrency,
         paymentProcessorFeeInHostCurrency: transaction.paymentProcessorFeeInHostCurrency,
       };
     } else {
+      // Is the target "collective" (account) "Active" (has an host, manage its own budget)
       const currency = fromCollective.currency;
       const hostCurrency = fromCollectiveHost.currency;
 
-      const hostCurrencyFxRate = await getFxRate(currency, hostCurrency, transaction.createdAt);
-      const oppositeTransactionCurrencyFxRate = await getFxRate(transaction.currency, currency, transaction.createdAt);
-      const oppositeTransactionFeesCurrencyFxRate = await getFxRate(
+      const hostCurrencyFxRate = await Transaction.getFxRate(currency, hostCurrency, transaction);
+      const oppositeTransactionCurrencyFxRate = await Transaction.getFxRate(
+        transaction.currency,
+        currency,
+        transaction,
+      );
+      const oppositeTransactionHostCurrencyFxRate = await Transaction.getFxRate(
         transaction.hostCurrency,
         hostCurrency,
-        transaction.createdAt,
+        transaction,
       );
 
       const amount = -Math.round(transaction.netAmountInCollectiveCurrency * oppositeTransactionCurrencyFxRate);
@@ -495,16 +526,22 @@ export default (Sequelize, DataTypes) => {
         amount,
         netAmountInCollectiveCurrency: -Math.round(transaction.amount * oppositeTransactionCurrencyFxRate),
         amountInHostCurrency: Math.round(amount * hostCurrencyFxRate),
-        hostFeeInHostCurrency: Math.round(transaction.hostFeeInHostCurrency * oppositeTransactionFeesCurrencyFxRate),
+        hostFeeInHostCurrency: Math.round(transaction.hostFeeInHostCurrency * oppositeTransactionHostCurrencyFxRate),
         platformFeeInHostCurrency: Math.round(
-          transaction.platformFeeInHostCurrency * oppositeTransactionFeesCurrencyFxRate,
+          transaction.platformFeeInHostCurrency * oppositeTransactionHostCurrencyFxRate,
         ),
         paymentProcessorFeeInHostCurrency: Math.round(
-          transaction.paymentProcessorFeeInHostCurrency * oppositeTransactionFeesCurrencyFxRate,
+          transaction.paymentProcessorFeeInHostCurrency * oppositeTransactionHostCurrencyFxRate,
         ),
-        data: { ...transaction.data, oppositeTransactionCurrencyFxRate, oppositeTransactionFeesCurrencyFxRate },
+        data: { ...transaction.data, oppositeTransactionCurrencyFxRate, oppositeTransactionHostCurrencyFxRate },
       };
     }
+
+    // Adjust currency of the transaction if necessary
+    // NOTE: disabled for now, many tests failing
+    // if (transaction.currency !== collective.currency) {
+    //   transaction = await Transaction.updateCurrency(collective.currency, transaction);
+    // }
 
     debug('createDoubleEntry', transaction, 'opposite', oppositeTransaction);
 
@@ -605,9 +642,12 @@ export default (Sequelize, DataTypes) => {
     transaction.CreatedByUserId = CreatedByUserId;
     transaction.FromCollectiveId = FromCollectiveId;
     transaction.CollectiveId = CollectiveId;
-    transaction.TransactionGroup = uuid();
     transaction.PaymentMethodId = transaction.PaymentMethodId || PaymentMethodId;
+
+    // Compute these values, they will eventually be checked again by createDoubleEntry
+    transaction.TransactionGroup = uuid();
     transaction.type = transaction.amount > 0 ? TransactionTypes.CREDIT : TransactionTypes.DEBIT;
+
     transaction.hostFeeInHostCurrency = toNegative(transaction.hostFeeInHostCurrency);
     transaction.platformFeeInHostCurrency = toNegative(transaction.platformFeeInHostCurrency);
     transaction.taxAmount = toNegative(transaction.taxAmount);
@@ -618,19 +658,10 @@ export default (Sequelize, DataTypes) => {
       transaction = await Transaction.createFeesOnTopTransaction({ transaction });
     }
 
+    // populate netAmountInCollectiveCurrency for financial contributions
+    // TODO: why not for other transactions?
     if (transaction.amount > 0) {
-      // populate netAmountInCollectiveCurrency for donations
-      const fees =
-        (transaction.taxAmount || 0) +
-        transaction.platformFeeInHostCurrency +
-        transaction.hostFeeInHostCurrency +
-        transaction.paymentProcessorFeeInHostCurrency;
-      transaction.netAmountInCollectiveCurrency = transaction.amountInHostCurrency + fees; // `fees` is a negative number
-      if (transaction.hostCurrencyFxRate) {
-        transaction.netAmountInCollectiveCurrency = Math.round(
-          transaction.netAmountInCollectiveCurrency / transaction.hostCurrencyFxRate,
-        );
-      }
+      transaction.netAmountInCollectiveCurrency = Transaction.calculateNetAmountInCollectiveCurrency(transaction);
     }
 
     return Transaction.createDoubleEntry(transaction);
@@ -707,6 +738,156 @@ export default (Sequelize, DataTypes) => {
     };
 
     return models.Transaction.create(payload);
+  };
+
+  Transaction.calculateNetAmountInCollectiveCurrency = function (transaction) {
+    const transactionFees =
+      transaction.platformFeeInHostCurrency +
+      transaction.hostFeeInHostCurrency +
+      transaction.paymentProcessorFeeInHostCurrency;
+
+    const transactionTaxes = transaction.taxAmount || 0;
+
+    const hostCurrencyFxRate = transaction.hostCurrencyFxRate || 1;
+
+    return Math.round((transaction.amountInHostCurrency + transactionFees) / hostCurrencyFxRate + transactionTaxes);
+  };
+
+  Transaction.getFxRate = async function (fromCurrency, toCurrency, transaction) {
+    if (fromCurrency === toCurrency) {
+      return 1;
+    }
+
+    // If Stripe transaction, we check if we have the rate stored locally in the transaction
+    // eslint-disable-next-line camelcase
+    if (transaction.data?.balanceTransaction?.exchange_rate) {
+      if (
+        transaction.data?.charge?.currency === fromCurrency.toLowerCase() &&
+        transaction.data?.balanceTransaction?.currency === toCurrency.toLowerCase()
+      ) {
+        return transaction.data.balanceTransaction.exchange_rate; // eslint-disable-line camelcase
+      }
+      if (
+        transaction.data?.charge?.currency === toCurrency.toLowerCase() &&
+        transaction.data?.balanceTransaction?.currency === fromCurrency.toLowerCase()
+      ) {
+        return 1 / transaction.data.balanceTransaction.exchange_rate; // eslint-disable-line camelcase
+      }
+    }
+
+    return getFxRate(fromCurrency, toCurrency, transaction.createdAt);
+  };
+
+  Transaction.updateCurrency = async function (currency, transaction) {
+    // Nothing to do
+    if (currency === transaction.currency) {
+      return transaction;
+    }
+
+    // Immediately convert taxAmount if necessary
+    // We don't store it in hostCurrency and can't populate like other values
+    if (transaction.taxAmount) {
+      const previousCurrency = transaction.currency;
+      const fxRate = await Transaction.getFxRate(previousCurrency, currency, transaction);
+      transaction.taxAmount = Math.round(transaction.taxAmount * fxRate);
+    }
+
+    transaction.currency = currency;
+    transaction.hostCurrencyFxRate = await Transaction.getFxRate(
+      transaction.currency,
+      transaction.hostCurrency,
+      transaction,
+    );
+
+    // REMINDER: amount * hostCurrencyFxRate = amountInHostCurrency
+    // so: amount = amountInHostCurrency / hostCurrencyFxRate
+    transaction.amount = Math.round(transaction.amountInHostCurrency / transaction.hostCurrencyFxRate);
+    transaction.netAmountInCollectiveCurrency = Transaction.calculateNetAmountInCollectiveCurrency(transaction);
+
+    return transaction;
+  };
+
+  Transaction.validate = async transaction => {
+    // Skip as there is a known bug there
+    // https://github.com/opencollective/opencollective/issues/3935
+    if (transaction.PlatformTipForTransactionGroup) {
+      return;
+    }
+
+    // Skip as there is a known bug there
+    // https://github.com/opencollective/opencollective/issues/3934
+    if (transaction.PlatformTipForTransactionGroup && transaction.taxAmount) {
+      return;
+    }
+
+    const hostCurrencyFxRate = transaction.hostCurrencyFxRate || 1;
+
+    Transaction.assertAmountsLooselyEqual(
+      transaction.amount,
+      Math.round(transaction.amountInHostCurrency / hostCurrencyFxRate),
+      'amount and amountInHostCurrency should match',
+    );
+
+    const netAmountInCollectiveCurrency = Transaction.calculateNetAmountInCollectiveCurrency(transaction);
+    Transaction.assertAmountsLooselyEqual(
+      transaction.netAmountInCollectiveCurrency,
+      netAmountInCollectiveCurrency,
+      'netAmountInCollectiveCurrency should be accurate',
+    );
+
+    // Stop there in this case, no need to check oppositeTransaction as it doesn't exist
+    if (transaction.CollectiveId === transaction.FromCollectiveId) {
+      return;
+    }
+
+    const oppositeTransaction = await transaction.getOppositeTransaction();
+    assert(oppositeTransaction, 'oppositeTransaction should be existing');
+
+    // Opposite transaction should match
+    if (transaction.currency === oppositeTransaction.currency) {
+      // Simple case
+      Transaction.assertAmountsStrictlyEqual(
+        oppositeTransaction.netAmountInCollectiveCurrency,
+        -1 * transaction.amount,
+        'netAmountInCollectiveCurrency in oppositeTransaction should match',
+      );
+      Transaction.assertAmountsStrictlyEqual(
+        oppositeTransaction.amount,
+        -1 * transaction.netAmountInCollectiveCurrency,
+        'amount in oppositeTransaction should match',
+      );
+    } else {
+      // Complex case
+      const oppositeTransactionCurrencyFxRate =
+        // Use the one stored locally in oppositeTransaction
+        oppositeTransaction.data?.oppositeTransactionCurrencyFxRate ||
+        // Use the one stored locally in transaction
+        (transaction.data?.oppositeTransactionCurrencyFxRate
+          ? 1 / transaction.data?.oppositeTransactionCurrencyFxRate
+          : null) ||
+        // Fetch from getFxRate
+        (await Transaction.getFxRate(transaction.currency, oppositeTransaction.currency, transaction));
+
+      Transaction.assertAmountsLooselyEqual(
+        oppositeTransaction.netAmountInCollectiveCurrency,
+        -Math.round(transaction.amount * oppositeTransactionCurrencyFxRate),
+        'netAmountInCollectiveCurrency in oppositeTransaction should match',
+      );
+
+      Transaction.assertAmountsLooselyEqual(
+        oppositeTransaction.amount,
+        -Math.round(transaction.netAmountInCollectiveCurrency * oppositeTransactionCurrencyFxRate),
+        'amount in oppositeTransaction should match',
+      );
+    }
+  };
+
+  Transaction.assertAmountsStrictlyEqual = (actual, expected, message) => {
+    assert.equal(actual, expected, `${message}: ${actual} doesn't strictly equal to ${expected}`);
+  };
+
+  Transaction.assertAmountsLooselyEqual = (actual, expected, message) => {
+    assert(Math.abs(actual - expected) <= 1, `${message}: ${actual} doesn't loosely equal to ${expected}`);
   };
 
   return Transaction;

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -319,7 +319,7 @@ export const fakeConversation = async (conversationData = {}) => {
 export const fakeTier = async (tierData = {}) => {
   const name = randStr('tier');
   const interval = sample(['month', 'year']);
-  const currency = sample(['USD', 'EUR']);
+  const currency = tierData.currency || sample(['USD', 'EUR']);
   const amount = tierData.amount || randAmount(1, 100) * 100;
   const description = `$${amount / 100}/${interval}`;
 


### PR DESCRIPTION
- Cascade to transactions, transaction.setCurrency
- GraphQL mutation to do it for admins and root admins
- Fix issue for hosted collectives (will be backported)
- Allow hosts and self hosted to update (if hostCurrency is already good in the ledger)
- Skip Tiers if they have attached orders