### PR TITLE
Allow error Expense to be marked as Unapproved

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -293,7 +293,7 @@ export const canMarkAsSpam = async (req: express.Request, expense: typeof models
  * Returns true if expense can be unapproved by user
  */
 export const canUnapprove = async (req: express.Request, expense: typeof models.Expense): Promise<boolean> => {
-  if (expense.status !== expenseStatus.APPROVED) {
+  if (![expenseStatus.APPROVED, expenseStatus.ERROR].includes(expense.status)) {
     return false;
   } else if (!canUseFeature(req.remoteUser, FEATURE.USE_EXPENSES)) {
     return false;

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -316,7 +316,7 @@ describe('server/graphql/common/expenses', () => {
       await expense.update({ status: 'PROCESSING' });
       expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
       await expense.update({ status: 'ERROR' });
-      expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
+      expect(await canUnapprove(hostAdminReq, expense)).to.be.true;
       await expense.update({ status: 'PAID' });
       expect(await canUnapprove(hostAdminReq, expense)).to.be.false;
       await expense.update({ status: 'REJECTED' });


### PR DESCRIPTION
The error state is basically an approved state, this means we should allow the expense to be unapproved if we decide we should take a step back.