### PR TITLE
enhancement: send notification to all admins of collective

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -610,7 +610,12 @@ const sendOrderConfirmedEmail = async (order, transaction) => {
       attachments,
     };
 
-    return emailLib.send('thankyou', user.email, data, emailOptions);
+    const activity = {
+      type: 'thankyou',
+      data,
+    };
+
+    return notifyAdminsOfCollective(data.fromCollective.id, activity, emailOptions);
   }
 };
 

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -8,7 +8,6 @@ import status from '../constants/order_status';
 import { PAYMENT_METHOD_TYPE } from '../constants/paymentMethods';
 import models from '../models';
 
-import emailLib from './email';
 import logger from './logger';
 import { notifyAdminsOfCollective } from './notifications';
 import * as paymentsLib from './payments';

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -10,6 +10,7 @@ import models from '../models';
 
 import emailLib from './email';
 import logger from './logger';
+import { notifyAdminsOfCollective } from './notifications';
 import * as paymentsLib from './payments';
 import { getTransactionPdf } from './pdf';
 import { sleep, toIsoDateStr } from './utils';
@@ -332,43 +333,51 @@ export async function cancelSubscriptionAndNotifyUser(order) {
 
 /** Send `archived.collective` email */
 export async function sendArchivedCollectiveEmail(order) {
-  const user = order.createdByUser;
-  return emailLib.send(
-    'archived.collective',
-    user.email,
-    {
-      order: order.info,
-      collective: order.collective.info,
-      fromCollective: order.fromCollective.minimal,
-    },
-    {
-      from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
-    },
-  );
+  const data = {
+    order: order.info,
+    collective: order.collective.info,
+    fromCollective: order.fromCollective.minimal,
+  };
+
+  const emailOptions = {
+    from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
+  };
+
+  const activity = {
+    type: 'archived.collective',
+    data,
+  };
+
+  return notifyAdminsOfCollective(data.fromCollective.id, activity, emailOptions);
 }
 
 /** Send `payment.failed` email */
 export async function sendFailedEmail(order, lastAttempt) {
-  const user = order.createdByUser;
   let errorMessage = get(order, 'data.error.message');
+
   if (errorMessage && errorMessage.includes('Something went wrong with the payment')) {
     errorMessage = 'Something went wrong with the payment.';
   }
-  return emailLib.send(
-    'payment.failed',
-    user.email,
-    {
-      lastAttempt,
-      order: order.info,
-      collective: order.collective.info,
-      fromCollective: order.fromCollective.minimal,
-      subscriptionsLink: `${config.host.website}/${order.fromCollective.slug}/recurring-contributions`,
-      errorMessage: errorMessage,
-    },
-    {
-      from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
-    },
-  );
+
+  const data = {
+    lastAttempt,
+    order: order.info,
+    collective: order.collective.info,
+    fromCollective: order.fromCollective.minimal,
+    subscriptionsLink: `${config.host.website}/${order.fromCollective.slug}/recurring-contributions`,
+    errorMessage: errorMessage,
+  };
+
+  const activity = {
+    type: 'payment.failed',
+    data,
+  };
+
+  const emailOptions = {
+    from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
+  };
+
+  return notifyAdminsOfCollective(data.fromCollective.id, activity, emailOptions);
 }
 
 /** Send `thankyou` email */
@@ -426,22 +435,30 @@ export async function sendThankYouEmail(order, transaction, isFirstPayment = fal
     attachments,
   };
 
-  return emailLib.send('thankyou', user.email, data, emailOptions);
+  const activity = {
+    type: 'thankyou',
+    data,
+  };
+
+  return notifyAdminsOfCollective(data.fromCollective.id, activity, emailOptions);
 }
 
 export async function sendCreditCardConfirmationEmail(order) {
-  const user = order.createdByUser;
-  return emailLib.send(
-    'payment.creditcard.confirmation',
-    user.email,
-    {
-      order: order.info,
-      collective: order.collective.info,
-      fromCollective: order.fromCollective.minimal,
-      confirmOrderLink: `${config.host.website}/orders/${order.id}/confirm`,
-    },
-    {
-      from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
-    },
-  );
+  const data = {
+    order: order.info,
+    collective: order.collective.info,
+    fromCollective: order.fromCollective.minimal,
+    confirmOrderLink: `${config.host.website}/orders/${order.id}/confirm`,
+  };
+
+  const activity = {
+    type: 'payment.creditcard.confirmation',
+    data,
+  };
+
+  const emailOptions = {
+    from: `${order.collective.name} <no-reply@${order.collective.slug}.opencollective.com>`,
+  };
+
+  return notifyAdminsOfCollective(data.fromCollective.id, activity, emailOptions);
 }

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1155,7 +1155,8 @@ function defineModel() {
    * Get the admin users { id, email } of this collective
    */
   Collective.prototype.getAdminUsers = async function ({ userQueryParams, paranoid = true } = {}) {
-    if (this.type === 'USER') {
+    if (this.type === 'USER' && !this.isIncognito) {
+      // Incognito profiles rely on the `Members` entry to know which user it belongs to
       return [await this.getUser({ paranoid, ...userQueryParams })];
     }
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4559

Following are some corresponding screenshots for a collective with two admins.

<img width="361" alt="Screenshot 2021-08-20 at 8 17 46 AM" src="https://user-images.githubusercontent.com/46647141/130171656-bab2c3f8-1c09-4870-bb1e-b05fb36d6b34.png">
<img width="362" alt="Screenshot 2021-08-20 at 8 21 39 AM" src="https://user-images.githubusercontent.com/46647141/130171665-53265b0a-200d-4869-b411-ca00e39cd38f.png">
<img width="356" alt="Screenshot 2021-08-20 at 8 21 49 AM" src="https://user-images.githubusercontent.com/46647141/130171667-a0566f86-6889-4f63-9085-d624cf27d841.png">
