### PR TITLE
Correctly Reset the Host by Setting the `isHostAccount` flag to `false`

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2096,8 +2096,6 @@ function defineModel() {
 
     // Self Hosted Collective
     if (this.id === this.HostCollectiveId) {
-      this.isHostAccount = false;
-      this.plan = null;
       await models.ConnectedAccount.destroy({
         where: {
           service: 'stripe',
@@ -2124,6 +2122,7 @@ function defineModel() {
       hostFeePercent: null,
       platformFeePercent: null,
       isHostAccount: false,
+      plan: null,
     });
 
     // Add new host


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4861

![reset-fiscal-host](https://user-images.githubusercontent.com/12435965/138520871-81fa988b-2ab7-4dcb-9e0d-224dba3ecc0a.gif)


