### PR TITLE
Add expense data to all expense-related activity webhooks

### DIFF
--- a/server/lib/webhooks.js
+++ b/server/lib/webhooks.js
@@ -55,6 +55,21 @@ const getOrderInfo = order => {
   }
 };
 
+const expenseActivities = [
+  activities.COLLECTIVE_EXPENSE_CREATED,
+  activities.COLLECTIVE_EXPENSE_DELETED,
+  activities.COLLECTIVE_EXPENSE_UPDATED,
+  activities.COLLECTIVE_EXPENSE_REJECTED,
+  activities.COLLECTIVE_EXPENSE_APPROVED,
+  activities.COLLECTIVE_EXPENSE_UNAPPROVED,
+  activities.COLLECTIVE_EXPENSE_PAID,
+  activities.COLLECTIVE_EXPENSE_MARKED_AS_UNPAID,
+  activities.COLLECTIVE_EXPENSE_PROCESSING,
+  activities.COLLECTIVE_EXPENSE_ERROR,
+  activities.COLLECTIVE_EXPENSE_SCHEDULED_FOR_PAYMENT,
+  activities.COLLECTIVE_EXPENSE_MARKED_AS_SPAM,
+];
+
 /**
  * Sanitize an activity to make it suitable for posting on external webhooks
  */
@@ -78,7 +93,7 @@ export const sanitizeActivity = activity => {
       'update.tags',
       'update.isPrivate',
     ]);
-  } else if (type === activities.COLLECTIVE_EXPENSE_CREATED) {
+  } else if (expenseActivities.includes(type)) {
     cleanActivity.data = pick(activity.data, [
       'expense.id',
       'expense.description',

--- a/test/server/lib/webhooks.test.js
+++ b/test/server/lib/webhooks.test.js
@@ -28,6 +28,52 @@ describe('server/lib/webhooks', () => {
       expect(sanitized.data.member.memberCollective.id).to.eq(42);
       expect(sanitized.data.collective).to.not.exist;
     });
+
+    it('Sanitizes COLLECTIVE_EXPENSE_CREATED', () => {
+      const sanitized = sanitizeActivity({
+        type: activities.COLLECTIVE_EXPENSE_CREATED,
+        data: {
+          user: {
+            id: 2,
+          },
+          fromCollective: { slug: 'cslug' },
+          expense: {
+            id: 42,
+            amount: 100,
+            lastEditedById: 2,
+          },
+        },
+      });
+
+      expect(sanitized.data.expense.id).to.eq(42);
+      expect(sanitized.data.expense.amount).to.eq(100);
+      expect(sanitized.data.expense.lastEditedById).to.not.exist;
+      expect(sanitized.data.fromCollective.slug).to.eq('cslug');
+      expect(sanitized.data.user).to.not.exist;
+    });
+
+    it('Sanitizes COLLECTIVE_EXPENSE_REJECTED', () => {
+      const sanitized = sanitizeActivity({
+        type: activities.COLLECTIVE_EXPENSE_REJECTED,
+        data: {
+          user: {
+            id: 2,
+          },
+          fromCollective: { slug: 'cslug' },
+          expense: {
+            id: 42,
+            amount: 100,
+            lastEditedById: 2,
+          },
+        },
+      });
+
+      expect(sanitized.data.expense.id).to.eq(42);
+      expect(sanitized.data.expense.amount).to.eq(100);
+      expect(sanitized.data.expense.lastEditedById).to.not.exist;
+      expect(sanitized.data.fromCollective.slug).to.eq('cslug');
+      expect(sanitized.data.user).to.not.exist;
+    });
   });
 
   describe('enrichActivity', () => {


### PR DESCRIPTION
Include sanitized expense and collective data in the webhook request body for all `collective.expense.*` events. Previously, this data was only included for `collective.expense.created` events.