### PR TITLE
PayPal: Correct currency for one-time contributions

### DIFF
--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -133,7 +133,7 @@ export function recordPaypalTransaction(order, paypalTransaction) {
 }
 
 const recordPaypalCapture = async (order, capture) => {
-  const currency = capture.amount.currency;
+  const currency = capture.amount.currency_code;
   const amount = paypalAmountToCents(capture.amount.value);
   const fee = paypalAmountToCents(get(capture, 'seller_receivable_breakdown.paypal_fee.value', '0.0'));
   return recordTransaction(order, amount, currency, fee, { capture });

--- a/server/paymentProviders/paypal/webhook.ts
+++ b/server/paymentProviders/paypal/webhook.ts
@@ -83,9 +83,6 @@ const loadSubscriptionForWebhookEvent = async (req: Request, subscriptionId: str
 };
 
 async function handleSaleCompleted(req: Request): Promise<void> {
-  // TODO During the internal testing phase, we're logging all webhooks events to make debugging easier
-  logger.info(`PayPal webhook (PAYMENT.SALE.COMPLETED): ${JSON.stringify(req.body)}`);
-
   // 1. Retrieve the order for this subscription & validate webhook event
   const sale = req.body.resource;
   const subscriptionId = sale.billing_agreement_id;
@@ -123,9 +120,6 @@ async function handleSaleCompleted(req: Request): Promise<void> {
  * in the the same way, by marking order as cancelled.
  */
 async function handleSubscriptionCancelled(req: Request): Promise<void> {
-  // TODO During the internal testing phase, we're logging all webhooks events to make debugging easier
-  logger.info(`PayPal webhook (${get(req, 'body.event_type')}): ${JSON.stringify(req.body)}`);
-
   const subscription = req.body.resource;
   const { order } = await loadSubscriptionForWebhookEvent(req, subscription.id);
   if (order.status !== OrderStatus.CANCELLED) {


### PR DESCRIPTION
For recurring contributions, PayPal passes the currency as a `currency` parameter. But for one-time captures, they use the `currency_code` parameter. We've therefore recorded one-time contributions (~150) in `USD` rather than their real currency.

This is an immediate fix for the issue, as it's currently preventing the transactions from being recorded in the ledger because of the new checks we've put in place. I'm working on a migration to fix past data.