### PR TITLE
Wise batch payment to fulfill expenses that did work

### DIFF
--- a/server/controllers/transferwise.ts
+++ b/server/controllers/transferwise.ts
@@ -13,21 +13,24 @@ import models, { Op } from '../models';
 import transferwise from '../paymentProviders/transferwise';
 
 const processPaidExpense = (host, remoteUser, fundData) => async expense => {
-  const payoutMethod = await expense.getPayoutMethod();
-  const { feesInHostCurrency } = await getExpenseFeesInHostCurrency({
-    host,
-    expense,
-    payoutMethod,
-    fees: {},
-    forceManual: false,
-  });
-  return createTransferWiseTransactionsAndUpdateExpense({
-    host,
-    expense,
-    data: { ...pick(expense.data, ['transfer']), fundData },
-    fees: feesInHostCurrency,
-    remoteUser,
-  });
+  await expense.reload();
+  if (expense.data?.transfer) {
+    const payoutMethod = await expense.getPayoutMethod();
+    const { feesInHostCurrency } = await getExpenseFeesInHostCurrency({
+      host,
+      expense,
+      payoutMethod,
+      fees: {},
+      forceManual: false,
+    });
+    return createTransferWiseTransactionsAndUpdateExpense({
+      host,
+      expense,
+      data: { ...pick(expense.data, ['transfer']), fundData },
+      fees: feesInHostCurrency,
+      remoteUser,
+    });
+  }
 };
 
 export async function payBatch(

--- a/test/server/controllers/transferwise.test.ts
+++ b/test/server/controllers/transferwise.test.ts
@@ -186,6 +186,8 @@ describe('server/controllers/transferwise', () => {
 
   it('should create transactions for paid expenses when retrying with OTT header', async () => {
     req.headers['x-2fa-approval'] = 'hash';
+    // Simulate paid expenses because we stub fundExpensesBatchGroup
+    await expense.update({ data: { ...expense.data, transfer: { id: 1234 } } });
     await transferwiseController.payBatch(req, res);
 
     await expense.reload();


### PR DESCRIPTION
Don't scratch out the whole batch if some expense fails to be created.
There's still and edge-case related to validations that happen only when funding the batch or transaction but I think this is a step in the right direction.