### PR TITLE
Add customData to Order

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -3174,6 +3174,8 @@ type Query {
     If false, only the transactions not linked to an expense (orders/refunds) will be returned
     """
     includeExpenseTransactions: Boolean
+    fetchDataFromLedger: Boolean
+    includeHostedCollectivesTransactions: Boolean
   ): [Transaction]
   Application(id: Int): Application
   allUpdates(CollectiveId: Int!, includeHostedCollectives: Boolean, limit: Int, offset: Int): [UpdateType]

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -6725,6 +6725,11 @@ type Order {
   Data related to the order
   """
   data: JSON
+
+  """
+  Custom data related to the order, based on the fields described by tier.customFields
+  """
+  customData: JSON
 }
 
 """
@@ -6869,6 +6874,11 @@ input OrderReferenceInput {
   The public id identifying the order (ie: dgm9bnk8-0437xqry-ejpvzeol-jdayw5re)
   """
   id: String
+
+  """
+  The legacy public id identifying the order (ie: 4242)
+  """
+  legacyId: Int
 }
 
 """

--- a/server/graphql/v2/input/OrderReferenceInput.js
+++ b/server/graphql/v2/input/OrderReferenceInput.js
@@ -1,4 +1,4 @@
-import { GraphQLInputObjectType, GraphQLString } from 'graphql';
+import { GraphQLInputObjectType, GraphQLInt, GraphQLString } from 'graphql';
 
 import models from '../../../models';
 import { NotFound } from '../../errors';
@@ -10,6 +10,10 @@ export const OrderReferenceInput = new GraphQLInputObjectType({
     id: {
       type: GraphQLString,
       description: 'The public id identifying the order (ie: dgm9bnk8-0437xqry-ejpvzeol-jdayw5re)',
+    },
+    legacyId: {
+      type: GraphQLInt,
+      description: 'The legacy public id identifying the order (ie: 4242)',
     },
   }),
 });
@@ -28,6 +32,8 @@ export const fetchOrderWithReference = async input => {
   if (input.id) {
     const id = idDecode(input.id, 'order');
     order = await loadOrderById(id);
+  } else if (input.legacyId) {
+    order = await loadOrderById(input.legacyId);
   } else {
     throw new Error('Please provide an id');
   }

--- a/server/graphql/v2/object/Order.js
+++ b/server/graphql/v2/object/Order.js
@@ -216,6 +216,18 @@ export const Order = new GraphQLObjectType({
           return pick(order.data, ['customData.pledgeCurrency', 'customData.pledgeAmount']);
         },
       },
+      customData: {
+        type: GraphQLJSON,
+        description:
+          'Custom data related to the order, based on the fields described by tier.customFields. Must be authenticated as an admin of the fromAccount or toAccount (returns null otherwise)',
+        resolve(order, _, { remoteUser }) {
+          if (!remoteUser || !(remoteUser.isAdmin(order.CollectiveId) || remoteUser.isAdmin(order.FromCollectiveId))) {
+            return null;
+          } else {
+            return order.data?.customData || {};
+          }
+        },
+      },
     };
   },
 });

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -27,6 +27,7 @@ const CREATE_ORDER_MUTATION = gqlV2/* GraphQL */ `
         quantity
         frequency
         tags
+        customData
         tier {
           legacyId
         }
@@ -185,6 +186,9 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
               tier: { legacyId: tier.id },
               quantity: 3,
               tags: ['wow', 'it', 'supports', 'tags!'],
+              customData: {
+                message: 'Hello world',
+              },
             },
           },
           fromUser,
@@ -200,6 +204,7 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
         expect(order.quantity).to.eq(3);
         expect(order.tier.legacyId).to.eq(tier.id);
         expect(order.tags).to.deep.eq(['wow', 'it', 'supports', 'tags!']);
+        expect(order.customData).to.deep.eq({ message: 'Hello world' });
       });
 
       it('can add platform contribution', async () => {

--- a/test/server/graphql/v2/query/OrderQuery.test.ts
+++ b/test/server/graphql/v2/query/OrderQuery.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import gqlV2 from 'fake-tag';
+
+import { fakeCollective, fakeHost, fakeOrder, fakeUser } from '../../../../test-helpers/fake-data';
+import { graphqlQueryV2, resetTestDB } from '../../../../utils';
+
+describe('server/graphql/v2/query/ExpenseQuery', () => {
+  before(resetTestDB);
+
+  let order, ownerUser, collectiveAdminUser, hostAdminUser, randomUser;
+
+  const orderQuery = gqlV2/* GraphQL */ `
+    query Order($legacyId: Int!) {
+      order(order: { legacyId: $legacyId }) {
+        id
+        customData
+      }
+    }
+  `;
+
+  before(async () => {
+    ownerUser = await fakeUser({}, { legalName: 'A Legal Name' });
+    hostAdminUser = await fakeUser();
+    collectiveAdminUser = await fakeUser();
+    randomUser = await fakeUser();
+
+    const host = await fakeHost({ admin: hostAdminUser });
+    const collective = await fakeCollective({ admin: collectiveAdminUser, HostCollectiveId: host.id });
+    order = await fakeOrder({
+      FromCollectiveId: ownerUser.CollectiveId,
+      CollectiveId: collective.id,
+      data: {
+        customData: {
+          hello: 'world',
+        },
+      },
+    });
+  });
+
+  const fetchOrder = (legacyId, remoteUser = undefined) => {
+    return graphqlQueryV2(orderQuery, { legacyId }, remoteUser).then(result => result.data.order);
+  };
+
+  describe('Permissions', () => {
+    describe('data', () => {
+      describe('customData', () => {
+        it('can only be fetched by admins', async () => {
+          const fetchedOrderUnauthenticated = await fetchOrder(order.id);
+          const fetchedOrderRandomUser = await fetchOrder(order.id, randomUser);
+          const fetchedOrderOwner = await fetchOrder(order.id, ownerUser);
+          const fetchedOrderCollectiveAdmin = await fetchOrder(order.id, collectiveAdminUser);
+          // TODO: Host admins are currently treated as admins of all the collectives they're hosting. See https://github.com/opencollective/opencollective-api/blob/b0cfdf190b28d83ec66071b00e158685bd99da91/server/models/User.js#L298
+          // const fetchedOrderHostAdmin = await fetchOrder(order.id, hostAdminUser);
+
+          // Only collective admin + owner can fetch custom data
+          expect(fetchedOrderOwner.customData).to.deep.eq(order.data.customData);
+          expect(fetchedOrderCollectiveAdmin.customData).to.deep.eq(order.data.customData);
+
+          // Others can't
+          expect(fetchedOrderUnauthenticated.customData).to.be.null;
+          expect(fetchedOrderRandomUser.customData).to.be.null;
+          // expect(fetchedOrderHostAdmin.customData).to.be.null;
+        });
+      });
+    });
+  });
+});

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -128,12 +128,13 @@ export const fakeCollective = async (collectiveData = {}, sequelizeParams = {}) 
   }
   if (collectiveData.admin) {
     try {
+      const isUser = collectiveData.admin instanceof models.User;
       await models.Member.create(
         {
           CollectiveId: collective.id,
-          MemberCollectiveId: collectiveData.admin.id,
+          MemberCollectiveId: isUser ? collectiveData.admin.CollectiveId : collectiveData.admin.id,
           role: roles.ADMIN,
-          CreatedByUserId: collectiveData.admin.CreatedByUserId,
+          CreatedByUserId: isUser ? collectiveData.admin.id : collectiveData.admin.CreatedByUserId,
         },
         sequelizeParams,
       );


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4677

I couldn't prevent host admins from accessing this information, since they're de facto treated as collective admins.

- [x] Add a `customData` field (`JSON`) on `Order`
- [x] Return `null` if the user does not have permission to see the field
- [x] Only allow users to see the field if one of these conditions is met:
  - They're an admin of the account that made the contribution (`order.FromCollectiveId`)
  - They're an admin of the account that received the contribution (`order.CollectiveId`)