### PR TITLE
Correct the Month in GCal Invites

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -766,14 +766,14 @@ function defineModel() {
         const endDate = new Date(this.endsAt);
         const start = [
           startDate.getFullYear(),
-          startDate.getMonth(),
+          startDate.getMonth() + 1,
           startDate.getDate(),
           startDate.getHours(),
           startDate.getMinutes(),
         ];
         const end = [
           endDate.getFullYear(),
-          endDate.getMonth(),
+          endDate.getMonth() + 1,
           endDate.getDate(),
           endDate.getHours(),
           endDate.getMinutes(),


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-api/pull/6266

This was a mistake introduced in the above PR. The month here is zero indexed so we need to compensate by adding 1 to it. 😃 