### PR TITLE
Make Sure Login method Runs Properly with the `thegivingblock-connect.js` Script

### DIFF
--- a/server/paymentProviders/thegivingblock/index.js
+++ b/server/paymentProviders/thegivingblock/index.js
@@ -62,8 +62,12 @@ export async function login(login, password, account) {
   body.set('login', login);
   body.set('password', password);
 
-  const { accessToken, refreshToken } = await apiRequest(`/login`, { method: 'POST', body });
-  return account.update({ data: { ...account.data, accessToken, refreshToken } });
+  const data = await apiRequest(`/login`, { method: 'POST', body });
+  // We need to return the data is no account was passed (especially for thegivingblock-connect.js script)
+  if (!account) {
+    return data;
+  }
+  return account.update({ data: { ...account.data, accessToken: data.accessToken, refreshToken: data.refreshToken } });
 }
 
 export async function refresh(account) {


### PR DESCRIPTION
This is a regression introduced in https://github.com/opencollective/opencollective-api/pull/6443. We need to make sure if no account is passed the `login` method does not crash. This is important for the case of the `thegivingblock-connect.js` script to run properly. 

Related to https://github.com/opencollective/opencollective/issues/4546