### PR TITLE
Correct .nvmrc to use node `14.x`

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+v14.x


### PR DESCRIPTION
This was a mistake introduced in a previous commit; rather we should force the use of node 14.x for `nvm` just like we do in the front-end.

Related Slack thread: https://opencollective.slack.com/archives/C0RMV6F8C/p1628517217051100 