### PR TITLE
Expense across hosts

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -524,7 +524,16 @@ const getPayoutMethodFromExpenseData = async (expenseData, remoteUser, fromColle
       const pm = await models.PayoutMethod.findByPk(expenseData.payoutMethod.id);
       if (!pm || !remoteUser.isAdmin(pm.CollectiveId)) {
         throw new Error("This payout method does not exist or you don't have the permission to use it");
-      } else if (pm.CollectiveId !== fromCollective.id) {
+      }
+      if (
+        // Payout Method from Collective
+        pm.CollectiveId !== fromCollective.id &&
+        // Bank Account or PayPal Payout Method from Host
+        !(
+          pm.CollectiveId === fromCollective.HostCollectiveId &&
+          [PayoutMethodTypes.BANK_ACCOUNT, PayoutMethodTypes.PAYPAL].includes(pm.type)
+        )
+      ) {
         throw new Error('This payout method cannot be used for this collective');
       }
       return pm;


### PR DESCRIPTION
let Collectives use Bank Account and PayPal payout methods of the host