### PR TITLE
Correct mistake in dependabot branch exclusion for force pushes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,6 @@
 name: E2E
 
-on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
+on: [push]
 
 env:
   CI: true
@@ -32,6 +29,7 @@ env:
 
 jobs:
   e2e:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
Fixes a small mistake I made on, https://github.com/opencollective/opencollective-api/pull/5931