### PR TITLE
PayPal: Add scripts to migrate invalid transactions

### DIFF
--- a/scripts/fixes/create-missing-paypal-transactions.ts
+++ b/scripts/fixes/create-missing-paypal-transactions.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+import '../../server/env';
+
+import { omit } from 'lodash';
+
+import models, { sequelize } from '../../server/models';
+import { paypalRequestV2 } from '../../server/paymentProviders/paypal/api';
+import { recordPaypalCapture } from '../../server/paymentProviders/paypal/payment';
+
+const migrate = async () => {
+  const orders = await sequelize.query(
+    `
+    SELECT
+      o.*,
+      pm.data -> 'orderId' AS "__paypalOrderId__"
+    FROM
+      "Orders" o
+    INNER JOIN
+      "PaymentMethods" pm ON o."PaymentMethodId" = pm.id
+    INNER JOIN
+      "Collectives" c ON o."CollectiveId" = c.id
+    LEFT JOIN "Transactions" t
+      ON t."OrderId" = o.id
+    WHERE
+      o."data" -> 'error' ->> 'message' = 'createFromContributionPayload: currency should be set'
+      AND t.id IS NULL
+  `,
+    {
+      type: sequelize.QueryTypes.SELECT,
+      model: models.Order,
+      mapToModel: true,
+    },
+  );
+
+  for (const order of orders) {
+    // Preload data
+    order.collective = await order.getCollective();
+    order.paymentMethod = await order.getPaymentMethod();
+    const hostCollective = await order.collective.getHostCollective();
+
+    // Fetch payment info
+    const paypalOrderId = order.dataValues.__paypalOrderId__;
+    const paypalOrderUrl = `checkout/orders/${paypalOrderId}`;
+    const paypalOrderDetails = await paypalRequestV2(paypalOrderUrl, hostCollective, 'GET');
+    const captureId = paypalOrderDetails.purchase_units[0].payments.captures[0].id;
+    const captureDetails = await paypalRequestV2(`payments/captures/${captureId}`, hostCollective, 'GET');
+
+    // Record payment info
+    if (process.env.DRY) {
+      console.log(`Would migrate order #${order.id} with ${JSON.stringify(captureDetails)}`);
+    } else {
+      await recordPaypalCapture(order, captureDetails);
+      const newOrderData = omit(order.data, 'error');
+      await order.update({ processedAt: new Date(), status: 'PAID', data: newOrderData });
+    }
+  }
+};
+
+const main = async () => {
+  return migrate();
+};
+
+main()
+  .then(() => process.exit())
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/scripts/fixes/fix-paypal-transactions-currency.ts
+++ b/scripts/fixes/fix-paypal-transactions-currency.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+import '../../server/env';
+
+import { get, groupBy } from 'lodash';
+
+import { getFxRate } from '../../server/lib/currency';
+import { paypalAmountToCents } from '../../server/lib/paypal';
+import models, { sequelize } from '../../server/models';
+
+const migrate = async () => {
+  // Update credits, should update transactions:
+  const transactions = await sequelize.query(
+    `
+    SELECT
+      t.*
+    FROM
+      "Transactions" t 
+    WHERE
+      t.kind = 'CONTRIBUTION'
+      AND t."data" -> 'capture' -> 'amount' ->> 'currency_code' IS NOT NULL 
+      AND t."data" -> 'capture' -> 'amount' ->> 'currency_code' != t.currency 
+  `,
+    {
+      type: sequelize.QueryTypes.SELECT,
+      model: models.Transaction,
+      mapToModel: true,
+    },
+  );
+
+  // Group transactions by order, to treat DEBIT and CREDIT at the same time
+  const groupedTransactions = Object.values(groupBy(transactions, 'OrderId'));
+  console.log(`Updating ${groupedTransactions.length} transactions pairs`);
+
+  for (const transactions of groupedTransactions) {
+    const credit = transactions.find(t => t.type === 'CREDIT');
+    const debit = transactions.find(t => t.type === 'DEBIT');
+
+    // Extract PayPal data
+    const amount = paypalAmountToCents(credit.data.capture.amount.value);
+    const rawPaypalFee = get(credit.data.capture, 'seller_receivable_breakdown.paypal_fee.value', '0.0');
+    const paypalFee = paypalAmountToCents(rawPaypalFee);
+    const currency = credit.data.capture.amount.currency_code;
+
+    // Compute amounts
+    const hostCurrencyFxRate = await getFxRate(currency, credit.hostCurrency, credit.createdAt);
+    const amountInHostCurrency = Math.round(hostCurrencyFxRate * amount);
+    const hostFeePercent = Math.abs(credit.hostFeeInHostCurrency) / credit.amountInHostCurrency;
+    const hostFeeInHostCurrency = -Math.round(amountInHostCurrency * hostFeePercent);
+    const paymentProcessorFeeInHostCurrency = -Math.round(hostCurrencyFxRate * paypalFee);
+    const transactionFees = hostFeeInHostCurrency + paymentProcessorFeeInHostCurrency;
+    const netAmountInCollectiveCurrency = Math.round((amountInHostCurrency + transactionFees) / hostCurrencyFxRate);
+
+    // Update credit transaction
+    const creditData = {
+      currency,
+      amount,
+      hostFeeInHostCurrency,
+      paymentProcessorFeeInHostCurrency,
+      hostCurrencyFxRate,
+      amountInHostCurrency,
+      netAmountInCollectiveCurrency,
+    };
+
+    const debitData = {
+      currency,
+      amount: -netAmountInCollectiveCurrency,
+      hostFeeInHostCurrency,
+      paymentProcessorFeeInHostCurrency,
+      hostCurrencyFxRate,
+      amountInHostCurrency: -Math.round(netAmountInCollectiveCurrency * hostCurrencyFxRate),
+      netAmountInCollectiveCurrency: -amount,
+    };
+
+    if (process.env.DRY) {
+      console.log(`Would update CREDIT #${credit.id} with ${JSON.stringify(creditData)}`);
+      console.log(`Would update DEBIT #${debit.id} with ${JSON.stringify(debitData)}`);
+    } else {
+      await credit.update(creditData);
+      await debit.update(debitData);
+    }
+  }
+};
+
+const main = async () => {
+  return migrate();
+};
+
+main()
+  .then(() => process.exit())
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/server/paymentProviders/paypal/api.ts
+++ b/server/paymentProviders/paypal/api.ts
@@ -36,7 +36,7 @@ export async function retrieveOAuthToken({ clientId, clientSecret }): Promise<st
 export async function paypalRequest(urlPath, body, hostCollective, method = 'POST'): Promise<Record<string, unknown>> {
   const paypal = await getHostPaypalAccount(hostCollective);
   if (!paypal) {
-    throw new Error("Host doesn't support PayPal payments.");
+    throw new Error(`Host ${hostCollective.name} doesn't support PayPal payments.`);
   }
 
   const url = paypalUrl(urlPath);
@@ -77,7 +77,7 @@ export async function paypalRequestV2(
 ): Promise<Record<string, unknown>> {
   const paypal = await getHostPaypalAccount(hostCollective);
   if (!paypal) {
-    throw new Error("Host doesn't support PayPal payments.");
+    throw new Error(`Host ${hostCollective.name} doesn't support PayPal payments.`);
   }
 
   const url = paypalUrl(urlPath, 'v2');

--- a/server/paymentProviders/paypal/payment.js
+++ b/server/paymentProviders/paypal/payment.js
@@ -132,7 +132,7 @@ export function recordPaypalTransaction(order, paypalTransaction) {
   return recordTransaction(order, amount, currency, fee, { paypalTransaction });
 }
 
-const recordPaypalCapture = async (order, capture) => {
+export const recordPaypalCapture = async (order, capture) => {
   const currency = capture.amount.currency_code;
   const amount = paypalAmountToCents(capture.amount.value);
   const fee = paypalAmountToCents(get(capture, 'seller_receivable_breakdown.paypal_fee.value', '0.0'));


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-api/pull/6137

This PR introduces two scripts for fixing invalid transactions for PayPal one-time contributions:
1. `scripts/fixes/create-missing-paypal-transactions.ts`: between the deployment of https://github.com/opencollective/opencollective-api/pull/6115 and https://github.com/opencollective/opencollective-api/pull/6137, we failed to create transactions for 23 successful orders. This script will create the missing transactions.
2. `scripts/fixes/fix-paypal-transactions-currency.ts`: we have 49 transactions recorded in `USD` rather than their real currency. This script updates the transactions, loading the amounts from the original PayPal payload.