### PR TITLE
Various enhancements for pending bank transfers

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1005,7 +1005,7 @@ export async function markExpenseAsUnpaid(req, ExpenseId, processorFeeRefunded):
     }
 
     const transaction = await models.Transaction.findOne({
-      where: { ExpenseId },
+      where: { ExpenseId, RefundTransactionId: null },
       include: [{ model: models.Expense }],
     });
 

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -19,6 +19,7 @@ import { getTransactionPdf } from './pdf';
 import { subscribeOrUpgradePlan, validatePlanRequest } from './plans';
 import { createPrepaidPaymentMethod, isPrepaidBudgetOrder } from './prepaid-budget';
 import { getNextChargeAndPeriodStartDates } from './recurring-contributions';
+import { stripHTML } from './sanitize-html';
 import { netAmount } from './transactions';
 import { formatAccountDetails } from './transferwise';
 import { formatCurrency, toIsoDateStr } from './utils';
@@ -492,11 +493,11 @@ export const sendOrderProcessingEmail = async order => {
       // @deprecated but we still have some entries in the DB
       OrderId: order.id,
     };
-    data.instructions = instructions.replace(/{([\s\S]+?)}/g, (match, key) => {
+    data.instructions = stripHTML(instructions).replace(/{([\s\S]+?)}/g, (match, key) => {
       if (key && formatValues[key]) {
-        return formatValues[key];
+        return `<strong>${stripHTML(formatValues[key])}</strong>`;
       } else {
-        return match;
+        return stripHTML(match);
       }
     });
   }

--- a/templates/emails/collective.expense.paid.hbs
+++ b/templates/emails/collective.expense.paid.hbs
@@ -11,7 +11,16 @@ Subject: {{#ifCond expense.currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond expen
 
 <center>
   <h3>Hi there!</h3>
-  <p>Just a quick note to let you know that your expense <b><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b> that you filed on {{moment expense.createdAt}} to the <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}} collective</a> has just been paid.</p>
+  <p>
+    Just a quick note to let you know that your expense <b><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b> that you filed on {{moment expense.createdAt}} to the <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}} collective</a> has just been paid.
+    {{#if expense.payoutMethod}}
+      {{#ifCond expense.payoutMethod.type '===' 'BANK_ACCOUNT'}}
+        The money can take a few days to arrive, depending on each bank's timeline.
+      {{/ifCond}}
+    {{else}}
+      The money can take a few days to arrive, depending on each bank's timeline.
+    {{/if}}
+  </p>
   <h2>{{currency expense.amount currency=expense.currency precision=2}}</h2>
   <div>{{transaction.description}}</div>
   <table>

--- a/templates/emails/order.processing.hbs
+++ b/templates/emails/order.processing.hbs
@@ -29,7 +29,7 @@ currency=order.currency}}} {{order.type}} to {{collective.name}} is pending
 {{#if instructions}}
 <section>
   <h2>Instructions</h2>
-  <pre>{{instructions}}</pre>
+  <pre>{{{instructions}}}</pre>
 </section>
 {{/if}}
 

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -303,7 +303,7 @@ describe('server/graphql/v1/createOrder', () => {
     expect(actionRequiredEmailArgs[0]).to.equal(remoteUser.email);
     expect(actionRequiredEmailArgs[2]).to.match(/IBAN 1234567890987654321/);
     expect(actionRequiredEmailArgs[2]).to.match(
-      /for the amount of \$20\.00 with the mention: webpack event backer order: [0-9]+/,
+      /for the amount of <strong>\$20\.00<\/strong> with the mention: <strong>webpack event<\/strong> <strong>backer<\/strong> order: <strong>[0-9]+<\/strong>/,
     );
     expect(actionRequiredEmailArgs[1]).to.equal('ACTION REQUIRED: your $20 registration to meetup is pending');
   });


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3916

- Mark unpaid crash when already refunded in the past
- Bold reference for pending orders
- Add info about the processing time for the "expense paid" email

![image](https://user-images.githubusercontent.com/1556356/108698211-2b32ca80-7504-11eb-9707-d0dae4f96cbc.png)
