### PR TITLE
Disable delegated authentication for HelloWorks

### DIFF
--- a/server/lib/tax-forms.ts
+++ b/server/lib/tax-forms.ts
@@ -134,7 +134,7 @@ export async function sendHelloWorksUsTaxForm(
       callbackUrl,
       workflowId,
       documentDelivery: true,
-      delegatedAuthentication: true, // See "authenticated link" below. While not fully supported yet, this flag at least ensures that HelloWorks doesn't send its own email
+      // delegatedAuthentication: true, // See "authenticated link" below.
       participants,
       metadata: {
         accountType: account.type,
@@ -152,19 +152,20 @@ export async function sendHelloWorksUsTaxForm(
     });
 
     // Get the authenticated link ("delegated authentication")
-    const step = instance.steps[0];
-    let documentLink = step.url;
-    try {
-      documentLink = await client.workflowInstances.getAuthenticatedLinkForStep({
-        instanceId: instance.id,
-        step: step.step,
-      });
-    } catch (e) {
-      // Fallback to the default `step.url` (unauthenticated link)
-      logger.warn(`Tax form: error getting authenticated link for ${instance.id}: ${e.message}`);
-    }
+    // We currently don't have access to this feature with our pricing plan
+    // try {
+    //   documentLink = await client.workflowInstances.getAuthenticatedLinkForStep({
+    //     instanceId: instance.id,
+    //     step: step.step,
+    //   });
+    // } catch (e) {
+    //   // Fallback to the default `step.url` (unauthenticated link)
+    //   logger.warn(`Tax form: error getting authenticated link for ${instance.id}: ${e.message}`);
+    // }
 
     // Save the authenticated link to the database, in case we want to send it again later
+    const step = instance.steps[0];
+    const documentLink = step.url;
     await document.update({ data: deepMerge(document.data, { helloWorks: { documentLink } }) });
 
     // Send the actual email

--- a/test/server/lib/tax-forms.test.js
+++ b/test/server/lib/tax-forms.test.js
@@ -351,8 +351,8 @@ describe('server/lib/tax-forms', () => {
 
     it('creates the documents if it does no exists', async () => {
       const documentLink = 'https://hello-works.com/fake-tax-form';
-      const createInstanceReponse = { id: 'fake-instance-id', steps: [{ step: 'fake-step-id', url: documentLink }] };
-      replace(client.workflowInstances, 'createInstance', fake.resolves(createInstanceReponse));
+      const createInstanceResponse = { id: 'fake-instance-id', steps: [{ step: 'fake-step-id', url: documentLink }] };
+      replace(client.workflowInstances, 'createInstance', fake.resolves(createInstanceResponse));
       replace(client.workflowInstances, 'getAuthenticatedLinkForStep', fake.resolves(documentLink));
 
       const newUser = await fakeUser({ email: `${randStr()}@opencollective.com` });
@@ -368,8 +368,8 @@ describe('server/lib/tax-forms', () => {
       const doc = await LegalDocument.create(legalDoc);
 
       const documentLink = 'https://hello-works.com/fake-tax-form';
-      const createInstanceReponse = { id: 'fake-instance-id', steps: [{ step: 'fake-step-id', url: documentLink }] };
-      replace(client.workflowInstances, 'createInstance', fake.resolves(createInstanceReponse));
+      const createInstanceResponse = { id: 'fake-instance-id', steps: [{ step: 'fake-step-id', url: documentLink }] };
+      replace(client.workflowInstances, 'createInstance', fake.resolves(createInstanceResponse));
       replace(client.workflowInstances, 'getAuthenticatedLinkForStep', fake.resolves(documentLink));
 
       await sendHelloWorksUsTaxForm(client, user.collective, year, callbackUrl, workflowId, user);
@@ -378,7 +378,7 @@ describe('server/lib/tax-forms', () => {
       expect(client.workflowInstances.createInstance.called).to.be.true;
       const callArgs = client.workflowInstances.createInstance.firstCall.args;
       expect(callArgs[0].participants['participant_swVuvW'].fullName).to.eq('Mr. Legal Name');
-      expect(client.workflowInstances.getAuthenticatedLinkForStep.called).to.be.true;
+      // when we'll activate authenticated links  expect(client.workflowInstances.getAuthenticatedLinkForStep.called).to.be.true;
       expect(doc.requestStatus).to.eq(REQUESTED);
 
       assert.callCount(sendMessageSpy, 1);


### PR DESCRIPTION
HelloWorks started blocking all requests where `delegatedAuthentication` is true, saying we need to upgrade our plan. Rolling back to standard links.