### PR TITLE
Hide incognito details for admins

### DIFF
--- a/server/graphql/loaders/user.ts
+++ b/server/graphql/loaders/user.ts
@@ -7,33 +7,6 @@ import models, { Op } from '../../models';
 import { sortResultsSimple } from './helpers';
 
 /**
- * Build a map like { CollectiveId: IncognitoCollectiveId }
- */
-const getIncognitoCollectiveIdsMapping = async users => {
-  const incognitoMembers = await models.Member.findAll({
-    attributes: ['MemberCollectiveId', 'CollectiveId'],
-    group: ['MemberCollectiveId', 'CollectiveId'],
-    raw: true,
-    mapToModel: false,
-    where: {
-      MemberCollectiveId: users.map(u => u.CollectiveId),
-      role: 'ADMIN',
-    },
-    include: {
-      association: 'collective',
-      required: true,
-      attributes: [],
-      where: { isIncognito: true },
-    },
-  });
-
-  return incognitoMembers.reduce((result, member) => {
-    result[member.MemberCollectiveId] = member.CollectiveId;
-    return result;
-  }, {});
-};
-
-/**
  * To check if remoteUser has access to user's private info. `remoteUser` must either:
  * - be the user himself
  * - be an admin of a collective where user is a member (even as incognito, and regardless of the role)
@@ -47,18 +20,15 @@ export const generateCanSeeUserPrivateInfoLoader = (req: express.Request): DataL
     }
 
     let administratedMembers = [];
-    let incognitoProfilesMapping = {};
 
-    // Aggregates all the profiles linked to users (including the incognito ones)
+    // Aggregates all the profiles linked to users
     const uniqueUsers = uniqBy(users.filter(Boolean), 'id');
     const otherUsers = uniqueUsers.filter(user => user.id !== remoteUser.id);
-    const otherUserCollectiveIds = otherUsers.map(user => user.CollectiveId);
-    incognitoProfilesMapping = await getIncognitoCollectiveIdsMapping(uniqueUsers);
+    const otherUsersCollectiveIds = otherUsers.map(user => user.CollectiveId);
 
     // Fetch all the admin memberships of `remoteUser` to collectives or collective's hosts
     // that are linked to users`
-    const allMemberCollectiveIds = [...otherUserCollectiveIds, ...Object.values(incognitoProfilesMapping)];
-    if (allMemberCollectiveIds.length) {
+    if (otherUsersCollectiveIds.length) {
       await remoteUser.populateRoles();
       const adminOfCollectiveIds = Object.keys(remoteUser.rolesByCollectiveId).filter(id => remoteUser.isAdmin(id));
       administratedMembers = await models.Member.findAll({
@@ -66,7 +36,7 @@ export const generateCanSeeUserPrivateInfoLoader = (req: express.Request): DataL
         group: ['MemberCollectiveId'],
         raw: true,
         mapToModel: false,
-        where: { MemberCollectiveId: allMemberCollectiveIds },
+        where: { MemberCollectiveId: otherUsersCollectiveIds },
         include: {
           association: 'collective',
           required: true,
@@ -82,22 +52,10 @@ export const generateCanSeeUserPrivateInfoLoader = (req: express.Request): DataL
       });
     }
 
+    // User must be self or directly administered by remoteUser
     const administratedCollectiveIds = new Set(administratedMembers.map(m => m.MemberCollectiveId));
     return users.map(user => {
-      if (!user) {
-        return false;
-      } else if (user.id === remoteUser.id || administratedCollectiveIds.has(user.CollectiveId)) {
-        // User is self or directly administered by remoteUser
-        return true;
-      } else {
-        const incognitoProfileId = incognitoProfilesMapping[user.CollectiveId];
-        if (incognitoProfileId) {
-          // Is user indirectly administered by remoteUser via its incognito profile?
-          return administratedCollectiveIds.has(incognitoProfileId);
-        } else {
-          return false;
-        }
-      }
+      return Boolean(user && (user.id === remoteUser.id || administratedCollectiveIds.has(user.CollectiveId)));
     });
   });
 };

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -161,15 +161,19 @@ export const UserType = new GraphQLObjectType({
       firstName: {
         type: GraphQLString,
         deprecationReason: '2021-09-24: Use "name"',
-        resolve(user) {
-          return user.firstName;
+        async resolve(user, _, req) {
+          if (req.remoteUser && (await req.loaders.User.canSeeUserPrivateInfo.load(user))) {
+            return user.firstName;
+          }
         },
       },
       lastName: {
         type: GraphQLString,
         deprecationReason: '2021-09-24: Use "name"',
-        resolve(user) {
-          return user.lastName;
+        async resolve(user, _, req) {
+          if (req.remoteUser && (await req.loaders.User.canSeeUserPrivateInfo.load(user))) {
+            return user.lastName;
+          }
         },
       },
       name: {

--- a/test/server/graphql/loaders/user.test.js
+++ b/test/server/graphql/loaders/user.test.js
@@ -94,16 +94,16 @@ describe('server/graphql/loaders/user', () => {
         expect(result).to.be.true;
       });
 
-      it('Can see infos if collective admin', async () => {
+      it('Cannot see infos if collective admin', async () => {
         const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: collectiveAdmin });
         const result = await loader.load(userWithPrivateInfo);
-        expect(result).to.be.true;
+        expect(result).to.be.false;
       });
 
-      it('Can see infos if host admin', async () => {
+      it('Cannot see infos if host admin', async () => {
         const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: hostAdmin });
         const result = await loader.load(userWithPrivateInfo);
-        expect(result).to.be.true;
+        expect(result).to.be.false;
       });
     });
   });

--- a/test/server/graphql/v1/query.test.js
+++ b/test/server/graphql/v1/query.test.js
@@ -304,7 +304,7 @@ describe('server/graphql/v1/query', () => {
                     address: '505 Broadway, NY 10012',
                   },
                   backgroundImage: null,
-                  createdByUser: { id: 1, firstName: 'Phil' },
+                  createdByUser: { id: 1, firstName: null },
                   tiers: [
                     {
                       id: 3,
@@ -325,7 +325,7 @@ describe('server/graphql/v1/query', () => {
                     address: '547 Broadway, NY 10012',
                   },
                   backgroundImage: 'http://opencollective.com/backgroundimage.png',
-                  createdByUser: { id: 1, firstName: 'Phil' },
+                  createdByUser: { id: 1, firstName: null },
                   tiers: [
                     {
                       id: 1,
@@ -337,19 +337,19 @@ describe('server/graphql/v1/query', () => {
                         {
                           id: 1,
                           description: 'I work on bitcoin',
-                          createdByUser: { id: 2, firstName: 'Anish' },
+                          createdByUser: { id: 2, firstName: null },
                         },
                         {
                           id: 2,
                           description: 'I have been working on open source for over a decade',
-                          createdByUser: { id: 3, firstName: 'Xavier' },
+                          createdByUser: { id: 3, firstName: null },
                         },
                         {
                           id: 3,
                           description: 'I have been working on open source for over a decade',
                           createdByUser: {
                             id: 1,
-                            firstName: 'Phil',
+                            firstName: null,
                           },
                         },
                       ],
@@ -364,7 +364,7 @@ describe('server/graphql/v1/query', () => {
                         {
                           id: 4,
                           description: null,
-                          createdByUser: { id: 3, firstName: 'Xavier' },
+                          createdByUser: { id: 3, firstName: null },
                         },
                       ],
                     },


### PR DESCRIPTION
Based on https://github.com/opencollective/opencollective/issues/4537

This PR prevents host/collective admins from accessing incognito profiles details (i.e. email).