### PR TITLE
PayPal: Automatic webhook management

### DIFF
--- a/scripts/update-hosts-paypal-webhooks.ts
+++ b/scripts/update-hosts-paypal-webhooks.ts
@@ -1,0 +1,43 @@
+/**
+ * This script can be used whenever PayPal webhooks event types change to update
+ * Host's connected accounts.
+ */
+
+import '../server/env';
+
+import logger from '../server/lib/logger';
+import * as PaypalLib from '../server/lib/paypal';
+import models, { Op, sequelize } from '../server/models';
+
+const getAllHostsWithPaypalAccounts = () => {
+  return models.Collective.findAll({
+    where: { isHostAccount: true },
+    group: [sequelize.col('Collective.id')],
+    include: [
+      {
+        association: 'ConnectedAccounts',
+        required: true,
+        attributes: [],
+        where: { service: 'paypal', clientId: { [Op.not]: null }, token: { [Op.not]: null } },
+      },
+    ],
+  });
+};
+
+const main = async (): Promise<void> => {
+  const allHosts = await getAllHostsWithPaypalAccounts();
+
+  for (const host of allHosts) {
+    logger.info(`Checking PayPal webhook for ${host.slug}...`);
+    await PaypalLib.setupPaypalWebhookForHost(host);
+  }
+
+  return;
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/server/graphql/v2/mutation/ConnectedAccountMutations.ts
+++ b/server/graphql/v2/mutation/ConnectedAccountMutations.ts
@@ -88,6 +88,10 @@ const connectedAccountMutations = {
         hash: crypto.hash(args.connectedAccount.service + args.connectedAccount.token),
       });
 
+      if (args.connectedAccount.service === Service.PAYPAL) {
+        await paypal.setupPaypalWebhookForHost(collective);
+      }
+
       return connectedAccount;
     },
   },

--- a/server/lib/paypal.ts
+++ b/server/lib/paypal.ts
@@ -2,10 +2,26 @@
 import paypal from '@paypal/payouts-sdk';
 import config from 'config';
 import express from 'express';
+import { difference, find } from 'lodash';
 
-import { PayoutBatchDetails, PayoutRequestBody, PayoutRequestResult } from '../types/paypal';
+import models, { Op } from '../models';
+import { paypalRequest } from '../paymentProviders/paypal/api';
+import {
+  PayoutBatchDetails,
+  PayoutRequestBody,
+  PayoutRequestResult,
+  PaypalWebhook,
+  PaypalWebhookEventType,
+  PaypalWebhookPatch,
+} from '../types/paypal';
 
+import logger from './logger';
 import { floatAmountToCents } from './math';
+
+const PAYPAL_WEBHOOK_URL =
+  config.env === 'development'
+    ? 'https://smee.io/opencollective-paypal-dev-testing' // localhost URLs are not supported by PayPal
+    : `${config.host.api}/webhooks/paypal`;
 
 const parseError = e => {
   try {
@@ -70,6 +86,19 @@ export const validateConnectedAccount = async ({ token, clientId }: ConnectedAcc
   await client.fetchAccessToken();
 };
 
+export const getHostPaypalAccount = async (host): Promise<typeof models.ConnectedAccount> => {
+  const [account] = await host.getConnectedAccounts({
+    where: { service: 'paypal', clientId: { [Op.not]: null }, token: { [Op.not]: null } },
+    order: [['createdAt', 'DESC']],
+  });
+
+  if (!account || !account.clientId || !account.token) {
+    return null;
+  } else {
+    return account;
+  }
+};
+
 export const validateWebhookEvent = async (
   { token, clientId, settings }: ConnectedAccount,
   req: express.Request,
@@ -104,6 +133,169 @@ export const validateWebhookEvent = async (
 /** Converts a PayPal amount like '12.50' to its value in cents (1250) */
 export const paypalAmountToCents = (amountStr: string): number => {
   return floatAmountToCents(parseFloat(amountStr));
+};
+
+// ---- Webhooks management ----
+
+/**
+ * This array defines all the event types that we're watching in `server/paymentProviders/paypal/webhook.ts`.
+ * After adding something here, you'll need to run `scripts/update-hosts-paypal-webhooks.ts` to update
+ * all the existing webhooks.
+ */
+const WATCHED_EVENT_TYPES = [
+  // Payouts
+  'PAYMENT.PAYOUTSBATCH.DENIED',
+  'PAYMENT.PAYOUTSBATCH.PROCESSING',
+  'PAYMENT.PAYOUTSBATCH.SUCCESS',
+  'PAYMENT.PAYOUTS-ITEM.BLOCKED',
+  'PAYMENT.PAYOUTS-ITEM.CANCELED',
+  'PAYMENT.PAYOUTS-ITEM.DENIED',
+  'PAYMENT.PAYOUTS-ITEM.FAILED',
+  'PAYMENT.PAYOUTS-ITEM.HELD',
+  'PAYMENT.PAYOUTS-ITEM.REFUNDED',
+  'PAYMENT.PAYOUTS-ITEM.RETURNED',
+  'PAYMENT.PAYOUTS-ITEM.SUCCEEDED',
+  'PAYMENT.PAYOUTS-ITEM.UNCLAIMED',
+  // Subscriptions
+  'BILLING.SUBSCRIPTION.CANCELLED',
+  'BILLING.SUBSCRIPTION.SUSPENDED',
+  'BILLING.SUBSCRIPTION.ACTIVATED',
+  'PAYMENT.SALE.COMPLETED',
+];
+
+/**
+ * See https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_list
+ */
+const listPaypalWebhooks = async (host): Promise<PaypalWebhook[]> => {
+  const result = await paypalRequest('notifications/webhooks', null, host, 'GET');
+  return <PaypalWebhook[]>result['webhooks'];
+};
+
+/**
+ * See https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_post
+ */
+const createPaypalWebhook = async (host, webhookData): Promise<PaypalWebhook> => {
+  return <PaypalWebhook>await paypalRequest(`notifications/webhooks`, webhookData, host, 'POST');
+};
+
+/**
+ * See https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_update
+ */
+const updatePaypalWebhook = async (
+  host,
+  webhookId: string,
+  patchRequest: PaypalWebhookPatch,
+): Promise<PaypalWebhook> => {
+  return <PaypalWebhook>await paypalRequest(`notifications/webhooks/${webhookId}`, patchRequest, host, 'PATCH');
+};
+
+/**
+ * See https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_get
+ */
+const getPaypalWebhook = async (host, webhookId): Promise<PaypalWebhook> => {
+  return <PaypalWebhook>await paypalRequest(`notifications/webhooks/${webhookId}`, null, host, 'GET');
+};
+
+/**
+ * See https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_delete
+ */
+const deletePaypalWebhook = async (host, webhookId): Promise<void> => {
+  await paypalRequest(`notifications/webhooks/${webhookId}`, null, host, 'DELETE');
+};
+
+const isOpenCollectiveWebhook = (webhook: PaypalWebhook): boolean => {
+  return webhook.url !== PAYPAL_WEBHOOK_URL;
+};
+
+/**
+ * Check if a webhook has all event types required by Open Collective
+ */
+const isCompatibleWebhook = (webhook: PaypalWebhook): boolean => {
+  if (!isOpenCollectiveWebhook(webhook)) {
+    return false;
+  } else {
+    const webhookEvents = webhook['event_types'].map(event => event.name);
+    const differences = difference(webhookEvents, WATCHED_EVENT_TYPES);
+    return differences.length === 0;
+  }
+};
+
+/**
+ * Check if the connected account setup for this host is compatible with our system
+ */
+const hostPaypalWebhookIsReady = async (host): Promise<boolean> => {
+  const connectedAccount = await getHostPaypalAccount(host);
+  const webhookId = connectedAccount?.settings?.webhookId;
+  if (!webhookId) {
+    return false;
+  }
+
+  const webhook = await getPaypalWebhook(host, webhookId);
+  return webhook ? isCompatibleWebhook(webhook) : false;
+};
+
+const updatePaypalAccountWithWebhook = async (connectedAccount, webhook: PaypalWebhook) => {
+  if (connectedAccount.settings?.webhookId === webhook.id) {
+    return connectedAccount; // Nothing to do
+  }
+
+  return connectedAccount.update({ settings: { ...connectedAccount.settings, webhookId: webhook.id } });
+};
+
+/**
+ * If needed, create a new webhook on PayPal and update host's connected account with its new info
+ */
+export const setupPaypalWebhookForHost = async (host): Promise<void> => {
+  if (await hostPaypalWebhookIsReady(host)) {
+    logger.debug(`Host ${host.slug} already has a compatible webhook linked, skipping`);
+    return;
+  }
+
+  let newWebhook;
+  const connectedAccount = await getHostPaypalAccount(host);
+  const existingWebhooks = await listPaypalWebhooks(host);
+  const existingOCWebhook = find(existingWebhooks, isOpenCollectiveWebhook);
+
+  if (existingOCWebhook) {
+    if (isCompatibleWebhook(existingOCWebhook)) {
+      // Link webhook directly if it has the right events
+      logger.info(`Found an existing PayPal webhook to use, linking ${existingOCWebhook.id} to ${host.slug}`);
+      newWebhook = existingOCWebhook;
+    } else {
+      // Update webhook
+      logger.info(`Updating PayPal webhook ${existingOCWebhook.id} for ${host.slug}`);
+      const eventTypes = <PaypalWebhookEventType[]>WATCHED_EVENT_TYPES.map(name => ({ name }));
+      const patchRequest = [{ op: 'replace', path: '/event_types', value: eventTypes }];
+      newWebhook = await updatePaypalWebhook(host, existingOCWebhook.id, patchRequest);
+    }
+  } else {
+    // Create webhook
+    logger.info(`Creating PayPal webhook for ${host.slug}`);
+    const eventTypes = WATCHED_EVENT_TYPES.map(name => ({ name }));
+    const webhookData = { url: PAYPAL_WEBHOOK_URL, event_types: eventTypes };
+    newWebhook = await createPaypalWebhook(host, webhookData);
+  }
+
+  await updatePaypalAccountWithWebhook(connectedAccount, newWebhook);
+};
+
+/**
+ * Removes all the Paypal webhooks pointing to Open Collective that are currently not used
+ */
+export const removeUnusedPaypalWebhooks = async (host): Promise<number> => {
+  const connectedAccount = await getHostPaypalAccount(host);
+  const currentWebhookId = connectedAccount?.settings?.webhookId;
+  const allHostWebhooks = await listPaypalWebhooks(host);
+  let deletedCount = 0;
+
+  for (const webhook of allHostWebhooks) {
+    if (webhook.url === PAYPAL_WEBHOOK_URL && webhook.id !== currentWebhookId) {
+      await deletePaypalWebhook(host, webhook.id);
+      deletedCount += 1;
+    }
+  }
+
+  return deletedCount;
 };
 
 export { paypal };

--- a/server/paymentProviders/paypal/webhook.ts
+++ b/server/paymentProviders/paypal/webhook.ts
@@ -145,6 +145,11 @@ async function handleSubscriptionActivated(req: Request): Promise<void> {
   }
 }
 
+/**
+ * Webhook entrypoint. When adding a new event type here, you should also add it to
+ * `server/lib/paypal.ts` > `WATCHED_EVENT_TYPES` and run `scripts/update-hosts-paypal-webhooks.ts`
+ * to update all existing webhooks.
+ */
 async function webhook(req: Request): Promise<void> {
   debug('new event', req.body);
   const eventType = get(req, 'body.event_type');

--- a/server/types/paypal.ts
+++ b/server/types/paypal.ts
@@ -147,3 +147,20 @@ export type PayoutWebhookRequest = {
   };
   links: PayPalLink[];
 };
+
+export type PaypalWebhookEventType = {
+  name: string;
+  description: string;
+};
+
+export type PaypalWebhook = {
+  id: string;
+  url: string;
+  event_types: PaypalWebhookEventType[];
+};
+
+export type PaypalWebhookPatch = {
+  op: string;
+  path: string;
+  value: string | PaypalWebhookEventType[];
+}[];


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4096

This PR implements automatic PayPal webhooks management through two separate mechanisms:

1. **`scripts/update-hosts-paypal-webhooks.ts`**
The script can be triggered on the API to update the webhooks for all existing PayPal accounts. It will basically go through each one of them, and either create, link, or update the webhook to make sure events match what we expect.
If we ever need to support (or remove) an event in our webhook for PayPal, all we have to do is to run `npm run script scripts/update-hosts-paypal-webhooks.ts` and it will take care of updating all PayPal integrations.

2. **Automatically create the webhook when a PayPal account is linked**
See screencast below. https://github.com/opencollective/opencollective-frontend/pull/6167 will take care of removing the field in the frontend.

![Peek 2021-04-13 17-29](https://user-images.githubusercontent.com/1556356/114579131-d991fb00-9c7d-11eb-8650-bcbb6789793f.gif)
