### PR TITLE
Add Expense.quote resolver and Wise quote caching

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -2570,6 +2570,7 @@ type Expense implements Transaction {
     """
     fetchHostFee: Boolean = false
   ): Int
+  amountInHostCurrency: Int
   host: User
   createdByUser: UserDetails
   fromCollective: CollectiveInterface
@@ -2603,6 +2604,7 @@ interface Transaction {
     """
     fetchHostFee: Boolean = false
   ): Int
+  amountInHostCurrency: Int
 
   """
   Fee kept by the host in the lowest unit of the currency of the host (ie. in cents)
@@ -2683,6 +2685,7 @@ type Order implements Transaction {
     """
     fetchHostFee: Boolean = false
   ): Int
+  amountInHostCurrency: Int
   host: User
   createdByUser: UserDetails
   fromCollective: CollectiveInterface

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -437,6 +437,11 @@ interface Transaction {
   ): String
   amount: Amount!
   amountInHostCurrency: Amount!
+
+  """
+  Exchange rate between the currency of the transaction and the currency of the host (transaction.amount * transaction.hostCurrencyFxRate = transaction.amountInHostCurrency)
+  """
+  hostCurrencyFxRate: Float
   netAmount(
     """
     Fetch HOST_FEE transaction and integrate in calculation for retro-compatiblity.
@@ -678,6 +683,7 @@ type Expense {
   The account that requested this expense to be submitted
   """
   requestedByAccount: Account
+  quote: ExpenseQuote
 }
 
 """
@@ -1758,6 +1764,26 @@ enum LegalDocumentType {
   US tax form (W9)
   """
   US_TAX_FORM
+}
+
+"""
+Fields for an expense quote
+"""
+type ExpenseQuote {
+  """
+  Amount of this item
+  """
+  totalAmount: Amount!
+
+  """
+  Amount of payment processor fee
+  """
+  paymentProcessorFeeAmount: Amount!
+
+  """
+  The date on which the item was created
+  """
+  estimatedDeliveryAt: DateTime!
 }
 
 """
@@ -4102,6 +4128,11 @@ type Credit implements Transaction {
   ): String
   amount: Amount!
   amountInHostCurrency: Amount!
+
+  """
+  Exchange rate between the currency of the transaction and the currency of the host (transaction.amount * transaction.hostCurrencyFxRate = transaction.amountInHostCurrency)
+  """
+  hostCurrencyFxRate: Float
   netAmount(
     """
     Fetch HOST_FEE transaction and integrate in calculation for retro-compatiblity.
@@ -4200,6 +4231,11 @@ type Debit implements Transaction {
   ): String
   amount: Amount!
   amountInHostCurrency: Amount!
+
+  """
+  Exchange rate between the currency of the transaction and the currency of the host (transaction.amount * transaction.hostCurrencyFxRate = transaction.amountInHostCurrency)
+  """
+  hostCurrencyFxRate: Float
   netAmount(
     """
     Fetch HOST_FEE transaction and integrate in calculation for retro-compatiblity.

--- a/server/graphql/v2/object/ExpenseQuote.ts
+++ b/server/graphql/v2/object/ExpenseQuote.ts
@@ -1,0 +1,25 @@
+import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-iso-date';
+
+import { Amount } from './Amount';
+
+const ExpenseQuote = new GraphQLObjectType({
+  name: 'ExpenseQuote',
+  description: 'Fields for an expense quote',
+  fields: () => ({
+    totalAmount: {
+      type: new GraphQLNonNull(Amount),
+      description: 'Amount of this item',
+    },
+    paymentProcessorFeeAmount: {
+      type: new GraphQLNonNull(Amount),
+      description: 'Amount of payment processor fee',
+    },
+    estimatedDeliveryAt: {
+      type: new GraphQLNonNull(GraphQLDateTime),
+      description: 'The date on which the item was created',
+    },
+  }),
+});
+
+export default ExpenseQuote;

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -26,6 +26,7 @@ describe('server/paymentProviders/transferwise/index', () => {
     targetAmount: 90.44,
     rate: 0.9044,
     payOut: 'BANK_TRANSFER',
+    expirationTime: moment().add(5, 'minutes').format(),
     paymentOptions: [
       {
         formattedEstimatedDelivery: 'by March 18th',
@@ -181,6 +182,18 @@ describe('server/paymentProviders/transferwise/index', () => {
       expect(quote)
         .to.have.nested.property('targetAmount')
         .equals((expense.amount / 100) * quote.rate);
+    });
+
+    it('should set expense.data.quote', async () => {
+      await expense.reload();
+      expect(expense).to.have.nested.property('data.quote');
+    });
+
+    it('should use existing quote if available', async () => {
+      createQuote.resetHistory();
+      const newQuote = await transferwise.quoteExpense(connectedAccount, payoutMethod, expense);
+      console.log(JSON.stringify(newQuote, null, 2));
+      expect(createQuote.callCount).to.be.equal(0);
     });
   });
 


### PR DESCRIPTION
Solves https://github.com/opencollective/opencollective/issues/3089.
Solves https://github.com/opencollective/opencollective/issues/4963.

This allows us to display Wise fees before paying for the expense and optimizing the performance of Wise expense payment flow.