### PR TITLE
feat: add reply button to expense notifications for expense submitters

### DIFF
--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -337,7 +337,9 @@ async function notifyByEmail(activity) {
         viewLatestExpenses: `${config.host.website}/${activity.data.collective.slug}/expenses#expense${activity.data.expense.id}`,
       };
       activity.data.expense.payoutMethodLabel = models.PayoutMethod.getLabel(activity.data.payoutMethod);
-      notifyUserId(activity.data.expense.UserId, activity);
+      notifyUserId(activity.data.expense.UserId, activity, {
+        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+      });
       // We only notify the admins of the host if the collective is active (ie. has been approved by the host)
       if (get(activity, 'data.host.id') && get(activity, 'data.collective.isActive')) {
         notifyAdminsOfCollective(activity.data.host.id, activity, {
@@ -352,7 +354,9 @@ async function notifyByEmail(activity) {
         viewLatestExpenses: `${config.host.website}/${activity.data.collective.slug}/expenses#expense${activity.data.expense.id}`,
       };
       activity.data.expense.payoutMethodLabel = models.PayoutMethod.getLabel(activity.data.payoutMethod);
-      notifyUserId(activity.data.expense.UserId, activity);
+      notifyUserId(activity.data.expense.UserId, activity, {
+        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+      });
       if (get(activity, 'data.host.id')) {
         notifyAdminsOfCollective(activity.data.host.id, activity, {
           template: 'collective.expense.paid.for.host',
@@ -365,7 +369,9 @@ async function notifyByEmail(activity) {
       activity.data.actions = {
         viewLatestExpenses: `${config.host.website}/${activity.data.collective.slug}/expenses#expense${activity.data.expense.id}`,
       };
-      notifyUserId(activity.data.expense.UserId, activity);
+      notifyUserId(activity.data.expense.UserId, activity, {
+        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+      });
       if (get(activity, 'data.host.id')) {
         notifyAdminsOfCollective(activity.data.host.id, activity, {
           template: 'collective.expense.error.for.host',
@@ -378,7 +384,9 @@ async function notifyByEmail(activity) {
       activity.data.actions = {
         viewLatestExpenses: `${config.host.website}/${activity.data.collective.slug}/expenses#expense${activity.data.expense.id}`,
       };
-      notifyUserId(activity.data.expense.UserId, activity);
+      notifyUserId(activity.data.expense.UserId, activity, {
+        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+      });
       break;
 
     case activityType.COLLECTIVE_EXPENSE_SCHEDULED_FOR_PAYMENT:

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -338,7 +338,7 @@ async function notifyByEmail(activity) {
       };
       activity.data.expense.payoutMethodLabel = models.PayoutMethod.getLabel(activity.data.payoutMethod);
       notifyUserId(activity.data.expense.UserId, activity, {
-        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+        replyTo: `no-reply@opencollective.com`,
       });
       // We only notify the admins of the host if the collective is active (ie. has been approved by the host)
       if (get(activity, 'data.host.id') && get(activity, 'data.collective.isActive')) {
@@ -355,7 +355,7 @@ async function notifyByEmail(activity) {
       };
       activity.data.expense.payoutMethodLabel = models.PayoutMethod.getLabel(activity.data.payoutMethod);
       notifyUserId(activity.data.expense.UserId, activity, {
-        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+        replyTo: `no-reply@opencollective.com`,
       });
       if (get(activity, 'data.host.id')) {
         notifyAdminsOfCollective(activity.data.host.id, activity, {
@@ -370,7 +370,7 @@ async function notifyByEmail(activity) {
         viewLatestExpenses: `${config.host.website}/${activity.data.collective.slug}/expenses#expense${activity.data.expense.id}`,
       };
       notifyUserId(activity.data.expense.UserId, activity, {
-        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+        replyTo: `no-reply@opencollective.com`,
       });
       if (get(activity, 'data.host.id')) {
         notifyAdminsOfCollective(activity.data.host.id, activity, {
@@ -385,7 +385,7 @@ async function notifyByEmail(activity) {
         viewLatestExpenses: `${config.host.website}/${activity.data.collective.slug}/expenses#expense${activity.data.expense.id}`,
       };
       notifyUserId(activity.data.expense.UserId, activity, {
-        replyTo: `no-reply@${activity.data.collective.slug}.opencollective.com`,
+        replyTo: `no-reply@opencollective.com`,
       });
       break;
 

--- a/templates/emails/collective.expense.approved.hbs
+++ b/templates/emails/collective.expense.approved.hbs
@@ -29,6 +29,14 @@ Subject: Your expense to {{collective.name}} for {{currency expense.amount curre
   <br /><br />
   <a href="{{actions.viewLatestExpenses}}" class="btn"><div>View Latest Expenses</div></a>
 
+  <p>
+    <center>
+      <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}#new-comment-on-expense" class="btn blue">
+        <div>Reply</div>
+      </a>
+    </center>
+  </p>
+
 </center>
 
 {{> footer}}

--- a/templates/emails/collective.expense.error.hbs
+++ b/templates/emails/collective.expense.error.hbs
@@ -14,4 +14,10 @@ Subject: Payment from {{collective.name}} for {{expense.description}} expense fa
   </p>
 </center>
 
+  <center>
+    <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}#new-comment-on-expense" class="btn blue">
+      <div>Reply</div>
+    </a>
+  </center>
+
 {{> footer}}

--- a/templates/emails/collective.expense.paid.hbs
+++ b/templates/emails/collective.expense.paid.hbs
@@ -36,6 +36,14 @@ Subject: {{#ifCond expense.currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond expen
   <a href="{{config.host.website}}/{{collective.slug}}/expenses/new" class="btn blue"><div>Submit Another Expenses</div></a>
   <a href="{{config.host.website}}/{{collective.slug}}/expenses" class="btn"><div>View All Expenses</div></a>
 
+  <p>
+    <center>
+      <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}#new-comment-on-expense" class="btn blue">
+        <div>Reply</div>
+      </a>
+    </center>
+  </p>
+
 </center>
 
 {{> footer}}

--- a/templates/emails/collective.expense.processing.hbs
+++ b/templates/emails/collective.expense.processing.hbs
@@ -13,4 +13,12 @@ Subject: Expense from {{collective.name}} for {{expense.description}} is being P
   </p>
 </center>
 
+<p>
+  <center>
+    <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}" class="btn blue">
+      <div>Reply</div>
+    </a>
+  </center>
+</p>
+
 {{> footer}}


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/3740

This PR adds a reply button to emails that are sent to an expense submitter. It also sets the `reply-to` as the no-reply email address. I wasn't sure if it was necessary for the email sent when an expense is approved or paid but I added it anyways.

### Screenshots
* Approved Expense Email
![Approved](https://user-images.githubusercontent.com/24629960/110734877-b3002080-81f6-11eb-9fa3-a44d661def29.png)

* Transaction Failed Expense Email
![Transaction Failed](https://user-images.githubusercontent.com/24629960/110734878-b398b700-81f6-11eb-951b-d4c747ff1674.png)
