### PR TITLE
getHostedCollectives performance: add attributes (select)

### DIFF
--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -178,14 +178,8 @@ export async function getTotalMoneyManagedAmount(host, { startDate, endDate, col
   if (collectiveIds?.length > 0) {
     ids = collectiveIds;
   } else {
-    const results = await sequelize.query(
-      `SELECT id FROM "Collectives" WHERE "HostCollectiveId" = :HostCollectiveId AND "deletedAt" IS NULL AND "isActive" = TRUE`,
-      {
-        replacements: { HostCollectiveId: host.id },
-        type: sequelize.QueryTypes.SELECT,
-      },
-    );
-    ids = results.map(result => result.id);
+    const collectives = await host.getHostedCollectives({ attributes: ['id'] });
+    ids = collectives.map(result => result.id);
   }
 
   if (host.isActive) {

--- a/server/lib/host-metrics.js
+++ b/server/lib/host-metrics.js
@@ -272,14 +272,8 @@ export async function getTotalMoneyManagedTimeSeries(
   { startDate, endDate, collectiveIds = null, timeUnit } = {},
 ) {
   if (!collectiveIds) {
-    const results = await sequelize.query(
-      `SELECT id FROM "Collectives" WHERE "HostCollectiveId" = :HostCollectiveId AND "deletedAt" IS NULL AND "isActive" = TRUE`,
-      {
-        replacements: { HostCollectiveId: host.id },
-        type: sequelize.QueryTypes.SELECT,
-      },
-    );
-    collectiveIds = results.map(result => result.id);
+    const collectives = await host.getHostedCollectives({ attributes: ['id'] });
+    collectiveIds = collectives.map(result => result.id);
     collectiveIds.push(host.id);
   }
 

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1728,12 +1728,19 @@ function defineModel() {
    *
    * It's expected that child Collectives like EVENTS are returned
    */
-  Collective.prototype.getHostedCollectives = async function () {
-    const hostedCollectives = await models.Member.findAll({
-      where: { MemberCollectiveId: this.id, role: roles.HOST },
+  Collective.prototype.getHostedCollectives = async function (queryParams = {}) {
+    return models.Collective.findAll({
+      ...queryParams,
+      where: { isActive: true, HostCollectiveId: this.id },
+      includes: [
+        {
+          attributes: [],
+          association: 'members',
+          required: true,
+          where: { MemberCollectiveId: this.id, role: roles.HOST },
+        },
+      ],
     });
-    const hostedCollectiveIds = hostedCollectives.map(m => m.CollectiveId);
-    return models.Collective.findAll({ where: { id: { [Op.in]: hostedCollectiveIds } } });
   };
 
   Collective.prototype.getHostedCollectiveAdmins = async function () {


### PR DESCRIPTION
This PR is both a performance optimization (by using a single SQL query + `attributes`) and the first step towards https://github.com/opencollective/opencollective/issues/4987 as it adds a filter on `HostCollectiveId` + `isActive` to the query we return.