### PR TITLE
Implement readOnly database configuration

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -19,7 +19,8 @@
         "min": "PG_MIN_CONNECTIONS",
         "max": "PG_MAX_CONNECTIONS"
       }
-    }
+    },
+    "readOnly": "DATABASE_READ_ONLY"
   },
   "graphql": {
     "apolloEngineAPIKey": "APOLLO_ENGINE_API_KEY",

--- a/config/default.json
+++ b/config/default.json
@@ -14,7 +14,8 @@
       },
       "logging": false,
       "benchmark": true
-    }
+    },
+    "readOnly": false
   },
   "maintenancedb": {
     "url": "postgres://127.0.0.1:5432/postgres"


### PR DESCRIPTION
Sometimes, for dev/test purpose we interact with a readOnly connection to the database.

It works well but it's currently impossible to Sign In with such configuration.

This is taking care of it.