### PR TITLE
Implement TransactionSettlements

### DIFF
--- a/migrations/20210422133652-add-transaction-settlements.js
+++ b/migrations/20210422133652-add-transaction-settlements.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('TransactionSettlements', {
+      TransactionGroup: {
+        type: Sequelize.UUID,
+        allowNull: false,
+      },
+      kind: {
+        // Re-using the same ENUM than `Transactions` so that we don't have to maintain two of them
+        type: '"public"."enum_Transactions_kind"',
+        allowNull: false,
+      },
+      status: {
+        type: Sequelize.ENUM('OWED', 'INVOICED', 'SETTLED'),
+        allowNull: false,
+      },
+      ExpenseId: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'Expenses', key: 'id' },
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.NOW,
+        allowNull: false,
+      },
+      deletedAt: {
+        type: Sequelize.DATE,
+      },
+    });
+
+    // Create unique index on TransactionGroup + kind
+    await queryInterface.addIndex('TransactionSettlements', ['TransactionGroup', 'kind'], {
+      unique: true,
+    });
+
+    // Add `isDebt` column on `Transactions`
+    await queryInterface.addColumn('Transactions', 'isDebt', { type: Sequelize.BOOLEAN, allowNull: true });
+  },
+
+  down: async queryInterface => {
+    await queryInterface.dropTable('TransactionSettlements');
+    await queryInterface.removeColumn('Transactions', 'isDebt');
+  },
+};

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -175,6 +175,11 @@ function defineModel() {
         defaultValue: false,
       },
 
+      isDebt: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+      },
+
       createdAt: {
         type: DataTypes.DATE,
         defaultValue: DataTypes.NOW,
@@ -187,6 +192,11 @@ function defineModel() {
 
       deletedAt: {
         type: DataTypes.DATE,
+      },
+
+      /** A virtual field to make working with settlements easier. Must be preloaded manually. */
+      settlementStatus: {
+        type: DataTypes.VIRTUAL,
       },
     },
     {

--- a/server/models/TransactionSettlement.ts
+++ b/server/models/TransactionSettlement.ts
@@ -1,0 +1,188 @@
+import { groupBy } from 'lodash';
+
+import { TransactionKind } from '../constants/transaction-kind';
+import restoreSequelizeAttributesOnClass from '../lib/restore-sequelize-attributes-on-class';
+import sequelize, { DataTypes, Model, Op } from '../lib/sequelize';
+
+import Collective from './Collective';
+import Transaction from './Transaction';
+
+export enum TransactionSettlementStatus {
+  OWED = 'OWED',
+  INVOICED = 'INVOICED',
+  SETTLED = 'SETTLED',
+}
+
+interface TransactionSettlementAttributes {
+  TransactionGroup: string;
+  kind: TransactionKind;
+  status: TransactionSettlementStatus;
+  ExpenseId: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+}
+
+interface TransactionSettlementCreateAttributes {
+  TransactionGroup: string;
+  kind: TransactionKind;
+  status: TransactionSettlementStatus;
+  ExpenseId?: number;
+}
+
+class TransactionSettlement
+  extends Model<TransactionSettlementAttributes, TransactionSettlementCreateAttributes>
+  implements TransactionSettlementAttributes {
+  TransactionGroup: string;
+  kind: TransactionKind;
+  status: TransactionSettlementStatus;
+  ExpenseId: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+
+  constructor(...args) {
+    super(...args);
+    restoreSequelizeAttributesOnClass(new.target, this);
+  }
+
+  static async getAccountsWithOwedSettlements(): Promise<typeof Collective[]> {
+    return sequelize.query(
+      `
+        SELECT c.*
+        FROM "Collectives" c
+        INNER JOIN "Transactions" t ON t."CollectiveId" = c.id
+        INNER JOIN "TransactionSettlements" ts
+          ON t."TransactionGroup" = ts."TransactionGroup"
+          AND t."kind" = ts."kind"
+        WHERE t."type" = 'CREDIT'
+        AND t."isDebt" IS TRUE
+        AND t."deletedAt" IS NULL
+        AND ts."deletedAt" IS NULL
+        AND ts."status" = 'OWED'
+        GROUP BY c.id
+      `,
+      {
+        model: Collective,
+        mapToModel: true,
+      },
+    );
+  }
+
+  static async getHostDebts(
+    hostId: number,
+    settlementStatus: TransactionSettlementStatus = undefined,
+  ): Promise<typeof Transaction[]> {
+    return sequelize.query(
+      `
+        SELECT t.*, ts.status as "settlementStatus"
+        FROM "Transactions" t
+        INNER JOIN "TransactionSettlements" ts
+          ON t."TransactionGroup" = ts."TransactionGroup"
+          AND t."kind" = ts."kind"
+        WHERE t."type" = 'CREDIT'
+        AND t."isDebt" IS TRUE
+        AND t."deletedAt" IS NULL
+        AND ts."deletedAt" IS NULL
+        ${settlementStatus ? 'AND ts."status" = :settlementStatus' : ''}
+      `,
+      {
+        model: Transaction,
+        mapToModel: true,
+        replacements: { settlementStatus, hostId },
+      },
+    );
+  }
+
+  /**
+   * Update
+   */
+  static async updateTransactionsSettlementStatus(
+    transactions: typeof Transaction[],
+    status: TransactionSettlementStatus,
+    expenseId: number = undefined,
+  ): Promise<void> {
+    const newData = { status };
+    if (expenseId !== undefined) {
+      newData['ExpenseId'] = expenseId;
+    }
+
+    await TransactionSettlement.update(newData, {
+      where: {
+        [Op.or]: transactions.map(transaction => ({
+          TransactionGroup: transaction.TransactionGroup,
+          kind: transaction.kind,
+        })),
+      },
+    });
+  }
+
+  static async createForTransaction(
+    transaction: typeof Transaction,
+    status = TransactionSettlementStatus.OWED,
+  ): Promise<TransactionSettlement> {
+    return TransactionSettlement.create({
+      TransactionGroup: transaction.TransactionGroup,
+      kind: transaction.kind,
+      status,
+    });
+  }
+
+  static async attachStatusesToTransactions(transactions: typeof Transaction[]): Promise<void> {
+    const debts = transactions.filter(t => t.isDebt);
+    const where = { [Op.or]: debts.map(t => ({ TransactionGroup: t.TransactionGroup, kind: t.kind })) };
+    const settlements = await TransactionSettlement.findAll({ where });
+    const groupedSettlements = groupBy(settlements, 'TransactionGroup');
+
+    debts.forEach(transaction => {
+      const settlement = groupedSettlements[transaction.TransactionGroup]?.find(s => transaction.kind === s.kind);
+      transaction['dataValues']['settlementStatus'] = settlement?.status || null;
+    });
+  }
+}
+
+TransactionSettlement.init(
+  {
+    TransactionGroup: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    kind: {
+      // Re-using the same ENUM than `Transactions` so that we don't have to maintain two of them.
+      // We'll have a better way of doing this with https://github.com/sequelize/sequelize/issues/2577
+      type: '"public"."enum_Transactions_kind"',
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.ENUM(...Object.values(TransactionSettlementStatus)),
+      allowNull: false,
+    },
+    ExpenseId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: { model: 'Expenses', key: 'id' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'TransactionSettlements',
+    paranoid: true,
+  },
+);
+
+export default TransactionSettlement;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -27,6 +27,7 @@ import Session from './Session';
 import Subscription from './Subscription';
 import Tier from './Tier';
 import Transaction from './Transaction';
+import TransactionSettlement from './TransactionSettlement';
 import Update from './Update';
 import User from './User';
 import VirtualCard from './VirtualCard';
@@ -67,6 +68,7 @@ export function setupModels() {
   m['Subscription'] = Subscription;
   m['Tier'] = Tier;
   m['Transaction'] = Transaction;
+  m['TransactionSettlement'] = TransactionSettlement;
   m['Update'] = Update;
   m['User'] = User;
   m['VirtualCard'] = VirtualCard;

--- a/test/server/models/TransactionSettlement.test.ts
+++ b/test/server/models/TransactionSettlement.test.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai';
+import { times } from 'lodash';
+
+import { TransactionKind } from '../../../server/constants/transaction-kind';
+import { FEES_ON_TOP_TRANSACTION_PROPERTIES } from '../../../server/constants/transactions';
+import models, { Op } from '../../../server/models';
+import TransactionSettlement, { TransactionSettlementStatus } from '../../../server/models/TransactionSettlement';
+import {
+  fakeCollective,
+  fakeExpense,
+  fakeHost,
+  fakeOrganization,
+  fakeTransaction,
+  fakeUser,
+  fakeUUID,
+} from '../../test-helpers/fake-data';
+import * as utils from '../../utils';
+
+// ---- Helpers ----
+
+const fakeContribution = (fromCollective, collective, transactionGroup) => {
+  return fakeTransaction(
+    {
+      TransactionGroup: fakeUUID(transactionGroup),
+      kind: TransactionKind.CONTRIBUTION,
+      CollectiveId: collective.id,
+      FromCollectiveId: fromCollective.id,
+      amount: 1000,
+      type: 'CREDIT',
+      description: 'A simple contribution **without** platform tip',
+    },
+    {
+      createDoubleEntry: true,
+    },
+  );
+};
+
+// Insert contributions **with platform tips**, using the new format described in https://github.com/opencollective/opencollective/issues/4124.
+// As writing this, the rest of the code is not yet using this new format.
+const fakeContributionWithPlatformTipNewFormat = async (fromCollective, collective, transactionGroup) => {
+  // Base transaction
+  const transaction = await fakeTransaction(
+    {
+      TransactionGroup: fakeUUID(transactionGroup),
+      kind: TransactionKind.CONTRIBUTION,
+      FromCollectiveId: fromCollective.id,
+      CollectiveId: collective.id,
+      HostCollectiveId: collective.isHostAccount ? collective.id : collective.HostCollectiveId,
+      amount: 1000,
+      description: 'A contribution **with** platform tip',
+    },
+    {
+      createDoubleEntry: true,
+    },
+  );
+
+  // DEBIT Tip transaction (contributor -> OC)
+  await fakeTransaction({
+    TransactionGroup: transaction.TransactionGroup,
+    kind: TransactionKind.PLATFORM_TIP,
+    type: 'DEBIT',
+    amount: -200,
+    CollectiveId: transaction.FromCollectiveId,
+    FromCollectiveId: FEES_ON_TOP_TRANSACTION_PROPERTIES.CollectiveId,
+    HostCollectiveId: null,
+    description: 'Tip transaction from the contributor to Open Collective',
+  });
+
+  // CREDIT Tip transaction (contributor -> OC)
+  await fakeTransaction({
+    TransactionGroup: transaction.TransactionGroup,
+    kind: TransactionKind.PLATFORM_TIP,
+    type: 'CREDIT',
+    amount: 200,
+    FromCollectiveId: transaction.FromCollectiveId,
+    CollectiveId: FEES_ON_TOP_TRANSACTION_PROPERTIES.CollectiveId,
+    HostCollectiveId: FEES_ON_TOP_TRANSACTION_PROPERTIES.HostCollectiveId,
+    description: 'Tip transaction from the contributor to Open Collective',
+  });
+
+  // [Debt] DEBIT Tip transaction (host -> OC)
+  await fakeTransaction({
+    kind: TransactionKind.PLATFORM_TIP,
+    TransactionGroup: transaction.TransactionGroup,
+    type: 'DEBIT',
+    amount: -200,
+    FromCollectiveId: transaction.HostCollectiveId,
+    CollectiveId: FEES_ON_TOP_TRANSACTION_PROPERTIES.CollectiveId,
+    HostCollectiveId: transaction.HostCollectiveId,
+    isDebt: true,
+    description: 'Tip transaction from the HOST to Open Collective',
+  });
+
+  // [Debt] CREDIT Tip transaction (host -> OC)
+  const tipDebtCreditTransaction = await fakeTransaction({
+    kind: TransactionKind.PLATFORM_TIP,
+    type: 'CREDIT',
+    TransactionGroup: transaction.TransactionGroup,
+    amount: 200,
+    FromCollectiveId: FEES_ON_TOP_TRANSACTION_PROPERTIES.CollectiveId,
+    CollectiveId: transaction.HostCollectiveId,
+    HostCollectiveId: FEES_ON_TOP_TRANSACTION_PROPERTIES.HostCollectiveId,
+    isDebt: true,
+    description: 'Tip transaction from the HOST to Open Collective',
+  });
+
+  // [Debt] Transaction Settlement
+  await models.TransactionSettlement.createForTransaction(tipDebtCreditTransaction);
+};
+
+const SNAPSHOT_COLUMNS = [
+  'TransactionGroup',
+  'type',
+  'amount',
+  'CollectiveId',
+  'FromCollectiveId',
+  'HostCollectiveId',
+  'kind',
+  'isDebt',
+  'settlementStatus',
+  'description',
+];
+
+// ---- Test ----
+
+describe('server/models/TransactionSettlement', () => {
+  let host, collective;
+
+  before(async () => {
+    await utils.resetTestDB();
+
+    await fakeOrganization({ id: FEES_ON_TOP_TRANSACTION_PROPERTIES.CollectiveId, name: 'Open Collective' });
+    host = await fakeHost({ name: 'Open Source' });
+    collective = await fakeCollective({ HostCollectiveId: host.id, name: 'ESLint' });
+
+    // Insert unrelated transactions (to make sure they won't appear in the results)
+    await Promise.all(
+      times(5, () =>
+        fakeTransaction({ description: 'Random contribution to another collective' }, { createDoubleEntry: true }),
+      ),
+    );
+
+    // Insert contributions to host and hosted collectives
+    const fromUser = await fakeUser(undefined, { name: 'Benjamin' });
+    await fakeContribution(fromUser.collective, host, '00000001');
+    await fakeContribution(fromUser.collective, collective, '00000002');
+
+    // Insert contributions with platform tips to host and hosted collectives
+    await fakeContributionWithPlatformTipNewFormat(fromUser.collective, host, '00000003');
+    await fakeContributionWithPlatformTipNewFormat(fromUser.collective, collective, '00000004');
+  });
+
+  it('0. Properly initializes test data', async () => {
+    // Snapshot initial state for simpler reviews & debug. Ignore unrelated transactions
+    const watchedCollectiveIds = [collective.id, host.id, FEES_ON_TOP_TRANSACTION_PROPERTIES.CollectiveId];
+    const transactions = await models.Transaction.findAll({
+      include: [{ association: 'host' }, { association: 'collective' }, { association: 'fromCollective' }],
+      order: [['id', 'ASC']],
+      where: {
+        [Op.or]: [
+          { CollectiveId: watchedCollectiveIds },
+          { FromCollectiveId: watchedCollectiveIds },
+          { HostCollectiveId: watchedCollectiveIds },
+        ],
+      },
+    });
+
+    await TransactionSettlement.attachStatusesToTransactions(transactions);
+    utils.snapshotTransactions(transactions, { columns: SNAPSHOT_COLUMNS });
+  });
+
+  it('1. getHostDebts returns all debts for host', async () => {
+    const debts = await TransactionSettlement.getHostDebts(host.id);
+    await utils.preloadAssociationsForTransactions(debts, SNAPSHOT_COLUMNS);
+    utils.snapshotTransactions(debts, { columns: SNAPSHOT_COLUMNS, loadAssociations: true });
+  });
+
+  it('2. updateTransactionsSettlementStatus updates statuses selectively', async () => {
+    const debts = await TransactionSettlement.getHostDebts(host.id);
+    const debtToUpdate = debts[0]; // Only settle the first debt
+    const newStatus = TransactionSettlementStatus.SETTLED;
+    const settlementExpense = await fakeExpense();
+    await TransactionSettlement.updateTransactionsSettlementStatus([debtToUpdate], newStatus, settlementExpense.id);
+
+    const updatedDebts = await TransactionSettlement.getHostDebts(host.id);
+    await utils.preloadAssociationsForTransactions(updatedDebts, SNAPSHOT_COLUMNS);
+    utils.snapshotTransactions(updatedDebts, { columns: SNAPSHOT_COLUMNS, loadAssociations: true });
+  });
+
+  it('3. getHostDebts can then filter by settlement status', async () => {
+    const debts = await TransactionSettlement.getHostDebts(host.id, TransactionSettlementStatus.OWED);
+    await utils.preloadAssociationsForTransactions(debts, SNAPSHOT_COLUMNS);
+    utils.snapshotTransactions(debts, { columns: SNAPSHOT_COLUMNS, loadAssociations: true });
+  });
+
+  it('4. getAccountsWithOwedSettlements returns all accounts with OWED debts', async () => {
+    const collectives = await TransactionSettlement.getAccountsWithOwedSettlements();
+    expect(collectives.length).to.eq(1);
+    expect(collectives[0].id).to.eq(host.id);
+  });
+});

--- a/test/server/models/TransactionSettlement.test.ts.snap
+++ b/test/server/models/TransactionSettlement.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`server/models/TransactionSettlement 0. Properly initializes test data 1`] = `
+"
+| Group     | type   | amount | To              | From            | Host            | kind         | isDebt | Settlement | description                                             |
+| --------- | ------ | ------ | --------------- | --------------- | --------------- | ------------ | ------ | ---------- | ------------------------------------------------------- |
+| #00000001 | DEBIT  | -1000  | Benjamin        | Open Source     | NULL            | CONTRIBUTION | false  |            | A simple contribution **without** platform tip          |
+| #00000001 | CREDIT | 1000   | Open Source     | Benjamin        | NULL            | CONTRIBUTION | false  |            | A simple contribution **without** platform tip          |
+| #00000002 | DEBIT  | -1000  | Benjamin        | ESLint          | NULL            | CONTRIBUTION | false  |            | A simple contribution **without** platform tip          |
+| #00000002 | CREDIT | 1000   | ESLint          | Benjamin        | NULL            | CONTRIBUTION | false  |            | A simple contribution **without** platform tip          |
+| #00000003 | DEBIT  | -1000  | Benjamin        | Open Source     | NULL            | CONTRIBUTION | false  |            | A contribution **with** platform tip                    |
+| #00000003 | CREDIT | 1000   | Open Source     | Benjamin        | Open Source     | CONTRIBUTION | false  |            | A contribution **with** platform tip                    |
+| #00000003 | DEBIT  | -200   | Benjamin        | Open Collective | NULL            | PLATFORM_TIP | false  |            | Tip transaction from the contributor to Open Collective |
+| #00000003 | CREDIT | 200    | Open Collective | Benjamin        | Open Collective | PLATFORM_TIP | false  |            | Tip transaction from the contributor to Open Collective |
+| #00000003 | DEBIT  | -200   | Open Collective | Open Source     | Open Source     | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective        |
+| #00000003 | CREDIT | 200    | Open Source     | Open Collective | Open Collective | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective        |
+| #00000004 | DEBIT  | -1000  | Benjamin        | ESLint          | NULL            | CONTRIBUTION | false  |            | A contribution **with** platform tip                    |
+| #00000004 | CREDIT | 1000   | ESLint          | Benjamin        | Open Source     | CONTRIBUTION | false  |            | A contribution **with** platform tip                    |
+| #00000004 | DEBIT  | -200   | Benjamin        | Open Collective | NULL            | PLATFORM_TIP | false  |            | Tip transaction from the contributor to Open Collective |
+| #00000004 | CREDIT | 200    | Open Collective | Benjamin        | Open Collective | PLATFORM_TIP | false  |            | Tip transaction from the contributor to Open Collective |
+| #00000004 | DEBIT  | -200   | Open Collective | Open Source     | Open Source     | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective        |
+| #00000004 | CREDIT | 200    | Open Source     | Open Collective | Open Collective | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective        |"
+`;
+
+exports[`server/models/TransactionSettlement 1. getHostDebts returns all debts for host 1`] = `
+"
+| Group     | type   | amount | To          | From            | Host            | kind         | isDebt | Settlement | description                                      |
+| --------- | ------ | ------ | ----------- | --------------- | --------------- | ------------ | ------ | ---------- | ------------------------------------------------ |
+| #00000003 | CREDIT | 200    | Open Source | Open Collective | Open Collective | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective |
+| #00000004 | CREDIT | 200    | Open Source | Open Collective | Open Collective | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective |"
+`;
+
+exports[`server/models/TransactionSettlement 2. updateTransactionsSettlementStatus updates statuses selectively 1`] = `
+"
+| Group     | type   | amount | To          | From            | Host            | kind         | isDebt | Settlement | description                                      |
+| --------- | ------ | ------ | ----------- | --------------- | --------------- | ------------ | ------ | ---------- | ------------------------------------------------ |
+| #00000003 | CREDIT | 200    | Open Source | Open Collective | Open Collective | PLATFORM_TIP | true   | SETTLED    | Tip transaction from the HOST to Open Collective |
+| #00000004 | CREDIT | 200    | Open Source | Open Collective | Open Collective | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective |"
+`;
+
+exports[`server/models/TransactionSettlement 3. getHostDebts can then filter by settlement status 1`] = `
+"
+| Group     | type   | amount | To          | From            | Host            | kind         | isDebt | Settlement | description                                      |
+| --------- | ------ | ------ | ----------- | --------------- | --------------- | ------------ | ------ | ---------- | ------------------------------------------------ |
+| #00000004 | CREDIT | 200    | Open Source | Open Collective | Open Collective | PLATFORM_TIP | true   | OWED       | Tip transaction from the HOST to Open Collective |"
+`;


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/4077

This PR implements the base system for settlements, without making any change to the way transactions are generated today (in other words, it's not active yet with real data). Tests in `test/server/models/TransactionSettlement.test.ts` are recreating the desired environment and are there to assert that the settlement system works, but this new system won't be active until we switch to the new data model proposed in https://github.com/opencollective/opencollective/issues/4124 where we actually have two transactions pairs for platform tips (one from the contributor to the host, and the other as a debt from the host to Open Collective).

It's also the first use case for ledger snapshots. [This file](https://github.com/opencollective/opencollective-api/blob/feat/transactions-settlement-table/test/server/models/TransactionSettlement.test.ts.snap) will show you the evolution of the ledger after calling the different methods. It's intended to match what's described in https://github.com/opencollective/opencollective/issues/4124.

Next steps after we merge this PR:
- Record platform tips with the debt transaction
- Update `cron/monthly/invoice-platform-fees.js` with this new settlement mechanism