### PR TITLE
Fix Privacy duplicated Transactions when reconciling refunds

### DIFF
--- a/migrations/20210615130700-index-transaction-privacy-id.js
+++ b/migrations/20210615130700-index-transaction-privacy-id.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY privacy_transfer_id ON "Transactions" (((data ->> 'token')::text)) WHERE (data ->> 'token') IS NOT NULL;
+    `);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS privacy_transfer_id;
+    `);
+  },
+};


### PR DESCRIPTION
Since we use expenses to detect if the transaction was already reconciled and we're not creating expenses for refunds, there's an edge case that will cause the worker to create multiple refund transactions on the ledger.

I'm solving this by updating the `processTransaction()` method to check our table for an existing transaction with repeated id (in Privacy's context defined by token) if the charge we're reconciling is a refund.

This could also be solved at the worker level by updating how we paginate the transaction request using information stored in the `Expense.data` and the reason why I didn't do that is due to the fact we are planning to implement a webhook interface to sync these transactions.