### PR TITLE
fix: correct `InvalidToken` usage in email confirmation

### DIFF
--- a/server/graphql/v1/mutations/users.js
+++ b/server/graphql/v1/mutations/users.js
@@ -81,7 +81,9 @@ export const confirmUserEmail = async emailConfirmationToken => {
   const user = await models.User.findOne({ where: { emailConfirmationToken } });
 
   if (!user) {
-    throw new InvalidToken('Invalid email confirmation token', { internalData: { emailConfirmationToken } });
+    throw new InvalidToken('Invalid email confirmation token', 'INVALID_TOKEN', {
+      internalData: { emailConfirmationToken },
+    });
   }
 
   return user.update({


### PR DESCRIPTION
For https://github.com/opencollective/opencollective-frontend/pull/7450

The usage was incorrect, the second argument should be the `code` string.

https://github.com/opencollective/opencollective-api/blob/7190454f9b123f86193bdcf8e5739b417e75ca93/server/graphql/errors.ts#L49-L53