### PR TITLE
Fix tip check with fixed amounts

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -538,7 +538,8 @@ export async function createOrder(order, loaders, remoteUser, reqIp, userAgent, 
         order.totalAmount = Math.round(order.quantity * tier.amount * (1 + taxPercent / 100));
       }
 
-      const netAmountForCollective = order.totalAmount - order.taxAmount - (order.platformFee || 0);
+      const tipAmount = order.platformTipAmount || 0;
+      const netAmountForCollective = order.totalAmount - order.taxAmount - (order.platformFee || 0) - tipAmount;
       const expectedAmountForCollective = order.quantity * tier.amount;
       const expectedTaxAmount = Math.round((expectedAmountForCollective * taxPercent) / 100);
       if (netAmountForCollective !== expectedAmountForCollective || order.taxAmount !== expectedTaxAmount) {


### PR DESCRIPTION
It seems that https://github.com/opencollective/opencollective-api/pull/7019 introduced a regression in the scenario of fixed amount tier + platform tip. We were not deducing the tip from the expected amount anymore, which resulted in an error like:
> This tier uses a fixed amount. Order total must be $xx. You set $yy

I randomly discovered this while testing the "move tiers" feature, it seems that no user has been impacted by this.