### PR TITLE
Fix Stripe mock for zero decimal currencies

### DIFF
--- a/test/server/graphql/v1/zero-decimal-currencies.test.js
+++ b/test/server/graphql/v1/zero-decimal-currencies.test.js
@@ -63,9 +63,9 @@ describe('server/graphql/v1/zero-decimal-currencies', () => {
       expect(amount).to.equal(10000);
       expect(platformFeeInHostCurrency).to.equal(-25 * 100);
       expect(paymentProcessorFeeInHostCurrency).to.equal(-35 * 100);
-      expect(hostFeeInHostCurrency).to.equal((-(10000 * 5) / 100) * 100);
+      expect(hostFeeInHostCurrency).to.equal(-(10000 * 5) / 100);
       expect(netAmountInCollectiveCurrency).to.equal(
-        amount + (platformFeeInHostCurrency + paymentProcessorFeeInHostCurrency + hostFeeInHostCurrency) / 100,
+        amount + (platformFeeInHostCurrency + paymentProcessorFeeInHostCurrency + hostFeeInHostCurrency),
       );
     });
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -15,7 +15,7 @@ import schemaV2 from '../server/graphql/v2/schema';
 import cache from '../server/lib/cache';
 import * as libpayments from '../server/lib/payments';
 /* Server code being used */
-import stripe from '../server/lib/stripe';
+import stripe, { convertToStripeAmount } from '../server/lib/stripe';
 import models, { sequelize } from '../server/models';
 
 /* Test data */
@@ -257,11 +257,11 @@ export function stubStripeBalance(sandbox, amount, currency, applicationFee = 0,
   const balanceTransaction = {
     id: 'txn_1Bs9EEBYycQg1OMfTR33Y5Xr',
     object: 'balance_transaction',
-    amount,
+    amount: convertToStripeAmount(currency, amount),
     currency: currency.toLowerCase(),
     fee,
     fee_details: feeDetails, // eslint-disable-line camelcase
-    net: amount - fee,
+    net: convertToStripeAmount(currency, amount - fee),
     status: 'pending',
     type: 'charge',
   };


### PR DESCRIPTION
Stumbled upon this while working on https://github.com/opencollective/opencollective-api/pull/6176

This PR fixes a test introduced in https://github.com/opencollective/opencollective-api/pull/6045. We were not properly converting data in Stripe's mock, and the tests had some `expect` plugged with wrong results:
![image](https://user-images.githubusercontent.com/1556356/122735761-a1abc300-d27f-11eb-9bb1-45c1be45ec3a.png)

Prod data is not impacted by this.

