### PR TITLE
Fix PayPal Payouts cross-currency transaction FXRate

### DIFF
--- a/server/lib/transactions.js
+++ b/server/lib/transactions.js
@@ -1,3 +1,5 @@
+import { round, toNumber } from 'lodash';
+
 import { TransactionTypes } from '../constants/transactions';
 import { getFxRate } from '../lib/currency';
 import errors from '../lib/errors';
@@ -116,6 +118,17 @@ export async function createFromPaidExpense(
     const currencyConversion = createPaymentResponse.defaultFundingPlan.currencyConversion || { exchangeRate: 1 };
     hostCurrencyFxRate = 1 / parseFloat(currencyConversion.exchangeRate); // paypal returns a float from host.currency to expense.currency
     paymentProcessorFeeInHostCurrency = Math.round(hostCurrencyFxRate * paymentProcessorFeeInCollectiveCurrency);
+  }
+  // PayPal Payouts
+  else if (payoutMethodType === PayoutMethodTypes.PAYPAL && transactionData?.payout_batch_id) {
+    hostCurrencyFxRate = transactionData.currency_conversion?.exchange_rate
+      ? 1 / toNumber(transactionData.currency_conversion?.exchange_rate)
+      : await getFxRate(expense.currency, host.currency, expense.incurredAt || expense.createdAt);
+
+    paymentProcessorFeeInCollectiveCurrency = round(toNumber(transactionData.payout_item_fee?.value) * 100);
+    paymentProcessorFeeInHostCurrency = Math.round(hostCurrencyFxRate * paymentProcessorFeeInCollectiveCurrency);
+    hostFeeInCollectiveCurrency = Math.round((1 / hostCurrencyFxRate) * hostFeeInHostCurrency);
+    platformFeeInCollectiveCurrency = Math.round((1 / hostCurrencyFxRate) * platformFeeInHostCurrency);
   } else if (payoutMethodType === PayoutMethodTypes.BANK_ACCOUNT) {
     // Notice this is the FX rate between Host and Collective, the user is not involved here and that's why TransferWise quote rate is irrelevant here.
     hostCurrencyFxRate = await getFxRate(expense.currency, host.currency);

--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import { isNil, round, toNumber } from 'lodash';
+import { isNil, round } from 'lodash';
 import moment from 'moment';
 
 import activities from '../../constants/activities';
@@ -84,21 +84,10 @@ export const checkBatchItemStatus = async (
     throw new Error(`Item does not belongs to expense it claims it does.`);
   }
 
-  const paymentProcessorFeeInHostCurrency = round(toNumber(item.payout_item_fee?.value) * 100);
   switch (item.transaction_status) {
     case 'SUCCESS':
       if (expense.status !== status.PAID) {
-        await createTransactionFromPaidExpense(
-          host,
-          null,
-          expense,
-          null,
-          expense.UserId,
-          paymentProcessorFeeInHostCurrency,
-          0,
-          0,
-          item,
-        );
+        await createTransactionFromPaidExpense(host, null, expense, null, expense.UserId, 0, 0, 0, item);
         await expense.setPaid(expense.lastEditedById);
         const user = await models.User.findByPk(expense.lastEditedById);
         await expense.createActivity(activities.COLLECTIVE_EXPENSE_PAID, user);


### PR DESCRIPTION
Last week we had our first cross-currency PayPal Payout expense settlement and we found a small bug.
This fix will detect when dealing with PayPal Payout transaction and it will use PayPal's FX on our transactions.