### PR TITLE
Fix Expense varchar (255) size error

### DIFF
--- a/migrations/20210129133000-switch-expense-text-types.js
+++ b/migrations/20210129133000-switch-expense-text-types.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async function (queryInterface, DataTypes) {
+    await queryInterface.changeColumn('Expenses', 'privateMessage', {
+      type: DataTypes.TEXT,
+    });
+    await queryInterface.changeColumn('ExpenseHistories', 'privateMessage', {
+      type: DataTypes.TEXT,
+    });
+    await queryInterface.changeColumn('ExpenseItems', 'description', {
+      type: DataTypes.TEXT,
+    });
+  },
+
+  down: async function (queryInterface, DataTypes) {
+    await queryInterface.changeColumn('Expenses', 'privateMessage', {
+      type: DataTypes.STRING,
+    });
+    await queryInterface.changeColumn('ExpenseHistories', 'privateMessage', {
+      type: DataTypes.STRING,
+    });
+    await queryInterface.changeColumn('ExpenseItems', 'description', {
+      type: DataTypes.STRING,
+    });
+  },
+};

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -139,7 +139,7 @@ export default function (Sequelize, DataTypes) {
       },
 
       privateMessage: {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT,
         set(value) {
           if (value) {
             const cleanHtml = sanitizeHTML(value, PRIVATE_MESSAGE_SANITIZE_OPTS).trim();

--- a/server/models/ExpenseItem.ts
+++ b/server/models/ExpenseItem.ts
@@ -104,7 +104,7 @@ export default (sequelize, DataTypes): typeof ExpenseItem => {
         },
       },
       description: {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT,
         allowNull: true,
       },
       createdAt: {


### PR DESCRIPTION
Both `Expense.privateMessage` and `ExpenseItem.description` accept HTML content.
Our tables are apparently correct in the case of `Expense.privateMessage` but the Sequelize model is not.
Either way, I'm updating both models and writing a migration to make it consistent.