### PR TITLE
Correct the default start/end times for host metrics

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -659,8 +659,8 @@ export const Host = new GraphQLObjectType({
           }
 
           const expenseAmountOverTime = async () => {
-            const dateFrom = args.dateFrom ? moment(args.dateFrom): null;
-            const dateTo = args.dateTo ? moment(args.dateTo): null;
+            const dateFrom = args.dateFrom ? moment(args.dateFrom) : null;
+            const dateTo = args.dateTo ? moment(args.dateTo) : null;
             const timeUnit = args.timeUnit || getTimeUnit(numberOfDays);
 
             const amountDataPoints = await queries.getTransactionsTimeSeries(

--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -565,8 +565,8 @@ export const Host = new GraphQLObjectType({
           }
 
           const contributionAmountOverTime = async () => {
-            const dateFrom = args.dateFrom ? moment(args.dateFrom).toISOString() : undefined;
-            const dateTo = args.dateTo ? moment(args.dateTo).toISOString() : undefined;
+            const dateFrom = args.dateFrom ? moment(args.dateFrom) : null;
+            const dateTo = args.dateTo ? moment(args.dateTo) : null;
             const timeUnit = args.timeUnit || getTimeUnit(numberOfDays);
 
             const amountDataPoints = await queries.getTransactionsTimeSeries(
@@ -659,8 +659,8 @@ export const Host = new GraphQLObjectType({
           }
 
           const expenseAmountOverTime = async () => {
-            const dateFrom = args.dateFrom ? moment(args.dateFrom).toISOString() : undefined;
-            const dateTo = args.dateTo ? moment(args.dateTo).toISOString() : undefined;
+            const dateFrom = args.dateFrom ? moment(args.dateFrom): null;
+            const dateTo = args.dateTo ? moment(args.dateTo): null;
             const timeUnit = args.timeUnit || getTimeUnit(numberOfDays);
 
             const amountDataPoints = await queries.getTransactionsTimeSeries(

--- a/server/lib/host-metrics.js
+++ b/server/lib/host-metrics.js
@@ -1,12 +1,11 @@
 import config from 'config';
 import { orderBy } from 'lodash';
-import moment from 'moment';
 
 import { sequelize } from '../models';
 
 import { getTotalMoneyManagedAmount } from './budget';
 import { getFxRate } from './currency';
-import { parseToBoolean } from './utils';
+import { computeDates, parseToBoolean } from './utils';
 
 function oppositeTotal(total) {
   return total !== 0 ? -total : total;
@@ -54,14 +53,10 @@ async function convertCurrencyForTimeSeries(results, currency) {
   return results;
 }
 
-function computeDates(startDate, endDate) {
-  startDate = startDate ? moment(startDate) : moment().utc().startOf('month');
-  endDate = endDate ? moment(endDate) : moment(startDate).utc().endOf('month');
-
-  return { startDate: startDate.toISOString(), endDate: endDate.toISOString() };
-}
-
-export async function getPlatformTips(host, { startDate, endDate, groupTimeUnit, collectiveIds = null } = {}) {
+export async function getPlatformTips(
+  host,
+  { startDate = null, endDate = null, groupTimeUnit, collectiveIds = null } = {},
+) {
   const timeUnitFragments = { select: '', groupBy: '', orderBy: '' };
   if (groupTimeUnit) {
     timeUnitFragments.select = ', DATE_TRUNC(:groupTimeUnit, t1."createdAt") AS "date"';
@@ -94,7 +89,8 @@ INNER JOIN "Collectives" as h
 ON t1."HostCollectiveId" = h."id"
 WHERE t1."HostCollectiveId" = :HostCollectiveId
 ${collectiveIds ? `AND t1."CollectiveId" IN (:CollectiveIds)` : ``}
-AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND (t1."kind" IS NULL OR t1."kind" IN ('CONTRIBUTION', 'ADDED_FUNDS'))
 AND t2."kind" = 'PLATFORM_TIP'
 AND t2."type" = 'CREDIT'
@@ -160,7 +156,7 @@ GROUP BY t."hostCurrency"`,
   return computeTotal(results, host.currency);
 }
 
-export async function getHostFees(host, { startDate, endDate, fromCollectiveIds = null } = {}) {
+export async function getHostFees(host, { startDate = null, endDate = null, fromCollectiveIds = null } = {}) {
   let newResults;
   if (parseToBoolean(config.ledger.separateHostFees) === true) {
     newResults = await sequelize.query(
@@ -169,7 +165,8 @@ FROM "Transactions" as t1
 WHERE t1."CollectiveId" = :CollectiveId
 ${fromCollectiveIds ? `AND t1."FromCollectiveId" IN (:FromCollectiveIds)` : ``}
 AND t1."kind" = 'HOST_FEE'
-AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency"`,
       {
@@ -189,7 +186,8 @@ GROUP BY t1."hostCurrency"`,
 FROM "Transactions" as t1
 WHERE t1."HostCollectiveId" = :HostCollectiveId
 ${fromCollectiveIds ? `AND t1."FromCollectiveId" IN (:FromCollectiveIds)` : ``}
-AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND NOT (t1."type" = 'DEBIT' AND t1."kind" = 'ADDED_FUNDS')
 AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency"`,
@@ -215,13 +213,14 @@ GROUP BY t1."hostCurrency"`,
   return total;
 }
 
-export async function getHostFeesTimeSeries(host, { startDate, endDate, timeUnit } = {}) {
+export async function getHostFeesTimeSeries(host, { startDate = null, endDate = null, timeUnit } = {}) {
   const newResults = await sequelize.query(
     `SELECT SUM(t1."amountInHostCurrency") as "_amount", t1."hostCurrency" as "_currency", DATE_TRUNC(:timeUnit, t1."createdAt") as "date"
 FROM "Transactions" as t1
 WHERE t1."CollectiveId" = :CollectiveId
 AND t1."kind" = 'HOST_FEE'
-AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt")
 ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
@@ -239,7 +238,8 @@ ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
       `SELECT SUM(t1."hostFeeInHostCurrency") as "_amount", t1."hostCurrency" as "_currency", DATE_TRUNC(:timeUnit, t1."createdAt") as "date"
 FROM "Transactions" as t1
 WHERE t1."HostCollectiveId" = :HostCollectiveId
-AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND NOT (t1."type" = 'DEBIT' AND t1."kind" = 'ADDED_FUNDS')
 AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt")
@@ -273,7 +273,7 @@ ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
 
 export async function getTotalMoneyManagedTimeSeries(
   host,
-  { startDate, endDate, collectiveIds = null, timeUnit } = {},
+  { startDate = null, endDate = null, collectiveIds = null, timeUnit } = {},
 ) {
   if (!collectiveIds) {
     const collectives = await host.getHostedCollectives({ attributes: ['id'] });
@@ -293,7 +293,8 @@ export async function getTotalMoneyManagedTimeSeries(
 FROM "Transactions" as t1
 WHERE t1."HostCollectiveId" = :HostCollectiveId
 AND t1."CollectiveId" IN (:CollectiveIds)
-AND t1."createdAt" >= :startDate AND t1."createdAt" < :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt")
 ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
@@ -321,7 +322,7 @@ ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
   });
 }
 
-export async function getHostFeeShare(host, { startDate, endDate, collectiveIds = null } = {}) {
+export async function getHostFeeShare(host, { startDate = null, endDate = null, collectiveIds = null } = {}) {
   if (config.env === 'production' && host.slug === 'opencollective') {
     return 0;
   }
@@ -341,7 +342,8 @@ ${
     : `WHERE t1."CollectiveId" = :CollectiveId`
 }
 AND t1."kind" = 'HOST_FEE_SHARE'
-AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency"`,
       {
@@ -370,7 +372,7 @@ GROUP BY t1."hostCurrency"`,
   return Math.round((hostFees * hostFeeSharePercent) / 100);
 }
 
-export async function getHostFeeShareTimeSeries(host, { startDate, endDate, timeUnit } = {}) {
+export async function getHostFeeShareTimeSeries(host, { startDate = null, endDate = null, timeUnit } = {}) {
   const results = await sequelize.query(
     `SELECT
       SUM(t1."amountInHostCurrency") as "_amount",
@@ -384,7 +386,8 @@ export async function getHostFeeShareTimeSeries(host, { startDate, endDate, time
       AND ts."deletedAt" IS NULL
     WHERE t1."CollectiveId" = :CollectiveId
     AND t1."kind" = 'HOST_FEE_SHARE'
-    AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+    ${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+    ${endDate ? `AND t1."createdAt" <= :endDate` : ``}
     AND t1."deletedAt" IS NULL
     GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt"), COALESCE(ts."status", 'SETTLED')
     ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt"), COALESCE(ts."status", 'SETTLED')`,
@@ -447,7 +450,8 @@ LEFT JOIN "PaymentMethods" pm ON
 LEFT JOIN "PaymentMethods" spm ON
   spm.id = pm."SourcePaymentMethodId"
 WHERE t1."HostCollectiveId" = :HostCollectiveId
-AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate
+${startDate ? `AND t1."createdAt" >= :startDate` : ``}
+${endDate ? `AND t1."createdAt" <= :endDate` : ``}
 AND t1."deletedAt" IS NULL
 AND (
   pm."service" != 'stripe'

--- a/server/lib/host-metrics.js
+++ b/server/lib/host-metrics.js
@@ -5,7 +5,7 @@ import { sequelize } from '../models';
 
 import { getTotalMoneyManagedAmount } from './budget';
 import { getFxRate } from './currency';
-import { computeDates, parseToBoolean } from './utils';
+import { computeDatesAsISOStrings, parseToBoolean } from './utils';
 
 function oppositeTotal(total) {
   return total !== 0 ? -total : total;
@@ -102,7 +102,7 @@ GROUP BY "_currency"${timeUnitFragments.groupBy} ${timeUnitFragments.orderBy}`,
       replacements: {
         HostCollectiveId: host.id,
         CollectiveIds: collectiveIds,
-        ...computeDates(startDate, endDate),
+        ...computeDatesAsISOStrings(startDate, endDate),
         groupTimeUnit,
       },
       type: sequelize.QueryTypes.SELECT,
@@ -147,7 +147,7 @@ GROUP BY t."hostCurrency"`,
         HostCollectiveId: host.id,
         CollectiveIds: collectiveIds,
         status: status,
-        ...computeDates(startDate, endDate),
+        ...computeDatesAsISOStrings(startDate, endDate),
       },
       type: sequelize.QueryTypes.SELECT,
     },
@@ -173,7 +173,7 @@ GROUP BY t1."hostCurrency"`,
         replacements: {
           CollectiveId: host.id,
           FromCollectiveIds: fromCollectiveIds,
-          ...computeDates(startDate, endDate),
+          ...computeDatesAsISOStrings(startDate, endDate),
         },
         type: sequelize.QueryTypes.SELECT,
       },
@@ -195,7 +195,7 @@ GROUP BY t1."hostCurrency"`,
       replacements: {
         HostCollectiveId: host.id,
         FromCollectiveIds: fromCollectiveIds,
-        ...computeDates(startDate, endDate),
+        ...computeDatesAsISOStrings(startDate, endDate),
       },
       type: sequelize.QueryTypes.SELECT,
     },
@@ -225,7 +225,7 @@ AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt")
 ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
     {
-      replacements: { CollectiveId: host.id, ...computeDates(startDate, endDate), timeUnit },
+      replacements: { CollectiveId: host.id, ...computeDatesAsISOStrings(startDate, endDate), timeUnit },
       type: sequelize.QueryTypes.SELECT,
     },
   );
@@ -245,7 +245,7 @@ AND t1."deletedAt" IS NULL
 GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt")
 ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
       {
-        replacements: { HostCollectiveId: host.id, ...computeDates(startDate, endDate), timeUnit },
+        replacements: { HostCollectiveId: host.id, ...computeDatesAsISOStrings(startDate, endDate), timeUnit },
         type: sequelize.QueryTypes.SELECT,
       },
     );
@@ -300,7 +300,7 @@ GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt")
 ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt")`,
     {
       replacements: {
-        ...computeDates(startDate, endDate),
+        ...computeDatesAsISOStrings(startDate, endDate),
         timeUnit,
         HostCollectiveId: host.id,
         CollectiveIds: collectiveIds,
@@ -350,7 +350,7 @@ GROUP BY t1."hostCurrency"`,
         replacements: {
           CollectiveId: host.id,
           CollectiveIds: collectiveIds,
-          ...computeDates(startDate, endDate),
+          ...computeDatesAsISOStrings(startDate, endDate),
         },
         type: sequelize.QueryTypes.SELECT,
       },
@@ -392,7 +392,7 @@ export async function getHostFeeShareTimeSeries(host, { startDate = null, endDat
     GROUP BY t1."hostCurrency", DATE_TRUNC(:timeUnit, t1."createdAt"), COALESCE(ts."status", 'SETTLED')
     ORDER BY DATE_TRUNC(:timeUnit, t1."createdAt"), COALESCE(ts."status", 'SETTLED')`,
     {
-      replacements: { CollectiveId: host.id, ...computeDates(startDate, endDate), timeUnit },
+      replacements: { CollectiveId: host.id, ...computeDatesAsISOStrings(startDate, endDate), timeUnit },
       type: sequelize.QueryTypes.SELECT,
     },
   );
@@ -433,7 +433,7 @@ export async function getPendingHostFeeShare(
           CollectiveId: host.id,
           FromCollectiveIds: collectiveIds,
           status: status,
-          ...computeDates(startDate, endDate),
+          ...computeDatesAsISOStrings(startDate, endDate),
         },
         type: sequelize.QueryTypes.SELECT,
       },
@@ -463,7 +463,7 @@ AND (
 )
 GROUP BY t1."hostCurrency"`,
     {
-      replacements: { HostCollectiveId: host.id, ...computeDates(startDate, endDate) },
+      replacements: { HostCollectiveId: host.id, ...computeDatesAsISOStrings(startDate, endDate) },
       type: sequelize.QueryTypes.SELECT,
     },
   );

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -9,6 +9,7 @@ import { memoize } from './cache';
 import { convertToCurrency } from './currency';
 import sequelize, { Op } from './sequelize';
 import { amountsRequireTaxForm } from './tax-forms';
+import { computeDates } from './utils';
 
 const twoHoursInSeconds = 2 * 60 * 60;
 const models = sequelize.models;
@@ -1128,7 +1129,15 @@ const getTaxFormsRequiredForAccounts = async (accountIds = [], year) => {
 /**
  * Returns the contribution or expense amounts over time.
  */
-const getTransactionsTimeSeries = async (kind, type, hostCollectiveId, timeUnit, collectiveIds, dateFrom, dateTo) => {
+const getTransactionsTimeSeries = async (
+  kind,
+  type,
+  hostCollectiveId,
+  timeUnit,
+  collectiveIds,
+  dateFrom = null,
+  dateTo = null,
+) => {
   return sequelize.query(
     `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", sum("amountInHostCurrency") as "amount", "hostCurrency" as "currency"
        FROM "Transactions"
@@ -1137,8 +1146,8 @@ const getTransactionsTimeSeries = async (kind, type, hostCollectiveId, timeUnit,
          AND type = :type
          AND "deletedAt" IS NULL
          ${collectiveIds ? `AND "CollectiveId" IN (:collectiveIds)` : ``}
-         ${dateFrom ? `AND "createdAt" >= :dateFrom` : ``}
-         ${dateTo ? `AND "createdAt" <= :dateTo` : ``}
+         ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
+         ${dateTo ? `AND "createdAt" <= :endDate` : ``}
        GROUP BY DATE_TRUNC(:timeUnit, "createdAt"), "hostCurrency"
        ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
       `,
@@ -1150,8 +1159,7 @@ const getTransactionsTimeSeries = async (kind, type, hostCollectiveId, timeUnit,
         hostCollectiveId,
         timeUnit,
         collectiveIds,
-        dateFrom,
-        dateTo,
+        ...computeDates(dateFrom, dateTo),
       },
     },
   );

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -9,7 +9,7 @@ import { memoize } from './cache';
 import { convertToCurrency } from './currency';
 import sequelize, { Op } from './sequelize';
 import { amountsRequireTaxForm } from './tax-forms';
-import { computeDates } from './utils';
+import { computeDatesAsISOStrings } from './utils';
 
 const twoHoursInSeconds = 2 * 60 * 60;
 const models = sequelize.models;
@@ -1159,7 +1159,7 @@ const getTransactionsTimeSeries = async (
         hostCollectiveId,
         timeUnit,
         collectiveIds,
-        ...computeDates(startDate, endDate),
+        ...computeDatesAsISOStrings(startDate, endDate),
       },
     },
   );

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1135,8 +1135,8 @@ const getTransactionsTimeSeries = async (
   hostCollectiveId,
   timeUnit,
   collectiveIds,
-  dateFrom = null,
-  dateTo = null,
+  startDate = null,
+  endDate = null,
 ) => {
   return sequelize.query(
     `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", sum("amountInHostCurrency") as "amount", "hostCurrency" as "currency"
@@ -1146,8 +1146,8 @@ const getTransactionsTimeSeries = async (
          AND type = :type
          AND "deletedAt" IS NULL
          ${collectiveIds ? `AND "CollectiveId" IN (:collectiveIds)` : ``}
-         ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
-         ${dateTo ? `AND "createdAt" <= :endDate` : ``}
+         ${startDate ? `AND "createdAt" >= :startDate` : ``}
+         ${endDate ? `AND "createdAt" <= :endDate` : ``}
        GROUP BY DATE_TRUNC(:timeUnit, "createdAt"), "hostCurrency"
        ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
       `,
@@ -1159,7 +1159,7 @@ const getTransactionsTimeSeries = async (
         hostCollectiveId,
         timeUnit,
         collectiveIds,
-        ...computeDates(dateFrom, dateTo),
+        ...computeDates(startDate, endDate),
       },
     },
   );

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -7,6 +7,7 @@ import Promise from 'bluebird';
 import config from 'config';
 import pdf from 'html-pdf';
 import { filter, get, isEqual, padStart, sumBy } from 'lodash';
+import moment from 'moment';
 
 import { ZERO_DECIMAL_CURRENCIES } from '../constants/currencies';
 
@@ -553,3 +554,10 @@ export const getTokenFromRequestHeaders = req => {
 };
 
 export const sumByWhen = (vector, iteratee, predicate) => sumBy(filter(vector, predicate), iteratee);
+
+export const computeDates = (startDate, endDate) => {
+  startDate = startDate ? moment(startDate) : moment().utc().startOf('month');
+  endDate = endDate ? moment(endDate) : moment(startDate).utc().endOf('month');
+
+  return { startDate: startDate.toISOString(), endDate: endDate.toISOString() };
+};

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -7,7 +7,6 @@ import Promise from 'bluebird';
 import config from 'config';
 import pdf from 'html-pdf';
 import { filter, get, isEqual, padStart, sumBy } from 'lodash';
-import moment from 'moment';
 
 import { ZERO_DECIMAL_CURRENCIES } from '../constants/currencies';
 
@@ -555,9 +554,12 @@ export const getTokenFromRequestHeaders = req => {
 
 export const sumByWhen = (vector, iteratee, predicate) => sumBy(filter(vector, predicate), iteratee);
 
-export const computeDates = (startDate, endDate) => {
-  startDate = startDate ? moment(startDate) : moment().utc().startOf('month');
-  endDate = endDate ? moment(endDate) : moment(startDate).utc().endOf('month');
+/**
+ * Returns the start and end dates as ISO 8601 strings.
+ */
+export const computeDatesAsISOStrings = (startDate, endDate) => {
+  startDate = startDate ? startDate.toISOString() : null;
+  endDate = endDate ? endDate.toISOString() : null;
 
-  return { startDate: startDate.toISOString(), endDate: endDate.toISOString() };
+  return { startDate, endDate };
 };

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -3037,8 +3037,8 @@ function defineModel() {
 
   /**
    * Returns financial metrics from the Host collective.
-   * @param {Date} from Defaults to beginning of the current month.
-   * @param {Date} [to] Optional, defaults to the end of the 'from' month and 'from' is reseted to the beginning of its month.
+   * @param {Date} from The start date from which the metrics should be calculated.
+   * @param {Date} to The end date upto which the metrics should be calculated.
    * @param {[Integer]} [collectiveIds] Optional, a list of collective ids for which the metrics are returned.
    */
   Collective.prototype.getHostMetrics = async function (from, to, collectiveIds) {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -3045,9 +3045,8 @@ function defineModel() {
     if (!this.isHostAccount || !this.isActive || this.type !== types.ORGANIZATION) {
       return null;
     }
-
-    from = from ? moment(from) : moment().utc().startOf('month');
-    to = to ? moment(to) : moment(from).utc().endOf('month');
+    from = from ? moment(from) : null;
+    to = to ? moment(to) : null;
 
     const plan = await this.getPlan();
     const hostFeeSharePercent = plan.hostFeeSharePercent || 0;


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4995

This handles the default start time and end time inconsistencies in the API. The problem I saw here is that on some metrics we use things like,

`AND t1."createdAt" >= :startDate AND t1."createdAt" <= :endDate`

I've made things consistent by using two separate template strings for `startDate` and `endDate` at all places. 