### PR TITLE
Move from graphql-iso-date to graphql-scalars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9126,10 +9126,25 @@
         }
       }
     },
-    "graphql-iso-date": {
+    "graphql-scalars": {
       "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-3.6.1.tgz",
       "integrity": "sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q=="
+    },
+    "graphql-scalars": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.14.1.tgz",
+      "integrity": "sha512-IrJ2SI9IkCmWHyr7yIvtPNGWTWF3eTS+iNnw1DQMmEtsOgs1dUmT0ge+8M1+1xm+q3/5ZqB95yUYyThDyOTE+Q==",
+      "requires": {
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "graphql-tag": {
       "version": "2.12.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "fs-extra": "10.0.0",
     "get-urls": "10.0.1",
     "graphql": "15.8.0",
-    "graphql-iso-date": "3.6.1",
+    "graphql-scalars": "1.14.1",
     "graphql-type-json": "0.3.2",
     "handlebars": "4.7.7",
     "hashids": "2.2.10",

--- a/server/graphql/v2/input/UpdateUpdateInput.js
+++ b/server/graphql/v2/input/UpdateUpdateInput.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { AccountReferenceInput } from './AccountReferenceInput';
 

--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 import { assign, get, invert, isEmpty } from 'lodash';
 

--- a/server/graphql/v2/interface/AccountWithHost.ts
+++ b/server/graphql/v2/interface/AccountWithHost.ts
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLInterfaceType, GraphQLNonNull } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { HOST_FEE_STRUCTURE } from '../../../constants/host-fee-structure';
 import models from '../../../models';

--- a/server/graphql/v2/interface/TimeSeries.ts
+++ b/server/graphql/v2/interface/TimeSeries.ts
@@ -1,5 +1,5 @@
 import { GraphQLInterfaceType, GraphQLNonNull } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { TimeUnit } from '../enum/TimeUnit';
 

--- a/server/graphql/v2/interface/Transaction.js
+++ b/server/graphql/v2/interface/Transaction.js
@@ -8,7 +8,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { pick } from 'lodash';
 
 import orderStatus from '../../../constants/order_status';

--- a/server/graphql/v2/mutation/IndividualMutations.js
+++ b/server/graphql/v2/mutation/IndividualMutations.js
@@ -1,5 +1,5 @@
 import { GraphQLNonNull } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { Unauthorized } from '../../errors';
 import { Individual } from '../object/Individual';

--- a/server/graphql/v2/mutation/MemberInvitationMutations.js
+++ b/server/graphql/v2/mutation/MemberInvitationMutations.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { pick } from 'lodash';
 
 import { types as CollectiveTypes } from '../../../constants/collectives';

--- a/server/graphql/v2/mutation/MemberMutations.js
+++ b/server/graphql/v2/mutation/MemberMutations.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { pick } from 'lodash';
 
 import MemberRoles from '../../../constants/roles';

--- a/server/graphql/v2/object/AccountStats.js
+++ b/server/graphql/v2/object/AccountStats.js
@@ -1,5 +1,5 @@
 import { GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { get, has } from 'lodash';
 
 import queries from '../../../lib/queries';

--- a/server/graphql/v2/object/Activity.ts
+++ b/server/graphql/v2/object/Activity.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 import { pick } from 'lodash';
 

--- a/server/graphql/v2/object/Comment.js
+++ b/server/graphql/v2/object/Comment.js
@@ -1,5 +1,5 @@
 import { GraphQLList, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 
 import { collectiveResolver, fromCollectiveResolver } from '../../common/comment';

--- a/server/graphql/v2/object/ConnectedAccount.ts
+++ b/server/graphql/v2/object/ConnectedAccount.ts
@@ -1,5 +1,5 @@
 import { GraphQLInt, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 
 import { ConnectedAccountService } from '../enum/ConnectedAccountService';

--- a/server/graphql/v2/object/Contributor.ts
+++ b/server/graphql/v2/object/Contributor.ts
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { getCollectiveAvatarUrl } from '../../../lib/collectivelib';
 import { ContributorRoleEnum } from '../../v1/types';

--- a/server/graphql/v2/object/Conversation.js
+++ b/server/graphql/v2/object/Conversation.js
@@ -1,5 +1,5 @@
 import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import models, { Op } from '../../../models';
 import { AccountCollection } from '../collection/AccountCollection';

--- a/server/graphql/v2/object/Event.js
+++ b/server/graphql/v2/object/Event.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { Account, AccountFields } from '../interface/Account';
 import { AccountWithContributions, AccountWithContributionsFields } from '../interface/AccountWithContributions';

--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -1,5 +1,5 @@
 import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 import { pick } from 'lodash';
 

--- a/server/graphql/v2/object/ExpenseItem.ts
+++ b/server/graphql/v2/object/ExpenseItem.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { GraphQLInt, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { getContextPermission, PERMISSION_TYPE } from '../../common/context-permissions';
 import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';

--- a/server/graphql/v2/object/ExpenseQuote.ts
+++ b/server/graphql/v2/object/ExpenseQuote.ts
@@ -1,5 +1,5 @@
 import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { Amount } from './Amount';
 

--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -7,7 +7,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { find, get, isEmpty, keyBy, mapValues, pick } from 'lodash';
 import moment from 'moment';
 

--- a/server/graphql/v2/object/HostApplication.ts
+++ b/server/graphql/v2/object/HostApplication.ts
@@ -1,5 +1,5 @@
 import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 
 import { HostApplicationStatus } from '../enum/HostApplicationStatus';

--- a/server/graphql/v2/object/Member.js
+++ b/server/graphql/v2/object/Member.js
@@ -1,5 +1,5 @@
 import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { MemberRole } from '../enum/MemberRole';
 import { idEncode } from '../identifiers';

--- a/server/graphql/v2/object/MemberInvitation.ts
+++ b/server/graphql/v2/object/MemberInvitation.ts
@@ -1,5 +1,5 @@
 import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { MemberRole } from '../enum/MemberRole';
 import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';

--- a/server/graphql/v2/object/Order.js
+++ b/server/graphql/v2/object/Order.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 import { pick } from 'lodash';
 

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -1,5 +1,5 @@
 import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 import { get, pick } from 'lodash';
 

--- a/server/graphql/v2/object/Tier.js
+++ b/server/graphql/v2/object/Tier.js
@@ -1,5 +1,5 @@
 import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 
 import models, { Op } from '../../../models';

--- a/server/graphql/v2/object/TimeSeriesAmount.ts
+++ b/server/graphql/v2/object/TimeSeriesAmount.ts
@@ -1,5 +1,5 @@
 import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { getTimeSeriesFields, TimeSeries } from '../interface/TimeSeries';
 

--- a/server/graphql/v2/object/TimeSeriesAmountWithSettlement.ts
+++ b/server/graphql/v2/object/TimeSeriesAmountWithSettlement.ts
@@ -1,5 +1,5 @@
 import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import { TransactionSettlementStatus } from '../enum/TransactionSettlementStatus';
 import { getTimeSeriesFields, TimeSeries } from '../interface/TimeSeries';

--- a/server/graphql/v2/object/Update.js
+++ b/server/graphql/v2/object/Update.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 
 import { types as CollectiveType } from '../../../constants/collectives';

--- a/server/graphql/v2/object/VirtualCard.ts
+++ b/server/graphql/v2/object/VirtualCard.ts
@@ -1,5 +1,5 @@
 import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSONObject } from 'graphql-type-json';
 
 import { Currency } from '../enum/Currency';

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { isEmpty, partition } from 'lodash';
 
 import { expenseStatus } from '../../../../constants';

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { GraphQLBoolean, GraphQLInt, GraphQLNonNull, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 
 import models, { Op } from '../../../../models';
 import { OrderCollection } from '../../collection/OrderCollection';

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-iso-date';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { cloneDeep, flatten, uniq } from 'lodash';
 
 import models, { Op, sequelize } from '../../../../models';


### PR DESCRIPTION
graphql-iso-date is not actively maintained anymore and has moved to graphql-scalars.