### PR TITLE
PaymentMethod: Always store collective id

### DIFF
--- a/migrations/20210503103943-fill-payment-methods-collective-id.js
+++ b/migrations/20210503103943-fill-payment-methods-collective-id.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      UPDATE
+        "PaymentMethods" pm
+      SET
+        "CollectiveId" = o."FromCollectiveId",
+        "saved" = FALSE,
+        -- Set a special flag in data for easier debugging & rollback
+        "data" = JSONB_SET(
+          COALESCE(pm."data", '{}'::jsonb),
+          '{CollectiveIdMigratedIn}',
+          '"20210503103943-fill-payment-methods-collective-id"'
+        )
+      FROM
+        "Orders" o
+      WHERE
+        o."PaymentMethodId" = pm.id
+        AND pm."CollectiveId" IS NULL
+    `);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      UPDATE
+        "PaymentMethods"
+      SET
+        "CollectiveId" = NULL
+      WHERE
+        "data" ->> 'CollectiveIdMigratedIn' = '20210503103943-fill-payment-methods-collective-id'
+    `);
+  },
+};

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -541,11 +541,12 @@ export async function createOrder(order, loaders, remoteUser, reqIp, userAgent) 
       if (get(order, 'paymentMethod.type') === 'manual') {
         orderCreated.paymentMethod = order.paymentMethod;
       } else {
-        // Ideally, we should always save CollectiveId
-        // but this is breaking some conventions elsewhere
-        // Always link the payment method to the collective for guests but make sure `save` is false
-        if (orderCreated.data.savePaymentMethod || isGuest) {
-          order.paymentMethod.CollectiveId = orderCreated.FromCollectiveId;
+        order.paymentMethod.CollectiveId = orderCreated.FromCollectiveId;
+        if (get(order, 'paymentMethod.service') === 'stripe') {
+          // For Stripe `save` will be manually set to `true`, in `processOrder` if the order succeed
+          order.paymentMethod.saved = null;
+        } else {
+          order.paymentMethod.saved = Boolean(orderCreated.data.savePaymentMethod);
         }
 
         if (isGuest) {

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -39,7 +39,6 @@ export const PaymentMethod = new GraphQLObjectType({
 
           if (
             (paymentMethod.CollectiveId && req.remoteUser?.isAdmin(paymentMethod.CollectiveId)) ||
-            (paymentMethod.CreatedByUserId && paymentMethod.CreatedByUserId === req.remoteUser?.id) ||
             publicProviders.some(([service, type]) => paymentMethod.service === service && paymentMethod.type === type)
           ) {
             return paymentMethod.name;

--- a/server/paymentProviders/stripe/creditcard.js
+++ b/server/paymentProviders/stripe/creditcard.js
@@ -358,7 +358,10 @@ export default {
       throw new Error(UNKNOWN_ERROR_MSG);
     }
 
-    await order.paymentMethod.update({ confirmedAt: new Date() });
+    await order.paymentMethod.update({
+      confirmedAt: new Date(),
+      saved: order.paymentMethod.saved || Boolean(order.data?.savePaymentMethod),
+    });
 
     return transactions;
   },

--- a/test/server/graphql/v1/user.test.js
+++ b/test/server/graphql/v1/user.test.js
@@ -177,7 +177,8 @@ describe('server/graphql/v1/user', () => {
           where: { CreatedByUserId: user1.id },
         });
         expect(paymentMethods).to.have.length(1);
-        expect(paymentMethods[0].CollectiveId).to.be.null;
+        expect(paymentMethods[0].CollectiveId).to.be.eq(user1.CollectiveId);
+        expect(paymentMethods[0].saved).to.be.null;
       });
 
       it("doesn't get the payment method of the user if not logged in", async () => {


### PR DESCRIPTION
Experiment on reverting a change from https://github.com/opencollective/opencollective-api/pull/2428, where we decided to not store the `CollectiveId` for payment methods. This behavior is causing some complications like https://sentry.io/organizations/open-collective/issues/2374987288 and https://opencollective.slack.com/archives/GRN3WA3BM/p1618932868011200 - basically most of the places where we check payment methods permissions are not ready to handle this and will reject users that should be allowed.

I did not find much context about why the change was initially done, but it's possibly related to Stripe CSA / 3D secure.

