### PR TITLE
Use Consistent Nodejs Versions Among All Dev Machines

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v14
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -233,8 +233,8 @@
     "type:check": "tsc"
   },
   "engines": {
-    "node": "14.15.3",
-    "npm": "7.5.2"
+    "node": "14.x",
+    "npm": "6.x"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This makes sure all devs use consistent node versions especially since otherwise the package-lock.json version could change and create unnecessary oscillation in the package-lock.json file.

Related to https://github.com/opencollective/opencollective/issues/4177

Related to https://github.com/opencollective/opencollective-frontend/pull/6157