### PR TITLE
Update TransactionGroup for past tips

### DIFF
--- a/migrations/20210628152853-update-tip-refunds-transaction-group.js
+++ b/migrations/20210628152853-update-tip-refunds-transaction-group.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    return queryInterface.sequelize.query(`
+      UPDATE
+        "Transactions" tip
+      SET
+        "TransactionGroup" = t."TransactionGroup",
+        "data" = JSONB_SET(tip."data", '{transactionGroupBeforeTipRefundMigration}', tip."TransactionGroup"::varchar::jsonb, TRUE)
+      FROM
+        "Transactions" t
+      WHERE tip."OrderId" = t."OrderId"
+      AND t."type" = tip."type" 
+      AND ABS(EXTRACT(EPOCH FROM (tip."createdAt" - t."createdAt"))) < 2 -- Less than 2 seconds difference in createdAt
+      AND tip."TransactionGroup" != t."TransactionGroup" 
+      AND tip."kind" = 'PLATFORM_TIP'
+      AND tip."isRefund" IS TRUE
+      AND t."OrderId" IS NOT NULL
+      AND t."kind" IN ('CONTRIBUTION', 'ADDED_FUNDS') 
+      AND t."isRefund" IS TRUE
+    `);
+  },
+
+  down: async () => {
+    // Empty
+  },
+};


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4343

Updates all refunds created before 2021-06-10, ~220 transactions.