### PR TITLE
Features: Improve returned values

### DIFF
--- a/server/graphql/common/features.ts
+++ b/server/graphql/common/features.ts
@@ -11,6 +11,21 @@ const checkIsActive = (
   return promise.then(result => (result ? FEATURE_STATUS.ACTIVE : fallback));
 };
 
+const checkReceiveFinancialContributions = collective => {
+  if (!collective.HostCollectiveId || !collective.approvedAt) {
+    return FEATURE_STATUS.DISABLED;
+  } else if (!collective.isActive) {
+    return FEATURE_STATUS.UNSUPPORTED;
+  } else {
+    return checkIsActive(
+      models.Order.count({
+        where: { CollectiveId: collective.id, status: { [Op.or]: ['PAID', 'ACTIVE'] } },
+        limit: 1,
+      }),
+    );
+  }
+};
+
 /**
  * Returns a resolved that will give the `FEATURE_STATUS` for the given collective/feature.
  */
@@ -28,6 +43,8 @@ export const getFeatureStatusResolver = (feature: FEATURE) => async (
   // Add some special cases that check for data to see if the feature is `ACTIVE` or just `AVAILABLE`
   // Right now only UPDATES, CONVERSATIONS, and RECURRING CONTRIBUTIONS
   switch (feature) {
+    case FEATURE.RECEIVE_FINANCIAL_CONTRIBUTIONS:
+      return checkReceiveFinancialContributions(collective);
     case FEATURE.RECEIVE_EXPENSES:
       return checkIsActive(models.Expense.count({ where: { CollectiveId: collective.id }, limit: 1 }));
     case FEATURE.UPDATES:


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-frontend/pull/5836 to be deployed first

Better differentiate between `RECEIVE_FINANCIAL_CONTRIBUTIONS` status