### PR TITLE
Cascade host fees changes to children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5848,9 +5848,10 @@
       }
     },
     "commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true
     },
     "commitizen": {
       "version": "4.2.4",
@@ -10533,6 +10534,13 @@
         "mensch": "^0.3.4",
         "slick": "^1.12.2",
         "web-resource-inliner": "^5.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        }
       }
     },
     "just-extend": {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-jest-snapshot": "^2.0.0",
     "codecov": "^3.8.2",
+    "commander": "^8.3.0",
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.1.0",

--- a/scripts/common/helpers.ts
+++ b/scripts/common/helpers.ts
@@ -1,0 +1,16 @@
+import readline from 'readline';
+
+export const confirm = question => {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  return new Promise(resolve => {
+    rl.question(`${question}\n> `, input => {
+      if (input.toLowerCase() === 'yes') {
+        resolve(true);
+      } else {
+        rl.close();
+        resolve(false);
+      }
+    });
+  });
+};

--- a/scripts/ledger/update-transactions.ts
+++ b/scripts/ledger/update-transactions.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+
+/**
+ * This script aims to provide a command-line interface to update transactions in a safe way.
+ */
+
+import '../../server/env';
+
+import { Command } from 'commander'; // eslint-disable-line node/no-unpublished-import
+import { groupBy, pick } from 'lodash';
+
+import models, { Op } from '../../server/models';
+import { confirm } from '../common/helpers';
+
+// Some local caches to optimize the process
+let accountsCache = {};
+
+// Define modifiers as a map of option<>settings
+const MODIFIERS = {
+  hostFeePercent: {
+    description: 'Update transactions with this host fee percent',
+    parseArgs: value => {
+      const result = parseFloat(value);
+      if (isNaN(result)) {
+        throw new Error(`Invalid host fee percent: ${value}`);
+      } else if (!result) {
+        throw new Error('Host fee percent cannot be 0'); // Not supported yet, but we could support it
+      }
+
+      return result;
+    },
+    shouldUpdate: transaction => {
+      return transaction.type === 'CREDIT';
+    },
+    summarize: (transactions, percentage) => {
+      return `Update ${transactions.length} transactions with ${percentage}% host fee`;
+    },
+    update: async (transaction, percentage) => {
+      const existingHostFee = await transaction.getHostFeeTransaction();
+      if (existingHostFee) {
+        throw new Error("This script doesn't support updating existing host fee transactions yet"); // TODO: update existing host fee
+      } else {
+        const host = accountsCache[transaction.HostCollectiveId] || (await transaction.getHostCollective());
+        accountsCache[transaction.HostCollectiveId] = host;
+        transaction.hostFeeInHostCurrency = transaction.amount * (percentage / 100);
+        await models.Transaction.createHostFeeTransactions(transaction, host);
+      }
+    },
+  },
+};
+
+/** Parse command-line arguments */
+const getProgram = argv => {
+  const program = new Command();
+  program.exitOverride();
+  program.showSuggestionAfterError();
+  const commaSeparatedArgs = list => list.split(',');
+
+  // Misc options
+  program.option('--yes', 'Will not prompt for confirmation');
+
+  // Filters
+  program.option('--account <accounts>', 'Comma-separated list of accounts', commaSeparatedArgs);
+  program.option('--kind <kinds>', 'Comma-separated list of transaction kinds', commaSeparatedArgs);
+
+  // Value updaters
+  Object.entries(MODIFIERS).forEach(([option, settings]) => {
+    program.option(`--${option} <newValue>`, settings.description, settings.parseArgs);
+  });
+
+  // Parse arguments
+  program.parse(argv);
+
+  return program;
+};
+
+// Main
+export const main = async (argv = process.argv) => {
+  const program = getProgram(argv);
+  const options = program.opts();
+  const selectedModifiers = pick(MODIFIERS, Object.keys(options));
+
+  // Validation
+  const accountsSlugs = options.account || [];
+  const accounts = await models.Collective.findAll({ where: { slug: accountsSlugs } });
+  accountsCache = groupBy(accounts, 'id');
+  const accountsIds = accounts.map(a => a.id);
+  if (!accountsSlugs.length) {
+    console.error('You must specify at least one account slug');
+    program.help({ error: true });
+  } else if (accounts.length !== accountsSlugs.length) {
+    console.error('Some accounts were not found');
+    program.help({ error: true });
+  }
+
+  if (options.hostFeePercent === undefined) {
+    console.error('You must specify at least one info to update (hostFeePercent)');
+    program.help({ error: true });
+  }
+
+  // Fetch transactions
+  const where = { [Op.or]: [{ CollectiveId: accountsIds }, { FromCollectiveId: accountsIds }] };
+  if (options.kind) {
+    where['kind'] = options.kind;
+  }
+
+  const transactions = await models.Transaction.findAll({ where });
+
+  // Display summary and ask confirmation
+  console.log(`${transactions.length} transaction(s) to update with the following infos:`);
+  Object.entries(selectedModifiers).forEach(([option, modifier]) => {
+    const filteredTransactions = transactions.filter(modifier.shouldUpdate);
+    console.log(`  - ${modifier.summarize(filteredTransactions, options[option])}`);
+  });
+
+  if (!options.yes) {
+    const isConfirmed = await confirm('This action is irreversible. Are you sure you want to continue? (Yes/No)');
+    if (!isConfirmed) {
+      console.log('Aborted');
+      return;
+    }
+  }
+
+  // Trigger the actual update
+  console.log('Updating transactions...');
+  for (let i = 0; i < transactions.length; i++) {
+    const transaction = transactions[i];
+    // Apply all modifiers on transaction
+    for (const [option, modifier] of Object.entries(selectedModifiers)) {
+      if (modifier.shouldUpdate(transaction)) {
+        await modifier.update(transaction, options[option]);
+      }
+    }
+
+    if (i % 100 === 0) {
+      console.log(`Processed ${i}/${transactions.length} transactions...`);
+    }
+  }
+
+  console.log(`Processed ${transactions.length}/${transactions.length} transactions...`);
+  console.log('Done!');
+};
+
+// Only run script if called directly (to allow unit tests)
+if (!module.parent) {
+  main()
+    .then(() => process.exit())
+    .catch(e => {
+      if (e.name !== 'CommanderError') {
+        console.error(e);
+      }
+
+      process.exit(1);
+    });
+}

--- a/scripts/merge-collectives.js
+++ b/scripts/merge-collectives.js
@@ -1,25 +1,10 @@
 #!/usr/bin/env ./node_modules/.bin/babel-node
 import '../server/env';
 
-import readline from 'readline';
-
 import { mergeAccounts, simulateMergeAccounts } from '../server/lib/merge-accounts';
 import models from '../server/models';
 
-const confirmAction = question => {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-
-  return new Promise(resolve => {
-    rl.question(`${question}\n> `, input => {
-      if (input.toLowerCase() === 'yes') {
-        resolve(true);
-      } else {
-        rl.close();
-        resolve(false);
-      }
-    });
-  });
-};
+import { confirm } from './common/helpers';
 
 const printMergeSummary = async (fromCollective, intoCollective) => {
   console.log('==============================================================');
@@ -53,7 +38,7 @@ async function main() {
   await printMergeSummary(fromCollective, intoCollective);
   console.log('---------------------------------------------------------------');
 
-  const isConfirmed = await confirmAction('This action is irreversible. Are you sure you want to continue? (Yes/No)');
+  const isConfirmed = await confirm('This action is irreversible. Are you sure you want to continue? (Yes/No)');
   if (isConfirmed) {
     console.log(
       `\nMerging ${fromCollective.slug} (#${fromCollective.id}) into ${intoCollective.slug} (#${intoCollective.id})...`,

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -161,11 +161,12 @@ export async function createCollective(_, args, req) {
   }
 
   // Inherit fees from parent collective after setting its host (events)
-  if (parentCollective && parentCollective.hostFeePercent !== collective.hostFeePercent) {
-    await collective.update({ hostFeePercent: parentCollective.hostFeePercent });
+  if (parentCollective) {
+    await collective.update({
+      hostFeePercent: parentCollective.hostFeePercent,
+      data: { ...collective.data, useCustomHostFee: Boolean(parentCollective.data?.useCustomHostFee) },
+    });
   }
-
-  // if the type of collective is an organization or an event, we don't send notification
 
   return collective;
 }

--- a/server/graphql/v2/mutation/CreateProjectMutation.js
+++ b/server/graphql/v2/mutation/CreateProjectMutation.js
@@ -47,7 +47,7 @@ async function createProject(_, args, req) {
     type: 'PROJECT',
     slug: args.project.slug.toLowerCase(),
     ...pick(args.project, ['name', 'description']),
-    ...pick(parent.info, ['currency', 'isActive', 'platformFeePercent', 'hostFeePercent']),
+    ...pick(parent, ['currency', 'isActive', 'platformFeePercent', 'hostFeePercent', 'data.useCustomHostFee']),
     approvedAt: parent.isActive ? new Date() : null,
     ParentCollectiveId: parent.id,
     CreatedByUserId: remoteUser.id,
@@ -68,6 +68,12 @@ async function createProject(_, args, req) {
     const host = await loaders.Collective.byId.load(parent.HostCollectiveId);
     if (host) {
       await project.addHost(host, remoteUser);
+
+      // Inherit fees from parent collective after setting its host
+      await project.update({
+        hostFeePercent: parent.hostFeePercent,
+        data: { ...project.data, useCustomHostFee: Boolean(parent.data?.useCustomHostFee) },
+      });
     }
   }
 

--- a/test/scripts/ledger/update-transactions.test.ts
+++ b/test/scripts/ledger/update-transactions.test.ts
@@ -1,0 +1,25 @@
+import { main } from '../../../scripts/ledger/update-transactions';
+import { fakeTransaction } from '../../test-helpers/fake-data';
+import { resetTestDB, snapshotLedger } from '../../utils';
+
+const SNAPSHOT_COLUMNS = ['kind', 'type', 'amount', 'CollectiveId', 'FromCollectiveId', 'HostCollectiveId'];
+
+describe('scripts/ledger/update-transactions', () => {
+  before('reset test database', () => resetTestDB());
+
+  it('update hostFeePercent when it does not exists yet', async () => {
+    const transaction = await fakeTransaction({ amount: 500, kind: 'CONTRIBUTION' }, { createDoubleEntry: true });
+    const collective = await transaction.getCollective();
+    await main([
+      'npm run script',
+      'scripts/ledger/update-transactions.ts',
+      '--yes',
+      '--account',
+      collective.slug,
+      '--hostFeePercent',
+      '20.00',
+    ]);
+
+    snapshotLedger(SNAPSHOT_COLUMNS);
+  });
+});

--- a/test/scripts/ledger/update-transactions.test.ts.snap
+++ b/test/scripts/ledger/update-transactions.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`scripts/ledger/update-transactions update hostFeePercent when it does not exists yet 1`] = `
+"
+| kind         | type   | amount | To                       | From                     | Host               |
+| ------------ | ------ | ------ | ------------------------ | ------------------------ | ------------------ |
+| HOST_FEE     | CREDIT | 100    | Test Host a7a188ca       | Test Collective bbe279cb | Test Host a7a188ca |
+| HOST_FEE     | DEBIT  | -100   | Test Collective bbe279cb | Test Host a7a188ca       | Test Host d461f8ee |
+| CONTRIBUTION | CREDIT | 500    | Test Collective bbe279cb | Test Collective 3d10f256 | NULL               |
+| CONTRIBUTION | DEBIT  | -500   | Test Collective 3d10f256 | Test Collective bbe279cb | Test Host a7a188ca |"
+`;

--- a/test/server/graphql/v2/mutation/CreateProjectMutation.ts
+++ b/test/server/graphql/v2/mutation/CreateProjectMutation.ts
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import gqlV2 from 'fake-tag';
+
+import { fakeCollective, fakeUser, randStr } from '../../../../test-helpers/fake-data';
+import * as utils from '../../../../utils';
+
+const createProjectMutation = gqlV2/* GraphQL */ `
+  mutation CreateProject($project: ProjectCreateInput!, $parent: AccountReferenceInput!) {
+    createProject(project: $project, parent: $parent) {
+      id
+      name
+      slug
+      hostFeePercent
+      hostFeesStructure
+    }
+  }
+`;
+
+const VALID_PROJECT_ATTRIBUTES = {
+  name: 'NewProject',
+  description: 'A new project',
+  slug: 'a-project-slug',
+};
+
+describe('server/graphql/v2/mutation/CreateProjectMutation', () => {
+  before(async () => {
+    await utils.resetTestDB();
+  });
+
+  it('must be an admin of parent', async () => {
+    const adminUser = await fakeUser();
+    const parentCollective = await fakeCollective({ admin: adminUser });
+    const parent = { legacyId: parentCollective.id };
+    const mutationArgs = { parent, project: { ...VALID_PROJECT_ATTRIBUTES, slug: randStr() } };
+
+    // Unauthenticated
+    const resultUnauthenticated = await utils.graphqlQueryV2(createProjectMutation, mutationArgs);
+    expect(resultUnauthenticated.errors).to.exist;
+    expect(resultUnauthenticated.errors[0].message).to.equal('You need to be logged in to create a Project');
+
+    // Random user
+    const expectedMessage = `You must be logged in as a member of the ${parentCollective.slug} collective to create a Project`;
+    const resultRandomUser = await utils.graphqlQueryV2(createProjectMutation, mutationArgs, await fakeUser());
+    expect(resultRandomUser.errors).to.exist;
+    expect(resultRandomUser.errors[0].message).to.equal(expectedMessage);
+
+    // Non-admin
+    const backer = await fakeUser();
+    await parentCollective.addUserWithRole(backer, 'BACKER');
+    const resultBacker = await utils.graphqlQueryV2(createProjectMutation, mutationArgs, backer);
+    expect(resultBacker.errors).to.exist;
+    expect(resultBacker.errors[0].message).to.equal(expectedMessage);
+  });
+
+  it('is set to default fee if the parent has a default fee', async () => {
+    const adminUser = await fakeUser();
+    const parentCollective = await fakeCollective({ admin: adminUser, data: { useCustomHostFee: false } });
+    const parent = { legacyId: parentCollective.id };
+    const mutationArgs = { parent, project: { ...VALID_PROJECT_ATTRIBUTES, slug: randStr() } };
+    const result = await utils.graphqlQueryV2(createProjectMutation, mutationArgs, adminUser);
+    const project = result.data.createProject;
+    expect(project.hostFeesStructure).to.equal('DEFAULT');
+  });
+
+  it('inherits of parent fee configuration if custom', async () => {
+    const adminUser = await fakeUser();
+    const parentCollective = await fakeCollective({
+      admin: adminUser,
+      hostFeePercent: 7.77,
+      data: { useCustomHostFee: true },
+    });
+    const parent = { legacyId: parentCollective.id };
+    const mutationArgs = { parent, project: { ...VALID_PROJECT_ATTRIBUTES, slug: randStr() } };
+    const result = await utils.graphqlQueryV2(createProjectMutation, mutationArgs, adminUser);
+    const project = result.data.createProject;
+    expect(project.hostFeePercent).to.equal(7.77);
+    expect(project.hostFeesStructure).to.equal('CUSTOM_FEE');
+  });
+});

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -157,7 +157,7 @@ export const fakeOrganization = (organizationData = {}) => {
 };
 
 /**
- * Creates a fake update. All params are optionals.
+ * Creates a fake event. All params are optionals.
  */
 export const fakeEvent = async (collectiveData = {}) => {
   const ParentCollectiveId = collectiveData.ParentCollectiveId || (await fakeCollective()).id;
@@ -167,6 +167,22 @@ export const fakeEvent = async (collectiveData = {}) => {
     slug: randStr('event-'),
     ...collectiveData,
     type: 'EVENT',
+    ParentCollectiveId: ParentCollectiveId,
+    HostCollectiveId: parentCollective.HostCollectiveId,
+  });
+};
+
+/**
+ * Creates a fake project. All params are optionals.
+ */
+export const fakeProject = async (collectiveData = {}) => {
+  const ParentCollectiveId = collectiveData.ParentCollectiveId || (await fakeCollective()).id;
+  const parentCollective = await models.Collective.findByPk(ParentCollectiveId);
+  return fakeCollective({
+    name: randStr('Test Project '),
+    slug: randStr('project-'),
+    ...collectiveData,
+    type: 'PROJECT',
     ParentCollectiveId: ParentCollectiveId,
     HostCollectiveId: parentCollective.HostCollectiveId,
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -300,7 +300,7 @@ export function traverse(obj, cb) {
   }
 }
 
-const prettifyTransactionsData = (transactions, columns) => {
+export const prettifyTransactionsData = (transactions, columns) => {
   // Alias some columns for a simpler output
   const TRANSACTION_KEY_ALIASES = {
     HostCollectiveId: 'Host',


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5065

- Cascade host fee changes to children
- Add a script to update host fees for existing transactions

Usage:

```bash
$ npm run script scripts/ledger/update-transactions.ts -- --account apex --hostFeePercent 15
648 transaction(s) to update with the following infos:
 - Update 324 transactions with 15% host fee

This action is irreversible. Are you sure you want to continue? (Yes/No)
> 
```

# Migration strategy for the Social Change Nest

1. Deploy
2. Run the script
3. Manually update the fee structure and `hostFeePercent` for all concerned accounts (see the slugs list below)
4. Check the budgets to make sure everything is correct

> 'gaf-film-club-discusses-social-reproduction-and-solidarity-economy-53e79758','connecting-with-health-professionals-58e2cba9','calling-ethnic-minority-applied-psychologists-32cff7cb','trust-the-people-online-course-0160501e','global-poetry-showcase','vappaw-future','reclaiming-our-town-centres-7c343779','community-family-christmas-party-c9e5e5cb','cylch-merched-launch-party-e5144e59'

SQL query:
```sql
SELECT c."hostFeePercent", pc."hostFeePercent", pc."data", c."data" 
FROM "Collectives" c 
INNER JOIN "Collectives" pc ON c."ParentCollectiveId" = pc.id
WHERE c."HostCollectiveId" = 98478
AND c."isActive" IS TRUE
AND c."hostFeePercent" != pc."hostFeePercent" 
AND c."deletedAt" IS NULL
```