### PR TITLE
refact(Wise): unscheduleExpenseForPayment to fetch batch version from Wise

### DIFF
--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 
 import config from 'config';
 import express from 'express';
-import { compact, difference, find, first, has, max, omit, pick, split, toNumber } from 'lodash';
+import { compact, difference, find, first, has, omit, pick, split, toNumber } from 'lodash';
 import moment from 'moment';
 import { v4 as uuid } from 'uuid';
 
@@ -304,8 +304,7 @@ async function scheduleExpenseForPayment(expense: typeof models.Expense): Promis
 }
 
 async function unscheduleExpenseForPayment(expense: typeof models.Expense): Promise<typeof models.Expense> {
-  const batchGroup: BatchGroup = expense.data.batchGroup;
-  if (!batchGroup) {
+  if (!expense.data.batchGroup) {
     throw new Error(`Expense does not belong to any batch group`);
   }
 
@@ -318,16 +317,16 @@ async function unscheduleExpenseForPayment(expense: typeof models.Expense): Prom
   if (!connectedAccount) {
     throw new Error('Host is not connected to TransferWise');
   }
+  const profileId = connectedAccount.data.id;
   const token = await getToken(connectedAccount);
 
+  const batchGroup = await transferwise.getBatchGroup(token, profileId, expense.data.batchGroup.id);
   const expensesInBatch = await models.Expense.findAll({
     where: { data: { batchGroup: { id: batchGroup.id } } },
   });
 
   logger.warn(`Wise: canceling batchGroup ${batchGroup.id} with ${expensesInBatch.length} for host ${host.slug}`);
-  const profileId = connectedAccount.data.id;
-  const version: number = max(expensesInBatch.map(expense => expense.data.batchGroup.version));
-  await transferwise.cancelBatchGroup(token, profileId, batchGroup.id, version);
+  await transferwise.cancelBatchGroup(token, profileId, batchGroup.id, batchGroup.version);
   await Promise.all(
     expensesInBatch.map(expense => {
       return expense.update({

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -336,6 +336,10 @@ describe('server/paymentProviders/transferwise/index', () => {
       });
       expense.PayoutMethod = payoutMethod;
       cancelBatchGroup.resolves({ id: batchGroupId, status: 'MARKED_FOR_CANCELLATION' });
+      getBatchGroup.resolves({
+        version: 6,
+        id: batchGroupId,
+      });
       await transferwise.unscheduleExpenseForPayment(expenses[0]);
       await Promise.all(expenses.map(e => e.reload()));
     });


### PR DESCRIPTION
Fixes bug where the version number we persisted on our side does not match the latest version of the Batch Group.
```
opencollective-prod-api app/web.1 error: Error: Group version conflict
```