### PR TITLE
Disable two factor authentication for read only mode

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -10,7 +10,7 @@ import {
   verifyTwoFactorAuthenticationRecoveryCode,
   verifyTwoFactorAuthenticatorCode,
 } from '../lib/two-factor-authentication';
-import { isValidEmail } from '../lib/utils';
+import { isValidEmail, parseToBoolean } from '../lib/utils';
 import models from '../models';
 
 const { Unauthorized, ValidationFailed, TooManyRequests } = errors;
@@ -87,7 +87,7 @@ export const signin = (req, res, next) => {
  * the 2FA flow on the frontend
  */
 export const updateToken = async (req, res) => {
-  if (req.remoteUser.twoFactorAuthToken !== null) {
+  if (req.remoteUser.twoFactorAuthToken !== null && !parseToBoolean(config.database.readOnly)) {
     const token = req.remoteUser.jwt({ scope: 'twofactorauth' }, auth.TOKEN_EXPIRATION_SESSION);
     res.send({ token });
   } else {


### PR DESCRIPTION
If someone has enabled two factor authentication and try to connect to the prod db for example with read only mode there's errors since decryption of the two factor authentication doesn't work without the `DB_ENCRYPTION_SECRET_KEY` from prod. 

Thus I suggest we disable the two factor authentication when connecting with readonly mode so that when testing we don't have to disable the two factor authentication for the account. 🤔 