### PR TITLE
Fix viewDetailsLink in order.reminder.pendingFinancialContribution.hbs

### DIFF
--- a/templates/emails/order.reminder.pendingFinancialContribution.hbs
+++ b/templates/emails/order.reminder.pendingFinancialContribution.hbs
@@ -23,7 +23,7 @@ currency=order.currency}}} arrived for {{collective.name}}?
 
 <p>Click the button below to confirm the funds as received or cancel the pending contribution. If you are still expecting the funds but they have not yet arrived, no action is required.</p>
 
-<a class="btn blue" href="{{pendingOrderLink}}">
+<a class="btn blue" href="{{viewDetailsLink}}">
   <div style="font-size: 15px;">View Details</div>
 </a>
 


### PR DESCRIPTION
Was broken in https://github.com/opencollective/opencollective-api/commit/b709dfa3f29ffa292ebf4a246dee97c3c6cb8a56