### PR TITLE
GraphQL: Don't cache results if there is an error

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -160,7 +160,7 @@ export default app => {
     formatResponse: (response, ctx) => {
       const req = ctx.context;
 
-      if (req.cacheKey) {
+      if (req.cacheKey && !response?.errors) {
         cache.set(req.cacheKey, response, Number(config.graphql.cache.ttl));
       }
 


### PR DESCRIPTION
This morning, a migration that removed some columns caused requests made to the collective page to fail. This was resolved as soon as the deployment completed, but failed requests were kept in the cache and had to be cleaned manually.

It seems like a good practice to not cache responses if there's an error:
1. To have a faster refresh when the root error gets fixed
2. To prevent one-time errors from being sent for all future requests

The main downside for this can be the server load if we keep fetching a page that is erroring with an expensive query.