### PR TITLE
PayPal Webhook DOS

### DIFF
--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -8,7 +8,7 @@ import status from '../../constants/expense_status';
 import logger from '../../lib/logger';
 import * as paypal from '../../lib/paypal';
 import { createFromPaidExpense as createTransactionFromPaidExpense } from '../../lib/transactions';
-import models, { Op, sequelize } from '../../models';
+import models from '../../models';
 import { PayoutItemDetails } from '../../types/paypal';
 
 export const payExpensesBatch = async (expenses: any[]): Promise<any[]> => {
@@ -78,20 +78,6 @@ export const checkBatchItemStatus = async (item: PayoutItemDetails, expense: any
   await expense.reload();
   if (expense.data.payout_batch_id !== item.payout_batch_id) {
     throw new Error(`Item does not belongs to expense it claims it does.`);
-  }
-  // Checks existing transaction to prevent race conditions from multiple webhook calls.
-  const existingTransaction = await models.Transaction.findOne({
-    where: {
-      data: { payout_item_id: item.payout_item_id, transaction_id: item.transaction_id },
-      // We add a time-frame here as a boundary to this data (JSONB) query
-      createdAt: {
-        [Op.gte]: sequelize.literal("NOW() - INTERVAL '1 hour'"),
-      },
-    },
-  });
-  if (existingTransaction) {
-    logger.debug(`Item already processed as transaction #${existingTransaction.id}`);
-    return;
   }
 
   const paymentProcessorFeeInHostCurrency = round(toNumber(item.payout_item_fee?.value) * 100);


### PR DESCRIPTION
Turns out the race-condition verification is a bit expensive:
```
Seq Scan on "Transactions" "Transaction"  (cost=0.00..75323.30 rows=1 width=812) (actual time=7262.463..7262.463 rows=0 loops=1)
  Filter: (("deletedAt" IS NULL) AND ((data #>> '{payout_item_id}'::text[]) = 'xxxx'::text) AND ((data #>> '{transaction_id}'::text[]) = 'xxxx'::text) AND ("createdAt" >= (now() - '01:00:00'::interval)))
  Rows Removed by Filter: 696172
Planning time: 1.123 ms
Execution time: 7262.528 ms
```

I'm reverting this, which is OK because we actually had a single case in the past year and it turns out most of the duplicate charges on expenses are due to multiple payments of the expense.

I'm also adding a bit more info in our PayPal webhook handler.