### PR TITLE
Member Invitations: Improve validations

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,7 +67,7 @@
     "searchEmailPerHour": 150,
     "searchEmailPerHourPerIp": 50,
     "collectiveEmailMessagePerHour": 5,
-    "maxMemberInvitationsPerCollective": 50
+    "maxCoreContributorsPerAccount": 60
   },
   "email": {
     "from": "Open Collective <info@opencollective.com>"

--- a/server/graphql/v2/mutation/MemberInvitationMutations.js
+++ b/server/graphql/v2/mutation/MemberInvitationMutations.js
@@ -5,6 +5,7 @@ import { pick } from 'lodash';
 import { types as CollectiveTypes } from '../../../constants/collectives';
 import MemberRoles from '../../../constants/roles';
 import models from '../../../models';
+import { MEMBER_INVITATION_SUPPORTED_ROLES } from '../../../models/MemberInvitation';
 import { Forbidden, Unauthorized } from '../../errors';
 import { MemberRole } from '../enum';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
@@ -52,7 +53,7 @@ const memberInvitationMutations = {
         throw new Unauthorized('Only admins can send an invitation.');
       }
 
-      if (![MemberRoles.ACCOUNTANT, MemberRoles.ADMIN, MemberRoles.MEMBER].includes(args.role)) {
+      if (!MEMBER_INVITATION_SUPPORTED_ROLES.includes(args.role)) {
         throw new Forbidden('You can only invite accountants, admins, or members.');
       } else if (memberAccount.type !== CollectiveTypes.USER) {
         throw new Forbidden('You can only invite users.');


### PR DESCRIPTION
- Add a maximum limit on the number of members an account can have. The previous limit included only invitations, while this one is a sum of existing members + invitations.
- Prevent adding members on an Individual account