### PR TITLE
Payment processor fees on platform tips optional by host

### DIFF
--- a/test/server/models/Transaction.test.js
+++ b/test/server/models/Transaction.test.js
@@ -22,7 +22,7 @@ describe('server/models/Transaction', () => {
       CreatedByUserId: user.id,
       HostCollectiveId: 8686,
     });
-    host = await fakeHost({ id: 2, CreatedByUserId: user.id });
+    host = await fakeHost({ id: 2, CreatedByUserId: user.id, data: { reimbursePaymentProcessorFeeOnTips: true } });
     collective = await fakeCollective({ id: 3, HostCollectiveId: host.id, CreatedByUserId: user.id });
     defaultTransactionData = {
       CreatedByUserId: user.id,


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/4107
This will turn payment processor fees reimbursement on platform tips transaction off by default but will keep it for hosts where `data.reimbursePaymentProcessorFeeOnTips = true`.