### PR TITLE
resendDraftExpenseInvite: Include key in URL

### DIFF
--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -404,7 +404,8 @@ const expenseMutations = {
         throw new Unauthorized("You don't have the permission to edit this expense.");
       }
 
-      const inviteUrl = `${config.host.website}/${expense.collective.slug}/expenses/${expense.id}`;
+      const draftKey = expense.data.draftKey;
+      const inviteUrl = `${config.host.website}/${expense.collective.slug}/expenses/${expense.id}?key=${draftKey}`;
       expense
         .createActivity(activities.COLLECTIVE_EXPENSE_INVITE_DRAFTED, req.remoteUser, { ...expense.data, inviteUrl })
         .catch(e => logger.error('An error happened when creating the COLLECTIVE_EXPENSE_INVITE_DRAFTED activity', e));


### PR DESCRIPTION
Reported in https://opencollective.freshdesk.com/a/tickets/14309

The key was missing from the email that was sent back to the user