### PR TITLE
Disable owner when doing pg_restore

### DIFF
--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -58,11 +58,11 @@ psql "${LOCALDBNAME}" -c "CREATE EXTENSION POSTGIS;" 1> /dev/null
 
 # The first time we run it, we will trigger FK constraints errors
 set +e
-pg_restore --no-acl -n public -O -c -d "${LOCALDBNAME}" "${DBDUMP_FILE}" 2>/dev/null
+pg_restore --no-acl --no-owner -n public -O -c -d "${LOCALDBNAME}" "${DBDUMP_FILE}" 2>/dev/null
 set -e
 
 # So we run it twice :-)
-pg_restore --no-acl -n public -O -c -d "${LOCALDBNAME}" "${DBDUMP_FILE}"
+pg_restore --no-acl --no-owner -n public -O -c -d "${LOCALDBNAME}" "${DBDUMP_FILE}"
 
 echo "DB restored to postgres://localhost/${LOCALDBNAME}"
 


### PR DESCRIPTION
These permissions can create issues later in the process, as the PG_USER may be different from the one that was used for the `pg_dump` that generated the backup file.