### PR TITLE
Fix a crash on expense's host resolver for un-hosted collectives

### DIFF
--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -154,8 +154,9 @@ const Expense = new GraphQLObjectType({
             return req.loaders.Collective.byId.load(expense.HostCollectiveId);
           } else {
             const collective = await req.loaders.Collective.byId.load(expense.CollectiveId);
-
-            return req.loaders.Collective.byId.load(collective.HostCollectiveId);
+            if (collective.HostCollectiveId) {
+              return req.loaders.Collective.byId.load(collective.HostCollectiveId);
+            }
           }
         },
       },


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2748456037
Spotted on https://opencollective.com/uk-collective/expenses/18304

Though they cannot be paid, expenses on collectives without fiscal host are still valid.