### PR TITLE
Flag to include/exclude GiftCard Transactions

### DIFF
--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -83,6 +83,11 @@ const TransactionsCollectionQuery = {
       defaultValue: false,
       description: 'Whether to include transactions from children (Events and Projects)',
     },
+    includeGiftCardTransactions: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      defaultValue: false,
+      description: 'Whether to include transactions from Gift Cards issued by the account.',
+    },
     includeDebts: {
       type: new GraphQLNonNull(GraphQLBoolean),
       defaultValue: false,
@@ -138,13 +143,17 @@ const TransactionsCollectionQuery = {
         }
       }
 
-      where.push({
-        [Op.or]: [
-          { UsingGiftCardFromCollectiveId: fromAccount.id, type: 'CREDIT' },
-          // prettier, please keep line break for readability please
-          { FromCollectiveId: fromAccountCondition },
-        ],
-      });
+      if (args.includeGiftCardTransactions) {
+        where.push({
+          [Op.or]: [
+            { UsingGiftCardFromCollectiveId: fromAccount.id, type: 'CREDIT' },
+            // prettier, please keep line break for readability please
+            { FromCollectiveId: fromAccountCondition },
+          ],
+        });
+      } else {
+        where.push({ FromCollectiveId: fromAccountCondition });
+      }
     }
 
     if (account) {
@@ -170,13 +179,17 @@ const TransactionsCollectionQuery = {
         }
       }
 
-      where.push({
-        [Op.or]: [
-          { UsingGiftCardFromCollectiveId: account.id, type: 'DEBIT' },
-          // prettier, please keep line break for readability please
-          { CollectiveId: accountCondition },
-        ],
-      });
+      if (args.includeGiftCardTransactions) {
+        where.push({
+          [Op.or]: [
+            { UsingGiftCardFromCollectiveId: account.id, type: 'DEBIT' },
+            // prettier, please keep line break for readability please
+            { CollectiveId: accountCondition },
+          ],
+        });
+      } else {
+        where.push({ CollectiveId: accountCondition });
+      }
     }
 
     if (host) {


### PR DESCRIPTION
I decided to default to false because I think that despite being different than the current behavior, it's the most sensible choice. 

This is something that developers need to ask as an extra, not something that they need to filter. We can simply set the flag to true on the frontend where we need it.

Asking review from @Betree because this is related to Gift Cards. And @kewitz because it's related to the Transactions / CSV project.