### PR TITLE
update OCF collective approved email

### DIFF
--- a/templates/emails/collective.approved.foundation.hbs
+++ b/templates/emails/collective.approved.foundation.hbs
@@ -14,12 +14,12 @@ Subject: 🎉 Your Collective has been approved!
   </center>
 </p>
 
-<p>Let us know if you need any help—we are here to help you succeed!</p>
+<p>We'd love to show you around! Please (<a href="https://calendly.com/openmike/ocf-onb">book an onboarding call with us here</a>). You are also welcome to <a href="https://slack.opencollective.com">join our Slack</a> and find us in the #OCF channel.</p>
 
-<p>Feel free to schedule a call with me (<a href="http://calendly.com/piamancini/call">calendly.com/piamancini/call</a>), reply to this email, or <a href="https://slack.opencollective.com">join our Slack</a>.</p>
+<p>Also <a href="https://docs.opencollective.foundation">check out our documentation</a>, which has answers to many frequently asked questions.</p>
 
-<p>Best,</p>
+<p>We're so glad you're here. Welcome!</p>
 
-<p>Pía, and the Open Collective Team</p>
+<p>— the Open Collective Foundation Team</p>
 
 {{> footer}}

--- a/templates/emails/collective.approved.foundation.hbs
+++ b/templates/emails/collective.approved.foundation.hbs
@@ -14,7 +14,7 @@ Subject: 🎉 Your Collective has been approved!
   </center>
 </p>
 
-<p>We'd love to show you around! Please (<a href="https://calendly.com/openmike/ocf-onb">book an onboarding call with us here</a>). You are also welcome to <a href="https://slack.opencollective.com">join our Slack</a> and find us in the #OCF channel.</p>
+<p>We'd love to show you around! Please <a href="https://calendly.com/openmike/ocf-onb">book an onboarding call with us here</a>. You are also welcome to <a href="https://slack.opencollective.com">join our Slack</a> and find us in the <a href="https://opencollective.slack.com/archives/C7U3AD29F">#OCF channel</a>.</p>
 
 <p>Also <a href="https://docs.opencollective.foundation">check out our documentation</a>, which has answers to many frequently asked questions.</p>
 


### PR DESCRIPTION
Changed calendly link from Pia's to OCF onboarding and updated the text and links to be more specifically relevant.