### PR TITLE
Transactions: use dataloader generators

### DIFF
--- a/cron/monthly/collective-report.js
+++ b/cron/monthly/collective-report.js
@@ -7,7 +7,7 @@ import { isEmpty, omit, pick } from 'lodash';
 import moment from 'moment';
 
 import { TransactionKind } from '../../server/constants/transaction-kind';
-import { hostFeeAmountForTransaction } from '../../server/graphql/loaders/transactions';
+import { generateHostFeeAmountForTransactionLoader } from '../../server/graphql/loaders/transactions';
 import { notifyAdminsOfCollective } from '../../server/lib/notifications';
 import { getConsolidatedInvoicePdfs } from '../../server/lib/pdf';
 import { getTiersStats } from '../../server/lib/utils';
@@ -37,8 +37,10 @@ const processCollectives = collectives => {
   return Promise.map(collectives, processCollective, { concurrency: 1 });
 };
 
+const hostFeeAmountForTransactionLoader = generateHostFeeAmountForTransactionLoader();
+
 const enrichTransactionsWithHostFee = async transactions => {
-  const hostFees = await hostFeeAmountForTransaction.loadMany(transactions);
+  const hostFees = await hostFeeAmountForTransactionLoader.loadMany(transactions);
   transactions.forEach((transaction, idx) => {
     const hostFeeInHostCurrency = hostFees[idx];
     if (hostFeeInHostCurrency && hostFeeInHostCurrency !== transaction.hostFeeInHostCurrency) {

--- a/reports/host-report.js
+++ b/reports/host-report.js
@@ -5,7 +5,7 @@ import { groupBy, keyBy, pick, sumBy } from 'lodash';
 import moment from 'moment';
 
 import MemberRoles from '../server/constants/roles.ts';
-import { hostFeeAmountForTransaction } from '../server/graphql/loaders/transactions';
+import { generateHostFeeAmountForTransactionLoader } from '../server/graphql/loaders/transactions';
 import emailLib from '../server/lib/email';
 import { getBackersStats, getHostedCollectives, sumTransactions } from '../server/lib/hostlib';
 import { stripHTML } from '../server/lib/sanitize-html';
@@ -30,8 +30,10 @@ const summary = {
   hosts: [],
 };
 
+const hostFeeAmountForTransactionLoader = generateHostFeeAmountForTransactionLoader();
+
 const enrichTransactionsWithHostFee = async transactions => {
-  const hostFees = await hostFeeAmountForTransaction.loadMany(transactions);
+  const hostFees = await hostFeeAmountForTransactionLoader.loadMany(transactions);
   transactions.forEach((transaction, idx) => {
     const hostFeeInHostCurrency = hostFees[idx];
     if (transaction.kind === 'ADDED_FUNDS' || transaction.kind === 'CONTRIBUTION') {

--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -645,8 +645,8 @@ export const loaders = req => {
         });
       }),
     ),
-    hostFeeAmountForTransaction: transactionLoaders.hostFeeAmountForTransaction,
-    relatedTransactions: transactionLoaders.relatedTransactions,
+    hostFeeAmountForTransaction: transactionLoaders.generateHostFeeAmountForTransactionLoader(),
+    relatedTransactions: transactionLoaders.generateRelatedTransactionsLoader(),
   };
 
   return context.loaders;

--- a/server/graphql/loaders/transactions.ts
+++ b/server/graphql/loaders/transactions.ts
@@ -4,8 +4,8 @@ import { groupBy } from 'lodash';
 import { TransactionKind } from '../../constants/transaction-kind';
 import models, { Op } from '../../models';
 
-export const hostFeeAmountForTransaction: DataLoader<number, number[]> = new DataLoader(
-  async (transactions: typeof models.Transaction[]) => {
+export const generateHostFeeAmountForTransactionLoader = (): DataLoader<number, number[]> =>
+  new DataLoader(async (transactions: typeof models.Transaction[]) => {
     const transactionsWithoutHostFee = transactions.filter(transaction => {
       // Legacy transactions have their host fee set on `hostFeeInHostCurrency`. No need to fetch for them
       // Also only contributions and added funds can have host fees
@@ -41,11 +41,13 @@ export const hostFeeAmountForTransaction: DataLoader<number, number[]> = new Dat
         }
       }
     });
-  },
-);
+  });
 
-export const relatedTransactions: DataLoader<typeof models.Transaction, typeof models.Transaction[]> = new DataLoader(
-  async (transactions: typeof models.Transaction[]) => {
+export const generateRelatedTransactionsLoader = (): DataLoader<
+  typeof models.Transaction,
+  typeof models.Transaction[]
+> =>
+  new DataLoader(async (transactions: typeof models.Transaction[]) => {
     const transactionGroups = transactions.map(transaction => transaction.TransactionGroup);
     const relatedTransactions = await models.Transaction.findAll({ where: { TransactionGroup: transactionGroups } });
     const groupedTransactions = groupBy(relatedTransactions, 'TransactionGroup');
@@ -56,5 +58,4 @@ export const relatedTransactions: DataLoader<typeof models.Transaction, typeof m
         return [];
       }
     });
-  },
-);
+  });


### PR DESCRIPTION
This PR should hopefully fix the memory leak that we're facing for a few weeks. Since the data loaders were created at the top level, my guess is that they were never cleared and grew indefinitely. 