### PR TITLE
CollectiveFeatures: Add id on the object

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -337,9 +337,13 @@ input CollectiveAttributesInputType {
 }
 
 """
-Describes the features enabled and available for this collective
+Describes the features enabled and available for this account
 """
 type CollectiveFeatures {
+  """
+  The id of the account
+  """
+  id: String!
   RECEIVE_FINANCIAL_CONTRIBUTIONS: CollectiveFeatureStatus
   RECURRING_CONTRIBUTIONS: CollectiveFeatureStatus
   TRANSACTIONS: CollectiveFeatureStatus

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -231,7 +231,7 @@ interface Account {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -779,7 +779,7 @@ type Bot implements Account {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -1039,7 +1039,7 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -1139,9 +1139,13 @@ input CollectiveCreateInput {
 }
 
 """
-Describes the features enabled and available for this collective
+Describes the features enabled and available for this account
 """
 type CollectiveFeatures {
+  """
+  The id of the account
+  """
+  id: String!
   RECEIVE_FINANCIAL_CONTRIBUTIONS: CollectiveFeatureStatus
   RECURRING_CONTRIBUTIONS: CollectiveFeatureStatus
   TRANSACTIONS: CollectiveFeatureStatus
@@ -3281,7 +3285,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -4232,7 +4236,7 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -4569,7 +4573,7 @@ type Host implements Account & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -5133,7 +5137,7 @@ type Individual implements Account {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -6551,7 +6555,7 @@ type Organization implements Account & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -7088,7 +7092,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -8254,7 +8258,7 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -25,6 +25,7 @@ import models, { Op } from '../../models';
 import { hostResolver } from '../common/collective';
 import { getContextPermission, PERMISSION_TYPE } from '../common/context-permissions';
 import { getFeatureStatusResolver } from '../common/features';
+import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../v2/identifiers';
 
 import { ApplicationType } from './Application';
 import { TransactionInterfaceType } from './TransactionInterface';
@@ -1953,9 +1954,14 @@ export const CollectiveFeatureStatus = new GraphQLEnumType({
 
 export const CollectiveFeatures = new GraphQLObjectType({
   name: 'CollectiveFeatures',
-  description: 'Describes the features enabled and available for this collective',
+  description: 'Describes the features enabled and available for this account',
   fields: () => {
     return {
+      id: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: 'The id of the account',
+        resolve: getIdEncodeResolver(IDENTIFIER_TYPES.ACCOUNT),
+      },
       ...FeaturesFields(),
     };
   },

--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -364,7 +364,7 @@ const accountFieldsDefinition = () => ({
   },
   features: {
     type: new GraphQLNonNull(CollectiveFeatures),
-    description: 'Describes the features enabled and available for this collective',
+    description: 'Describes the features enabled and available for this account',
     resolve(collective) {
       return collective;
     },


### PR DESCRIPTION
First part for fixing this warning:

```
Warning: fragment with name NavbarFields already exists.
graphql-tag enforces all fragment names across your application to be unique; read more about
this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
Cache data may be lost when replacing the features field of a Organization object.

To address this problem (which is not a bug in Apollo Client), either ensure all objects of type CollectiveFeatures have an ID or a custom merge function, or define a custom merge function for the Organization.features field, so InMemoryCache can safely merge these objects:

  existing: {"__typename":"CollectiveFeatures","VIRTUAL_CARDS":"DISABLED"}
  incoming: {"__typename":"CollectiveFeatures","ABOUT":"ACTIVE","CONNECTED_ACCOUNTS":"AVAILABLE","RECEIVE_FINANCIAL_CONTRIBUTIONS":"ACTIVE","RECURRING_CONTRIBUTIONS":"AVAILABLE","EVENTS":"AVAILABLE","PROJECTS":"UNSUPPORTED","USE_EXPENSES":"ACTIVE","RECEIVE_EXPENSES":"AVAILABLE","COLLECTIVE_GOALS":"DISABLED","TOP_FINANCIAL_CONTRIBUTORS":"ACTIVE","CONVERSATIONS":"AVAILABLE","UPDATES":"ACTIVE","TEAM":"ACTIVE","CONTACT_FORM":"ACTIVE","RECEIVE_HOST_APPLICATIONS":"ACTIVE","HOST_DASHBOARD":"ACTIVE","TRANSACTIONS":"ACTIVE","REQUEST_VIRTUAL_CARDS":"DISABLED"}

For more information about these options, please refer to the documentation:

  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
```