### PR TITLE
Use collective name in manual bank transfer instructions

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -674,7 +674,6 @@ export const sendOrderProcessingEmail = async order => {
   const { collective, fromCollective } = order;
   const user = order.createdByUser;
   const host = await collective.getHostCollective();
-  const parentCollective = await collective.getParentCollective();
   const manualPayoutMethod = await models.PayoutMethod.findOne({
     where: { CollectiveId: host.id, data: { isManualBankTransfer: true } },
   });
@@ -695,7 +694,7 @@ export const sendOrderProcessingEmail = async order => {
       account,
       reference: order.id,
       amount: formatCurrency(order.totalAmount, order.currency, 2),
-      collective: parentCollective ? `${parentCollective.slug} event` : order.collective.slug,
+      collective: order.collective.name,
       tier: get(order, 'tier.slug') || get(order, 'tier.name'),
       // @deprecated but we still have some entries in the DB
       OrderId: order.id,

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -293,7 +293,7 @@ describe('server/graphql/v1/createOrder', () => {
     expect(actionRequiredEmailArgs[0]).to.equal(remoteUser.email);
     expect(actionRequiredEmailArgs[2]).to.match(/IBAN 1234567890987654321/);
     expect(actionRequiredEmailArgs[2]).to.match(
-      /for the amount of <strong>\$20\.00<\/strong> with the mention: <strong>webpack event<\/strong> <strong>backer<\/strong> order: <strong>[0-9]+<\/strong>/,
+      /for the amount of <strong>\$20\.00<\/strong> with the mention: <strong>meetup<\/strong> <strong>backer<\/strong> order: <strong>[0-9]+<\/strong>/,
     );
     expect(actionRequiredEmailArgs[1]).to.equal('ACTION REQUIRED: your $20.00 registration to meetup is pending');
   });


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4839