### PR TITLE
Wise: Validate currency when creating expense

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -631,6 +631,7 @@ export async function createExpense(
     const host = await collective.getHostCollective();
     const [connectedAccount] = await host.getConnectedAccounts({ where: { service: 'transferwise' } });
     if (connectedAccount) {
+      paymentProviders.transferwise.validatePayoutMethod(connectedAccount, payoutMethod);
       recipient = await paymentProviders.transferwise.createRecipient(connectedAccount, payoutMethod);
     }
   }

--- a/server/models/PayoutMethod.ts
+++ b/server/models/PayoutMethod.ts
@@ -5,6 +5,7 @@ import { isEmail } from 'validator';
 import restoreSequelizeAttributesOnClass from '../lib/restore-sequelize-attributes-on-class';
 import sequelize from '../lib/sequelize';
 import { objHasOnlyKeys } from '../lib/utils';
+import { RecipientAccount as BankAccountPayoutMethodData } from '../types/transferwise';
 
 import models from '.';
 
@@ -30,7 +31,11 @@ export interface OtherPayoutMethodData {
 }
 
 /** Group all the possible types for payout method's data */
-export type PayoutMethodDataType = PaypalPayoutMethodData | OtherPayoutMethodData | Record<string, unknown>;
+export type PayoutMethodDataType =
+  | PaypalPayoutMethodData
+  | OtherPayoutMethodData
+  | BankAccountPayoutMethodData
+  | Record<string, unknown>;
 
 /**
  * Sequelize model to represent an PayoutMethod, linked to the `PayoutMethods` table.
@@ -60,6 +65,8 @@ export class PayoutMethod extends Model {
         return { email: this.data['email'] } as PaypalPayoutMethodData;
       case PayoutMethodTypes.OTHER:
         return { content: this.data['content'] } as OtherPayoutMethodData;
+      case PayoutMethodTypes.BANK_ACCOUNT:
+        return this.data as BankAccountPayoutMethodData;
       default:
         return {};
     }

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -355,6 +355,22 @@ async function getAvailableCurrencies(
   return currencies.filter(c => !currencyBlockList.includes(c.code));
 }
 
+function validatePayoutMethod(connectedAccount: typeof models.ConnectedAccount, payoutMethod: PayoutMethod): void {
+  const currency = (<RecipientAccount>payoutMethod.data)?.currency;
+  if (connectedAccount.data?.type === 'business' && blockedCurrenciesForBusinessProfiles.includes(currency)) {
+    throw new Error(`Sorry, this host's business profile can not create a transaction to ${currency}`);
+  }
+  if (
+    connectedAccount.data?.details?.companyType === 'NON_PROFIT_CORPORATION' &&
+    blockedCurrenciesForNonProfits.includes(currency)
+  ) {
+    throw new Error(`Sorry, this host's non profit corporation can not create a transaction to ${currency}`);
+  }
+  if (connectedAccount.data?.blockedCurrencies?.includes(currency)) {
+    throw new Error(`Sorry, this host's account can not create a transaction to ${currency}`);
+  }
+}
+
 async function getRequiredBankInformation(
   host: typeof models.Collective,
   currency: string,
@@ -506,5 +522,6 @@ export default {
   createExpensesBatchGroup,
   fundExpensesBatchGroup,
   setUpWebhook,
+  validatePayoutMethod,
   oauth,
 };


### PR DESCRIPTION
We need to prevent expenses from being submitted outside the rules enforced by Wise.
Some currencies shouldn't be supported and sometimes Wise fails to validate and end up sending emails saying we shouldn't accept those transactions and our account could be canceled if we continue to do so.