### PR TITLE
createUpdate: Fix account reference input

### DIFF
--- a/server/graphql/v2/input/UpdateCreateInput.js
+++ b/server/graphql/v2/input/UpdateCreateInput.js
@@ -12,7 +12,7 @@ export const UpdateCreateInput = new GraphQLInputObjectType({
     isPrivate: { type: GraphQLBoolean },
     isChangelog: { type: GraphQLBoolean },
     makePublicOn: { type: IsoDateString },
-    html: { type: GraphQLString },
+    html: { type: new GraphQLNonNull(GraphQLString) },
     fromAccount: { type: AccountReferenceInput },
     account: { type: new GraphQLNonNull(AccountReferenceInput) },
   }),


### PR DESCRIPTION
For https://github.com/opencollective/opencollective-frontend/pull/6537

The mutation was only working with `legacyId`, I moved to `fetchAccountWithReference` to support standard usage.