### PR TITLE
improved tax form email text

### DIFF
--- a/templates/emails/tax-form-request.hbs
+++ b/templates/emails/tax-form-request.hbs
@@ -1,25 +1,25 @@
-Subject: Action required: Submit your tax form for {{{accountName}}}
+Subject: Action required: Submit tax form for {{{accountName}}}
 
 {{> header}}
 
 {{#if recipientName}}
-<p>Dear {{recipientName}},</p>
+<p>Hi {{recipientName}},</p>
 {{else}}
 <p>Hi,</p>
 {{/if}}
 
 <p>
-  In order to comply with the US regulations, we need you to submit your tax form for <strong>{{{accountName}}}</strong>.
-  The link below will take you to HelloWorks, the service that we use to collect your tax information securely.
+  US regulations require US entities to collect certain information about payees for tax reporting purposes. The button below will take you to HelloWorks, the service we use to collect your tax information securely.
 </p>
 
 <div style="text-align: center; margin: 32px 0;">
   <a class="btn blue" href="{{documentLink}}">
-    Fill tax form
+    Submit tax form
+  </a></div>
+<p>
+  <a href="https://docs.opencollective.com/help/expenses-and-getting-paid/tax-information">
+    Questions? Learn more.
   </a>
-  <a class="btn" href="https://docs.opencollective.com/help/expenses-and-getting-paid/tax-information#for-the-open-source-collective-and-open-collective-foundation">
-    Learn more
-  </a>
-</div>
+</p>
 
 {{> footer}}

--- a/test/server/lib/tax-forms.test.js
+++ b/test/server/lib/tax-forms.test.js
@@ -380,7 +380,7 @@ describe('server/lib/tax-forms', () => {
       assert.callCount(sendMessageSpy, 1);
       const [recipient, title, content] = sendMessageSpy.firstCall.args;
       expect(recipient).to.eq(user.email);
-      expect(title).to.eq(`Action required: Submit your tax form for ${user.collective.legalName}`);
+      expect(title).to.eq(`Action required: Submit tax form for ${user.collective.legalName}`);
       expect(content).to.include(documentLink);
     });
 


### PR DESCRIPTION
I also updated the docs page it links to.

I changed the link to docs to be text instead of button so the action button is more clearly emphasized. Hopefully I got the line breaks/styling right.