### PR TITLE
HostMetrics: Fix collectiveIds args

### DIFF
--- a/server/lib/host-metrics.js
+++ b/server/lib/host-metrics.js
@@ -279,7 +279,7 @@ GROUP BY t1."hostCurrency"`,
       {
         replacements: {
           CollectiveId: host.id,
-          CollectiveIds: collectiveIds?.toString(),
+          CollectiveIds: collectiveIds,
           ...computeDates(startDate, endDate),
         },
         type: sequelize.QueryTypes.SELECT,
@@ -358,7 +358,7 @@ export async function getPendingHostFeeShare(host, { startDate, endDate, collect
       {
         replacements: {
           CollectiveId: host.id,
-          FromCollectiveIds: collectiveIds?.toString(),
+          FromCollectiveIds: collectiveIds,
           ...computeDates(startDate, endDate),
         },
         type: sequelize.QueryTypes.SELECT,


### PR DESCRIPTION
Fix a crash when selecting multiple collectives on the report page.

![image](https://user-images.githubusercontent.com/1556356/141483722-f876f3da-75cc-44e7-8ea4-fe750813ad12.png)
