### PR TITLE
payExpense: Fix double notification with PayPal

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -853,8 +853,9 @@ async function payExpenseWithPayPal(remoteUser, expense, host, paymentMethod, to
       fees['hostFeeInHostCurrency'],
       fees['platformFeeInHostCurrency'],
     );
-    await markExpenseAsPaid(expense, remoteUser);
+    const updatedExpense = await markExpenseAsPaid(expense, remoteUser);
     await paymentMethod.updateBalance();
+    return updatedExpense;
   } catch (err) {
     debug('paypal> error', JSON.stringify(err, null, '  '));
     if (
@@ -1055,7 +1056,7 @@ export async function payExpense(req: express.Request, args: Record<string, unkn
         } else if (args.forceManual) {
           await createTransactions(host, expense, feesInHostCurrency);
         } else if (paypalPaymentMethod) {
-          await payExpenseWithPayPal(remoteUser, expense, host, paypalPaymentMethod, paypalEmail, feesInHostCurrency);
+          return payExpenseWithPayPal(remoteUser, expense, host, paypalPaymentMethod, paypalEmail, feesInHostCurrency);
         } else {
           throw new Error('No Paypal account linked, please reconnect Paypal or pay manually');
         }


### PR DESCRIPTION
Introduced in https://github.com/opencollective/opencollective-api/pull/5424
Fix https://github.com/opencollective/opencollective/issues/4104

This fixes duplicate notifications when paying expenses with legacy PayPal (not Payout).