### PR TITLE
Ensure all `payExpense` paths update the settlements

### DIFF
--- a/migrations/20210729125942-fix-transaction-settlements-status.js
+++ b/migrations/20210729125942-fix-transaction-settlements-status.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      UPDATE "TransactionSettlements" ts
+      SET "status" = 'SETTLED'
+      FROM "Expenses" e
+      WHERE ts."ExpenseId" IS NOT NULL
+      AND ts."ExpenseId" = e.id
+      AND ts.status != 'SETTLED'
+      AND e.status = 'PAID'
+    `);
+  },
+
+  down: async () => {
+    // Nothing to do here
+  },
+};

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1238,11 +1238,6 @@ export async function payExpense(req: express.Request, args: Record<string, unkn
     return markExpenseAsPaid(expense, remoteUser, true);
   });
 
-  // Update transactions settlement
-  if (expense.data?.['isPlatformTipSettlement']) {
-    await models.TransactionSettlement.markExpenseAsSettled(expense);
-  }
-
   return expense;
 }
 

--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -365,6 +365,11 @@ function defineModel() {
   Expense.prototype.setPaid = async function (lastEditedById) {
     await this.update({ status: status.PAID, lastEditedById });
 
+    // Update transactions settlement
+    if (this.data?.['isPlatformTipSettlement']) {
+      await models.TransactionSettlement.markExpenseAsSettled(this);
+    }
+
     try {
       await this.createContributorMember();
     } catch (e) {


### PR DESCRIPTION
Moved the settlement update to `setPaid` to make sure all paths are updated regardless of the payout method, since in some cases we're calling the code to pay expenses from elsewhere (eg. for Transferwise, in the `handleTransferStateChange` webhook). 

Also added a migration to fix one invalid expense in the DB (97 transaction pairs).