### PR TITLE
SplitHostFeeShares: Add TODO comment

### DIFF
--- a/scripts/ledger/split-host-fee-shares.ts
+++ b/scripts/ledger/split-host-fee-shares.ts
@@ -53,6 +53,7 @@ const migrate = async () => {
 
     const host = await models.Collective.findByPk(hostFeeTransaction.CollectiveId, { paranoid: false });
     const transaction = await hostFeeTransaction.getRelatedTransaction({ kind: ['CONTRIBUTION', 'ADDED_FUNDS'] });
+    // TODO preload Payment method to define wether debts have ben created automatically
     const result = await models.Transaction.createHostFeeShareTransactions(
       { transaction, hostFeeTransaction },
       host,


### PR DESCRIPTION
Just in case we want to re-use this script to migrate past transactions in the future, I've added a `TODO` to acknowledge for something that needs to be fixed to avoid an issue we faced in the first migration (debts shouldn't be created for Stripe).