### PR TITLE
Misc optimizations for search

### DIFF
--- a/migrations/20211123102842-add-search-collectives-index.js
+++ b/migrations/20211123102842-add-search-collectives-index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    // Drop the existing search index
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "collective_search_index"`);
+
+    // Re-create it with latest params
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS
+        collective_search_index
+      ON
+        "Collectives"
+      USING
+        GIN((
+          to_tsvector('english', name)
+          || to_tsvector('simple', slug)
+          || to_tsvector('english', COALESCE(description, ''))
+          || COALESCE(array_to_tsvector(tags), '')
+        ))
+      WHERE "deletedAt" IS NULL
+      AND "deactivatedAt" IS NULL
+      AND ("data" ->> 'isGuest')::boolean IS NOT TRUE
+      AND ("data" ->> 'hideFromSearch')::boolean IS NOT TRUE
+      AND name != 'incognito'
+      AND name != 'anonymous'
+      AND "isIncognito" = FALSE
+    `);
+  },
+
+  down: async queryInterface => {
+    // Drop the existing search index
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "collective_search_index"`);
+
+    // Restore previous index
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS
+        collective_search_index
+      ON
+        "Collectives"
+      USING
+        gin((
+          to_tsvector('simple', name)
+          || to_tsvector('simple', slug)
+          || to_tsvector('simple', COALESCE(description, ''))
+          || COALESCE(array_to_tsvector(tags), '')
+          || to_tsvector('simple', COALESCE("longDescription", ''))
+        ))
+    `);
+  },
+};


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4885

- Stop searching in `longDescription`. While this can provide interesting results, long descriptions can be really long and are expensive to compute.
- Optimize searches with terms that start with an `@` (like `@betree)` by searching only in the slug
- Redefine the `collective_search_index` index to:
  - Not include the `longDescription`
  - Ignore entries that will be filtered by search (deleted ones, incognito, etc)