### PR TITLE
Addition of `if` conditions to make sure ci runs are not duplicated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ env:
 
 jobs:
   lint:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     timeout-minutes: 15
@@ -59,6 +61,8 @@ jobs:
       - run: npm run lint:check
 
   prettier:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     timeout-minutes: 15
@@ -96,6 +100,8 @@ jobs:
       - run: npm run prettier:check
 
   typescript:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     timeout-minutes: 15
@@ -133,6 +139,8 @@ jobs:
       - run: npm run type:check
 
   depcheck:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     timeout-minutes: 15
@@ -170,6 +178,8 @@ jobs:
       - run: npm run depcheck
 
   build:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     timeout-minutes: 15
@@ -272,6 +282,8 @@ jobs:
       - run: npm run test:coverage
 
   test-graphql:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
@@ -328,6 +340,8 @@ jobs:
       - run: npm run test:coverage
 
   schema-update:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The CI now runs fine but when doing pull requests for dependabot after, https://github.com/opencollective/opencollective-api/pull/5895 but there's a possibility of duplication of the CI runs (example: https://github.com/opencollective/opencollective-api/pull/5901). This PR takes care of that. 

Related to https://github.com/opencollective/opencollective/issues/4207