### PR TITLE
Remove double slash in URL from milestones tweets

### DIFF
--- a/cron/10mn/milestones.js
+++ b/cron/10mn/milestones.js
@@ -167,7 +167,7 @@ const compileTweet = async (collective, template, twitterAccount) => {
 
   let tweet = twitter.compileTweet(template, replacements, get(twitterAccount, `settings.${template}.tweet`));
   const path = await collective.getUrlPath();
-  tweet += `\nhttps://opencollective.com/${path}`;
+  tweet += `\nhttps://opencollective.com${path}`;
   return tweet;
 };
 


### PR DESCRIPTION
See [this tweet](https://twitter.com/opencollect/status/1374130217359409161) for example, it links to https://opencollective.com//openscad.

As per https://github.com/opencollective/opencollective-api/blob/db8e60caa819c8c02f0947530bf575c55fe6c079/server/models/Collective.js#L1116, the path is already prefixed with a slash in `getUrlPath`.