### PR TITLE
PayPal Payouts Cron: Ignore rejected and spam expenses

### DIFF
--- a/cron/hourly/11-check-pending-paypal-expenses.js
+++ b/cron/hourly/11-check-pending-paypal-expenses.js
@@ -18,7 +18,7 @@ export async function run() {
       [Op.or]: [
         { status: status.PROCESSING },
         {
-          status: { [Op.notIn]: [status.PAID, status.ERROR] },
+          status: { [Op.notIn]: [status.PAID, status.ERROR, status.REJECTED, status.SPAM] },
           updatedAt: {
             // 40 so we can cover the 30 day limit
             [Op.gte]: moment().subtract(40, 'days').toDate(),


### PR DESCRIPTION
The worker continuously is marking an expense as an error even though we already rejected the expense.
This update will add two more states that should be ignored by the PayPal payouts reconciliation worker.