### PR TITLE
Collective: Improve getUser definition

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1120,13 +1120,11 @@ export default function (Sequelize, DataTypes) {
   };
 
   // Returns the User model of the User that created this collective
-  Collective.prototype.getUser = function (queryParams) {
-    switch (this.type) {
-      case types.USER:
-      case types.ORGANIZATION:
-        return models.User.findByPk(this.CreatedByUserId, queryParams);
-      default:
-        return Promise.resolve(null);
+  Collective.prototype.getUser = async function (queryParams) {
+    if (this.type === types.USER) {
+      return models.User.findOne({ where: { CollectiveId: this.id, isIncognito: false }, ...queryParams });
+    } else {
+      return null;
     }
   };
 


### PR DESCRIPTION
I saw this while looking at this function to use it. Relying on `CreatedByUserId` is not what we want, but I hope changing that won't break anything.