### PR TITLE
Emails: Display raw HTML description for expense items

### DIFF
--- a/templates/emails/collective.expense.invite.drafted.hbs
+++ b/templates/emails/collective.expense.invite.drafted.hbs
@@ -33,7 +33,7 @@ Subject: {{{collective.name}}} wants you to pay you
   </tr>
   {{#each items}}
   <tr>
-    <td>{{description}}</td>
+    <td>{{{description}}}</td>
     <td>{{currency amount currency=@root.expense.currency}}</td>
   </tr>
   {{/each}}

--- a/templates/partials/expense-items.hbs
+++ b/templates/partials/expense-items.hbs
@@ -12,11 +12,11 @@
             </div>
           </td>
         {{/if}}
-        <td style="border-bottom: 1px dotted rgb(196, 199, 204); padding: 12px 0;">
-          <p style="margin: 0; margin-bottom: 4px;">{{this.description}}</p>
+        <td style="border-bottom: 1px dotted rgb(196, 199, 204); padding: 12px 0; border-right: 1px dotted rgb(223 223 225); padding-right: 10px;">
+          <p style="margin: 0; margin-bottom: 4px;">{{{this.description}}}</p>
           <p style="margin: 0; color: #9D9FA3;">{{moment this.incurredAt}}</p>
         </td>
-        <td style="border-bottom: 1px dotted rgb(196, 199, 204); padding: 12px 0;">
+        <td style="border-bottom: 1px dotted rgb(196, 199, 204); padding: 12px 10px;">
           <p style="text-align: right;">
             {{currency this.amount currency=../expense.currency}}
           </p>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4552

![image](https://user-images.githubusercontent.com/1556356/139858323-eacb0d2f-9fb1-40d3-8c42-cfddfd3d1e01.png)
