### PR TITLE
Ensure vendor uppercase slug consistency

### DIFF
--- a/migrations/20210420162000-uppercase-vendor-slugs.js
+++ b/migrations/20210420162000-uppercase-vendor-slugs.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      UPDATE "Collectives"
+        SET "slug" = UPPER("slug")
+      WHERE
+        "type" = 'VENDOR';
+    `);
+    await queryInterface.sequelize.query(`
+      UPDATE "CollectiveHistories"
+        SET "slug" = UPPER("slug")
+      WHERE
+        "type" = 'VENDOR';
+    `);
+  },
+};

--- a/server/paymentProviders/privacy/index.ts
+++ b/server/paymentProviders/privacy/index.ts
@@ -46,8 +46,9 @@ const createExpense = async (
   const UserId = collective.CreatedByUserId;
 
   const expense = await sequelize.transaction(async transaction => {
+    const slug = privacyTransaction.merchant.acceptor_id.toUpperCase();
     const [vendor] = await models.Collective.findOrCreate({
-      where: { slug: privacyTransaction.merchant.acceptor_id },
+      where: { slug },
       defaults: { name: privacyTransaction.merchant.descriptor, type: CollectiveTypes.VENDOR },
       transaction,
     });


### PR DESCRIPTION
Related to error caught on our production log:
![image](https://user-images.githubusercontent.com/2119706/115452997-824bd780-a1f5-11eb-8a32-a4771d90378d.png)
