### PR TITLE
Implement some optional resolvers

### DIFF
--- a/server/graphql/v2/interface/Collection.ts
+++ b/server/graphql/v2/interface/Collection.ts
@@ -59,7 +59,7 @@ export interface TransactionsCollectionReturnType {
   totalCount: number;
   limit: number;
   offset: number;
-  kinds?: Array<string>;
+  kinds?: string[] | (() => string[]);
 }
 
 export { Collection, CollectionFields, CollectionArgs };

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -210,15 +210,6 @@ const TransactionsCollectionQuery = {
       where.push({ HostCollectiveId: host.id });
     }
 
-    // No await needed, GraphQL will take care of it
-    // TODO: try to skip if it's not a requested field
-    const existingKinds = models.Transaction.findAll({
-      attributes: ['kind'],
-      where,
-      group: ['kind'],
-      raw: true,
-    }).then(results => results.map(m => m.kind).filter(kind => !!kind));
-
     if (args.searchTerm) {
       const sanitizedTerm = args.searchTerm.replace(/(_|%|\\)/g, '\\$1');
       const ilikeQuery = `%${sanitizedTerm}%`;
@@ -293,7 +284,14 @@ const TransactionsCollectionQuery = {
       totalCount: result.count,
       limit: args.limit,
       offset: args.offset,
-      kinds: existingKinds,
+      kinds: () => {
+        return models.Transaction.findAll({
+          attributes: ['kind'],
+          where,
+          group: ['kind'],
+          raw: true,
+        }).then(results => results.map(m => m.kind).filter(kind => !!kind));
+      },
     };
   },
 };


### PR DESCRIPTION
An alternative, simpler approach to what was proposed in https://github.com/opencollective/opencollective/issues/4586#issuecomment-912416325: if you return a function for one of your GraphQL object fields, it will automatically be resolved by GraphQL. The function doesn't run if the field is not fetched.