### PR TITLE
delete collective payment method before creating one

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1043,6 +1043,14 @@ function defineModel() {
       approvedAt: new Date(),
     });
 
+    await models.PaymentMethod.destroy({
+      where: {
+        CollectiveId: this.id,
+        service: 'opencollective',
+        type: 'collective',
+      },
+    });
+
     await models.PaymentMethod.create({
       CollectiveId: this.id,
       service: 'opencollective',
@@ -1074,18 +1082,13 @@ function defineModel() {
       },
     });
 
-    const collectivePaymentMethod = await models.PaymentMethod.findOne({
+    await models.PaymentMethod.destroy({
       where: {
         CollectiveId: this.id,
         service: 'opencollective',
         type: 'collective',
-        deletedAt: null,
       },
     });
-
-    if (collectivePaymentMethod) {
-      await collectivePaymentMethod.destroy();
-    }
 
     return this;
   };
@@ -1985,7 +1988,6 @@ function defineModel() {
         CollectiveId: this.id,
         service: 'opencollective',
         type: 'collective',
-        deletedAt: null,
       },
     });
 


### PR DESCRIPTION
Fix: https://github.com/opencollective/opencollective/issues/4964

Missing a migration to delete current duplicates.

```
UPDATE
    "PaymentMethods" pm1
SET "deletedAt" = NOW()
   FROM "PaymentMethods" pm2
        
WHERE
	pm1."type" = 'collective'
	AND pm2."type" = 'collective'
	AND pm1."CollectiveId" = pm2."CollectiveId"
	AND pm1."id" < pm2."id"
	AND pm1."deletedAt" IS NULL
	AND pm2."deletedAt" IS NULL
```