### PR TITLE
Add `goalsInterpolation` to collective setting keys

### DIFF
--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -65,6 +65,7 @@ export const COLLECTIVE_SETTINGS_KEYS_LIST = [
   'githubRepo',
   'githubUsers',
   'goals',
+  'goalsInterpolation',
   'hideCreditCardPostalCode',
   'hostCollective',
   'hostFeePercent',


### PR DESCRIPTION
I see this warning on the API side; 

```
warn: Invalid collective setting key detected: goalsInterpolation
```

I think we have forgotten to add a settings key here. 😄 

Related to https://github.com/opencollective/opencollective/issues/2703 and https://github.com/opencollective/opencollective-frontend/pull/6280