### PR TITLE
fix: use DEBIT transaction when refunding expenses

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -301,8 +301,12 @@ export async function createRefundTransaction(transaction, refundedPaymentProces
         `Partial processor fees refunds are not supported, got ${refundedPaymentProcessorFee} for #${transaction.id}`,
       );
     } else if (transaction.paymentProcessorFeeInHostCurrency) {
+      // When refunding an Expense, we need to use the DEBIT transaction which is attached to the Collective and its Host.
+      const transactionToRefundPaymentProcessorFee = transaction.ExpenseId
+        ? await transaction.getRelatedTransaction({ type: DEBIT })
+        : transaction;
       // Host take at their charge the payment processor fee that is lost when refunding a transaction
-      await refundPaymentProcessorFeeToCollective(transaction, transactionGroup);
+      await refundPaymentProcessorFeeToCollective(transactionToRefundPaymentProcessorFee, transactionGroup);
     }
   }
 

--- a/test/stories/ledger.test.ts.snap
+++ b/test/stories/ledger.test.ts.snap
@@ -94,6 +94,20 @@ exports[`test/stories/ledger Level 1: Same currency (USD) 5. Refunded contributi
 | PLATFORM_TIP            | DEBIT  | -1000  | 0          | Ben    | OC Inc | NULL   |            | false    |"
 `;
 
+exports[`test/stories/ledger Level 1: Same currency (USD) 6. Expense with Payment Processor fees marked as unpaid 1`] = `
+"
+| kind                    | type   | amount  | paymentFee | To     | From   | Host | Settlement | isRefund |
+| ----------------------- | ------ | ------- | ---------- | ------ | ------ | ---- | ---------- | -------- |
+| EXPENSE                 | CREDIT | 100500  | 0          | ESLint | Ben    | OSC  |            | true     |
+| EXPENSE                 | DEBIT  | -100500 | 0          | Ben    | ESLint | NULL |            | true     |
+| PAYMENT_PROCESSOR_COVER | CREDIT | 500     | 0          | ESLint | OSC    | OSC  |            | true     |
+| PAYMENT_PROCESSOR_COVER | DEBIT  | -500    | 0          | OSC    | ESLint | OSC  |            | true     |
+| EXPENSE                 | CREDIT | 100500  | -500       | Ben    | ESLint | NULL |            | false    |
+| EXPENSE                 | DEBIT  | -100000 | -500       | ESLint | Ben    | OSC  |            | false    |
+| CONTRIBUTION            | CREDIT | 150000  | 0          | ESLint | Ben    | OSC  |            | false    |
+| CONTRIBUTION            | DEBIT  | -150000 | 0          | Ben    | ESLint | NULL |            | false    |"
+`;
+
 exports[`test/stories/ledger Level 2: Host with a different currency (Host=EUR, Collective=EUR) Refunded contribution with host fees, payment processor fees and indirect platform tip 1`] = `
 "
 | kind                    | type   | amount | currency | amountInHostCurrency | hostCurrency | paymentFee | To     | From   | Host   | Settlement | isRefund |


### PR DESCRIPTION
Related to https://opencollective.freshdesk.com/a/tickets/35682

Otherwise we get the error:
```
TypeError: Cannot read property 'getHostCollective' of null
    at Function.<anonymous> (/home/leo/Code/opencollective/api/server/models/Transaction.js:522:53),    
    at Function.createDoubleEntry (/home/leo/Code/opencollective/api/server/models/Transaction.js:510:3),
    at /home/leo/Code/opencollective/api/server/lib/payments.js:195:28,
    at refundPaymentProcessorFeeToCollective (/home/leo/Code/opencollective/api/server/lib/payments.js:187:51),
    at Object.<anonymous> (/home/leo/Code/opencollective/api/server/lib/payments.js:305:13),
    at Object.createRefundTransaction (/home/leo/Code/opencollective/api/server/lib/payments.js:319:35),
    at /home/leo/Code/opencollective/api/server/graphql/common/expenses.ts:1284:23,
    at /home/leo/Code/opencollective/api/server/graphql/common/expenses.ts:994:12
```
