### PR TITLE
Don't authenticate users if no profile available

### DIFF
--- a/server/middleware/authentication.js
+++ b/server/middleware/authentication.js
@@ -89,9 +89,15 @@ export const _authenticateUserByJwt = async (req, res, next) => {
   }
 
   const userId = Number(req.jwtPayload.sub);
-  const user = await User.findByPk(userId);
+  const user = await User.findByPk(userId, {
+    include: [{ association: 'collective', required: false, attributes: ['id'] }],
+  });
   if (!user) {
     logger.warn(`User id ${userId} not found`);
+    next();
+    return;
+  } else if (!user.collective) {
+    logger.error(`User id ${userId} has no collective linked`);
     next();
     return;
   }


### PR DESCRIPTION
Though we'll always try to avoid it, it happens that we end up with a user whose `CollectiveId` is null or soft-deleted. In such cases we currently react poorly, allowing the user to log in but failing on the first query / mutation that will do a `remoteUser.getCollective()`.

This change will make authentication fail if we cannot retrieve the collective for user.