### PR TITLE
Fix Cache purging to delete all gQL operations

### DIFF
--- a/server/lib/cache/index.js
+++ b/server/lib/cache/index.js
@@ -97,6 +97,14 @@ const cache = {
       logger.warn(`Error while writing to cache: ${err.message}`);
     }
   },
+  keys: async pattern => {
+    try {
+      debugCache(`keys ${pattern}`);
+      return getDefaultProvider().keys?.(pattern);
+    } catch (err) {
+      logger.warn(`Error while listing keys from cache: ${err.message}`);
+    }
+  },
 };
 
 export async function fetchCollectiveId(collectiveSlug) {

--- a/server/lib/cache/index.js
+++ b/server/lib/cache/index.js
@@ -149,9 +149,12 @@ export function memoize(func, { key, maxAge = 0, serialize, unserialize }) {
   return memoizedFunction;
 }
 
-export function purgeGQLCacheForCollective(slug) {
+export async function purgeGQLCacheForCollective(slug) {
   for (const operationName of purgeCacheForCollectiveOperationNames) {
-    cache.del(`${operationName}_${slug}`);
+    const keys = await cache.keys(`${operationName}*${slug}`);
+    if (keys?.length) {
+      cache.del(keys);
+    }
   }
 }
 

--- a/server/lib/cache/memcache.js
+++ b/server/lib/cache/memcache.js
@@ -1,13 +1,20 @@
 import debug from 'debug';
 import memjs from 'memjs';
 
+import logger from '../logger';
 const debugCache = debug('cache');
 
 const makeMemcacheProvider = ({ servers, username, password }) => {
   const client = memjs.Client.create(servers, { username, password });
   return {
     clear: async () => client.flush(),
-    del: async key => client.delete(key),
+    del: async keys => {
+      if (Array.isArray(keys)) {
+        return Promise.all(keys.map(key => client.delete(key)));
+      } else {
+        return client.delete(keys);
+      }
+    },
     get: async (key, { unserialize = JSON.parse } = {}) => {
       const data = await client.get(key);
       if (data.value) {
@@ -27,6 +34,9 @@ const makeMemcacheProvider = ({ servers, username, password }) => {
       if (value !== undefined) {
         return client.set(key, serialize(value), { expires: expirationInSeconds });
       }
+    },
+    keys: () => {
+      logger.warn(`Memcache does not support keys() command.`);
     },
   };
 };

--- a/server/lib/cache/memory.js
+++ b/server/lib/cache/memory.js
@@ -4,10 +4,21 @@ const makeMemoryProvider = opts => {
   const lruCache = new LRU(opts);
   return {
     clear: async () => lruCache.reset(),
-    del: async key => lruCache.del(key),
+    del: async keys => {
+      if (Array.isArray(keys)) {
+        keys.forEach(key => lruCache.del(key));
+      } else {
+        lruCache.del(keys);
+      }
+    },
     get: async key => lruCache.get(key),
     has: async key => lruCache.has(key),
     set: async (key, value, expirationInSeconds) => lruCache.set(key, value, expirationInSeconds * 1000),
+    keys: async pattern => {
+      const r = new RegExp(pattern.replace('*', '.*'));
+      const keys = lruCache.keys().filter(k => r.test(k));
+      return keys;
+    },
   };
 };
 

--- a/server/lib/cache/redis.js
+++ b/server/lib/cache/redis.js
@@ -40,6 +40,7 @@ const makeRedisProvider = ({ serverUrl }) => {
         }
       }
     },
+    keys: async pattern => client.keys(pattern),
   };
 };
 


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4449.

In theory, this should fix https://github.com/opencollective/opencollective/issues/4449 but I'll need to test in production because cache works differently there.
The gQL cache is fixed, now only need to check if we're still not getting stuck with the SSR cached page, which is in fact the cache that holds the balance query rendered in the page.