### PR TITLE
Expense: Don't crash if payee is null

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -31,13 +31,16 @@ const debug = debugLib('expenses');
 const isOwner = async (req: express.Request, expense: typeof models.Expense): Promise<boolean> => {
   if (!req.remoteUser) {
     return false;
-  }
-
-  if (!expense.fromCollective) {
+  } else if (req.remoteUser.id === expense.UserId) {
+    return true;
+  } else if (!expense.fromCollective) {
     expense.fromCollective = await req.loaders.Collective.byId.load(expense.FromCollectiveId);
+    if (!expense.fromCollective) {
+      return false;
+    }
   }
 
-  return req.remoteUser.isAdminOfCollective(expense.fromCollective) || req.remoteUser.id === expense.UserId;
+  return req.remoteUser.isAdminOfCollective(expense.fromCollective);
 };
 
 const isCollectiveAccountant = async (req: express.Request, expense: typeof models.Expense): Promise<boolean> => {


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2377430834

We currently allow people to delete their user accounts if they don't have any paid expenses. There are a few problems with that:
- We still display rejected expenses, so the page crashes when someone deletes an account that has recently submitted an expense (see https://opencollective.com/frais-davocats-4f2840c4).
- We don't want people to delete their account if they have expenses that are scheduled for payment either

Alternative (or in addition to this): in `expenses` query, we could add a JOIN (required) on `fromCollective` to ignore expenses where the from collective has been deleted. That could be a safer thing to do since some pages are maybe not ready to handle a null `payee`.