### PR TITLE
Add orderLegacyId to host-settlement CSV

### DIFF
--- a/cron/monthly/host-settlement.ts
+++ b/cron/monthly/host-settlement.ts
@@ -202,6 +202,7 @@ AND ts."status" != 'SETTLED'`,
         startDate,
         endDate,
         kind: [PLATFORM_TIP_DEBT, HOST_FEE_SHARE_DEBT],
+        add: ['orderLegacyId'],
       });
       if (csvUrl) {
         await models.ExpenseAttachedFile.create({

--- a/server/lib/csv.js
+++ b/server/lib/csv.js
@@ -6,8 +6,10 @@ import { fetchWithTimeout } from './fetch';
 import logger from './logger';
 import { parseToBoolean } from './utils';
 
-export const getTransactionsCsvUrl = (type, collective, { startDate, endDate, kind } = {}) => {
+export const getTransactionsCsvUrl = (type, collective, options = {}) => {
   const url = new URL(`${config.host.rest}/v2/${collective.slug}/${type}.csv`);
+
+  const { startDate, endDate, kind, add, remove, fields } = options;
 
   if (startDate) {
     url.searchParams.set('dateFrom', moment.utc(startDate).toISOString());
@@ -18,14 +20,23 @@ export const getTransactionsCsvUrl = (type, collective, { startDate, endDate, ki
   if (kind) {
     url.searchParams.set('kind', kind.join(','));
   }
+  if (add) {
+    url.searchParams.set('add', kind.join(','));
+  }
+  if (remove) {
+    url.searchParams.set('remove', remove.join(','));
+  }
+  if (fields) {
+    url.searchParams.set('fields', fields.join(','));
+  }
 
   url.searchParams.set('fetchAll', '1');
 
   return url.toString();
 };
 
-const getTransactionsCsv = async (type, collective, { startDate, endDate, kind, useAdminAccount, add } = {}) => {
-  const url = getTransactionsCsvUrl(type, collective, { startDate, endDate, kind, add });
+const getTransactionsCsv = async (type, collective, { useAdminAccount, ...options } = {}) => {
+  const url = getTransactionsCsvUrl(type, collective, options);
 
   const headers = {};
 
@@ -53,18 +64,18 @@ const getTransactionsCsv = async (type, collective, { startDate, endDate, kind, 
     });
 };
 
-export const getCollectiveTransactionsCsv = async (collective, { startDate, endDate, kind } = {}) => {
+export const getCollectiveTransactionsCsv = async (collective, options) => {
   if (parseToBoolean(config.restService.fetchCollectiveTransactionsCsv) === false) {
     return;
   }
 
-  return getTransactionsCsv('transactions', collective, { startDate, endDate, kind });
+  return getTransactionsCsv('transactions', collective, options);
 };
 
-export const getHostTransactionsCsvAsAdmin = async (collective, { startDate, endDate } = {}) => {
+export const getHostTransactionsCsvAsAdmin = async (collective, options) => {
   if (parseToBoolean(config.restService.fetchHostTransactionsCsv) === false) {
     return;
   }
 
-  return getTransactionsCsv('hostTransactions', collective, { startDate, endDate, useAdminAccount: true });
+  return getTransactionsCsv('hostTransactions', collective, { ...options, useAdminAccount: true });
 };


### PR DESCRIPTION
I realize at least one of our Fiscal Host is relying on this field and there is no alternative at the moment for their use case.