### PR TITLE
Expose host.plan.platformTips in GraphQL

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -293,6 +293,9 @@ export const PlanType = new GraphQLObjectType({
     hostFeeSharePercent: {
       type: GraphQLInt,
     },
+    platformTips: {
+      type: GraphQLBoolean,
+    },
   },
 });
 

--- a/server/graphql/v2/object/HostPlan.ts
+++ b/server/graphql/v2/object/HostPlan.ts
@@ -65,5 +65,9 @@ export const HostPlan = new GraphQLObjectType({
       type: GraphQLInt,
       description: 'Charge on revenues made through Host Fees.',
     },
+    platformTips: {
+      type: GraphQLBoolean,
+      description: 'Ability to collect Platform Tips.',
+    },
   }),
 });


### PR DESCRIPTION
Support was already there in the `plan` structure.