### PR TITLE
Make hostFeePercent optional in addFunds mutation

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -625,9 +625,9 @@ export async function createOrder(order, loaders, remoteUser, reqIp, userAgent, 
     // Handle specific fees
     // we use data instead of a column for now because it's an edge/experimental case
     // should be moved to a column if it starts to be widely used
-    if (order.hostFeePercent) {
+    if (!isNil(order.hostFeePercent)) {
       orderData.data.hostFeePercent = order.hostFeePercent;
-    } else if (tier && tier.data && tier.data.hostFeePercent !== undefined) {
+    } else if (!isNil(tier?.data?.hostFeePercent)) {
       orderData.data.hostFeePercent = tier.data.hostFeePercent;
     }
 

--- a/server/graphql/v2/mutation/AddFundsMutations.ts
+++ b/server/graphql/v2/mutation/AddFundsMutations.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { GraphQLFloat, GraphQLNonNull, GraphQLString } from 'graphql';
+import { isNil } from 'lodash';
 
 import { addFunds } from '../../common/orders';
 import { ValidationFailed } from '../../errors';
@@ -17,7 +18,7 @@ export const addFundsMutation = {
     tier: { type: TierReferenceInput },
     amount: { type: new GraphQLNonNull(AmountInput) },
     description: { type: new GraphQLNonNull(GraphQLString) },
-    hostFeePercent: { type: new GraphQLNonNull(GraphQLFloat) },
+    hostFeePercent: { type: GraphQLFloat },
   },
   resolve: async (_, args, req: express.Request): Promise<Record<string, unknown>> => {
     const account = await fetchAccountWithReference(args.account, { throwIfMissing: true });
@@ -29,8 +30,10 @@ export const addFundsMutation = {
       throw new ValidationFailed(`Adding funds is only possible for the following types: ${allowedTypes.join(',')}`);
     }
 
-    if (args.hostFeePercent < 0 || args.hostFeePercent > 100) {
-      throw new ValidationFailed('hostFeePercent should be a value between 0 and 100.');
+    if (!isNil(args.hostFeePercent)) {
+      if (args.hostFeePercent < 0 || args.hostFeePercent > 100) {
+        throw new ValidationFailed('hostFeePercent should be a value between 0 and 100.');
+      }
     }
 
     return addFunds(

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -863,7 +863,7 @@ export const getHostFeePercent = async (order, host = null) => {
   }
 
   const possibleValues = [
-    // Fixed in the Order (special tiers: BackYourStack, Pre-Paid)
+    // Fixed in the Order (Added Funds or special tiers: BackYourStack, Pre-Paid)
     order.data?.hostFeePercent,
   ];
 
@@ -882,11 +882,16 @@ export const getHostFeePercent = async (order, host = null) => {
     }
   }
 
-  if (order.paymentMethod.service === 'opencollective') {
-    // Default to 0 for this kind of payments
-    if (order.paymentMethod.type === 'collective' || order.paymentMethod.type === 'host') {
-      possibleValues.push(0);
-    }
+  if (order.paymentMethod.service === 'opencollective' && order.paymentMethod.type === 'host') {
+    // Fixed for Added Funds at collective level
+    possibleValues.push(order.collective.data?.addedFundsHostFeePercent);
+    // Fixed for Added Funds at host level
+    possibleValues.push(host.data?.addedFundsHostFeePercent);
+  }
+
+  if (order.paymentMethod.service === 'opencollective' && order.paymentMethod.type === 'collective') {
+    // Default to 0 for Collective to Collective on the same Host
+    possibleValues.push(0);
   }
 
   if (order.paymentMethod.service === 'stripe') {

--- a/test/server/graphql/v1/paymentMethods.test.js
+++ b/test/server/graphql/v1/paymentMethods.test.js
@@ -129,6 +129,7 @@ describe('server/graphql/v1/paymentMethods', () => {
           paymentMethod: {
             uuid: pm.uuid,
           },
+          hostFeePercent: 0,
         };
       });
     });

--- a/test/stories/ledger.test.ts
+++ b/test/stories/ledger.test.ts
@@ -5,6 +5,7 @@
 
 import { expect } from 'chai';
 import express from 'express';
+import { set } from 'lodash';
 import moment from 'moment';
 import nock from 'nock';
 
@@ -492,6 +493,7 @@ describe('test/stories/ledger', () => {
   describe('Level 4: Refund added funds️', async () => {
     const refundTransaction = async (collective, host, contributorUser, baseOrderData) => {
       const order = await fakeOrder(baseOrderData);
+      set(order, 'data.hostFeePercent', 0);
       order.paymentMethod = { service: 'opencollective', type: 'host', CollectiveId: host.id };
       await executeOrder(contributorUser, order);
 


### PR DESCRIPTION
While working on a project using the API, I realized that it was not intuitive to force people to explicitly pass `hostFeePercent`. It's more intuitive to rely on the default.

Also taking this as an opportunity to introduce some configuration on the host or on the collective if we want custom values: `addedFundsHostFeePercent`.
