### PR TITLE
Virtual Cards: Update `expense.missing.receipt` to open expense in edit mode

### DIFF
--- a/templates/emails/collective.expense.missing.receipt.hbs
+++ b/templates/emails/collective.expense.missing.receipt.hbs
@@ -23,7 +23,7 @@ For accounting reasons, the Fiscal Host will need a description and receipt. The
 <br />
 
 <center>
-  <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}" class="btn blue">
+  <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}?edit=1" class="btn blue">
     <div>Submit Receipt</div>
   </a>
 </center>


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/4261

Update `expense.missing.receipt` to open expense in edit mode.