### PR TITLE
Handlebars: Set default precision to 2

### DIFF
--- a/server/lib/handlebars.js
+++ b/server/lib/handlebars.js
@@ -1,8 +1,15 @@
 import handlebars from 'handlebars';
-import { lowercase } from 'lodash';
+import { isNil, lowercase } from 'lodash';
 import moment from 'moment-timezone';
 
-import { capitalize, formatCurrency, formatCurrencyObject, pluralize, resizeImage } from './utils';
+import {
+  capitalize,
+  formatCurrency,
+  formatCurrencyObject,
+  getDefaultCurrencyPrecision,
+  pluralize,
+  resizeImage,
+} from './utils';
 
 // from https://stackoverflow.com/questions/8853396/logical-operator-in-a-handlebars-js-if-conditional
 handlebars.registerHelper('ifCond', function (v1, operator, v2, options) {
@@ -92,7 +99,7 @@ handlebars.registerHelper('moment', (value, props) => {
 });
 
 handlebars.registerHelper('currency', (value, props) => {
-  const { currency, precision, size, sign } = props.hash;
+  const { currency, size, sign, precision } = props.hash;
 
   if (isNaN(value)) {
     return '';
@@ -113,7 +120,7 @@ handlebars.registerHelper('currency', (value, props) => {
       style: 'currency',
       currency,
       minimumFractionDigits: precision || 0,
-      maximumFractionDigits: precision || 0,
+      maximumFractionDigits: !isNil(precision) ? precision : getDefaultCurrencyPrecision(currency),
     });
   })();
 

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -8,6 +8,8 @@ import config from 'config';
 import pdf from 'html-pdf';
 import { filter, get, isEqual, padStart, sumBy } from 'lodash';
 
+import { ZERO_DECIMAL_CURRENCIES } from '../constants/currencies';
+
 import errors from './errors';
 import handlebars from './handlebars';
 
@@ -372,6 +374,14 @@ export function formatArrayToString(arr, conjonction = 'and') {
   }
   return `${arr.slice(0, arr.length - 1).join(', ')} ${conjonction} ${arr.slice(-1)}`;
 }
+
+export const getDefaultCurrencyPrecision = currency => {
+  if (ZERO_DECIMAL_CURRENCIES.includes(currency?.toUpperCase())) {
+    return 0;
+  } else {
+    return 2;
+  }
+};
 
 export function formatCurrency(amount, currency, precision = 0) {
   amount = amount / 100; // converting cents


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4157

Showing the amount in cents should be the default (except for zero decimals currencies). This PR changes the default behavior for handlebar's `currency` helper to show two decimals when supported.

![image](https://user-images.githubusercontent.com/1556356/119995467-e2d8ec00-bfcd-11eb-958d-dbf9c630c15f.png)
