### PR TITLE
Members: Add email argument

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -83,6 +83,11 @@ interface Account {
     role: [MemberRole]
 
     """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
+
+    """
     Type of accounts (BOT/COLLECTIVE/EVENT/ORGANIZATION/INDIVIDUAL)
     """
     accountType: [AccountType]
@@ -585,6 +590,11 @@ type Bot implements Account {
     accountType: [AccountType]
 
     """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
+
+    """
     Order of the results
     """
     orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
@@ -812,6 +822,11 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     offset: Int = 0
     role: [MemberRole]
     accountType: [AccountType]
+
+    """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
 
     """
     Order of the results
@@ -2701,9 +2716,19 @@ All supported currencies
 """
 enum Currency {
   """
+  Argentine Peso
+  """
+  ARS
+
+  """
   Australian Dollar
   """
   AUD
+
+  """
+  Taka
+  """
+  BDT
 
   """
   Bulgarian Lev
@@ -2744,6 +2769,11 @@ enum Currency {
   Pound Sterling
   """
   GBP
+
+  """
+  Hong Kong Dollar
+  """
+  HKD
 
   """
   Kuna
@@ -2791,6 +2821,11 @@ enum Currency {
   NOK
 
   """
+  Nepalese Rupee
+  """
+  NPR
+
+  """
   New Zealand Dollar
   """
   NZD
@@ -2811,6 +2846,11 @@ enum Currency {
   SEK
 
   """
+  Singapore Dollar
+  """
+  SGD
+
+  """
   US Dollar
   """
   USD
@@ -2819,6 +2859,11 @@ enum Currency {
   Peso Uruguayo
   """
   UYU
+
+  """
+  Rand
+  """
+  ZAR
 }
 
 scalar DateString
@@ -2949,6 +2994,11 @@ type Event implements Account & AccountWithHost & AccountWithContributions {
     offset: Int = 0
     role: [MemberRole]
     accountType: [AccountType]
+
+    """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
 
     """
     Order of the results
@@ -3827,6 +3877,11 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
     accountType: [AccountType]
 
     """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
+
+    """
     Order of the results
     """
     orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
@@ -4131,6 +4186,11 @@ type Host implements Account & AccountWithContributions {
     offset: Int = 0
     role: [MemberRole]
     accountType: [AccountType]
+
+    """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
 
     """
     Order of the results
@@ -4638,6 +4698,11 @@ type Individual implements Account {
     offset: Int = 0
     role: [MemberRole]
     accountType: [AccountType]
+
+    """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
 
     """
     Order of the results
@@ -5895,6 +5960,11 @@ type Organization implements Account & AccountWithContributions {
     accountType: [AccountType]
 
     """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
+
+    """
     Order of the results
     """
     orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
@@ -6362,6 +6432,11 @@ type Project implements Account & AccountWithHost & AccountWithContributions {
     offset: Int = 0
     role: [MemberRole]
     accountType: [AccountType]
+
+    """
+    Admin only. To filter on the email address of a member, useful to check if a member exists.
+    """
+    email: EmailAddress
 
     """
     Order of the results

--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -32,6 +32,7 @@ import { PaymentMethod } from '../object/PaymentMethod';
 import PayoutMethod from '../object/PayoutMethod';
 import { TagStats } from '../object/TagStats';
 import { TransferWise } from '../object/TransferWise';
+import EmailAddress from '../scalar/EmailAddress';
 
 import { CollectionArgs } from './Collection';
 
@@ -132,6 +133,10 @@ const accountFieldsDefinition = () => ({
       limit: { type: GraphQLInt, defaultValue: 100 },
       offset: { type: GraphQLInt, defaultValue: 0 },
       role: { type: new GraphQLList(MemberRole) },
+      email: {
+        type: EmailAddress,
+        description: 'Admin only. To filter on the email address of a member, useful to check if a member exists.',
+      },
       accountType: {
         type: new GraphQLList(AccountType),
         description: 'Type of accounts (BOT/COLLECTIVE/EVENT/ORGANIZATION/INDIVIDUAL)',

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -186,6 +186,13 @@ export function setupModels(client) {
   m.Collective.hasMany(m.Member, { foreignKey: 'CollectiveId', as: 'members' });
   m.Collective.hasMany(m.Order, { foreignKey: 'CollectiveId', as: 'orders' });
   m.Collective.hasMany(m.LegalDocument, { foreignKey: 'CollectiveId', as: 'legalDocuments' });
+  m.Collective.hasOne(m.User, {
+    as: 'user',
+    foreignKey: 'CollectiveId',
+    constraints: false,
+    allowNull: true,
+    defaultValue: null,
+  });
   m.Transaction.belongsTo(m.Order);
   m.Order.hasMany(m.Transaction);
   m.Tier.hasMany(m.Order);

--- a/test/server/graphql/v2/query/AccountQuery.test.js
+++ b/test/server/graphql/v2/query/AccountQuery.test.js
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
 import gqlV2 from 'fake-tag';
+import { times } from 'lodash';
 
 import { roles } from '../../../../../server/constants';
+import { randEmail } from '../../../../stores';
 import { fakeCollective, fakeUser } from '../../../../test-helpers/fake-data';
 import { graphqlQueryV2 } from '../../../../utils';
 
@@ -46,6 +48,85 @@ describe('server/graphql/v2/query/AccountQuery', () => {
         expect(resultUnauthenticated.data.account.memberOf.totalCount).to.eq(0);
         expect(resultAsAnotherUser.data.account.memberOf.totalCount).to.eq(0);
       });
+    });
+  });
+
+  describe('members', () => {
+    let collective, collectiveBackers, adminUser;
+    const membersQuery = gqlV2/* GraphQL */ `
+      query AccountMembers($slug: String!, $email: EmailAddress) {
+        account(slug: $slug) {
+          id
+          members(email: $email) {
+            totalCount
+            nodes {
+              id
+              role
+              account {
+                id
+                legacyId
+                slug
+                ... on Individual {
+                  email
+                }
+                ... on Organization {
+                  email
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    before(async () => {
+      collective = await fakeCollective();
+      adminUser = await fakeUser();
+      collectiveBackers = await Promise.all(times(5, fakeUser));
+      await Promise.all(collectiveBackers.map(u => collective.addUserWithRole(u, 'BACKER')));
+      await collective.addUserWithRole(adminUser, 'ADMIN');
+    });
+
+    it('can list members without private info if not admin', async () => {
+      const resultPublic = await graphqlQueryV2(membersQuery, { slug: collective.slug });
+      const resultNonAdmin = await graphqlQueryV2(membersQuery, { slug: collective.slug });
+      expect(resultPublic).to.deep.equal(resultNonAdmin);
+      const members = resultPublic.data.account.members.nodes;
+      expect(members.length).to.eq(7); // 5 Backers + 1 Admin + 1 Host
+      expect(members.filter(m => m.role === 'ADMIN').length).to.eq(1);
+      expect(members.filter(m => m.role === 'HOST').length).to.eq(1);
+      expect(members.filter(m => m.role === 'BACKER').length).to.eq(5);
+      members.forEach(m => expect(m.account.email).to.be.null);
+    });
+
+    it('cannot use email argument if not admin', async () => {
+      const email = randEmail();
+      const resultPublic = await graphqlQueryV2(membersQuery, { slug: collective.slug, email });
+      const resultNonAdmin = await graphqlQueryV2(membersQuery, { slug: collective.slug, email });
+      expect(resultPublic).to.deep.equal(resultNonAdmin);
+      expect(resultPublic.errors).to.exist;
+      expect(resultPublic.errors[0].message).to.include(
+        'Only admins can lookup for members using the "email" argument',
+      );
+    });
+
+    it('has access to private info if admin', async () => {
+      const result = await graphqlQueryV2(membersQuery, { slug: collective.slug }, adminUser);
+      const members = result.data.account.members.nodes;
+      expect(members.length).to.eq(7); // 5 Backers + 1 Admin + 1 Host
+      expect(members.filter(m => m.role === 'ADMIN').length).to.eq(1);
+      expect(members.filter(m => m.role === 'HOST').length).to.eq(1);
+      expect(members.filter(m => m.role === 'BACKER').length).to.eq(5);
+      members.forEach(m => expect(m.account.email).to.not.be.null);
+    });
+
+    it('can fetch by member email if admin', async () => {
+      const email = collectiveBackers[0].email;
+      const result = await graphqlQueryV2(membersQuery, { slug: collective.slug, email }, adminUser);
+      const members = result.data.account.members.nodes;
+      expect(members.length).to.eq(1);
+      expect(members[0].account.legacyId).to.eq(collectiveBackers[0].collective.id);
+      expect(members[0].account.email).to.eq(email);
     });
   });
 });


### PR DESCRIPTION
Athens collective needs (see https://github.com/athensresearch/athens/issues/694) to be able to see if someone is a contributor using an email address on GQLV2. I've added that to the `member` field, so the query looks pretty much like that:

```graphql
{
  account(slug: "athens") {
    members(email: "searched@gmail.com") {
      nodes {
        id
        role
        account {
          id
          slug
          ... on Individual {
            email
          }
        }
      }
    }
  }
}
```

This argument can only be used by collective admins.