### PR TITLE
createOrder: handle null payment method

### DIFF
--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -78,7 +78,7 @@ const orderMutations = {
       const paymentMethod = await getLegacyPaymentMethodFromPaymentMethodInput(order.paymentMethod);
 
       // Limit Braintree to root users for now
-      if (paymentMethod.service === PAYMENT_METHOD_SERVICE.BRAINTREE && !req.remoteUser?.isRoot()) {
+      if (paymentMethod?.service === PAYMENT_METHOD_SERVICE.BRAINTREE && !req.remoteUser?.isRoot()) {
         throw new Error('Braintree payments are only available to root users at the moment');
       }
 


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2269225421
Was broken in https://github.com/opencollective/opencollective-api/pull/5392

The payment method can be null when making an order for free tickets.

Added a test to prevent similar regressions in the future.