### PR TITLE
Payment Receipts: Remove self-fulfilled receipts for Fiscal Hosts

### DIFF
--- a/server/lib/pdf.js
+++ b/server/lib/pdf.js
@@ -51,6 +51,11 @@ export const getConsolidatedInvoicesData = async fromCollective => {
     [Op.or]: [{ FromCollectiveId: fromAccountCondition }, { UsingGiftCardFromCollectiveId: fromCollective.id }],
   };
 
+  // If collective is a Host account, we'll ignore receipts that were fulfilled by the same host
+  if (fromCollective.isHostAccount) {
+    where['HostCollectiveId'] = { [Op.ne]: fromCollective.id };
+  }
+
   const transactions = await models.Transaction.findAll({
     attributes: ['createdAt', 'HostCollectiveId'],
     where,


### PR DESCRIPTION
I think it would be safe to always set `where['HostCollectiveId'] = { [Op.ne]: fromCollective.id }`, but I think this conditional adds a bit more context on why we're doing this.

Resolves: https://github.com/opencollective/opencollective/issues/5043.