### PR TITLE
Hide hidden collectives from results on discover page

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -461,7 +461,7 @@ const queries = {
     },
     async resolve(_, args) {
       const query = {
-        where: {},
+        where: { data: { hideFromSearch: { [Op.not]: true } } },
         limit: args.limit,
         include: [],
       };


### PR DESCRIPTION
Will improve the situation for https://github.com/opencollective/opencollective/issues/4944