### PR TITLE
Add delete action to `processExpense`

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -872,30 +872,21 @@ export async function editExpense(
   return updatedExpense;
 }
 
-export async function deleteExpense(req: express.Request, expenseId: number): Promise<typeof models.Expense> {
-  const { remoteUser } = req;
-  if (!remoteUser) {
+export async function deleteExpense(
+  req: express.Request,
+  expense: typeof models.Expense,
+): Promise<typeof models.Expense> {
+  if (!req.remoteUser) {
     throw new Unauthorized('You need to be logged in to delete an expense');
-  } else if (!canUseFeature(remoteUser, FEATURE.USE_EXPENSES)) {
+  } else if (!canUseFeature(req.remoteUser, FEATURE.USE_EXPENSES)) {
     throw new FeatureNotAllowedForUser();
-  }
-
-  const expense = await models.Expense.findByPk(expenseId, {
-    include: [{ model: models.Collective, as: 'collective' }],
-  });
-
-  if (!expense) {
-    throw new NotFound('Expense not found');
-  }
-
-  if (!(await canDeleteExpense(req, expense))) {
+  } else if (!(await canDeleteExpense(req, expense))) {
     throw new Unauthorized(
       "You don't have permission to delete this expense or it needs to be rejected before being deleted",
     );
   }
 
-  const res = await expense.destroy();
-  return res;
+  return expense.destroy();
 }
 
 /** Helper that finishes the process of paying an expense */

--- a/server/graphql/v2/enum/ExpenseProcessAction.ts
+++ b/server/graphql/v2/enum/ExpenseProcessAction.ts
@@ -28,5 +28,8 @@ export const ExpenseProcessAction = new GraphQLEnumType({
     MARK_AS_SPAM: {
       description: 'To mark the expense as spam',
     },
+    DELETE: {
+      description: 'To delete an expense. Only work if the expense is rejected; please check permissions.canDelete',
+    },
   },
 });

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -17,6 +17,7 @@ import {
   canDeleteExpense,
   canVerifyDraftExpense,
   createExpense,
+  deleteExpense,
   editExpense,
   markExpenseAsSpam,
   markExpenseAsUnpaid,
@@ -193,6 +194,7 @@ const expenseMutations = {
   deleteExpense: {
     type: new GraphQLNonNull(Expense),
     description: `Delete an expense. Only work if the expense is rejected - please check permissions.canDelete.`,
+    deprecationReason: '2021-08-31: Please use `processExpense` with a `DELETE` action',
     args: {
       expense: {
         type: new GraphQLNonNull(ExpenseReferenceInput),
@@ -284,6 +286,8 @@ const expenseMutations = {
             forceManual: args.paymentParams?.forceManual,
             twoFactorAuthenticatorCode: args.paymentParams?.twoFactorAuthenticatorCode,
           });
+        case 'DELETE':
+          return deleteExpense(req, expense);
         default:
           return expense;
       }


### PR DESCRIPTION
Treating this as another action for `processExpense` will make things easier, allowing to re-use helpers from `ProcessExpenseButtons`.