### PR TITLE
Relax Condition to Obtain Transaction to Refund

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -8,7 +8,6 @@ import statuses from '../../constants/expense_status';
 import expenseType from '../../constants/expense_type';
 import FEATURE from '../../constants/feature';
 import { TransactionKind } from '../../constants/transaction-kind';
-import { TransactionTypes } from '../../constants/transactions';
 import { getFxRate } from '../../lib/currency';
 import logger from '../../lib/logger';
 import { floatAmountToCents } from '../../lib/math';
@@ -1403,7 +1402,6 @@ export async function markExpenseAsUnpaid(
         RefundTransactionId: null,
         kind: TransactionKind.EXPENSE,
         isRefund: false,
-        type: TransactionTypes.CREDIT,
       },
       include: [{ model: models.Expense }],
     });


### PR DESCRIPTION
A small bug was introduced at, https://github.com/opencollective/opencollective-api/pull/6999. By fixing the condition `type: TransactionTypes.CREDIT` we are assuming that for all expenses a `CREDIT` exists. However when the expense is submitted from a collective to itself  and then when we try to refund it (supported by, https://github.com/opencollective/opencollective-api/pull/6985) this will give an error since for these kind of expenses a `CREDIT` does not exist. 

Related Slack Discussion: https://opencollective.slack.com/archives/CEZUS9WH3/p1643365892438949?thread_ts=1643361163.425029&cid=CEZUS9WH3