### PR TITLE
Sentry: Stringify variables

### DIFF
--- a/server/lib/sentry.ts
+++ b/server/lib/sentry.ts
@@ -58,7 +58,7 @@ export const SentryGraphQLPlugin = {
 
             // Log query and variables as extras
             scope.setExtra('query', ctx.request.query);
-            scope.setExtra('variables', ctx.request.variables);
+            scope.setExtra('variables', JSON.stringify(ctx.request.variables));
 
             // Add logged in user (if any)
             if (ctx.context.remoteUser) {


### PR DESCRIPTION
Without this change, we end up with objects not being stringified properly:

![image](https://user-images.githubusercontent.com/1556356/111275642-a6d0f480-8636-11eb-9ca6-ea855f28c221.png)
