### PR TITLE
Mark expense as Spam

### DIFF
--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -20,6 +20,7 @@ export default {
   COLLECTIVE_EXPENSE_UNAPPROVED: 'collective.expense.unapproved',
   COLLECTIVE_EXPENSE_PAID: 'collective.expense.paid',
   COLLECTIVE_EXPENSE_MARKED_AS_UNPAID: 'collective.expense.unpaid',
+  COLLECTIVE_EXPENSE_MARKED_AS_SPAM: 'collective.expense.spam',
   COLLECTIVE_EXPENSE_PROCESSING: 'collective.expense.processing',
   COLLECTIVE_EXPENSE_SCHEDULED_FOR_PAYMENT: 'collective.expense.scheduledForPayment',
   COLLECTIVE_EXPENSE_ERROR: 'collective.expense.error',

--- a/server/constants/expense_status.js
+++ b/server/constants/expense_status.js
@@ -27,4 +27,5 @@ export default {
   ERROR: 'ERROR',
   PAID: 'PAID',
   SCHEDULED_FOR_PAYMENT: 'SCHEDULED_FOR_PAYMENT',
+  SPAM: 'SPAM',
 };

--- a/server/graphql/loaders/expenses.ts
+++ b/server/graphql/loaders/expenses.ts
@@ -59,6 +59,7 @@ export const generateExpenseActivitiesLoader = (req: express.Request): DataLoade
             ACTIVITY.COLLECTIVE_EXPENSE_PROCESSING,
             ACTIVITY.COLLECTIVE_EXPENSE_ERROR,
             ACTIVITY.COLLECTIVE_EXPENSE_SCHEDULED_FOR_PAYMENT,
+            ACTIVITY.COLLECTIVE_EXPENSE_MARKED_AS_SPAM,
           ],
         },
       },

--- a/server/graphql/v2/enum/ExpenseProcessAction.ts
+++ b/server/graphql/v2/enum/ExpenseProcessAction.ts
@@ -22,5 +22,8 @@ export const ExpenseProcessAction = new GraphQLEnumType({
     PAY: {
       description: 'To trigger the payment',
     },
+    MARK_AS_SPAM: {
+      description: 'To mark the expense as spam',
+    },
   },
 });

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -18,6 +18,7 @@ import {
   canVerifyDraftExpense,
   createExpense,
   editExpense,
+  markExpenseAsSpam,
   markExpenseAsUnpaid,
   payExpense,
   rejectExpense,
@@ -267,6 +268,8 @@ const expenseMutations = {
           return unapproveExpense(req, expense);
         case 'REJECT':
           return rejectExpense(req, expense);
+        case 'MARK_AS_SPAM':
+          return markExpenseAsSpam(req, expense);
         case 'MARK_AS_UNPAID':
           return markExpenseAsUnpaid(req, expense.id, args.paymentParams?.paymentProcessorFee);
         case 'SCHEDULE_FOR_PAYMENT':

--- a/server/graphql/v2/object/ExpensePermissions.ts
+++ b/server/graphql/v2/object/ExpensePermissions.ts
@@ -56,6 +56,13 @@ const ExpensePermissions = new GraphQLObjectType({
         return ExpenseLib.canReject(req, expense);
       },
     },
+    canMarkAsSpam: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether the current user can mark this expense as spam',
+      async resolve(expense, _, req: express.Request): Promise<boolean> {
+        return ExpenseLib.canMarkAsSpam(req, expense);
+      },
+    },
     canMarkAsUnpaid: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'Whether the current user can mark this expense as unpaid',

--- a/server/graphql/v2/query/ExpensesQuery.ts
+++ b/server/graphql/v2/query/ExpensesQuery.ts
@@ -225,12 +225,13 @@ const ExpensesQuery = {
       if (req.remoteUser) {
         where[Op.and].push({
           [Op.or]: [
-            { status: { [Op.notIn]: [expenseStatus.DRAFT] } },
+            { status: { [Op.notIn]: [expenseStatus.DRAFT, expenseStatus.SPAM] } },
             { status: expenseStatus.DRAFT, UserId: req.remoteUser.id },
+            // TODO: we should ideally display SPAM expenses in some circumstances
           ],
         });
       } else {
-        where['status'] = { [Op.notIn]: [expenseStatus.DRAFT] };
+        where['status'] = { [Op.notIn]: [expenseStatus.DRAFT, expenseStatus.SPAM] };
       }
     }
 

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -285,7 +285,7 @@ function defineModel() {
    * @param {object} user: the user who triggered the activity. Leave blank for system activities.
    */
   Expense.prototype.createActivity = async function (type, user, data) {
-    const submittedByUser = this.user || (await models.User.findByPk(this.UserId));
+    const submittedByUser = await this.getSubmitterUser();
     const submittedByUserCollective = await models.Collective.findByPk(submittedByUser.CollectiveId);
     const fromCollective = this.fromCollective || (await models.Collective.findByPk(this.FromCollectiveId));
     if (!this.collective) {
@@ -299,7 +299,7 @@ function defineModel() {
       (await models.Transaction.findOne({
         where: { type: 'DEBIT', ExpenseId: this.id },
       }));
-    await models.Activity.create({
+    return models.Activity.create({
       type,
       UserId: user?.id,
       CollectiveId: this.collective.id,
@@ -324,6 +324,13 @@ function defineModel() {
           })),
       },
     });
+  };
+
+  Expense.prototype.getSubmitterUser = async function () {
+    if (!this.user) {
+      this.user = await models.User.findByPk(this.UserId);
+    }
+    return this.user;
   };
 
   Expense.prototype.setApproved = function (lastEditedById) {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -418,6 +418,18 @@ function defineModel() {
   };
 
   /**
+   * Limit the user account, preventing a specific feature
+   * @param feature:the feature to limit. See `server/constants/feature.ts`.
+   */
+  User.prototype.limitFeature = async function (feature) {
+    const features = get(this.data, 'features', {});
+
+    features[feature] = false;
+
+    return this.update({ data: { ...this.data, features } });
+  };
+
+  /**
    * Class Methods
    */
   User.createMany = (users, defaultValues = {}) => {


### PR DESCRIPTION
Frontend: https://github.com/opencollective/opencollective-frontend/pull/6065

As demoed today:
- Introduce a new SPAM status and new MARK_AS_SPAM action
- Hide from the expenses lists, a bit like DRAFT
- Send a notification to the abuse channel on slack
- Prevent user to submit more expenses
