### PR TITLE
GQLV2/Transaction: Handle null collectives

### DIFF
--- a/server/graphql/v2/object/Credit.js
+++ b/server/graphql/v2/object/Credit.js
@@ -14,13 +14,17 @@ export const Credit = new GraphQLObjectType({
       fromAccount: {
         type: Account,
         resolve(transaction, _, req) {
-          return req.loaders.Collective.byId.load(transaction.FromCollectiveId);
+          if (transaction.FromCollectiveId) {
+            return req.loaders.Collective.byId.load(transaction.FromCollectiveId);
+          }
         },
       },
       toAccount: {
         type: Account,
         resolve(transaction, _, req) {
-          return req.loaders.Collective.byId.load(transaction.CollectiveId);
+          if (transaction.CollectiveId) {
+            return req.loaders.Collective.byId.load(transaction.CollectiveId);
+          }
         },
       },
     };

--- a/server/graphql/v2/object/Debit.js
+++ b/server/graphql/v2/object/Debit.js
@@ -14,13 +14,17 @@ export const Debit = new GraphQLObjectType({
       fromAccount: {
         type: Account,
         resolve(transaction, _, req) {
-          return req.loaders.Collective.byId.load(transaction.CollectiveId);
+          if (transaction.CollectiveId) {
+            return req.loaders.Collective.byId.load(transaction.CollectiveId);
+          }
         },
       },
       toAccount: {
         type: Account,
         resolve(transaction, _, req) {
-          return req.loaders.Collective.byId.load(transaction.FromCollectiveId);
+          if (transaction.FromCollectiveId) {
+            return req.loaders.Collective.byId.load(transaction.FromCollectiveId);
+          }
         },
       },
     };


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2596510215

We have many transactions where one of the two values is null. Since the field is nullable, we should handle this case.

```sql
SELECT * FROM "Transactions" t WHERE "CollectiveId" IS NULL OR "FromCollectiveId" IS NULL
```