### PR TITLE
Emails/ExpenseComment: Add reply button and set no-reply from

### DIFF
--- a/templates/emails/collective.comment.created.hbs
+++ b/templates/emails/collective.comment.created.hbs
@@ -1,5 +1,5 @@
 {{#if expense }}
-Subject: {{collective.name}}: New comment on {{#if recipientIsAuthor}}your {{/if}}expense {{expense.description}} by {{fromCollective.name}}
+Subject: {{collective.name}}: New comment on expense {{expense.description}} by {{fromCollective.name}}
 {{else if conversation}}
 Subject: New comment from {{fromCollective.name}} on "{{conversation.title}}"
 {{else if update}}
@@ -46,9 +46,14 @@ Subject: {{collective.name}}: New comment
 
 <p>
   <center>
+  {{#if expense}}
+    <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}#new-comment-on-expense" class="btn blue">
+      <div>Reply</div>
+    </a>
+  {{else}}
     <a href="{{config.host.website}}{{path}}" class="btn blue"><div>View thread online</div></a>
+  {{/if}}
   </center>
 </p>
-
 
 {{> footer}}


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective/issues/3740

We forgot this in https://github.com/opencollective/opencollective-api/pull/5677. Also improved the notifications target to avoid duplicate and remove the "your" in the template that was broken (we were always including it since the same activity was passed to all notify functions).