### PR TITLE
feat(ocf-application): allow existing collective admin to apply to OCF host

### DIFF
--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -1,4 +1,5 @@
 import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
+import GraphQLJSON from 'graphql-type-json';
 
 import { activities } from '../../../constants';
 import { types as CollectiveType } from '../../../constants/collectives';
@@ -46,6 +47,10 @@ const HostApplicationMutations = {
         type: GraphQLString,
         description: 'A message to attach for the host to review the application',
       },
+      applicationData: {
+        type: GraphQLJSON,
+        description: 'Further information about collective applying to host',
+      },
     },
     async resolve(_, args, req): Promise<object> {
       if (!req.remoteUser) {
@@ -70,7 +75,10 @@ const HostApplicationMutations = {
 
       // No need to check the balance, this is being handled in changeHost, along with most other checks
 
-      return collective.changeHost(host.id, req.remoteUser, args.message);
+      return collective.changeHost(host.id, req.remoteUser, {
+        message: args.message,
+        applicationData: args.applicationData,
+      });
     },
   },
   processHostApplication: {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2056,7 +2056,7 @@ export default function (Sequelize, DataTypes) {
    * @param {*} newHostCollective: { id }
    * @param {*} remoteUser { id }
    */
-  Collective.prototype.changeHost = async function (newHostCollectiveId, remoteUser, message) {
+  Collective.prototype.changeHost = async function (newHostCollectiveId, remoteUser, options) {
     // Skip
     if (this.HostCollectiveId == newHostCollectiveId) {
       return this;
@@ -2112,7 +2112,10 @@ export default function (Sequelize, DataTypes) {
       if (!newHostCollective.isHostAccount) {
         await newHostCollective.becomeHost({ remoteUser });
       }
-      return this.addHost(newHostCollective, remoteUser, { message });
+      return this.addHost(newHostCollective, remoteUser, {
+        message: options?.message,
+        applicationData: options?.applicationData,
+      });
     } else {
       // if we remove the host
       return this.save();


### PR DESCRIPTION
Following up https://github.com/opencollective/opencollective-frontend/pull/5833 on the recent [update](https://github.com/opencollective/opencollective/issues/3683#issuecomment-769566325) to OCF onboarding flow, this PR allows authenticated admin of existing collective to apply to Open collective foundation.