### PR TITLE
Webhooks: Handle Slack/Discord/Mattermost URLs

### DIFF
--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -39,7 +39,6 @@ export default async activity => {
   };
 
   const notificationChannels = await models.Notification.findAll({ where });
-
   return Promise.map(notificationChannels, notifConfig => {
     if (notifConfig.channel === channels.GITTER) {
       return publishToGitter(activity, notifConfig);
@@ -72,9 +71,13 @@ function publishToGitter(activity, notifConfig) {
 }
 
 function publishToWebhook(activity, webhookUrl) {
-  const sanitizedActivity = sanitizeActivity(activity);
-  const enrichedActivity = enrichActivity(sanitizedActivity);
-  return axios.post(webhookUrl, enrichedActivity);
+  if (slackLib.isSlackWebhookUrl(webhookUrl)) {
+    return slackLib.postActivityOnPublicChannel(activity, webhookUrl);
+  } else {
+    const sanitizedActivity = sanitizeActivity(activity);
+    const enrichedActivity = enrichActivity(sanitizedActivity);
+    return axios.post(webhookUrl, enrichedActivity);
+  }
 }
 
 /**

--- a/server/lib/slack.js
+++ b/server/lib/slack.js
@@ -13,6 +13,9 @@ export const OPEN_COLLECTIVE_SLACK_CHANNEL = {
   ABUSE: 'abuse',
 };
 
+// Mattermost is compatible with Slack webhooks
+const KNOWN_MATTERMOST_INSTANCES = ['https://chat.diglife.coop/hooks/'];
+
 export default {
   /*
    * Post a given activity to a public channel (meaning scrubbed info only)
@@ -72,5 +75,16 @@ export default {
         return resolve();
       });
     });
+  },
+
+  isSlackWebhookUrl(url) {
+    if (url.startsWith('https://hooks.slack.com/')) {
+      return true;
+    } else if (url.match(/^https:\/\/discord(app)?\.com\/api\/webhooks\/.+\/slack$/)) {
+      // Discord slack-compatible webhook - See https://discord.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
+      return true;
+    }
+
+    return KNOWN_MATTERMOST_INSTANCES.some(mattermostUrl => url.startsWith(mattermostUrl));
   },
 };

--- a/test/server/lib/notifications.test.ts
+++ b/test/server/lib/notifications.test.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+import sinon from 'sinon';
+
+import { activities } from '../../../server/constants';
+import channels from '../../../server/constants/channels';
+import notify from '../../../server/lib/notifications';
+import slackLib from '../../../server/lib/slack';
+import { fakeActivity, fakeCollective, fakeNotification, fakeUser } from '../../test-helpers/fake-data';
+import { resetTestDB } from '../../utils';
+
+const generateCollectiveApplyActivity = async collective => {
+  return fakeActivity(
+    {
+      CollectiveId: collective.id,
+      type: activities.COLLECTIVE_APPLY,
+      data: {
+        host: collective.host.info,
+        collective: collective.info,
+        user: (await fakeUser()).info,
+      },
+    },
+    // Pass hooks false to only trigger `notify` manually
+    { hooks: false },
+  );
+};
+
+describe('server/lib/notification', () => {
+  let sandbox, axiosPostStub, slackPostActivityOnPublicChannelStub;
+
+  before(async () => {
+    await resetTestDB();
+    sandbox = sinon.createSandbox();
+  });
+
+  beforeEach(() => {
+    axiosPostStub = sandbox.stub(axios, 'post').resolves();
+    slackPostActivityOnPublicChannelStub = sandbox.stub(slackLib, 'postActivityOnPublicChannel').resolves();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('notify', () => {
+    describe('with channels.WEBHOOK', () => {
+      it('posts to regular webhooks', async () => {
+        const collective = await fakeCollective();
+        const notification = await fakeNotification({
+          channel: channels.WEBHOOK,
+          type: activities.COLLECTIVE_APPLY,
+          CollectiveId: collective.host.id,
+        });
+
+        const activity = await generateCollectiveApplyActivity(collective);
+        await notify(activity);
+        sinon.assert.calledWithMatch(axiosPostStub, notification.webhookUrl, { type: 'collective.apply' });
+      });
+
+      it('posts to slack webhooks', async () => {
+        const collective = await fakeCollective();
+        const notification = await fakeNotification({
+          channel: channels.WEBHOOK,
+          type: activities.COLLECTIVE_APPLY,
+          CollectiveId: collective.host.id,
+          webhookUrl: 'https://hooks.slack.com/services/xxxxx/yyyyy/zzzz',
+        });
+
+        const activity = await generateCollectiveApplyActivity(collective);
+        await notify(activity);
+        sinon.assert.notCalled(axiosPostStub);
+        sinon.assert.calledWith(slackPostActivityOnPublicChannelStub, activity, notification.webhookUrl);
+      });
+
+      it("posts to discord's slack-compatible webhooks", async () => {
+        const collective = await fakeCollective();
+        const notification = await fakeNotification({
+          channel: channels.WEBHOOK,
+          type: activities.COLLECTIVE_APPLY,
+          CollectiveId: collective.host.id,
+          webhookUrl: 'https://discord.com/api/webhooks/xxxxxxxx/yyyyyyyyyy/slack',
+        });
+
+        const activity = await generateCollectiveApplyActivity(collective);
+        await notify(activity);
+        sinon.assert.notCalled(axiosPostStub);
+        sinon.assert.calledWith(slackPostActivityOnPublicChannelStub, activity, notification.webhookUrl);
+      });
+
+      it("posts to Mattermost's slack-compatible webhooks", async () => {
+        const collective = await fakeCollective();
+        const notification = await fakeNotification({
+          channel: channels.WEBHOOK,
+          type: activities.COLLECTIVE_APPLY,
+          CollectiveId: collective.host.id,
+          webhookUrl: 'https://chat.diglife.coop/hooks/xxxxxxxxxxxxxxx',
+        });
+
+        const activity = await generateCollectiveApplyActivity(collective);
+        await notify(activity);
+        sinon.assert.notCalled(axiosPostStub);
+        sinon.assert.calledWith(slackPostActivityOnPublicChannelStub, activity, notification.webhookUrl);
+      });
+    });
+  });
+});

--- a/test/stores/index.js
+++ b/test/stores/index.js
@@ -32,8 +32,8 @@ export function randEmail(email = 'test-user@emailprovider.com') {
 }
 
 /** Returns a random URL. */
-export function randUrl() {
-  return `https://example.com/${uuid()}`;
+export function randUrl(base = 'example.com') {
+  return `https://${base}/${uuid()}`;
 }
 
 /** Convert string to lower case and swap spaces with dashes */

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -9,7 +9,7 @@
 import { get, padStart, sample } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
-import { roles } from '../../server/constants';
+import { activities, channels, roles } from '../../server/constants';
 import { types as CollectiveType } from '../../server/constants/collectives';
 import { PAYMENT_METHOD_SERVICES, PAYMENT_METHOD_TYPES } from '../../server/constants/paymentMethods';
 import { REACTION_EMOJI } from '../../server/constants/reaction-emoji';
@@ -407,6 +407,41 @@ export const fakeOrder = async (orderData = {}, { withSubscription = false, with
   order.collective = collective;
   order.createdByUser = user;
   return order;
+};
+
+export const fakeSubscription = (params = {}) => {
+  return models.Subscription.create({
+    amount: randAmount(),
+    currency: sample(['USD', 'EUR']),
+    interval: sample(['month', 'year']),
+    isActive: true,
+    quantity: 1,
+    ...params,
+  });
+};
+
+export const fakeNotification = async (data = {}) => {
+  return models.Notification.create({
+    channel: sample(Object.values(channels)),
+    type: sample(Object.values(activities)),
+    active: true,
+    CollectiveId: data.CollectiveId || (await fakeCollective()).id,
+    UserId: data.UserId || (await fakeUser()).id,
+    webhookUrl: randUrl('test.opencollective.com/webhooks'),
+    ...data,
+  });
+};
+
+export const fakeActivity = async (data = {}, sequelizeParams) => {
+  return models.Activity.create(
+    {
+      CollectiveId: data.CollectiveId || (await fakeCollective()).id,
+      UserId: data.UserId || (await fakeUser()).id,
+      type: sample(Object.values(activities)),
+      ...data,
+    },
+    sequelizeParams,
+  );
 };
 
 /**


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/3448
Part of https://github.com/opencollective/opencollective/issues/3632
Resolve https://github.com/opencollective/opencollective/issues/3951

This PR implements the quick fix suggested in https://github.com/opencollective/opencollective/issues/3448#issuecomment-815580185 to allow anyone to create Slack or Discord webhooks.

I've updated the specs in https://github.com/opencollective/opencollective/issues/3448#issue-690006587 to reflect the next steps, as this implementation still require a manual intervention if people want to add mattermost webhooks.