### PR TITLE
HostApplication: Prevent reject if already approved

### DIFF
--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -164,6 +164,10 @@ const approveApplication = async (host, collective, remoteUser) => {
 };
 
 const rejectApplication = async (host, collective, remoteUser, reason: string) => {
+  if (collective.isActive) {
+    throw new Error('This application has already been approved');
+  }
+
   const cleanReason = reason && stripHTML(reason).trim();
   await models.Activity.create({
     type: activities.COLLECTIVE_REJECTED,


### PR DESCRIPTION
If a host admin approved then rejects an application (ie. if they have two tabs open), we end up in a broken state where the collective is partially un-hosted (root cause for https://opencollective.freshdesk.com/a/tickets/23920). This PR prevents that.