### PR TITLE
Use SQL transactions for creating transactions

### DIFF
--- a/server/graphql/v2/mutation/TransactionMutations.ts
+++ b/server/graphql/v2/mutation/TransactionMutations.ts
@@ -65,8 +65,8 @@ const transactionMutations = {
       };
 
       const host = await models.Collective.findByPk(transaction.CollectiveId);
-      const { donationTransaction } = await models.Transaction.createFeesOnTopTransaction({ transaction, host });
-      return donationTransaction;
+      const { tipTransaction } = await models.Transaction.createFeesOnTopTransaction(transaction, host);
+      return tipTransaction;
     },
   },
   refundTransaction: {

--- a/test/server/models/Transaction.test.js
+++ b/test/server/models/Transaction.test.js
@@ -162,7 +162,7 @@ describe('server/models/Transaction', () => {
   });
 
   it('createFromPayload() generates a new activity', done => {
-    const createActivityStub = sinon.stub(Transaction, 'createActivity').callsFake(t => {
+    const createActivityStub = sinon.stub(Transaction, 'createActivity').callsFake(async t => {
       expect(Math.abs(t.amount)).to.equal(Math.abs(transactionsData[7].netAmountInCollectiveCurrency));
       createActivityStub.restore();
       done();


### PR DESCRIPTION
Out of simplicity, this PR extracts the changes related to using SQL transactions to create transactions from https://github.com/opencollective/opencollective-api/pull/5966.

Because we will be creating up to 6 transactions per contribution, having SQL transactions is a way to make sure we won't end up with an inconsistent state (ie. having half of the transactions created) if something fails in the process.