### PR TITLE
Update The Giving Block staging api url

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -194,6 +194,6 @@
     "aesEncryptionKey": "",
     "aesEncryptionIv": "",
     "aesEncryptionMethod": "aes-256-cbc",
-    "apiUrl": "https://public-api-nstaging.tgbwidget.com/v1"
+    "apiUrl": "https://public-api.tgb-preprod.com/v1"
   }
 }


### PR DESCRIPTION
The Giving Block staging api url was updated to the new domain https://public-api.tgb-preprod.com. 