### PR TITLE
Behavior consistency when an expense gets paid

### DIFF
--- a/migrations/20210224160945-fix-expense-contributor-members.js
+++ b/migrations/20210224160945-fix-expense-contributor-members.js
@@ -1,0 +1,68 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // 1. Add the missing CONTRIBUTOR members (~1143 entries)
+    await queryInterface.sequelize.query(`
+      INSERT INTO "Members" (
+        "CreatedByUserId", "MemberCollectiveId", "CollectiveId", "role", "since"
+      ) SELECT
+        u."id" AS "CreatedByUserId",
+        u."CollectiveId" AS "MemberCollectiveId",
+        e."CollectiveId" AS "CollectiveId",
+        'CONTRIBUTOR' as "role",
+        MIN(e."createdAt") AS "since"
+      FROM
+        "Expenses" e
+      INNER JOIN "Collectives" from_collective
+        ON e."FromCollectiveId" = from_collective.id
+        AND from_collective."type" = 'USER'
+      INNER JOIN "Users" u
+        ON u."CollectiveId" = from_collective.id
+      LEFT JOIN "Members" m
+        ON m."MemberCollectiveId" = e."FromCollectiveId"
+        AND m."CollectiveId" = e."CollectiveId"
+        AND "role" = 'CONTRIBUTOR'
+      WHERE
+        e."deletedAt" IS NULL
+        AND from_collective."deletedAt" IS NULL
+        AND u."deletedAt" IS NULL
+        AND e.status = 'PAID'
+      GROUP BY
+        e."CollectiveId",
+        u."id" 
+      HAVING
+        COUNT(m.id) = 0
+    `);
+
+    // 2. Remove duplicate members for role=CONTRIBUTOR (~20915 entries) - see https://github.com/opencollective/opencollective/issues/2753
+    await queryInterface.sequelize.query(`
+      WITH duplicate_members_to_remove AS (
+        SELECT
+          duplicate_members.id AS "id"
+        FROM
+          "Members" members,
+          "Members" duplicate_members
+        WHERE
+          -- Always keep the oldest entry
+          duplicate_members.id > members.id
+          AND members."CollectiveId" = duplicate_members."CollectiveId"
+          AND members."MemberCollectiveId" = duplicate_members."MemberCollectiveId"
+          AND members."role" = duplicate_members."role"
+          AND ((members."TierId" IS NULL AND duplicate_members."TierId" IS NULL) OR (members."TierId" = duplicate_members."TierId"))
+          AND members."deletedAt" IS NULL AND duplicate_members."deletedAt" IS NULL
+        GROUP BY duplicate_members.id
+      ) UPDATE "Members" member
+      SET
+        "deletedAt" = NOW()
+      FROM
+        duplicate_members_to_remove
+      WHERE
+        member.id = duplicate_members_to_remove.id
+    `);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /** Reverting should be done manually (using `createdAt`/`deletedAt`) */
+  },
+};

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1556,6 +1556,19 @@ export default function (Sequelize, DataTypes) {
       ...defaultAttributes,
     };
 
+    const existingMember = await models.Member.findOne({
+      where: {
+        role,
+        MemberCollectiveId: user.CollectiveId,
+        CollectiveId: this.id,
+        TierId: defaultAttributes?.TierId || null,
+      },
+    });
+
+    if (existingMember) {
+      return existingMember;
+    }
+
     debug('addUserWithRole', user.id, role, 'member', memberAttributes);
 
     const member = await models.Member.create(memberAttributes, sequelizeParams);


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-frontend/pull/5938

This PR addresses behavior inconsistencies when expenses get paid, mainly in the `CONTRIBUTOR` member creation and the "Expense paid" activity creation.

- Fix https://github.com/opencollective/opencollective/issues/2753: The new code now checks if a member exists before creating it and the migration makes sure we delete the duplicates

- Fix the missing member issue reported in [Slack](https://opencollective.slack.com/archives/C0RMV6F8C/p1614133975019300)
We were only adding users as contributors when the expense was paid manually. I've moved the member creation in `setPaid` to make sure we always create the entry, regardless of how the expense was paid. The migration takes care of creating all the entries that we missed.

- Fix missing webhook notifications: there was no `createActivity` when paying an expense with PayPal