### PR TITLE
PlatformTips: Deprecate `PlatformTipForTransactionGroup`

### DIFF
--- a/cron/monthly/invoice-platform-fees.js
+++ b/cron/monthly/invoice-platform-fees.js
@@ -71,9 +71,9 @@ export async function run() {
       FROM
         "Transactions" t
       LEFT JOIN "Transactions" ot ON
-        t."PlatformTipForTransactionGroup"::uuid = ot."TransactionGroup"
+        t."TransactionGroup" = ot."TransactionGroup"
         AND ot.type = 'CREDIT'
-        AND ot."PlatformTipForTransactionGroup" IS NULL
+        AND ot.kind IN ('CONTRIBUTION', 'ADDED_FUNDS') -- we only support adding tips on contributions and addedd funds for now
       LEFT JOIN "Collectives" h ON
         ot."HostCollectiveId" = h.id
       LEFT JOIN "Collectives" c ON
@@ -87,7 +87,7 @@ export async function run() {
         AND t."createdAt" < date_trunc('month', date :date)
         AND t."deletedAt" IS NULL
         AND t."CollectiveId" = 8686
-        AND t."PlatformTipForTransactionGroup" IS NOT NULL
+        AND t."kind" = 'PLATFORM_TIP'
         AND t."type" = 'CREDIT'
         AND ot."HostCollectiveId" NOT IN (8686)
         AND (
@@ -236,9 +236,9 @@ export async function run() {
       FROM
         "Transactions" t
       LEFT JOIN "Transactions" ot ON
-        t."PlatformTipForTransactionGroup"::uuid = ot."TransactionGroup"
+        t."TransactionGroup" = ot."TransactionGroup"
         AND ot.type = 'CREDIT'
-        AND ot."PlatformTipForTransactionGroup" IS NULL
+        AND ot.kind IN ('CONTRIBUTION', 'ADDED_FUNDS') -- we only support adding tips on contributions and addedd funds for now
       LEFT JOIN "Collectives" h ON
         ot."HostCollectiveId" = h.id
       LEFT JOIN "Collectives" c ON
@@ -252,7 +252,7 @@ export async function run() {
         AND t."createdAt" < date_trunc('month',  date :date)
         AND t."deletedAt" IS NULL
         AND t."CollectiveId" = 8686
-        AND t."PlatformTipForTransactionGroup" IS NOT NULL
+        AND t."kind" = 'PLATFORM_TIP'
         AND t."type" = 'CREDIT'
         AND ot."HostCollectiveId" NOT IN (8686)
         AND (

--- a/migrations/20210421135937-migrate-platform-tip-transaction-group.js
+++ b/migrations/20210421135937-migrate-platform-tip-transaction-group.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Migrate all entries (1198) missed by `migrations/20201016085526-add-platform-contribution-transaction-group.js`,
+ * ignoring the ones already migrated.
+ */
+module.exports = {
+  up: async queryInterface => {
+    return queryInterface.sequelize.query(`
+      UPDATE
+        "Transactions"
+      SET
+        "PlatformTipForTransactionGroup" = transaction_links."TransactionGroup"
+      FROM (
+        SELECT
+          t.id AS transaction_id,
+          t."TransactionGroup" AS "TransactionGroup",
+          platform_tip.id AS platform_tip_id
+        FROM
+          "Transactions" t
+        INNER JOIN "Transactions" platform_tip ON (
+          t."OrderId" = platform_tip."OrderId"
+          AND t."type" = platform_tip."type"
+          AND t.id != platform_tip.id 
+        )
+        INNER JOIN "PaymentMethods" pm ON
+          t."PaymentMethodId" = pm.id
+        LEFT JOIN "PaymentMethods" spm ON
+          pm."SourcePaymentMethodId" = spm.id
+        WHERE
+          -- We only want to migrate transactions that have been missed by the previous migration
+          platform_tip."PlatformTipForTransactionGroup" IS NULL
+          AND (t.data ->> 'isFeesOnTop')::boolean = TRUE
+          -- platform_tip: Only transactions on "opencollective" (#8686)
+          AND t."FromCollectiveId" != 8686 AND t."CollectiveId" != 8686
+          AND (
+            (platform_tip.type = 'CREDIT' AND platform_tip."CollectiveId" = 8686)
+            OR (platform_tip.type = 'DEBIT' AND platform_tip."FromCollectiveId" = 8686)
+          )
+          -- Link based on payment method
+          AND (
+            -- Stripe
+            (
+              ((pm.service = 'stripe' AND pm.type = 'creditcard') OR (spm.service = 'stripe' AND spm.type = 'creditcard'))
+              AND (platform_tip.data -> 'charge' ->> 'id') = (t.data -> 'charge' ->> 'id')
+            )
+            -- PayPal
+            OR (pm.service = 'paypal' AND pm.type = 'payment' AND (platform_tip.data ->> 'id') = (t.data ->> 'id'))
+            -- Collective PM
+            OR (pm.service = 'opencollective' AND pm.type = 'collective' )
+          )
+        GROUP BY t.id, platform_tip.id
+      ) AS transaction_links
+      WHERE
+        "Transactions".id = transaction_links.platform_tip_id
+    `);
+  },
+
+  down: async () => {
+    // Nothing to do
+  },
+};

--- a/migrations/20210421143121-remove-PlatformTipForTransactionGroup.js
+++ b/migrations/20210421143121-remove-PlatformTipForTransactionGroup.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    // Migrate all existing platform tips to make sure their TransactionGroup are the same
+    // as the transactions they're referring to.
+    await queryInterface.sequelize.query(`
+      UPDATE "Transactions"
+      SET "TransactionGroup" = "PlatformTipForTransactionGroup"::uuid
+      WHERE "PlatformTipForTransactionGroup" IS NOT NULL
+      AND "PlatformTipForTransactionGroup"::uuid != "TransactionGroup"
+      AND (data ->> 'isFeesOnTop')::boolean = TRUE
+    `);
+
+    // Remove `PlatformTipForTransactionGroup`
+    await queryInterface.removeColumn('Transactions', 'PlatformTipForTransactionGroup');
+
+    // Add an index on `TransactionGroup`, since we're going to use it more intensively from now on
+    await queryInterface.addIndex('Transactions', ['TransactionGroup'], { concurrently: true });
+  },
+
+  down: async () => {
+    // Nothing to do
+  },
+};

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -35,6 +35,7 @@ import FEATURE from '../constants/feature';
 import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../constants/paymentMethods';
 import plans from '../constants/plans';
 import roles, { MemberRoleLabels } from '../constants/roles';
+import { TransactionKind } from '../constants/transaction-kind';
 import { FEES_ON_TOP_TRANSACTION_PROPERTIES, TransactionTypes } from '../constants/transactions';
 import { hasOptedOutOfFeature, isFeatureAllowedForCollectiveType } from '../lib/allowed-features';
 import {
@@ -3021,7 +3022,8 @@ function defineModel() {
         ...pick(FEES_ON_TOP_TRANSACTION_PROPERTIES, ['CollectiveId', 'HostCollectiveId']),
         createdAt: { [Op.gte]: from, [Op.lt]: to },
         type: TransactionTypes.CREDIT,
-        PlatformTipForTransactionGroup: { [Op.in]: transactions.map(t => t.TransactionGroup) },
+        TransactionGroup: { [Op.in]: transactions.map(t => t.TransactionGroup) },
+        kind: TransactionKind.PLATFORM_TIP,
       },
       include: [
         {

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -170,11 +170,6 @@ function defineModel() {
         references: { model: 'Transactions', key: 'id' },
       },
 
-      PlatformTipForTransactionGroup: {
-        type: DataTypes.STRING,
-        allowNull: true,
-      },
-
       isRefund: {
         type: DataTypes.BOOLEAN,
         defaultValue: false,
@@ -320,7 +315,7 @@ function defineModel() {
   };
 
   Transaction.prototype.hasPlatformTip = function () {
-    return this.data?.isFeesOnTop ? true : false;
+    return Boolean(this.data?.isFeesOnTop && this.kind !== TransactionKind.PLATFORM_TIP);
   };
 
   Transaction.prototype.getPlatformTipTransaction = function () {
@@ -329,7 +324,8 @@ function defineModel() {
         where: {
           ...pick(FEES_ON_TOP_TRANSACTION_PROPERTIES, ['CollectiveId']),
           type: this.type,
-          PlatformTipForTransactionGroup: this.TransactionGroup,
+          TransactionGroup: this.TransactionGroup,
+          kind: TransactionKind.PLATFORM_TIP,
         },
       });
     }
@@ -342,7 +338,7 @@ function defineModel() {
         CollectiveId: this.FromCollectiveId,
         FromCollectiveId: this.CollectiveId,
         TransactionGroup: this.TransactionGroup,
-        PlatformTipForTransactionGroup: this.PlatformTipForTransactionGroup,
+        kind: this.kind,
       },
     });
   };
@@ -599,7 +595,7 @@ function defineModel() {
         ),
         // This is always 1 because OpenCollective and OpenCollective Inc (Host) are in USD.
         hostCurrencyFxRate: 1,
-        PlatformTipForTransactionGroup: transaction.TransactionGroup,
+        TransactionGroup: transaction.TransactionGroup,
         data: {
           hostToPlatformFxRate: await getFxRate(transaction.hostCurrency, FEES_ON_TOP_TRANSACTION_PROPERTIES.currency),
           feeOnTopPaymentProcessorFee,
@@ -840,13 +836,13 @@ function defineModel() {
   Transaction.validate = async (transaction, { validateOppositeTransaction = true } = {}) => {
     // Skip as there is a known bug there
     // https://github.com/opencollective/opencollective/issues/3935
-    if (transaction.PlatformTipForTransactionGroup) {
+    if (transaction.kind === TransactionKind.PLATFORM_TIP) {
       return;
     }
 
     // Skip as there is a known bug there
     // https://github.com/opencollective/opencollective/issues/3934
-    if (transaction.PlatformTipForTransactionGroup && transaction.taxAmount) {
+    if (transaction.kind === TransactionKind.PLATFORM_TIP && transaction.taxAmount) {
       return;
     }
 

--- a/test/cron/monthly/invoice-platform-fees.test.js
+++ b/test/cron/monthly/invoice-platform-fees.test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import moment from 'moment';
 
 import { run as invoicePlatformFees } from '../../../cron/monthly/invoice-platform-fees';
+import { TransactionKind } from '../../../server/constants/transaction-kind';
 import { sequelize } from '../../../server/models';
 import {
   fakeCollective,
@@ -51,6 +52,7 @@ describe('cron/monthly/invoice-platform-fees', () => {
     const socialCollective = await fakeCollective({ HostCollectiveId: gbpHost.id });
     const transactionProps = {
       type: 'CREDIT',
+      kind: TransactionKind.CONTRIBUTION,
       CollectiveId: socialCollective.id,
       currency: 'GBP',
       hostCurrency: 'GBP',
@@ -60,18 +62,21 @@ describe('cron/monthly/invoice-platform-fees', () => {
     // Create Platform Fees
     await fakeTransaction({
       ...transactionProps,
+      kind: TransactionKind.PLATFORM_FEE,
       amount: 3000,
       platformFeeInHostCurrency: -300,
       hostFeeInHostCurrency: -300,
     });
     await fakeTransaction({
       ...transactionProps,
+      kind: TransactionKind.PLATFORM_FEE,
       amount: 3000,
       platformFeeInHostCurrency: 0,
       hostFeeInHostCurrency: -200,
     });
     await fakeTransaction({
       ...transactionProps,
+      kind: TransactionKind.PLATFORM_FEE,
       amount: 3000,
       platformFeeInHostCurrency: 0,
       hostFeeInHostCurrency: -300,
@@ -87,7 +92,8 @@ describe('cron/monthly/invoice-platform-fees', () => {
       amount: 1000,
       currency: 'USD',
       data: { hostToPlatformFxRate: 1.23 },
-      PlatformTipForTransactionGroup: t.TransactionGroup,
+      TransactionGroup: t.TransactionGroup,
+      kind: TransactionKind.PLATFORM_TIP,
       createdAt: lastMonth,
     });
     // Collected Platform Tip with pending Payment Processor Fee
@@ -99,7 +105,8 @@ describe('cron/monthly/invoice-platform-fees', () => {
       amount: 1000,
       currency: 'USD',
       data: { hostToPlatformFxRate: 1.23 },
-      PlatformTipForTransactionGroup: t2.TransactionGroup,
+      TransactionGroup: t2.TransactionGroup,
+      kind: TransactionKind.PLATFORM_TIP,
       paymentProcessorFeeInHostCurrency: -100,
       PaymentMethodId: paymentMethod.id,
       createdAt: lastMonth,

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 
 import { expenseStatus, roles } from '../../../server/constants';
 import plans from '../../../server/constants/plans';
+import { TransactionKind } from '../../../server/constants/transaction-kind';
 import { getFxRate } from '../../../server/lib/currency';
 import emailLib from '../../../server/lib/email';
 import models, { Op, sequelize } from '../../../server/models';
@@ -1094,7 +1095,8 @@ describe('server/models/Collective', () => {
         amount: 100,
         currency: 'USD',
         data: { hostToPlatformFxRate: 1.23 },
-        PlatformTipForTransactionGroup: t.TransactionGroup,
+        TransactionGroup: t.TransactionGroup,
+        kind: TransactionKind.PLATFORM_TIP,
         createdAt: lastMonth,
       });
       await fakeTransaction({
@@ -1104,7 +1106,8 @@ describe('server/models/Collective', () => {
         amount: 300,
         currency: 'USD',
         data: { hostToPlatformFxRate: 1.2 },
-        PlatformTipForTransactionGroup: t.TransactionGroup,
+        TransactionGroup: t.TransactionGroup,
+        kind: TransactionKind.PLATFORM_TIP,
         createdAt: lastMonth,
         PaymentMethodId: stripePaymentMethod.id,
       });

--- a/test/server/models/Transaction.test.js
+++ b/test/server/models/Transaction.test.js
@@ -246,20 +246,16 @@ describe('server/models/Transaction', () => {
       expect(donationCredit).to.have.property('type').equal('CREDIT');
       expect(donationCredit).to.have.property('amount').equal(1000);
       expect(donationCredit).to.have.property('kind').equal(TransactionKind.PLATFORM_TIP);
-      expect(donationCredit)
-        .to.have.property('PlatformTipForTransactionGroup')
-        .equal(createdTransaction.TransactionGroup);
+      expect(donationCredit).to.have.property('TransactionGroup').equal(createdTransaction.TransactionGroup);
 
       const donationDebit = allTransactions.find(t => t.FromCollectiveId === inc.id);
       const partialPaymentProcessorFee = Math.round(200 * (1000 / 11000));
       expect(donationDebit).to.have.property('type').equal('DEBIT');
       expect(donationDebit).to.have.property('kind').equal(TransactionKind.PLATFORM_TIP);
+      expect(donationDebit).to.have.property('TransactionGroup').equal(createdTransaction.TransactionGroup);
       expect(donationDebit)
         .to.have.property('amount')
         .equal(-1000 + partialPaymentProcessorFee);
-      expect(donationDebit)
-        .to.have.property('PlatformTipForTransactionGroup')
-        .equal(createdTransaction.TransactionGroup);
     });
 
     it('should convert the donation transaction to USD and store the FX rate', async () => {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4205

- [x] Migrate platform tips without `PlatformTipForTransactionGroup`
- [x] Add tests to make sure new platform tips have the same `TransactionGroup` than their original transactions
- [x] Migrate all existing platform tips to make sure their `TransactionGroup` are the same as the transactions they're referring to
- [x] Update all queries using `PlatformTipForTransactionGroup`
- [x] Create index on `TransactionGroup`
- [x] Remove the `PlatformTipForTransactionGroup` column