### PR TITLE
Remove invalid collective setting key detected warning

### DIFF
--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -52,6 +52,7 @@ export const COLLECTIVE_SETTINGS_KEYS_LIST = [
   'bitcoin',
   'categories',
   'collectivePage',
+  'cryptoEnabled',
   'disableCustomContributions',
   'dismissedHelpMessages',
   'disableCryptoContributions',


### PR DESCRIPTION
It seems we have missed updating the `COLLECTIVE_SETTINGS_KEYS_LIST` to reflect the new `cryptoEnabled` setting. This PR corrects that. 