### PR TITLE
Update published email: Add back collective logo

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -531,6 +531,7 @@ function defineModel() {
             longDescription: this.longDescription,
             currency: this.currency,
             image: this.image,
+            previewImage: this.previewImage,
             data: this.data,
             backgroundImage: this.backgroundImage,
             maxQuantity: this.maxQuantity,


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3942

This originated in https://github.com/opencollective/opencollective-api/pull/3693: we lost the `previewImage` when we stopped using the model to rather rely on `collective.info`.