### PR TITLE
Keep ExpenseId in its refund transactions

### DIFF
--- a/migrations/20210210172000-fix-refunded-expense-transactions.js
+++ b/migrations/20210210172000-fix-refunded-expense-transactions.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      UPDATE "Transactions" t SET "ExpenseId" = r."ExpenseId"
+      FROM "Transactions" r
+      WHERE
+        t."RefundTransactionId" IS NOT NULL
+        AND t."isRefund" IS TRUE
+        AND t."RefundTransactionId" = r."id"
+        AND t."ExpenseId" IS NULL
+        AND r."ExpenseId" IS NOT NULL;
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -168,6 +168,7 @@ export async function createRefundTransaction(transaction, refundedPaymentProces
       'HostCollectiveId',
       'PaymentMethodId',
       'OrderId',
+      'ExpenseId',
       'hostCurrencyFxRate',
       'hostCurrency',
       'hostFeeInHostCurrency',


### PR DESCRIPTION
For debugging reasons.