### PR TITLE
createUser: Add support for legal name

### DIFF
--- a/server/graphql/common/user.ts
+++ b/server/graphql/common/user.ts
@@ -27,7 +27,7 @@ type CreateUserOptions = {
 };
 
 export const createUser = (
-  userData: { firstName: string; lastName: string; email: string; newsletterOptIn: boolean },
+  userData: { firstName: string; lastName: string; legalName: string; email: string; newsletterOptIn: boolean },
   { organizationData, sendSignInLink, throwIfExists, redirect, websiteUrl, creationRequest }: CreateUserOptions,
 ): Promise<{ user: typeof models.User; organization?: typeof models.Collective }> => {
   return sequelize.transaction(async transaction => {

--- a/server/graphql/v1/inputTypes.js
+++ b/server/graphql/v1/inputTypes.js
@@ -108,6 +108,7 @@ export const UserInputType = new GraphQLInputObjectType({
     email: { type: EmailType },
     firstName: { type: GraphQLString },
     lastName: { type: GraphQLString },
+    legalName: { type: GraphQLString },
     name: { type: GraphQLString },
     company: { type: GraphQLString },
     image: { type: GraphQLString },

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -3,7 +3,6 @@ import {
   GraphQLEnumType,
   GraphQLError,
   GraphQLFloat,
-  GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
@@ -2098,25 +2097,6 @@ export const SubscriptionType = new GraphQLObjectType({
         },
       },
     };
-  },
-});
-
-export const UserInputType = new GraphQLInputObjectType({
-  name: 'UserInput',
-  description: 'Create and edit options for users',
-  fields: {
-    email: {
-      type: GraphQLString,
-      description: 'User email address',
-    },
-    firstName: {
-      type: GraphQLString,
-      description: 'User first name',
-    },
-    lastName: {
-      type: GraphQLString,
-      description: 'User last name',
-    },
   },
 });
 


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4651

The field was introduced in the form and in the `createCollective` mutation but not in the `createUser` mutation, breaking the invite user feature.