### PR TITLE
fix(migrations/uppercase-vendor-slugs): Add empty down method

### DIFF
--- a/migrations/20210420162000-uppercase-vendor-slugs.js
+++ b/migrations/20210420162000-uppercase-vendor-slugs.js
@@ -15,4 +15,7 @@ module.exports = {
         "type" = 'VENDOR';
     `);
   },
+  down: async () => {
+    // Nothing to do
+  },
 };


### PR DESCRIPTION
Migrations must have a `down` key, otherwise rolling back produces a crash. We should probably add an ESLint rule for that.

```bash
➜  opencollective-api git:(main) npm run db:migrate:undo 
== 20210420162000-uppercase-vendor-slugs: reverting =======

ERROR: Could not find migration method: down
```