### PR TITLE
Edtimated Annual Budget: Better grouping for subscriptions

### DIFF
--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -304,7 +304,7 @@ export async function getYearlyIncome(collective) {
   const result = await sequelize.query(
     `
       WITH "activeMonthlySubscriptions" as (
-        SELECT DISTINCT d."SubscriptionId", t."netAmountInCollectiveCurrency"
+        SELECT d."SubscriptionId", ROUND(AVG(t."netAmountInCollectiveCurrency")) AS "netAmountInCollectiveCurrency"
         FROM "Transactions" t
         LEFT JOIN "Orders" d ON d.id = t."OrderId"
         LEFT JOIN "Subscriptions" s ON s.id = d."SubscriptionId"
@@ -313,6 +313,7 @@ export async function getYearlyIncome(collective) {
           AND s."isActive" IS TRUE
           AND s.interval = 'month'
           AND s."deletedAt" IS NULL
+        GROUP BY d."SubscriptionId"
       )
       SELECT
         (SELECT


### PR DESCRIPTION
The [code](https://github.com/opencollective/opencollective-api/blob/324ca162c636e6ed9835283442850545241c317f/server/lib/budget.js#L297) had a distinct on `SubscriptionId` + `netAmountInCollectiveCurrency`, so the subscriptions that have multiple transactions with different amounts were counted multiple times.

It's the case for https://opencollective.freshdesk.com/a/tickets/13801 (and supposedly all hosts that change their fee model at some point): since the `hostFee` changed one transaction was recorded with `hostFee=5` and the other with `hostFee=0`, resulting in different amounts.

I went with the simplest fix possible: use the average amount of the transactions.

An alternative would be to always use the latest transactions as a reference but:
- It might be less accurate in the short/mid term since it does not represent correctly the money collected before this transaction
- It's more complex to implement, and possibly less efficient