### PR TITLE
Unescape collective name in emails

### DIFF
--- a/server/lib/handlebars.js
+++ b/server/lib/handlebars.js
@@ -221,7 +221,7 @@ handlebars.registerHelper('debug', console.log);
  * ```
  */
 handlebars.registerHelper('escapeForSubject', str => {
-  return str ? str.replace(/[\r\n]/g, ' ') : '';
+  return str ? str.replaceAll(/[\r\n]/g, ' ') : '';
 });
 
 export default handlebars;

--- a/templates/emails/collective.apply.hbs
+++ b/templates/emails/collective.apply.hbs
@@ -1,4 +1,4 @@
-Subject: Thanks for applying to {{host.name}}
+Subject: Thanks for applying to {{{host.name}}}
 
 {{> header}}
 

--- a/templates/emails/collective.expense.recurring.drafted.hbs
+++ b/templates/emails/collective.expense.recurring.drafted.hbs
@@ -1,4 +1,4 @@
-Subject: Your recurring expense for {{collective.name}} was drafted
+Subject: Your recurring expense for {{{collective.name}}} was drafted
 
 
 {{> header}}

--- a/templates/emails/collective.member.created.hbs
+++ b/templates/emails/collective.member.created.hbs
@@ -1,4 +1,4 @@
-Subject: New financial contributor to {{{collective.name}}}: {{member.memberCollective.name}} {{#if order}}{{formatOrderAmountWithInterval order}}{{/if}}
+Subject: New financial contributor to {{{collective.name}}}: {{{member.memberCollective.name}}} {{#if order}}{{formatOrderAmountWithInterval order}}{{/if}}
 
 {{> header}}
 

--- a/templates/emails/collective.virtualcard.deleted.hbs
+++ b/templates/emails/collective.virtualcard.deleted.hbs
@@ -1,4 +1,4 @@
-Subject: ⚠ {{collective.name}}'s {{virtualCard.last4}} card was deleted
+Subject: ⚠ {{{collective.name}}}'s {{virtualCard.last4}} card was deleted
 
 {{> header}}
 

--- a/templates/emails/collective.virtualcard.missing.receipts.hbs
+++ b/templates/emails/collective.virtualcard.missing.receipts.hbs
@@ -1,4 +1,4 @@
-Subject: {{collective.name}}'s {{virtualCard.last4}} card is missing receipt(s)
+Subject: {{{collective.name}}}'s {{virtualCard.last4}} card is missing receipt(s)
 
 
 {{> header}}

--- a/templates/emails/collective.virtualcard.suspended.hbs
+++ b/templates/emails/collective.virtualcard.suspended.hbs
@@ -1,4 +1,4 @@
-Subject: ⚠ {{collective.name}}'s {{virtualCard.last4}} card was suspended
+Subject: ⚠ {{{collective.name}}}'s {{virtualCard.last4}} card was suspended
 
 
 {{> header}}

--- a/templates/emails/host.application.contact.hbs
+++ b/templates/emails/host.application.contact.hbs
@@ -1,4 +1,4 @@
-Subject: New message from {{host.name}} on Open Collective{{#if subject}} {{/if}}
+Subject: New message from {{{host.name}}} on Open Collective{{#if subject}} {{/if}}
 
 {{> header}}
 

--- a/templates/emails/host.report.hbs
+++ b/templates/emails/host.report.hbs
@@ -1,4 +1,4 @@
-Subject: {{#if erratumMessage}}Erratum{{#if erratumNumber}} {{erratumNumber}}{{/if}}: {{/if}}{{host.name}} Host {{reportName}}
+Subject: {{#if erratumMessage}}Erratum{{#if erratumNumber}} {{erratumNumber}}{{/if}}: {{/if}}{{{host.name}}} Host {{reportName}}
 
 {{> header}}
 

--- a/templates/emails/order.processing.crypto.hbs
+++ b/templates/emails/order.processing.crypto.hbs
@@ -1,4 +1,4 @@
-Subject: Your {{pledgeAmount}} {{pledgeCurrency}} {{order.type}} to {{collective.name}} is pending
+Subject: Your {{pledgeAmount}} {{pledgeCurrency}} {{order.type}} to {{{collective.name}}} is pending
 
 <style>
   code {

--- a/templates/emails/order.thankyou.foundation.hbs
+++ b/templates/emails/order.thankyou.foundation.hbs
@@ -1,4 +1,4 @@
-Subject: Thank you for your contribution to {{collective.name}}
+Subject: Thank you for your contribution to {{{collective.name}}}
 
 {{> header}}
 

--- a/templates/emails/order.thankyou.hbs
+++ b/templates/emails/order.thankyou.hbs
@@ -1,4 +1,4 @@
-Subject: Thank you for your contribution to {{collective.name}}
+Subject: Thank you for your contribution to {{{collective.name}}}
 
 {{> header}}
 

--- a/templates/emails/order.thankyou.opensource.hbs
+++ b/templates/emails/order.thankyou.opensource.hbs
@@ -1,4 +1,4 @@
-Subject: Thank you for your contribution to {{collective.name}}
+Subject: Thank you for your contribution to {{{collective.name}}}
 
 {{> header}}
 

--- a/templates/emails/organization.newmember.hbs
+++ b/templates/emails/organization.newmember.hbs
@@ -1,4 +1,4 @@
-Subject: {{remoteUser.collective.name}} added you as {{role}} to {{{collective.name}}} on Open Collective
+Subject: {{{remoteUser.collective.name}}} added you as {{role}} to {{{collective.name}}} on Open Collective
 
 {{> header}}
 

--- a/templates/emails/user.card.claimed.hbs
+++ b/templates/emails/user.card.claimed.hbs
@@ -1,4 +1,4 @@
-Subject: {{#ifCond currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶 {{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷 {{/ifCond}}You've got {{currency initialBalance currency=currency}} from {{emitter.name}} to spend on Open Collective
+Subject: {{#ifCond currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond currency '===' 'EUR'}}💶 {{/ifCond}}{{#ifCond currency '===' 'GBP'}}💷 {{/ifCond}}You've got {{currency initialBalance currency=currency}} from {{{emitter.name}}} to spend on Open Collective
 
 {{> header}}
 

--- a/templates/emails/user.card.invited.hbs
+++ b/templates/emails/user.card.invited.hbs
@@ -1,4 +1,4 @@
-Subject: 🎁 {{emitter.name}} has given you {{currency initialBalance currency=currency}} to spend on Open Collective!
+Subject: 🎁 {{{emitter.name}}} has given you {{currency initialBalance currency=currency}} to spend on Open Collective!
 
 {{> header}}
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4758

Names are sanitized so this should be a safe change.

**Todo before merging:**
- Check whether we have entries in the DB that could cause issues (e.g. things with `<` or `>` characters inside their names, or `\n`).