### PR TITLE
Add method to get the list of currencies supported by The Giving  Block

### DIFF
--- a/server/paymentProviders/thegivingblock/index.js
+++ b/server/paymentProviders/thegivingblock/index.js
@@ -86,6 +86,17 @@ export async function getOrganizationsList(account) {
   return apiRequest(`/organizations/list`, { headers }, account);
 }
 
+/*
+ * Gets the list of currencies that The Giving Block supports
+ */
+export async function getCurrenciesList(account) {
+  const headers = {
+    Authorization: `Bearer ${account.data.accessToken}`,
+  };
+
+  return apiRequest(`/currencies/list`, { method: 'POST', headers }, account);
+}
+
 export async function createDepositAddress(account, { organizationId, pledgeAmount, pledgeCurrency } = {}) {
   const headers = {
     Authorization: `Bearer ${account.data.accessToken}`,


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4743 and https://github.com/opencollective/opencollective-frontend/pull/6933

This adds a method for future usage, which returns all the currencies supported by The Giving Block.