### PR TITLE
getFxRate: Make sure currencies are uppercase

### DIFF
--- a/server/lib/currency.ts
+++ b/server/lib/currency.ts
@@ -130,6 +130,8 @@ export async function getFxRate(
   date: string | Date = 'latest',
 ): Promise<number> {
   debug(`getFxRate for ${date} ${fromCurrency} -> ${toCurrency}`);
+  fromCurrency = fromCurrency?.toUpperCase();
+  toCurrency = toCurrency?.toUpperCase();
 
   if (fromCurrency === toCurrency) {
     return 1;

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -215,7 +215,7 @@ const createChargeAndTransactions = async (hostStripeAccount, { order, hostStrip
       OrderId: order.id,
       amount: order.totalAmount,
       currency: order.currency,
-      hostCurrency: balanceTransaction.currency,
+      hostCurrency: balanceTransaction.currency?.toUpperCase(),
       amountInHostCurrency: balanceTransaction.amount,
       hostCurrencyFxRate: balanceTransaction.amount / order.totalAmount,
       paymentProcessorFeeInHostCurrency: fees.stripeFee,


### PR DESCRIPTION
This PR fixes one of the root cause for [this support ticket](https://opencollective.freshdesk.com/a/tickets/14258). 

In short, user payment was displayed as failed so they kept retrying, but the Stripe charge actually succeded. We failed to record the transaction because of two things:
1. Fixer API was down, so we could not fetch the conversion rate from there
2. Thew currency passed to `getFxRate` was coming from Stripe's `balanceTransaction` as lowercase (see [docs](https://stripe.com/docs/api/balance_transactions/object))

Because there was no Fixer API and fallback could not retrieve the fallback (it was expecting uppercase currencies) we failed to retrieve the FX Rate and crashed. This PR will fix most of the similar cases in the future if it happens again, and we'll address the underlying issue with https://github.com/opencollective/opencollective/issues/4174.