### PR TITLE
TransactionsQuery: Accept a list for `account` argument

### DIFF
--- a/server/graphql/v2/input/AccountReferenceInput.js
+++ b/server/graphql/v2/input/AccountReferenceInput.js
@@ -104,10 +104,7 @@ export const fetchAccountWithReference = async (
  *    - attributes: to apply a SELECT on the query
  *    - include: to include associated models
  */
-export const fetchAccountsWithReferences = async (
-  inputs,
-  { throwIfMissing = false, whereConditions = null, attributes, include } = {},
-) => {
+export const fetchAccountsWithReferences = async (inputs, { throwIfMissing = false, attributes, include } = {}) => {
   if (inputs.length > 200) {
     throw new Error('You can only fetch up to 200 accounts at once');
   } else if (inputs.length === 0) {
@@ -152,7 +149,7 @@ export const fetchAccountsWithReferences = async (
   const accounts = await models.Collective.findAll({
     attributes,
     include,
-    where: { ...whereConditions, [Op.or]: conditions },
+    where: { [Op.or]: conditions },
   });
 
   // Check if all accounts were found

--- a/server/graphql/v2/input/AccountReferenceInput.js
+++ b/server/graphql/v2/input/AccountReferenceInput.js
@@ -1,6 +1,7 @@
 import { GraphQLBoolean, GraphQLInputObjectType, GraphQLInt, GraphQLString } from 'graphql';
+import { intersection, uniq } from 'lodash';
 
-import models from '../../../models';
+import models, { Op } from '../../../models';
 import { NotFound } from '../../errors';
 import { idDecode } from '../identifiers';
 
@@ -92,4 +93,73 @@ export const fetchAccountWithReference = async (
     throw new NotFound('Account Not Found');
   }
   return collective;
+};
+/**
+ * Retrieves accounts for given ids or slugs
+ *
+ * @param {object} inputs - object containing slugs or ids of the collectives
+ * @param {object} params
+ *    - throwIfMissing: throws an exception if a collective is missing for a given id or slug
+ *    - whereConditions: additional where conditions to apply to the query
+ *    - attributes: to apply a SELECT on the query
+ *    - include: to include associated models
+ */
+export const fetchAccountsWithReferences = async (
+  inputs,
+  { throwIfMissing = false, whereConditions = null, attributes, include } = {},
+) => {
+  if (inputs.length > 200) {
+    throw new Error('You can only fetch up to 200 accounts at once');
+  } else if (inputs.length === 0) {
+    return [];
+  }
+
+  const getSQLConditionFromAccountReferenceInput = inputs => {
+    const conditions = [];
+    inputs.forEach(input => {
+      if (input.id) {
+        conditions.push({ id: idDecode(input.id, 'account') });
+      } else if (input.legacyId) {
+        conditions.push({ id: input.legacyId });
+      } else if (input.slug) {
+        conditions.push({ slug: input.slug.toLowerCase() });
+      } else {
+        throw new Error('Please provide an id or a slug');
+      }
+    });
+
+    return conditions;
+  };
+
+  // Checks whether the given account and input matches
+  const accountMatchesInput = (account, input) => {
+    if (input.id) {
+      return account.id === idDecode(input.id, 'account');
+    } else if (input.legacyId) {
+      return account.id === input.legacyId;
+    } else if (input.slug) {
+      return account.slug === input.slug;
+    }
+  };
+
+  // id and slug must always be included in the result if throwIfMissing is true
+  if (throwIfMissing && attributes && intersection(['id', 'slug'], attributes).length !== 2) {
+    attributes = uniq([...attributes, 'id', 'slug']);
+  }
+
+  // Fetch accounts
+  const conditions = getSQLConditionFromAccountReferenceInput(inputs);
+  const accounts = await models.Collective.findAll({
+    attributes,
+    include,
+    where: { ...whereConditions, [Op.or]: conditions },
+  });
+
+  // Check if all accounts were found
+  const accountLoadedForInput = input => accounts.some(account => accountMatchesInput(account, input));
+  if (throwIfMissing && !inputs.every(accountLoadedForInput)) {
+    throw new NotFound('Accounts not found for some of the given inputs');
+  }
+
+  return accounts;
 };

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -264,6 +264,7 @@ export function setupModels() {
   });
   m.Order.belongsTo(m.Tier);
   // m.Collective.hasMany(m.Order); // makes the test `mocha test/graphql.transaction.test.js -g "insensitive" fail
+  m.Collective.hasMany(m.Collective, { foreignKey: 'ParentCollectiveId', as: 'children' });
   m.Collective.hasMany(m.Member, { foreignKey: 'CollectiveId', as: 'members' });
   m.Collective.hasMany(m.Order, { foreignKey: 'CollectiveId', as: 'orders' });
   m.Collective.hasMany(m.LegalDocument, { foreignKey: 'CollectiveId', as: 'legalDocuments' });


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/4660
Related Frontend PR: https://github.com/opencollective/opencollective-frontend/pull/6931
Related REST service PR: https://github.com/opencollective/opencollective-rest/pull/396

Adds the ability to filter transactions when fetching for a host with a limited set of hosted accounts.


![image](https://user-images.githubusercontent.com/1556356/135251865-6754b7c5-7c72-4725-8c4d-8c48e4705244.png)
