### PR TITLE
Make sure allHosts and allCollectives are ordered

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -632,6 +632,10 @@ const queries = {
         query.order = [[args.orderBy, args.orderDirection]];
       }
 
+      // Make sure entries are always ordered
+      query.order = query.order || [];
+      query.order.push(['id', 'ASC']);
+
       if (args.minBackerCount) {
         const { total, collectives } = await rawQueries.getCollectivesWithMinBackers({
           ...args,

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -66,7 +66,9 @@ const getHosts = async args => {
     ) SELECT c.*, (SELECT COUNT(*) FROM all_hosts) AS __hosts_count__, SUM(all_hosts.count) as __members_count__
     FROM "Collectives" c INNER JOIN all_hosts ON all_hosts."HostCollectiveId" = c.id
     GROUP BY c.id
-    ORDER BY ${args.orderBy === 'collectives' ? '__members_count__' : args.orderBy} ${args.orderDirection}
+    ORDER BY
+      ${args.orderBy === 'collectives' ? '__members_count__' : args.orderBy} ${args.orderDirection},
+      id ASC
     LIMIT $limit
     OFFSET $offset
   `;


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4598

When ordering by contributors count or other non-unique fields, we must make sure there's a second ordering condition; otherwise, the order is not predictable and results in broken pagination results.