### PR TITLE
Guest: Don't change slug when validating the account

### DIFF
--- a/server/lib/guest-accounts.ts
+++ b/server/lib/guest-accounts.ts
@@ -129,7 +129,6 @@ export const confirmGuestAccount = async (
   const newName = userCollective.name !== DEFAULT_GUEST_NAME ? userCollective.name : 'Incognito';
   userCollective = await userCollective.update({
     name: newName,
-    slug: newName === 'Incognito' ? `user-${uuid().split('-')[0]}` : await models.Collective.generateSlug([newName]),
     data: { ...userCollective.data, isGuest: false, wasGuest: true },
   });
 

--- a/test/server/lib/guest-accounts.test.ts
+++ b/test/server/lib/guest-accounts.test.ts
@@ -91,7 +91,7 @@ describe('server/lib/guest-accounts.ts', () => {
       await user.reload({ include: [{ association: 'collective' }] });
       expect(user.confirmedAt).to.not.be.null;
       expect(user.collective.name).to.eq('Incognito');
-      expect(user.collective.slug).to.include('user-');
+      expect(user.collective.slug).to.include('guest-'); // slug doesn't get updated
     });
 
     it('verifies the account and updates the profile for users that already filled their profiles', async () => {
@@ -103,7 +103,7 @@ describe('server/lib/guest-accounts.ts', () => {
       await user.reload({ include: [{ association: 'collective' }] });
       expect(user.confirmedAt).to.not.be.null;
       expect(user.collective.name).to.eq('Zappa');
-      expect(user.collective.slug).to.include('zappa');
+      expect(user.collective.slug).to.include('guest'); // slug doesn't get updated
     });
   });
 });


### PR DESCRIPTION
Fix for https://opencollective.slack.com/archives/GFH4N961L/p1629368281010000

While changing the `slug` was nice to clearly distinguish verified accounts, doing so creates an issue where the recurring contributions link they receive by email (eg. `/guest-xxxxx/recurring-contributions`) turns up in a 404 when they login with the link.

The alternative solution was to rather link to `/recurring-contributions` and have a redirection there, but I preferred this approach because:
- It works with links already sent
- It will prevent similar issues that may occur in the future for different URLs
- It's a simpler behavior