### PR TITLE
Move orders mutations to common

### DIFF
--- a/server/graphql/common/orders.js
+++ b/server/graphql/common/orders.js
@@ -7,32 +7,26 @@ import * as hcaptcha from 'hcaptcha';
 import { get, isNil, omit, pick, set } from 'lodash';
 import { isEmail } from 'validator';
 
-import activities from '../../../constants/activities';
-import CAPTCHA_PROVIDERS from '../../../constants/captcha-providers';
-import { types } from '../../../constants/collectives';
-import FEATURE from '../../../constants/feature';
-import status from '../../../constants/order_status';
-import roles from '../../../constants/roles';
-import { VAT_OPTIONS } from '../../../constants/vat';
-import cache, { purgeCacheForCollective } from '../../../lib/cache';
-import * as github from '../../../lib/github';
-import { getOrCreateGuestProfile } from '../../../lib/guest-accounts';
-import logger from '../../../lib/logger';
-import * as libPayments from '../../../lib/payments';
-import recaptcha from '../../../lib/recaptcha';
-import { getChargeRetryCount, getNextChargeAndPeriodStartDates } from '../../../lib/recurring-contributions';
-import { canUseFeature } from '../../../lib/user-permissions';
-import { formatCurrency, md5, parseToBoolean, sleep } from '../../../lib/utils';
-import models from '../../../models';
-import { canRefund } from '../../common/transactions';
-import {
-  BadRequest,
-  FeatureNotAllowedForUser,
-  Forbidden,
-  NotFound,
-  Unauthorized,
-  ValidationFailed,
-} from '../../errors';
+import activities from '../../constants/activities';
+import CAPTCHA_PROVIDERS from '../../constants/captcha-providers';
+import { types } from '../../constants/collectives';
+import FEATURE from '../../constants/feature';
+import status from '../../constants/order_status';
+import roles from '../../constants/roles';
+import { VAT_OPTIONS } from '../../constants/vat';
+import cache, { purgeCacheForCollective } from '../../lib/cache';
+import * as github from '../../lib/github';
+import { getOrCreateGuestProfile } from '../../lib/guest-accounts';
+import logger from '../../lib/logger';
+import * as libPayments from '../../lib/payments';
+import recaptcha from '../../lib/recaptcha';
+import { getChargeRetryCount, getNextChargeAndPeriodStartDates } from '../../lib/recurring-contributions';
+import { canUseFeature } from '../../lib/user-permissions';
+import { formatCurrency, md5, parseToBoolean, sleep } from '../../lib/utils';
+import models from '../../models';
+import { BadRequest, FeatureNotAllowedForUser, Forbidden, NotFound, Unauthorized, ValidationFailed } from '../errors';
+
+import { canRefund } from './transactions';
 
 const oneHourInSeconds = 60 * 60;
 

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -6,6 +6,13 @@ import { editPublicMessage } from '../common/members';
 import { createUser } from '../common/user';
 import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../errors';
 
+import {
+  confirmOrder,
+  createOrder,
+  markOrderAsPaid,
+  markPendingOrderAsExpired,
+  refundTransaction,
+} from './../common/orders';
 import * as applicationMutations from './mutations/applications';
 import * as backyourstackMutations from './mutations/backyourstack';
 import {
@@ -25,13 +32,6 @@ import {
 import * as commentMutations from './mutations/comments';
 import { editConnectedAccount } from './mutations/connectedAccounts';
 import { createWebhook, deleteNotification, editWebhooks } from './mutations/notifications';
-import {
-  confirmOrder,
-  createOrder,
-  markOrderAsPaid,
-  markPendingOrderAsExpired,
-  refundTransaction,
-} from './mutations/orders';
 import * as paymentMethodsMutation from './mutations/paymentMethods';
 import { editTier, editTiers } from './mutations/tiers';
 import { confirmUserEmail, updateUserEmail } from './mutations/users';

--- a/server/graphql/v2/mutation/AddFundsMutations.ts
+++ b/server/graphql/v2/mutation/AddFundsMutations.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import { GraphQLFloat, GraphQLNonNull, GraphQLString } from 'graphql';
 
+import { addFundsToCollective } from '../../common/orders';
 import { ValidationFailed } from '../../errors';
-import { addFundsToCollective as addFundsToCollectiveLegacy } from '../../v1/mutations/orders';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { AmountInput, getValueInCentsFromAmountInput } from '../input/AmountInput';
 import { Order } from '../object/Order';
@@ -33,7 +33,7 @@ export const addFundsMutation = {
       throw new ValidationFailed('platformFeePercent should be a value between 0 and 100.');
     }
 
-    return addFundsToCollectiveLegacy(
+    return addFundsToCollective(
       {
         totalAmount: getValueInCentsFromAmountInput(args.amount),
         collective: account,

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -10,8 +10,8 @@ import {
 } from '../../../lib/subscriptions';
 import models from '../../../models';
 import { updateSubscriptionWithPaypal } from '../../../paymentProviders/paypal/subscription';
+import { confirmOrder, createOrder } from '../../common/orders';
 import { BadRequest, NotFound, Unauthorized, ValidationFailed } from '../../errors';
-import { confirmOrder as confirmOrderLegacy, createOrder as createOrderLegacy } from '../../v1/mutations/orders';
 import { getIntervalFromContributionFrequency } from '../enum/ContributionFrequency';
 import { ProcessOrderAction } from '../enum/ProcessOrderAction';
 import { getDecodedId } from '../identifiers';
@@ -99,7 +99,7 @@ const orderMutations = {
       };
 
       const userAgent = req.header('user-agent');
-      const result = await createOrderLegacy(legacyOrderObj, req.loaders, req.remoteUser, req.ip, userAgent, req.mask);
+      const result = await createOrder(legacyOrderObj, req.loaders, req.remoteUser, req.ip, userAgent, req.mask);
       return { order: result.order, stripeError: result.stripeError, guestToken: result.order.data?.guestToken };
     },
   },
@@ -280,7 +280,7 @@ const orderMutations = {
     },
     async resolve(_, args, req) {
       const baseOrder = await fetchOrderWithReference(args.order);
-      const updatedOrder = await confirmOrderLegacy(baseOrder, req.remoteUser, args.guestToken);
+      const updatedOrder = await confirmOrder(baseOrder, req.remoteUser, args.guestToken);
       return {
         order: updatedOrder,
         stripeError: updatedOrder.stripeError,

--- a/server/graphql/v2/mutation/TransactionMutations.ts
+++ b/server/graphql/v2/mutation/TransactionMutations.ts
@@ -6,9 +6,9 @@ import { TransactionKind } from '../../../constants/transaction-kind';
 import { purgeCacheForCollective } from '../../../lib/cache';
 import { notifyAdminsOfCollective } from '../../../lib/notifications';
 import models from '../../../models';
+import { refundTransaction } from '../../common/orders';
 import { canReject } from '../../common/transactions';
 import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../../errors';
-import { refundTransaction as legacyRefundTransaction } from '../../v1/mutations/orders';
 import { AmountInput, getValueInCentsFromAmountInput } from '../input/AmountInput';
 import { fetchTransactionWithReference, TransactionReferenceInput } from '../input/TransactionReferenceInput';
 import { Transaction } from '../interface/Transaction';
@@ -80,7 +80,7 @@ const transactionMutations = {
         throw new Unauthorized();
       }
       const transaction = await fetchTransactionWithReference(args.transaction);
-      return legacyRefundTransaction(undefined, { id: transaction.id }, req);
+      return refundTransaction(undefined, { id: transaction.id }, req);
     },
   },
   rejectTransaction: {
@@ -121,7 +121,7 @@ const transactionMutations = {
       let refundedTransaction;
       if (!transaction.RefundTransactionId) {
         const refundParams = { id: transaction.id, message: rejectionReason };
-        refundedTransaction = await legacyRefundTransaction(undefined, refundParams, req);
+        refundedTransaction = await refundTransaction(undefined, refundParams, req);
       } else {
         refundedTransaction = await fetchTransactionWithReference({ legacyId: transaction.RefundTransactionId });
       }

--- a/test/server/graphql/v2/mutation/TransactionMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TransactionMutations.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import gqlV2 from 'fake-tag';
 import sinon from 'sinon';
 
-import * as orders from '../../../../../server/graphql/v1/mutations/orders';
+import * as orders from '../../../../../server/graphql/common/orders';
 import emailLib from '../../../../../server/lib/email';
 import * as payments from '../../../../../server/lib/payments';
 import stripe from '../../../../../server/lib/stripe';


### PR DESCRIPTION
stop calling them "legacy" as they are actively used and maintained