### PR TITLE
PayPal: Manage/cancel recurring contribution

### DIFF
--- a/cron/disabled/reject-contributions.js
+++ b/cron/disabled/reject-contributions.js
@@ -148,7 +148,7 @@ async function run({ dryRun, limit, force } = {}) {
       if (subscription) {
         logger.info(`  - Deactivating subscription #${order.SubscriptionId}`);
         if (!dryRun) {
-          await subscription.deactivate();
+          await subscription.deactivate('Contribution rejected');
         }
         actionTaken = true;
       } else {

--- a/migrations/20210331085221-update-subscriptions-for-paypal.js
+++ b/migrations/20210331085221-update-subscriptions-for-paypal.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Add isManagedExternally
+    let colParams = { type: Sequelize.BOOLEAN, defaultValue: false };
+    await queryInterface.addColumn('Subscriptions', 'isManagedExternally', colParams);
+    await queryInterface.addColumn('SubscriptionHistories', 'isManagedExternally', colParams);
+    await queryInterface.sequelize.query('UPDATE "Subscriptions" SET "isManagedExternally" = false;');
+
+    // Add paypalSubscriptionId
+    colParams = { type: Sequelize.STRING, allowNull: true };
+    await queryInterface.addColumn('Subscriptions', 'paypalSubscriptionId', colParams);
+    await queryInterface.addColumn('SubscriptionHistories', 'paypalSubscriptionId', colParams);
+    await queryInterface.addIndex('Subscriptions', ['paypalSubscriptionId'], { unique: true });
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('Subscriptions', 'isManagedExternally');
+    await queryInterface.removeColumn('SubscriptionHistories', 'isManagedExternally');
+    await queryInterface.removeColumn('Subscriptions', 'paypalSubscriptionId');
+    await queryInterface.removeColumn('SubscriptionHistories', 'paypalSubscriptionId');
+  },
+};

--- a/server/constants/paymentMethods.ts
+++ b/server/constants/paymentMethods.ts
@@ -11,6 +11,7 @@ export enum PAYMENT_METHOD_TYPE {
   CREDITCARD = 'creditcard',
   PREPAID = 'prepaid',
   PAYMENT = 'payment',
+  SUBSCRIPTION = 'subscription',
   COLLECTIVE = 'collective',
   HOST = 'host',
   ADAPTIVE = 'adaptive',

--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -3540,7 +3540,9 @@ type TierStatsType {
   totalDonated: Int
 
   """
-  How much money is given for this tier for each tier.interval (monthly/yearly)
+  How much money is given for this tier for each tier.interval (monthly/yearly).
+  For flexible tiers, this amount is a monthly average of contributions amount,
+  taking into account both yearly and monthly subscriptions.
   """
   totalRecurringDonations: Int
 

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -3237,7 +3237,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions {
   """
   The Collective hosting this Event
   """
-  parent: Collective
+  parent: Account
 
   """
   The Collective hosting this Event
@@ -5111,12 +5111,12 @@ type Mutation {
     account: AccountReferenceInput!
     amount: AmountInput!
     description: String!
-    hostFeePercent: Int!
+    hostFeePercent: Float!
 
     """
     Can only be set if root
     """
-    platformFeePercent: Int
+    platformFeePercent: Float
   ): Order!
   createCollective(
     """
@@ -5594,6 +5594,11 @@ type Mutation {
     paymentMethod: PaymentMethodReferenceInput
 
     """
+    To update the order with a PayPal subscription
+    """
+    paypalSubscriptionId: String
+
+    """
     Reference to a Tier to update the order with
     """
     tier: TierReferenceInput
@@ -5737,6 +5742,7 @@ type Order {
   quantity: Int
   status: OrderStatus
   frequency: ContributionFrequency
+  nextChargeDate: DateTime
   tier: Tier
   fromAccount: Account
   toAccount: Account
@@ -6330,6 +6336,7 @@ enum PaymentMethodType {
   creditcard
   prepaid
   payment
+  subscription
   collective
   host
   adaptive
@@ -6387,7 +6394,6 @@ enum PayoutMethodType {
 input PaypalPaymentInput {
   token: String
   data: JSON
-  captureId: String
   orderId: String
   subscriptionId: String
   isNewApi: Boolean
@@ -6752,7 +6758,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions {
   """
   The Fund hosting this Project
   """
-  parent: Fund
+  parent: Account
 }
 
 input ProjectCreateInput {
@@ -7817,4 +7823,20 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
   """
   balance: Int @deprecated(reason: "2020/04/09 - Should not have been introduced. Use stats.balance.value")
   contributionPolicy: String
+}
+
+"""
+VirtualCard related properties.
+"""
+type VirtualCard {
+  id: String
+  CollectiveId: Int
+  HostCollectiveId: Int
+  name: String
+  last4: String
+  data: JSONObject
+  privateData: JSONObject
+  createdAt: DateTime
+  updatedAt: DateTime
+  deletedAt: DateTime
 }

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -250,7 +250,7 @@ const hasPaymentMethod = order => {
   if (!paymentMethod) {
     return false;
   } else if (paymentMethod.service === 'paypal' && paymentMethod.data?.isNewApi) {
-    return Boolean(paymentMethod.data.subscriptionId || paymentMethod.data.orderId);
+    return Boolean(paymentMethod.data.orderId);
   } else {
     return Boolean(paymentMethod.uuid || paymentMethod.token || paymentMethod.type === 'manual');
   }

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -20,7 +20,7 @@ import intervals from '../../constants/intervals';
 import INTERVALS from '../../constants/intervals';
 import { maxInteger } from '../../constants/math';
 import orderStatus from '../../constants/order_status';
-import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE, PAYMENT_METHOD_TYPES } from '../../constants/paymentMethods';
+import { PAYMENT_METHOD_TYPE } from '../../constants/paymentMethods';
 import roles from '../../constants/roles';
 import { getCollectiveAvatarUrl } from '../../lib/collectivelib';
 import { getContributorsForTier } from '../../lib/contributors';
@@ -1875,40 +1875,27 @@ export const PaymentMethodType = new GraphQLObjectType({
       data: {
         type: GraphQLJSON,
         resolve(paymentMethod, _, req) {
-          if (!paymentMethod.data) {
+          if (!req.remoteUser?.isAdmin(paymentMethod.CollectiveId)) {
             return null;
           }
 
-          // Protect and whitelist fields for gift cards
+          // Protect and limit fields
+          let allowedFields = [];
           if (paymentMethod.type === PAYMENT_METHOD_TYPE.GIFT_CARD) {
-            if (!req.remoteUser || !req.remoteUser.isAdmin(paymentMethod.CollectiveId)) {
-              return null;
-            }
-            return pick(paymentMethod.data, ['email']);
+            allowedFields = ['email'];
+          } else if (paymentMethod.type === PAYMENT_METHOD_TYPE.CREDITCARD) {
+            allowedFields = ['fullName', 'expMonth', 'expYear', 'brand', 'country', 'last4'];
           }
 
-          const data = paymentMethod.data;
-          // white list fields to send back; removes fields like CustomerIdForHost
-          const dataSubset = {
-            fullName: data.fullName,
-            expMonth: data.expMonth,
-            expYear: data.expYear,
-            brand: data.brand,
-            country: data.country,
-            last4: data.last4,
-          };
-          return dataSubset;
+          return pick(paymentMethod.data, allowedFields);
         },
       },
       name: {
         // last 4 digit of card number for Stripe
         type: GraphQLString,
         resolve(paymentMethod, _, req) {
-          if (
-            paymentMethod.service === PAYMENT_METHOD_SERVICE.PAYPAL &&
-            paymentMethod.type === PAYMENT_METHOD_TYPES.ADAPTIVE
-          ) {
-            return req.remoteUser?.isAdmin(paymentMethod.CollectiveId) ? paymentMethod.name : null;
+          if (!req.remoteUser?.isAdmin(paymentMethod.CollectiveId)) {
+            return null;
           } else {
             return paymentMethod.name;
           }

--- a/server/graphql/v2/input/PaymentMethodInput.ts
+++ b/server/graphql/v2/input/PaymentMethodInput.ts
@@ -111,15 +111,23 @@ export const getLegacyPaymentMethodFromPaymentMethodInput = async (
       data: pick(pm.creditCardInfo, ['brand', 'country', 'expMonth', 'expYear', 'fullName', 'funding', 'zip']),
     };
   } else if (pm.paypalInfo) {
-    return {
-      service: PAYMENT_METHOD_SERVICE.PAYPAL,
-      type: PAYMENT_METHOD_TYPE.PAYMENT,
-      ...pick(pm.paypalInfo, ['token']),
-      data: {
-        ...(pm.paypalInfo.data || {}),
-        ...pick(pm.paypalInfo, ['isNewApi', 'subscriptionId', 'orderId']),
-      },
-    };
+    if (pm.paypalInfo.isNewApi && pm.paypalInfo.subscriptionId) {
+      return {
+        service: PAYMENT_METHOD_SERVICE.PAYPAL,
+        type: PAYMENT_METHOD_TYPE.SUBSCRIPTION,
+        token: pm.paypalInfo.subscriptionId,
+      };
+    } else {
+      return {
+        service: PAYMENT_METHOD_SERVICE.PAYPAL,
+        type: PAYMENT_METHOD_TYPE.PAYMENT,
+        ...pick(pm.paypalInfo, ['token']),
+        data: {
+          ...(pm.paypalInfo.data || {}),
+          ...pick(pm.paypalInfo, ['isNewApi', 'orderId']),
+        },
+      };
+    }
   } else {
     return getServiceTypeFromLegacyPaymentMethodType(pm.type);
   }

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -217,6 +217,9 @@ const orderMutations = {
       } else if (args.paypalSubscriptionId && args.paymentMethod) {
         throw new Error('paypalSubscriptionId and paymentMethod are mutually exclusive');
       } else if (haveDetailsChanged && hasPaymentMethodChanged) {
+        // There's no transaction/rollback strategy if updating the payment method fails
+        // after updating the order. We could end up with partially migrated subscriptions
+        // if we allow changing both at the same time.
         throw new Error(
           'Amount and payment method cannot be updated at the same time, please update one after the other',
         );

--- a/server/graphql/v2/mutation/TransactionMutations.ts
+++ b/server/graphql/v2/mutation/TransactionMutations.ts
@@ -81,7 +81,7 @@ const transactionMutations = {
 
       if (orderToUpdate.SubscriptionId) {
         await orderToUpdate.update({ status: orderStatus.REJECTED });
-        await orderToUpdate.Subscription.deactivate();
+        await orderToUpdate.Subscription.deactivate('Contribution rejected');
       } else {
         // else just update the status to REJECTED
         await orderToUpdate.update({

--- a/server/graphql/v2/object/Order.js
+++ b/server/graphql/v2/object/Order.js
@@ -55,8 +55,8 @@ export const Order = new GraphQLObjectType({
       },
       frequency: {
         type: ContributionFrequency,
-        async resolve(order) {
-          const subscription = await order.getSubscription();
+        async resolve(order, _, req) {
+          const subscription = order.SubscriptionId && (await req.loaders.Subscription.byId.load(order.SubscriptionId));
           if (!subscription) {
             return 'ONETIME';
           }
@@ -65,6 +65,13 @@ export const Order = new GraphQLObjectType({
           } else if (subscription.interval === 'year') {
             return 'YEARLY';
           }
+        },
+      },
+      nextChargeDate: {
+        type: GraphQLDateTime,
+        async resolve(order, _, req) {
+          const subscription = order.SubscriptionId && (await req.loaders.Subscription.byId.load(order.SubscriptionId));
+          return subscription?.nextChargeDate;
         },
       },
       tier: {

--- a/server/graphql/v2/query/PaypalPlanQuery.ts
+++ b/server/graphql/v2/query/PaypalPlanQuery.ts
@@ -1,7 +1,8 @@
 import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 
 import RateLimit from '../../../lib/rate-limit';
-import { getOrCreatePlan } from '../../../paymentProviders/paypal/payment';
+import PaypalPlanModel from '../../../models/PaypalPlan';
+import { getOrCreatePlan } from '../../../paymentProviders/paypal/subscription';
 import { RateLimitExceeded } from '../../errors';
 import { ContributionFrequency } from '../enum';
 import { getIntervalFromContributionFrequency } from '../enum/ContributionFrequency';
@@ -38,7 +39,7 @@ const PaypalPlanQuery = {
       description: 'The tier you are contributing to',
     },
   },
-  async resolve(_, args, req): Promise<string> {
+  async resolve(_, args, req): Promise<PaypalPlanModel> {
     const rateLimit = new RateLimit(`paypal_plan_${req.remoteUser?.id || req.ip}`, 30, 60);
     if (!(await rateLimit.registerCall())) {
       throw new RateLimitExceeded();

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -253,13 +253,11 @@ export async function associateTransactionRefundId(transaction, refund, data) {
 export const sendEmailNotifications = (order, transaction) => {
   debug('sendEmailNotifications');
   // for gift cards and manual payment methods
-  if (!transaction) {
-    if (!order.data?.skipPendingEmail) {
-      sendOrderProcessingEmail(order); // This is the one for the Contributor
-      sendManualPendingOrderEmail(order); // This is the one for the Host Admins
-    }
-  } else {
+  if (transaction) {
     sendOrderConfirmedEmail(order, transaction); // async
+  } else if (order.status === status.PENDING) {
+    sendOrderProcessingEmail(order); // This is the one for the Contributor
+    sendManualPendingOrderEmail(order); // This is the one for the Host Admins
   }
 };
 

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -44,6 +44,7 @@ export async function ordersWithPendingCharges({ limit, startDate } = {}) {
           deactivatedAt: null,
           activatedAt: { [Op.lte]: startDate || new Date() },
           nextChargeDate: { [Op.lte]: startDate || new Date() },
+          isManagedExternally: false,
         },
       },
     ],

--- a/server/lib/subscriptions.ts
+++ b/server/lib/subscriptions.ts
@@ -1,0 +1,129 @@
+import { isEmpty, keys, pick } from 'lodash';
+
+import OrderStatus from '../constants/order_status';
+import { Unauthorized } from '../graphql/errors';
+import models, { sequelize } from '../models';
+
+import { findPaymentMethodProvider } from './payments';
+
+const getIsSubscriptionManagedExternally = pm => {
+  const provider = findPaymentMethodProvider(pm);
+  return Boolean(provider?.features?.isRecurringManagedExternally);
+};
+
+export const updatePaymentMethodForSubscription = async (
+  user: typeof models.User,
+  order: typeof models.Order,
+  newPaymentMethod: typeof models.PaymentMethod,
+): Promise<typeof models.Order> => {
+  const prevPaymentMethod = order.paymentMethod;
+  const newPaymentMethodCollective = await newPaymentMethod.getCollective();
+  if (!user.isAdminOfCollective(newPaymentMethodCollective)) {
+    throw new Unauthorized("You don't have permission to use this payment method");
+  }
+
+  // Order changes
+  const newStatus = order.status === OrderStatus.ERROR ? OrderStatus.ACTIVE : order.status;
+  const newOrderData = { PaymentMethodId: newPaymentMethod.id, status: newStatus };
+
+  // Subscription changes
+  let newSubscriptionData;
+  const wasManagedExternally = getIsSubscriptionManagedExternally(prevPaymentMethod);
+  const isManagedExternally = getIsSubscriptionManagedExternally(newPaymentMethod);
+  if (wasManagedExternally !== isManagedExternally) {
+    newSubscriptionData = { isManagedExternally, paypalSubscriptionId: null };
+  }
+
+  const { order: updatedOrder } = await updateOrderSubscription(order, newOrderData, newSubscriptionData);
+  return updatedOrder;
+};
+
+const checkSubscriptionDetails = (order, tier, amountInCents) => {
+  if (tier && tier.CollectiveId !== order.CollectiveId) {
+    throw new Error(`This tier (#${tier.id}) doesn't belong to the given Collective #${order.CollectiveId}`);
+  }
+
+  // The amount can never be less than $1.00
+  if (amountInCents < 100) {
+    throw new Error('Invalid amount.');
+  }
+
+  // If using a named tier, amount can never be less than the minimum amount
+  if (tier && tier.amountType === 'FLEXIBLE' && amountInCents < tier.minimumAmount) {
+    throw new Error('Amount is less than minimum value allowed for this Tier.');
+  }
+
+  // If using a FIXED tier, amount cannot be different from the tier's amount
+  // TODO: it should be amountInCents !== tier.amount, but we need to do work to make sure that would play well with platform fees/taxes
+  if (tier && tier.amountType === 'FIXED' && amountInCents < tier.amount) {
+    throw new Error('Amount is incorrect for this Tier.');
+  }
+};
+
+type OrderSubscriptionUpdate = {
+  order: typeof models.Order;
+  previousOrderValues: Record<string, unknown>;
+  previousSubscriptionValues: Record<string, unknown>;
+};
+
+/**
+ * Update the order and the subscription in a single transaction. Returns the modified values
+ * for each, to easily rollback if necessary.
+ */
+export const updateOrderSubscription = async (
+  order: typeof models.Order,
+  newOrderData: Record<string, unknown>,
+  newSubscriptionData: Record<string, unknown>,
+): Promise<OrderSubscriptionUpdate> => {
+  const previousOrderValues = pick(order.dataValues, keys(newOrderData));
+  const previousSubscriptionValues = pick(order.Subscription.dataValues, keys(newSubscriptionData));
+
+  if (isEmpty(newOrderData) && isEmpty(newSubscriptionData)) {
+    return { order, previousOrderValues, previousSubscriptionValues };
+  }
+
+  return sequelize.transaction(async transaction => {
+    if (!isEmpty(newOrderData)) {
+      order = await order.update(newOrderData, { transaction });
+    }
+
+    if (!isEmpty(newSubscriptionData)) {
+      order.Subscription = await order.Subscription.update(newSubscriptionData, { transaction });
+    }
+
+    return { order, previousOrderValues, previousSubscriptionValues };
+  });
+};
+
+export const updateSubscriptionDetails = async (
+  order: typeof models.Order,
+  tier: typeof models.Tier,
+  amountInCents: number,
+): Promise<OrderSubscriptionUpdate> => {
+  // Make sure the new details are ok values, that match tier's minimum amount if there's one
+  checkSubscriptionDetails(order, tier, amountInCents);
+
+  const newOrderData = {};
+  const newSubscriptionData = {};
+
+  // check if the amount is different from the previous amount
+  if (amountInCents !== order.totalAmount) {
+    newOrderData['totalAmount'] = amountInCents;
+    newSubscriptionData['amount'] = amountInCents;
+  }
+
+  // Update interval
+  if (tier?.interval && tier.interval !== 'flexible' && tier.interval !== order.interval) {
+    newOrderData['interval'] = tier.interval;
+    newSubscriptionData['interval'] = tier.interval;
+  }
+
+  // Update order's Tier
+  const newTierId = tier?.id || null;
+  if (newTierId !== order.TierId) {
+    newOrderData['TierId'] = newTierId;
+  }
+
+  // Backup previous values
+  return updateOrderSubscription(order, newOrderData, newSubscriptionData);
+};

--- a/server/models/PaypalProduct.ts
+++ b/server/models/PaypalProduct.ts
@@ -13,6 +13,7 @@ interface PaypalProductAttributes {
 export interface PaypalProductCreateAttributes {
   id: string;
   TierId: number;
+  CollectiveId: number;
 }
 
 class PaypalProduct

--- a/server/paymentProviders/braintree/paypal.ts
+++ b/server/paymentProviders/braintree/paypal.ts
@@ -8,6 +8,7 @@ import { createTransactionsPairFromBraintreeTransaction } from './helpers';
 const PayPal: PaymentProviderService = {
   features: {
     recurring: true,
+    isRecurringManagedExternally: true,
   },
 
   async processOrder(order: typeof models.Order): Promise<typeof models.Transaction> {

--- a/server/paymentProviders/paypal/api.ts
+++ b/server/paymentProviders/paypal/api.ts
@@ -1,0 +1,108 @@
+import config from 'config';
+import fetch from 'node-fetch';
+
+import logger from '../../lib/logger';
+
+/** Build an URL for the PayPal API */
+export function paypalUrl(path: string, version = 'v1'): string {
+  if (path.startsWith('/')) {
+    throw new Error("Please don't use absolute paths");
+  }
+  const baseUrl =
+    config.paypal.payment.environment === 'sandbox'
+      ? `https://api.sandbox.paypal.com/${version}/`
+      : `https://api.paypal.com/${version}/`;
+
+  return new URL(baseUrl + path).toString();
+}
+
+/** Exchange clientid and secretid by an auth token with PayPal API */
+export async function retrieveOAuthToken({ clientId, clientSecret }): Promise<string> {
+  const url = paypalUrl('oauth2/token');
+  const body = 'grant_type=client_credentials';
+  /* The OAuth token entrypoint uses Basic HTTP Auth */
+  const authStr = `${clientId}:${clientSecret}`;
+  const basicAuth = Buffer.from(authStr).toString('base64');
+  const headers = { Authorization: `Basic ${basicAuth}` };
+  /* Execute the request and unpack the token */
+  const response = await fetch(url, { method: 'post', body, headers });
+  const jsonOutput = await response.json();
+  return jsonOutput.access_token;
+}
+
+/** Assemble POST requests for communicating with PayPal API */
+export async function paypalRequest(urlPath, body, hostCollective, method = 'POST'): Promise<Record<string, unknown>> {
+  const connectedPaypalAccounts = await hostCollective.getConnectedAccounts({
+    where: { service: 'paypal', deletedAt: null },
+    order: [['createdAt', 'DESC']],
+  });
+  const paypal = connectedPaypalAccounts[0];
+  if (!paypal || !paypal.clientId || !paypal.token) {
+    throw new Error("Host doesn't support PayPal payments.");
+  }
+  const url = paypalUrl(urlPath);
+  const token = await retrieveOAuthToken({ clientId: paypal.clientId, clientSecret: paypal.token });
+
+  const params = {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  const result = await fetch(url, params);
+  if (!result.ok) {
+    let errorData = null;
+    let errorMessage = 'PayPal payment rejected';
+    try {
+      errorData = await result.json();
+      errorMessage = `${errorMessage}: ${errorData.message}`;
+    } catch (e) {
+      errorData = e;
+    }
+    logger.error('PayPal payment failed', result, errorData);
+    throw new Error(errorMessage);
+  } else if (result.status === 204) {
+    return null;
+  } else {
+    return result.json();
+  }
+}
+
+export async function paypalRequestV2(urlPath, hostCollective, method = 'POST'): Promise<Record<string, unknown>> {
+  const connectedPaypalAccounts = await hostCollective.getConnectedAccounts({
+    where: { service: 'paypal' },
+    order: [['createdAt', 'DESC']],
+  });
+  const paypal = connectedPaypalAccounts[0];
+  if (!paypal || !paypal.clientId || !paypal.token) {
+    throw new Error("Host doesn't support PayPal payments.");
+  }
+
+  const url = paypalUrl(urlPath, 'v2');
+  const token = await retrieveOAuthToken({ clientId: paypal.clientId, clientSecret: paypal.token });
+  const params = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  const result = await fetch(url, params);
+  if (!result.ok) {
+    let errorData = null;
+    let errorMessage = 'PayPal payment rejected';
+    try {
+      errorData = await result.json();
+      errorMessage = `${errorMessage}: ${errorData.message}`;
+    } catch (e) {
+      errorData = e;
+    }
+    logger.error('PayPal payment failed', result, errorData);
+    throw new Error(errorMessage);
+  }
+  return result.json();
+}

--- a/server/paymentProviders/paypal/index.js
+++ b/server/paymentProviders/paypal/index.js
@@ -11,6 +11,7 @@ import models, { Op } from '../../models';
 import adaptive from './adaptive';
 import paypalAdaptive from './adaptiveGateway';
 import payment from './payment';
+import subscription from './subscription';
 
 const debugPaypal = debug('paypal');
 
@@ -53,6 +54,7 @@ export default {
     default: adaptive,
     adaptive,
     payment,
+    subscription,
   },
 
   oauth: {

--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -384,6 +384,10 @@ const recordPaypalCapture = async (order, capture) => {
   return recordTransaction(order, amount, currency, fee, { capture });
 };
 
+export const cancelPaypalSubscription = async (subscriptionId, reason = undefined) => {
+  await paypalRequest(`billing/subscriptions/${subscriptionId}/cancel`, { reason });
+};
+
 /** Process order in paypal and create transactions in our db */
 export async function processOrder(order) {
   const hostCollective = await order.collective.getHostCollective();

--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -1,8 +1,5 @@
-import config from 'config';
 import { get, isNumber } from 'lodash';
-import fetch from 'node-fetch';
 
-import TierType from '../../constants/tiers';
 import * as constants from '../../constants/transactions';
 import { getFxRate } from '../../lib/currency';
 import logger from '../../lib/logger';
@@ -11,108 +8,7 @@ import { getHostFee, getPlatformFee } from '../../lib/payments';
 import { paypalAmountToCents } from '../../lib/paypal';
 import models from '../../models';
 
-/** Build an URL for the PayPal API */
-export function paypalUrl(path, version = 'v1') {
-  if (path.startsWith('/')) {
-    throw new Error("Please don't use absolute paths");
-  }
-  const baseUrl =
-    config.paypal.payment.environment === 'sandbox'
-      ? `https://api.sandbox.paypal.com/${version}/`
-      : `https://api.paypal.com/${version}/`;
-  return new URL(baseUrl + path).toString();
-}
-
-/** Exchange clientid and secretid by an auth token with PayPal API */
-export async function retrieveOAuthToken({ clientId, clientSecret }) {
-  const url = paypalUrl('oauth2/token');
-  const body = 'grant_type=client_credentials';
-  /* The OAuth token entrypoint uses Basic HTTP Auth */
-  const authStr = `${clientId}:${clientSecret}`;
-  const basicAuth = Buffer.from(authStr).toString('base64');
-  const headers = { Authorization: `Basic ${basicAuth}` };
-  /* Execute the request and unpack the token */
-  const response = await fetch(url, { method: 'post', body, headers });
-  const jsonOutput = await response.json();
-  return jsonOutput.access_token;
-}
-
-/** Assemble POST requests for communicating with PayPal API */
-export async function paypalRequest(urlPath, body, hostCollective, method = 'POST') {
-  const connectedPaypalAccounts = await hostCollective.getConnectedAccounts({
-    where: { service: 'paypal', deletedAt: null },
-    order: [['createdAt', 'DESC']],
-  });
-  const paypal = connectedPaypalAccounts[0];
-  if (!paypal || !paypal.clientId || !paypal.token) {
-    throw new Error("Host doesn't support PayPal payments.");
-  }
-  const url = paypalUrl(urlPath);
-  const token = await retrieveOAuthToken({ clientId: paypal.clientId, clientSecret: paypal.token });
-
-  const params = {
-    method,
-    body: body ? JSON.stringify(body) : undefined,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  };
-
-  const result = await fetch(url, params);
-  if (!result.ok) {
-    let errorData = null;
-    let errorMessage = 'PayPal payment rejected';
-    try {
-      errorData = await result.json();
-      errorMessage = `${errorMessage}: ${errorData.message}`;
-    } catch (e) {
-      errorData = e;
-    }
-    logger.error('PayPal payment failed', result, errorData);
-    throw new Error(errorMessage);
-  } else if (result.status === 204) {
-    return null;
-  } else {
-    return result.json();
-  }
-}
-
-export async function paypalRequestV2(hostCollective, urlPath, method = 'POST') {
-  const connectedPaypalAccounts = await hostCollective.getConnectedAccounts({
-    where: { service: 'paypal' },
-    order: [['createdAt', 'DESC']],
-  });
-  const paypal = connectedPaypalAccounts[0];
-  if (!paypal || !paypal.clientId || !paypal.token) {
-    throw new Error("Host doesn't support PayPal payments.");
-  }
-
-  const url = paypalUrl(urlPath, 'v2');
-  const token = await retrieveOAuthToken({ clientId: paypal.clientId, clientSecret: paypal.token });
-  const params = {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  };
-
-  const result = await fetch(url, params);
-  if (!result.ok) {
-    let errorData = null;
-    let errorMessage = 'PayPal payment rejected';
-    try {
-      errorData = await result.json();
-      errorMessage = `${errorMessage}: ${errorData.message}`;
-    } catch (e) {
-      errorData = e;
-    }
-    logger.error('PayPal payment failed', result, errorData);
-    throw new Error(errorMessage);
-  }
-  return result.json();
-}
+import { paypalRequest, paypalRequestV2 } from './api';
 
 /** Create a new payment object in the PayPal API
  *
@@ -144,146 +40,6 @@ export async function createPayment(req, res) {
   /* eslint-enable camelcase */
   const payment = await paypalRequest('payments/payment', paymentParams, hostCollective);
   return res.json({ id: payment.id });
-}
-
-/**
- * See https://developer.paypal.com/docs/api/catalog-products/v1/#products-create-response
- */
-export const getProductTypeAndCategory = tier => {
-  switch (tier?.type) {
-    case TierType.TICKET:
-      return ['DIGITAL'];
-    case TierType.PRODUCT:
-      return ['DIGITAL', 'MERCHANDISE'];
-    case TierType.SERVICE:
-      return ['SERVICE'];
-    case TierType.MEMBERSHIP:
-      return ['DIGITAL', 'MEMBERSHIP_CLUBS_AND_ORGANIZATIONS'];
-    default:
-      return ['DIGITAL', 'NONPROFIT'];
-  }
-};
-
-/**
- * PayPal crashes if imageUrl is from http://localhost, which can happen when developing with
- * a local images service.
- */
-const getImageUrlForPaypal = collective => {
-  if (config.host.images.startsWith('http://localhost')) {
-    return 'https://images.opencollective.com/opencollective/logo/256.png';
-  } else {
-    return collective.getImageUrl();
-  }
-};
-
-async function createPaypalProduct(host, collective, tier) {
-  const [type, category] = getProductTypeAndCategory(tier);
-
-  return paypalRequest(
-    `catalogs/products`,
-    {
-      /* eslint-disable camelcase */
-      name: `Financial contribution to ${collective.name}`,
-      description: `Financial contribution to ${collective.name}`,
-      type,
-      category,
-      image_url: getImageUrlForPaypal(collective),
-      home_url: `https://opencollective.com/${collective.slug}`,
-      /* eslint-enable camelcase */
-    },
-    host,
-  );
-}
-
-async function createPaypalPlan(host, collective, productId, interval, amount, currency, tier) {
-  const description = models.Order.generateDescription(collective, amount, interval, tier);
-  return paypalRequest(
-    `billing/plans`,
-    {
-      /* eslint-disable camelcase */
-      product_id: productId,
-      name: description,
-      description: description,
-      billing_cycles: [
-        {
-          tenure_type: 'REGULAR',
-          sequence: 1,
-          total_cycles: 0, // This tells PayPal this recurring payment never ends (INFINITE)
-          frequency: {
-            interval_count: 1,
-            interval_unit: interval.toUpperCase(), // month -> MONTH
-          },
-          pricing_scheme: {
-            fixed_price: {
-              value: (amount / 100).toString(), // 1667 -> '16.67'
-              currency_code: currency,
-            },
-          },
-        },
-      ],
-      payment_preferences: {
-        auto_bill_outstanding: true,
-        payment_failure_threshold: 4, // Will fail up to 4 times, after that the subscription gets cancelled
-      },
-      /* eslint-enable camelcase */
-    },
-    host,
-  );
-}
-
-export async function getOrCreatePlan(host, collective, interval, amount, currency, tier = null) {
-  const product = await models.PaypalProduct.findOne({
-    where: { CollectiveId: collective.id, TierId: tier?.id || null },
-    include: [
-      {
-        association: 'plans',
-        required: false,
-        where: { currency, interval, amount },
-      },
-    ],
-  });
-
-  if (product) {
-    const plans = product['plans'];
-    if (plans[0]) {
-      // If we found a product and a plan matching these parameters, we can directly return them
-      logger.debug(`PayPal: Returning existing plan ${plans[0].id}`);
-      return plans[0];
-    } else {
-      // Otherwise we can create a new plan based on this product
-      logger.debug(`PayPal: Re-using existing product ${product.id} and creating new plan`);
-      const paypalPlan = await createPaypalPlan(host, collective, product.id, interval, amount, currency, tier);
-      return models.PaypalPlan.create({
-        id: paypalPlan.id,
-        ProductId: product.id,
-        amount,
-        currency,
-        interval,
-      });
-    }
-  } else {
-    // If neither the plan or the product exist, we create both in one go
-    logger.debug(`PayPal: Creating a new plan`);
-    const paypalProduct = await createPaypalProduct(host, collective, tier);
-    const paypalPlan = await createPaypalPlan(host, collective, paypalProduct.id, interval, amount, currency, tier);
-    return models.PaypalPlan.create(
-      {
-        amount,
-        currency,
-        interval,
-        id: paypalPlan.id,
-        product: {
-          id: paypalProduct.id,
-          CollectiveId: collective.id,
-          TierId: tier?.id,
-        },
-      },
-      {
-        // Passing include for Sequelize to understand what `product` is
-        include: [{ association: 'product' }],
-      },
-    );
-  }
 }
 
 /** Execute an already created payment
@@ -384,27 +140,18 @@ const recordPaypalCapture = async (order, capture) => {
   return recordTransaction(order, amount, currency, fee, { capture });
 };
 
-export const cancelPaypalSubscription = async (subscriptionId, reason = undefined) => {
-  await paypalRequest(`billing/subscriptions/${subscriptionId}/cancel`, { reason });
-};
-
 /** Process order in paypal and create transactions in our db */
 export async function processOrder(order) {
-  const hostCollective = await order.collective.getHostCollective();
   if (order.paymentMethod.data.isNewApi) {
     if (order.paymentMethod.data.orderId) {
+      const hostCollective = await order.collective.getHostCollective();
       const orderId = order.paymentMethod.data.orderId;
-      const capture = await paypalRequestV2(hostCollective, `checkout/orders/${orderId}/capture`, 'POST');
+      const capture = await paypalRequestV2(`checkout/orders/${orderId}/capture`, hostCollective, 'POST');
       const captureId = capture.purchase_units[0].payments.captures[0].id;
-      const captureDetails = await paypalRequestV2(hostCollective, `payments/captures/${captureId}`, 'GET');
+      const captureDetails = await paypalRequestV2(`payments/captures/${captureId}`, hostCollective, 'GET');
       return recordPaypalCapture(order, captureDetails);
-    } else if (order.paymentMethod.data.subscriptionId) {
-      const subscriptionId = order.paymentMethod.data.subscriptionId;
-      await paypalRequest(`billing/subscriptions/${subscriptionId}/activate`, null, hostCollective, 'POST');
-      await order.update({ data: { ...order.data, paypalSubscriptionId: subscriptionId, skipPendingEmail: true } });
-      // Don't record the transaction here (will be done in the webhook event)
     } else {
-      throw new Error('Must either provide a subscriptionId or an orderId');
+      throw new Error('Must provide an orderId');
     }
   } else {
     const paymentInfo = await executePayment(order);
@@ -419,8 +166,6 @@ export async function processOrder(order) {
 
 /* Interface expected for a payment method */
 export default {
-  features: {
-    recurring: true,
-  },
+  features: { recurring: false },
   processOrder,
 };

--- a/server/paymentProviders/paypal/subscription.ts
+++ b/server/paymentProviders/paypal/subscription.ts
@@ -1,0 +1,315 @@
+import config from 'config';
+import { pick } from 'lodash';
+
+import INTERVALS from '../../constants/intervals';
+import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../constants/paymentMethods';
+import TierType from '../../constants/tiers';
+import logger from '../../lib/logger';
+import models from '../../models';
+import PaypalPlan from '../../models/PaypalPlan';
+import { PaymentProviderService } from '../types';
+
+import { paypalRequest } from './api';
+
+export const cancelPaypalSubscription = async (order: typeof models.Order, reason = undefined): Promise<void> => {
+  const collective = order.collective || (await order.getCollective());
+  const hostCollective = await collective.getHostCollective();
+  const subscription = order.Subscription || (await order.getSubscription());
+  await paypalRequest(`billing/subscriptions/${subscription.paypalSubscriptionId}/cancel`, { reason }, hostCollective);
+};
+
+export const createPaypalPaymentMethodForSubscription = (
+  order: typeof models.Order,
+  user: typeof models.User,
+  paypalSubscriptionId: string,
+): Promise<typeof models.PaymentMethod> => {
+  return models.PaymentMethod.create({
+    service: PAYMENT_METHOD_SERVICE.PAYPAL,
+    type: PAYMENT_METHOD_TYPE.SUBSCRIPTION,
+    CreatedByUserId: user.id,
+    CollectiveId: order.FromCollectiveId,
+    currency: order.currency,
+    saved: false,
+    token: paypalSubscriptionId,
+  });
+};
+
+type PaypalProductType = 'DIGITAL' | 'SERVICE';
+type PaypalProductCategory = 'MERCHANDISE' | 'MEMBERSHIP_CLUBS_AND_ORGANIZATIONS' | 'NONPROFIT';
+
+/**
+ * See https://developer.paypal.com/docs/api/catalog-products/v1/#products-create-response
+ */
+export const getProductTypeAndCategory = (tier: typeof models.Tier): [PaypalProductType, PaypalProductCategory?] => {
+  switch (tier?.type) {
+    case TierType.TICKET:
+      return ['DIGITAL'];
+    case TierType.PRODUCT:
+      return ['DIGITAL', 'MERCHANDISE'];
+    case TierType.SERVICE:
+      return ['SERVICE'];
+    case TierType.MEMBERSHIP:
+      return ['DIGITAL', 'MEMBERSHIP_CLUBS_AND_ORGANIZATIONS'];
+    default:
+      return ['DIGITAL', 'NONPROFIT'];
+  }
+};
+
+/**
+ * PayPal crashes if imageUrl is from http://localhost, which can happen when developing with
+ * a local images service.
+ */
+const getImageUrlForPaypal = collective => {
+  if (config.host.images.startsWith('http://localhost')) {
+    return 'https://images.opencollective.com/opencollective/logo/256.png';
+  } else {
+    return collective.getImageUrl();
+  }
+};
+
+async function createPaypalProduct(host, collective, tier) {
+  const [type, category] = getProductTypeAndCategory(tier);
+
+  return paypalRequest(
+    `catalogs/products`,
+    {
+      /* eslint-disable camelcase */
+      name: `Financial contribution to ${collective.name}`,
+      description: `Financial contribution to ${collective.name}`,
+      type,
+      category,
+      image_url: getImageUrlForPaypal(collective),
+      home_url: `https://opencollective.com/${collective.slug}`,
+      /* eslint-enable camelcase */
+    },
+    host,
+  );
+}
+
+async function createPaypalPlan(host, collective, productId, interval, amount, currency, tier) {
+  const description = models.Order.generateDescription(collective, amount, interval, tier);
+  return paypalRequest(
+    `billing/plans`,
+    {
+      /* eslint-disable camelcase */
+      product_id: productId,
+      name: description,
+      description: description,
+      billing_cycles: [
+        {
+          tenure_type: 'REGULAR',
+          sequence: 1,
+          total_cycles: 0, // This tells PayPal this recurring payment never ends (INFINITE)
+          frequency: {
+            interval_count: 1,
+            interval_unit: interval.toUpperCase(), // month -> MONTH
+          },
+          pricing_scheme: {
+            fixed_price: {
+              value: (amount / 100).toString(), // 1667 -> '16.67'
+              currency_code: currency,
+            },
+          },
+        },
+      ],
+      payment_preferences: {
+        auto_bill_outstanding: true,
+        payment_failure_threshold: 4, // Will fail up to 4 times, after that the subscription gets cancelled
+      },
+      /* eslint-enable camelcase */
+    },
+    host,
+  );
+}
+
+export async function getOrCreatePlan(
+  host: typeof models.Collective,
+  collective: typeof models.Collective,
+  interval: INTERVALS,
+  amount: number,
+  currency: string,
+  tier = null,
+): Promise<PaypalPlan> {
+  const product = await models.PaypalProduct.findOne({
+    where: { CollectiveId: collective.id, TierId: tier?.id || null },
+    include: [
+      {
+        association: 'plans',
+        required: false,
+        where: { currency, interval, amount },
+      },
+    ],
+  });
+
+  if (product) {
+    const plans = product['plans'];
+    if (plans[0]) {
+      // If we found a product and a plan matching these parameters, we can directly return them
+      logger.debug(`PayPal: Returning existing plan ${plans[0].id}`);
+      return plans[0];
+    } else {
+      // Otherwise we can create a new plan based on this product
+      logger.debug(`PayPal: Re-using existing product ${product.id} and creating new plan`);
+      const paypalPlan = await createPaypalPlan(host, collective, product.id, interval, amount, currency, tier);
+      return models.PaypalPlan.create({
+        id: <string>paypalPlan.id,
+        ProductId: product.id,
+        amount,
+        currency,
+        interval,
+      });
+    }
+  } else {
+    // If neither the plan or the product exist, we create both in one go
+    logger.debug(`PayPal: Creating a new plan`);
+    const paypalProduct = await createPaypalProduct(host, collective, tier);
+    const paypalPlan = await createPaypalPlan(host, collective, paypalProduct.id, interval, amount, currency, tier);
+    return models.PaypalPlan.create(
+      {
+        id: <string>paypalPlan.id,
+        amount,
+        currency,
+        interval,
+        product: {
+          id: <string>paypalProduct.id,
+          CollectiveId: collective.id,
+          TierId: tier?.id,
+        },
+      },
+      {
+        // Passing include for Sequelize to understand what `product` is
+        include: [{ association: 'product' }],
+      },
+    );
+  }
+}
+
+export const setupPaypalSubscriptionForOrder = async (
+  order: typeof models.Order,
+  paymentMethod: typeof models.PaymentMethod,
+): Promise<typeof models.Order> => {
+  const hostCollective = await order.collective.getHostCollective();
+  const existingSubscription = order.SubscriptionId && (await order.getSubscription());
+  const paypalSubscriptionId = paymentMethod.token;
+  const initialSubscriptionParams = pick(existingSubscription?.dataValues, [
+    'isManagedExternally',
+    'stripeSubscriptionId',
+    'paypalSubscriptionId',
+  ]);
+
+  // TODO handle case where a payment arrives on a cancelled subscription
+  // TODO refactor payment method to PayPal<>Subscription
+  try {
+    const newPaypalSubscription = await fetchPaypalSubscription(hostCollective, paypalSubscriptionId);
+    await verifySubscription(order, newPaypalSubscription);
+    await paymentMethod.update({ name: newPaypalSubscription.subscriber['email_address'] });
+
+    if (existingSubscription) {
+      // Cancel existing PayPal subscription
+      if (existingSubscription.paypalSubscriptionId) {
+        await cancelPaypalSubscription(order, 'Updated subscription');
+      }
+
+      // Update the subscription with the new params
+      await existingSubscription.update({
+        isManagedExternally: true,
+        stripeSubscriptionId: null,
+        paypalSubscriptionId,
+      });
+    } else {
+      await createSubscription(order, paypalSubscriptionId);
+    }
+
+    await paypalRequest(`billing/subscriptions/${paypalSubscriptionId}/activate`, null, hostCollective, 'POST');
+    if (order.PaymentMethodId !== paymentMethod.id) {
+      order = await order.update({ PaymentMethodId: paymentMethod.id });
+    }
+  } catch (e) {
+    logger.error(`[PayPal] Error while creating subscription: ${e}`);
+
+    // Restore the initial subscription
+    if (existingSubscription) {
+      await existingSubscription.update(initialSubscriptionParams);
+    }
+
+    const error = new Error('Failed to activate PayPal subscription');
+    error['rootException'] = e;
+    throw error;
+  }
+
+  return order;
+};
+
+export const updateSubscriptionWithPaypal = async (
+  user: typeof models.User,
+  order: typeof models.Order,
+  paypalSubscriptionId: string,
+): Promise<typeof models.Order> => {
+  const paymentMethod = await createPaypalPaymentMethodForSubscription(order, user, paypalSubscriptionId);
+  return setupPaypalSubscriptionForOrder(order, paymentMethod);
+};
+
+const createSubscription = async (order: typeof models.Order, paypalSubscriptionId) => {
+  return order.createSubscription({
+    paypalSubscriptionId,
+    amount: order.totalAmount,
+    currency: order.currency,
+    interval: order.interval,
+    quantity: order.quantity,
+    isActive: false, // Will be activated when the payment hits
+    isManagedExternally: true,
+    nextChargeDate: new Date(), // It's supposed to be charged now
+    nextPeriodStart: new Date(),
+    chargeNumber: 0,
+  });
+};
+
+const fetchPaypalSubscription = async (hostCollective, subscriptionId) => {
+  return paypalRequest(`billing/subscriptions/${subscriptionId}`, null, hostCollective, 'GET');
+};
+
+/**
+ * Ensures that subscription can be used for this contribution. This is to prevent malicious users
+ * from manually creating a subscription that would not match the minimum imposed by a tier.
+ */
+const verifySubscription = async (order: typeof models.Order, paypalSubscription) => {
+  if (paypalSubscription.status !== 'APPROVED') {
+    throw new Error('Subscription must be approved to be activated');
+  }
+
+  const plan = await models.PaypalPlan.findOne({
+    where: { id: paypalSubscription.plan_id },
+    include: [
+      {
+        association: 'product',
+        where: { CollectiveId: order.CollectiveId, TierId: order.TierId },
+        required: true,
+      },
+    ],
+  });
+
+  if (!plan) {
+    throw new Error(`PayPal plan does not match the subscription (#${paypalSubscription.id})`);
+  } else if (plan.amount !== order.totalAmount) {
+    throw new Error('The plan amount does not match the order amount');
+  }
+};
+
+export const isPaypalSubscriptionPaymentMethod = (paymentMethod: typeof models.PaymentMethod): boolean => {
+  return (
+    paymentMethod?.service === PAYMENT_METHOD_SERVICE.PAYPAL && paymentMethod.type === PAYMENT_METHOD_TYPE.SUBSCRIPTION
+  );
+};
+
+const PayPalSubscription: PaymentProviderService = {
+  features: {
+    recurring: true,
+    isRecurringManagedExternally: true,
+  },
+
+  async processOrder(order: typeof models.Order): Promise<typeof models.Transaction> {
+    return setupPaypalSubscriptionForOrder(order, order.paymentMethod);
+  },
+};
+
+export default PayPalSubscription;

--- a/server/paymentProviders/types.ts
+++ b/server/paymentProviders/types.ts
@@ -18,6 +18,7 @@ export interface PaymentProviderService {
    */
   features: {
     recurring: boolean;
+    isRecurringManagedExternally: boolean;
   };
 
   /**

--- a/sql/scrub_database.sql
+++ b/sql/scrub_database.sql
@@ -51,7 +51,7 @@ DELETE FROM "Donations" WHERE "CollectiveId" IS NULL;
 
 /* We delete all subscriptions that don't have a parent donation anymore */
 DELETE FROM "Subscriptions" WHERE id NOT IN (SELECT "SubscriptionId" FROM "Donations");
-UPDATE "Subscriptions" SET data = NULL, "stripeSubscriptionId"='*****';
+UPDATE "Subscriptions" SET data = NULL, "stripeSubscriptionId"='*****', "paypalSubscriptionId"='********';
 
 /* We only keep the StripeAccounts from Users that remain (their stripePublishableKey have already been sanitized) */
 DELETE FROM "StripeAccounts" WHERE id NOT IN (SELECT "StripeAccountId" FROM "Users");

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -552,9 +552,7 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
           updateOrderMutation,
           {
             order: { id: idEncode(order2.id, 'order') },
-            amount: {
-              value: 1000 / 100,
-            },
+            amount: { value: 1000 / 100 },
             tier: { legacyId: fixedTier.id }, // null or named tier
           },
           user,
@@ -592,7 +590,7 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
           },
           user,
         );
-
+        result.errors && console.error(result.errors);
         expect(result.errors).to.not.exist;
         expect(result.data.updateOrder.paymentMethod.id).to.eq(idEncode(paymentMethod.id, 'paymentMethod'));
       });

--- a/test/server/paymentProviders/paypal/api.test.ts
+++ b/test/server/paymentProviders/paypal/api.test.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import config from 'config';
+import nock from 'nock';
+import sinon from 'sinon';
+
+import models from '../../../../server/models';
+import { paypalRequest, paypalUrl, retrieveOAuthToken } from '../../../../server/paymentProviders/paypal/api';
+import { fakeCollective } from '../../../test-helpers/fake-data';
+import * as utils from '../../../utils';
+
+describe('server/paymentProviders/paypal/api', () => {
+  describe('#paypalUrl', () => {
+    let configStub;
+
+    afterEach(() => {
+      // The stub is created in each test and reset here.
+      configStub.restore();
+    }); /* End of `afterEach()' */
+
+    it('should use Sandbox API when config says so', () => {
+      configStub = sinon.stub(config.paypal.payment, 'environment').get(() => 'sandbox');
+      const url = paypalUrl('foo');
+      expect(url).to.equal('https://api.sandbox.paypal.com/v1/foo');
+    }); /* End of `should use Sandbox API when config says so' */
+
+    it('should use Production API when config says so', () => {
+      configStub = sinon.stub(config.paypal.payment, 'environment').get(() => 'production');
+      const url = paypalUrl('foo');
+      expect(url).to.equal('https://api.paypal.com/v1/foo');
+    }); /* End of `should use Production API when config says so' */
+  }); /* End of `#paypalUrl' */
+
+  describe('With PayPal auth', () => {
+    /* Another `describe' section is started here to share the stub of
+       the PayPal url `/v1/oauth2/token'. Which is pretty much
+       everything besides `paypalUrl` and`retrieveOAuthToken`. */
+
+    before(utils.resetTestDB);
+
+    let configStub;
+    before(() => {
+      /* Stub out the configuration with authentication information
+         and environment name. */
+      configStub = sinon.stub(config.paypal, 'payment').get(() => ({
+        environment: 'sandbox',
+      }));
+      /* Catch the retrieval of auth tokens */
+      nock('https://api.sandbox.paypal.com')
+        .persist()
+        .post('/v1/oauth2/token')
+        .basicAuth({ user: 'my-client-id', pass: 'my-client-secret' })
+        .reply(200, { access_token: 'dat-token' }); // eslint-disable-line camelcase
+    }); /* End of "before()" */
+
+    const secrets = {
+      clientId: 'my-client-id',
+      clientSecret: 'my-client-secret',
+    };
+    let host;
+    beforeEach(async () => {
+      const paypal = await models.ConnectedAccount.create({
+        service: 'paypal',
+        clientId: secrets.clientId,
+        token: secrets.clientSecret,
+      });
+      host = await fakeCollective({});
+      await host.addConnectedAccount(paypal);
+    });
+
+    after(() => {
+      configStub.restore();
+      nock.cleanAll();
+    }); /* End of "after()" */
+
+    describe('#retrieveOAuthToken', () => {
+      it('should retrieve the oauth token from PayPal API', async () => {
+        const token = await retrieveOAuthToken(secrets);
+        expect(token).to.equal('dat-token');
+      }); /* End of "should retrieve the oauth token from PayPal API" */
+    }); /* End of "#retrieveOAuthToken" */
+
+    describe('#paypalRequest', () => {
+      before(() => {
+        nock('https://api.sandbox.paypal.com')
+          .matchHeader('Authorization', 'Bearer dat-token')
+          .post('/v1/path/we/are/testing')
+          .reply(200, { success: 1 });
+      }); /* End of "before()" */
+
+      it('should request PayPal API endpoints', async () => {
+        const output = await paypalRequest('path/we/are/testing', {}, host);
+        expect(output).to.deep.equal({ success: 1 });
+      }); /* End of "#paypalRequest" */
+    }); /* End of "#paypalRequest" */
+  }); /* End of "With PayPal auth" */
+});

--- a/test/server/paymentProviders/paypal/payment.test.js
+++ b/test/server/paymentProviders/paypal/payment.test.js
@@ -21,27 +21,6 @@ describe('server/paymentProviders/paypal/payment', () => {
     expressApp = await app();
   });
 
-  describe('#paypalUrl', () => {
-    let configStub;
-
-    afterEach(() => {
-      // The stub is created in each test and reset here.
-      configStub.restore();
-    }); /* End of `afterEach()' */
-
-    it('should use Sandbox API when config says so', () => {
-      configStub = sinon.stub(config.paypal.payment, 'environment').get(() => 'sandbox');
-      const url = paypalPayment.paypalUrl('foo');
-      expect(url).to.equal('https://api.sandbox.paypal.com/v1/foo');
-    }); /* End of `should use Sandbox API when config says so' */
-
-    it('should use Production API when config says so', () => {
-      configStub = sinon.stub(config.paypal.payment, 'environment').get(() => 'production');
-      const url = paypalPayment.paypalUrl('foo');
-      expect(url).to.equal('https://api.paypal.com/v1/foo');
-    }); /* End of `should use Production API when config says so' */
-  }); /* End of `#paypalUrl' */
-
   describe('With PayPal auth', () => {
     /* Another `describe' section is started here to share the stub of
        the PayPal url `/v1/oauth2/token'. Which is pretty much
@@ -86,27 +65,6 @@ describe('server/paymentProviders/paypal/payment', () => {
       configStub.restore();
       nock.cleanAll();
     }); /* End of "after()" */
-
-    describe('#retrieveOAuthToken', () => {
-      it('should retrieve the oauth token from PayPal API', async () => {
-        const token = await paypalPayment.retrieveOAuthToken(secrets);
-        expect(token).to.equal('dat-token');
-      }); /* End of "should retrieve the oauth token from PayPal API" */
-    }); /* End of "#retrieveOAuthToken" */
-
-    describe('#paypalRequest', () => {
-      before(() => {
-        nock('https://api.sandbox.paypal.com')
-          .matchHeader('Authorization', 'Bearer dat-token')
-          .post('/v1/path/we/are/testing')
-          .reply(200, { success: 1 });
-      }); /* End of "before()" */
-
-      it('should request PayPal API endpoints', async () => {
-        const output = await paypalPayment.paypalRequest('path/we/are/testing', {}, host);
-        expect(output).to.deep.equal({ success: 1 });
-      }); /* End of "#paypalRequest" */
-    }); /* End of "#paypalRequest" */
 
     describe('#createPayment', () => {
       before(() => {

--- a/test/server/paymentProviders/paypal/subscription.test.ts
+++ b/test/server/paymentProviders/paypal/subscription.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable camelcase */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import * as PaypalAPI from '../../../../server/paymentProviders/paypal/api';
+import { setupPaypalSubscriptionForOrder } from '../../../../server/paymentProviders/paypal/subscription';
+import { randEmail } from '../../../stores';
+import {
+  fakeConnectedAccount,
+  fakeHost,
+  fakeOrder,
+  fakePaymentMethod,
+  fakePaypalPlan,
+  randStr,
+} from '../../../test-helpers/fake-data';
+import { resetTestDB } from '../../../utils';
+
+const fakePaypalSubscriptionPm = subscription => {
+  return fakePaymentMethod({ service: 'paypal', type: 'subscription', token: subscription.id });
+};
+
+describe('server/paymentProviders/paypal/subscription', () => {
+  let sandbox, host, plan, validSubscriptionParams;
+
+  before(async () => {
+    // Create host with PayPal
+    await resetTestDB();
+    host = await fakeHost();
+    await fakeConnectedAccount({ service: 'paypal', clientId: randStr(), token: randStr(), CollectiveId: host.id });
+    sandbox = sinon.createSandbox();
+    plan = await fakePaypalPlan({ product: { CollectiveId: host.id }, amount: 1000, interval: 'month' });
+  });
+
+  beforeEach(() => {
+    validSubscriptionParams = {
+      id: randStr(),
+      status: 'APPROVED',
+      plan_id: plan.id,
+      subscriber: {
+        email_address: randEmail(),
+      },
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('setupPaypalSubscriptionForOrder', () => {
+    it('activates the subscription when params are valid', async () => {
+      const paymentMethod = await fakePaypalSubscriptionPm(validSubscriptionParams);
+      const order = await fakeOrder({ CollectiveId: host.id, status: 'NEW', TierId: null, totalAmount: 1000 });
+      const paypalRequestStub = sandbox.stub(PaypalAPI, 'paypalRequest');
+      const subscriptionUrl = `billing/subscriptions/${paymentMethod.token}`;
+      paypalRequestStub.withArgs(subscriptionUrl).returns(validSubscriptionParams);
+      paypalRequestStub.withArgs(`${subscriptionUrl}/activate`).resolves();
+      await setupPaypalSubscriptionForOrder(order, paymentMethod);
+      sinon.assert.calledWith(paypalRequestStub, `${subscriptionUrl}/activate`);
+      const createdSubscription = await order.getSubscription();
+      expect(createdSubscription.paypalSubscriptionId).to.eq(validSubscriptionParams.id);
+      expect(createdSubscription.isActive).to.be.false; // Will be activated when the first payment hits
+    });
+
+    describe('subscription matches the contribution', () => {
+      it('must be APPROVED', async () => {
+        const paymentMethod = await fakePaypalSubscriptionPm(validSubscriptionParams);
+        const order = await fakeOrder({ CollectiveId: host.id, status: 'NEW', PaymentMethodId: paymentMethod.id });
+        const paypalRequestStub = sandbox.stub(PaypalAPI, 'paypalRequest');
+        const subscriptionUrl = `billing/subscriptions/${paymentMethod.token}`;
+        paypalRequestStub.withArgs(subscriptionUrl).returns({ ...validSubscriptionParams, status: 'ACTIVE' });
+        const error = await setupPaypalSubscriptionForOrder(order, paymentMethod).catch(e => e);
+        expect(error).to.exist;
+        expect(error['rootException'].message).to.eq('Subscription must be approved to be activated');
+        sinon.assert.calledOnce(paypalRequestStub); // We only fetch the subscription, not approving it
+      });
+
+      it('must have an existing plan', async () => {
+        const paymentMethod = await fakePaypalSubscriptionPm(validSubscriptionParams);
+        const order = await fakeOrder({ CollectiveId: host.id, status: 'NEW', TierId: null });
+        const paypalRequestStub = sandbox.stub(PaypalAPI, 'paypalRequest');
+        const subscriptionUrl = `billing/subscriptions/${paymentMethod.token}`;
+        paypalRequestStub.withArgs(subscriptionUrl).returns({ ...validSubscriptionParams, plan_id: 'xxxxxxx' });
+        const error = await setupPaypalSubscriptionForOrder(order, paymentMethod).catch(e => e);
+        expect(error).to.exist;
+        expect(error['rootException'].message).to.eq(
+          `PayPal plan does not match the subscription (#${validSubscriptionParams.id})`,
+        );
+        sinon.assert.calledOnce(paypalRequestStub); // We only fetch the subscription, not approving it
+      });
+
+      it('must have a plan that match amount', async () => {
+        const paymentMethod = await fakePaypalSubscriptionPm(validSubscriptionParams);
+        const order = await fakeOrder({ CollectiveId: host.id, status: 'NEW', TierId: null, totalAmount: 5000 });
+        const paypalRequestStub = sandbox.stub(PaypalAPI, 'paypalRequest');
+        const subscriptionUrl = `billing/subscriptions/${paymentMethod.token}`;
+        paypalRequestStub.withArgs(subscriptionUrl).returns(validSubscriptionParams);
+        const error = await setupPaypalSubscriptionForOrder(order, paymentMethod).catch(e => e);
+        expect(error).to.exist;
+        expect(error['rootException'].message).to.eq('The plan amount does not match the order amount');
+        sinon.assert.calledOnce(paypalRequestStub); // We only fetch the subscription, not approving it
+      });
+    });
+
+    describe('when a subscription already exists', () => {
+      const generateOrderWithSubscription = async () => {
+        const paypalSubscriptionId = randStr();
+        const paymentMethod = await fakePaypalSubscriptionPm({ ...validSubscriptionParams, id: paypalSubscriptionId });
+        return fakeOrder(
+          {
+            CollectiveId: host.id,
+            status: 'NEW',
+            TierId: null,
+            totalAmount: 1000,
+            subscription: { paypalSubscriptionId, isActive: false },
+            PaymentMethodId: paymentMethod.id,
+          },
+          {
+            withSubscription: true,
+          },
+        );
+      };
+
+      it('cancels/updates existing subscription', async () => {
+        const order = await generateOrderWithSubscription();
+        const previousSubscription = order.Subscription;
+        const newSubscriptionPm = await fakePaypalSubscriptionPm({ ...validSubscriptionParams, id: randStr() });
+
+        // PayPal API stubs
+        const paypalRequestStub = sandbox.stub(PaypalAPI, 'paypalRequest');
+        const oldSubscriptionUrl = `billing/subscriptions/${order.paymentMethod.token}`;
+        const subscriptionUrl = `billing/subscriptions/${newSubscriptionPm.token}`;
+        paypalRequestStub.withArgs(subscriptionUrl).returns(validSubscriptionParams);
+        paypalRequestStub.withArgs(`${subscriptionUrl}/activate`).resolves();
+        paypalRequestStub.withArgs(`${oldSubscriptionUrl}/cancel`).resolves();
+
+        await setupPaypalSubscriptionForOrder(order, newSubscriptionPm);
+        sinon.assert.calledWith(paypalRequestStub, subscriptionUrl);
+        sinon.assert.calledWith(paypalRequestStub, `${subscriptionUrl}/activate`);
+        sinon.assert.calledWith(paypalRequestStub, `${oldSubscriptionUrl}/cancel`);
+
+        const updatedSubscription = await order.getSubscription();
+        expect(updatedSubscription.paypalSubscriptionId).to.eq(newSubscriptionPm.token);
+        expect(previousSubscription.isActive).to.be.false;
+        expect(updatedSubscription.id).to.eq(previousSubscription.id);
+      });
+
+      it('does nothing if cancellation fails', async () => {
+        const order = await generateOrderWithSubscription();
+        const newSubscriptionPm = await fakePaypalSubscriptionPm({ ...validSubscriptionParams, id: randStr() });
+
+        // PayPal API stubs
+        const paypalRequestStub = sandbox.stub(PaypalAPI, 'paypalRequest');
+        const oldSubscriptionUrl = `billing/subscriptions/${order.paymentMethod.token}`;
+        const subscriptionUrl = `billing/subscriptions/${newSubscriptionPm.token}`;
+        paypalRequestStub.withArgs(subscriptionUrl).returns(validSubscriptionParams);
+        paypalRequestStub.withArgs(`${subscriptionUrl}/activate`).resolves();
+        paypalRequestStub.withArgs(`${oldSubscriptionUrl}/cancel`).rejects();
+
+        await expect(setupPaypalSubscriptionForOrder(order, newSubscriptionPm)).to.be.rejected;
+        sinon.assert.calledWith(paypalRequestStub, subscriptionUrl);
+        sinon.assert.calledWith(paypalRequestStub, `${oldSubscriptionUrl}/cancel`);
+        sinon.assert.callCount(paypalRequestStub, 2); // Must NOT call activate if cancellation fails
+      });
+    });
+  });
+});


### PR DESCRIPTION
Refactors:
- Move PayPal subscription to `paypal/subscription` provider/type. Store subscription ID in `token`
- Split `updateOrder` in smaller functions
- Moved PayPal API helpers (`paypalRequest` + `paypalRequestV2`) to `server/paymentProviders/paypal/api.ts`
- Paypal subscription now have an entry in the `Subscriptions` table, with `isManagedExternally` set to `true`. These subscriptions are ignored in the job used to charge contributions.