### PR TITLE
fix: space buttons on paid expense email

### DIFF
--- a/templates/emails/collective.expense.paid.hbs
+++ b/templates/emails/collective.expense.paid.hbs
@@ -33,7 +33,7 @@ Subject: {{#ifCond expense.currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond expen
   </table>
 
   <br /><br />
-  <a href="{{config.host.website}}/{{collective.slug}}/expenses/new" class="btn blue"><div>Submit Another Expenses</div></a>
+  <a href="{{config.host.website}}/{{collective.slug}}/expenses/new" class="btn blue" style="margin-bottom: 10px;"><div>Submit Another Expenses</div></a>
   <a href="{{config.host.website}}/{{collective.slug}}/expenses" class="btn"><div>View All Expenses</div></a>
 
   <p>


### PR DESCRIPTION
resolves https://github.com/opencollective/opencollective/issues/4103

### Screenshots
![Paid Expense email](https://user-images.githubusercontent.com/24629960/112093334-9d341900-8b6f-11eb-9134-17b6af61db9a.png)
