### PR TITLE
Expenses: Ignore null transaction when creating activities

### DIFF
--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -319,7 +319,7 @@ function defineModel() {
         user: submittedByUserCollective.minimal,
         fromCollective: fromCollective.minimal,
         expense: this.info,
-        transaction: transaction.info,
+        transaction: transaction?.info,
         payoutMethod: payoutMethod && pick(payoutMethod.dataValues, ['id', 'type', 'data']),
         items:
           !isEmpty(items) &&


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2354111563/?project=5199682

This sentry issue occurred with a virtual card, but I don't get how that was working before that for other event types like "expense approved" where there is no transaction.