### PR TITLE
Support for extra env in development environment

### DIFF
--- a/server/env.js
+++ b/server/env.js
@@ -1,6 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+
 import debug from 'debug';
 import dotenv from 'dotenv';
-import { get, has } from 'lodash';
+import { get, has, last } from 'lodash';
 
 if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'development';
@@ -16,6 +19,17 @@ if (!process.env.NODE_CONFIG_ENV) {
 }
 
 dotenv.config();
+
+// Load extra env file on demand
+// `npm run dev staging` / `npm run dev production`
+if (process.env.EXTRA_ENV || process.env.OC_ENV === 'development') {
+  const extraEnv = process.env.EXTRA_ENV || last(process.argv);
+  const extraEnvPath = path.join(__dirname, '..', `.env.${extraEnv}`);
+  if (fs.existsSync(extraEnvPath)) {
+    dotenv.config({ path: extraEnvPath });
+  }
+}
+
 debug.enable(process.env.DEBUG);
 
 // Normalize Memcachier environment variables (production / heroku)


### PR DESCRIPTION
I keep editing my `.env` file to switch between different environment variables and it's time to optimize this process for me.

This feature is completely optional but can be used like this.

1) Create an extra `.env` file named `.env.staging`, `.env.production` or `.env.local`
2) Run your `npm run dev staging`,  `npm run dev production` or  `npm run dev local` and this will include the extra env file on top of the default `.env` one.
