### PR TITLE
chore: update `sequelize` to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15081,9 +15081,9 @@
       }
     },
     "sequelize": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.16.1.tgz",
-      "integrity": "sha512-YFGqrwkmEhSbpZBxay5+PRKMiZNNUJzgIixCyFkLm9+/5Rqq5jBADEjTAC8RYHzwsOGNboYh18imXrYNCjBZCQ==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.16.3.tgz",
+      "integrity": "sha512-+YdpvaftD51diqy5QrgOrrw2NahHUGsPVRSGMAP6o0Tiuix5h+j1XFNujDpsSH0AtvJo15DTbx1WbASqoqXcqQ==",
       "requires": {
         "@types/debug": "^4.1.7",
         "debug": "^4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6481,7 +6481,7 @@
     },
     "enabled": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
@@ -8619,7 +8619,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -9695,9 +9695,9 @@
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
     "inflection": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz",
-      "integrity": "sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.2.tgz",
+      "integrity": "sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -15081,9 +15081,9 @@
       }
     },
     "sequelize": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.13.0.tgz",
-      "integrity": "sha512-p0dXXGZSc0Ng7CdGwlKN4P6DTRD/w9Ar2CnmHamNVDnqEWh6pMVOp3xrlG5+IWhbwrqL3SjIYEYt3Xog1vXRDw==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.16.1.tgz",
+      "integrity": "sha512-YFGqrwkmEhSbpZBxay5+PRKMiZNNUJzgIixCyFkLm9+/5Rqq5jBADEjTAC8RYHzwsOGNboYh18imXrYNCjBZCQ==",
       "requires": {
         "@types/debug": "^4.1.7",
         "debug": "^4.3.3",
@@ -15102,22 +15102,20 @@
         "wkx": "^0.5.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
           }
         },
         "yallist": {
@@ -16758,9 +16756,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prepend-http": "3.0.1",
     "redis": "3.1.2",
     "sanitize-html": "2.7.0",
-    "sequelize": "6.16.1",
+    "sequelize": "6.16.3",
     "sequelize-cli": "6.4.1",
     "sequelize-temporal": "1.0.8",
     "showdown": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prepend-http": "3.0.1",
     "redis": "3.1.2",
     "sanitize-html": "2.7.0",
-    "sequelize": "6.13.0",
+    "sequelize": "6.16.1",
     "sequelize-cli": "6.4.1",
     "sequelize-temporal": "1.0.8",
     "showdown": "2.0.0",

--- a/server/models/PaypalPlan.ts
+++ b/server/models/PaypalPlan.ts
@@ -29,7 +29,7 @@ interface PaypalPlanCreateWithProductAttributes extends PaypalPlanCommonCreateAt
   product?: PaypalProductCreateAttributes;
 }
 
-type PaypalPlanCreateAttributes = PaypalPlanCreateWithProductIdAttributes & PaypalPlanCreateWithProductAttributes;
+type PaypalPlanCreateAttributes = PaypalPlanCreateWithProductIdAttributes | PaypalPlanCreateWithProductAttributes;
 
 class PaypalPlan extends Model<PaypalPlanAttributes, PaypalPlanCreateAttributes> implements PaypalPlanAttributes {
   id: string;

--- a/server/models/PaypalPlan.ts
+++ b/server/models/PaypalPlan.ts
@@ -29,7 +29,7 @@ interface PaypalPlanCreateWithProductAttributes extends PaypalPlanCommonCreateAt
   product?: PaypalProductCreateAttributes;
 }
 
-type PaypalPlanCreateAttributes = PaypalPlanCreateWithProductIdAttributes | PaypalPlanCreateWithProductAttributes;
+type PaypalPlanCreateAttributes = PaypalPlanCreateWithProductIdAttributes & PaypalPlanCreateWithProductAttributes;
 
 class PaypalPlan extends Model<PaypalPlanAttributes, PaypalPlanCreateAttributes> implements PaypalPlanAttributes {
   id: string;


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5215

There was also an unknown bug in `sequelize` v6.16.0, I created a PR to point it out and fix the issue in the `sequelize` repository itself - https://github.com/sequelize/sequelize/pull/14071 https://github.com/sequelize/sequelize/pull/14071#issuecomment-1033487156

The change was accepted and a new patch version `v6.16.1` is now released.

## 

There was another unknown regression, I reported it in https://github.com/sequelize/sequelize/issues/14129

The issue was fixed and a new patch version `v6.16.3` is now released.