### PR TITLE
Validate uploaded images for collectives

### DIFF
--- a/server/lib/images.ts
+++ b/server/lib/images.ts
@@ -1,14 +1,33 @@
 import config from 'config';
 
+const TRUSTED_IMAGE_PROVIDERS = [
+  'gravatar.com',
+  'logo.clearbit.com',
+  'avatars.githubusercontent.com',
+  'pbs.twimg.com',
+  'abs.twimg.com',
+  'secure.meetupstatic.com',
+];
+
+const getHostname = url => {
+  return new URL(url).hostname.replace(/^www\./, '');
+};
+
 /**
  * Returns true if image is a valid image uploaded in our S3 bucket.
  * Allow any image on non-production environments
  */
-export const isValidUploadedImage = (url: string, ignoreInNonProductionEnv = true): boolean => {
+export const isValidUploadedImage = (
+  url: string,
+  { ignoreInNonProductionEnv = true, allowTrustedThirdPartyImages = false } = {},
+): boolean => {
   if (config.env !== 'production' && ignoreInNonProductionEnv) {
     return true;
-  } else {
-    const regex = new RegExp(`^https://${config.aws.s3.bucket}\\.s3[.-]us-west-1.amazonaws.com/`);
-    return regex.test(url);
+  } else if (new RegExp(`^https://${config.aws.s3.bucket}\\.s3[.-]us-west-1.amazonaws.com/`).test(url)) {
+    return true;
+  } else if (allowTrustedThirdPartyImages && TRUSTED_IMAGE_PROVIDERS.includes(getHostname(url))) {
+    return true;
   }
+
+  return false;
 };

--- a/server/lib/sanitize-html.ts
+++ b/server/lib/sanitize-html.ts
@@ -214,5 +214,8 @@ const isTrustedLinkUrl = (url: string): boolean => {
     /^(.+\.)?wikipedia.com$/,
   ];
 
-  return trustedDomains.some(regex => rootDomain.match(regex)) || isValidUploadedImage(url, false);
+  return (
+    trustedDomains.some(regex => rootDomain.match(regex)) ||
+    isValidUploadedImage(url, { ignoreInNonProductionEnv: false })
+  );
 };

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -66,6 +66,7 @@ import {
   getPendingPlatformTips,
   getPlatformTips,
 } from '../lib/host-metrics';
+import { isValidUploadedImage } from '../lib/images';
 import logger from '../lib/logger';
 import queries from '../lib/queries';
 import { buildSanitizerOptions, sanitizeHTML } from '../lib/sanitize-html';
@@ -310,6 +311,14 @@ function defineModel() {
         type: DataTypes.STRING,
         validate: {
           isUrl: true,
+          isValidImage(url) {
+            // Only validate for new images
+            if (!url || url === this.image) {
+              return;
+            } else if (!isValidUploadedImage(url, { allowTrustedThirdPartyImages: true })) {
+              throw new Error('The image URL is not valid');
+            }
+          },
         },
         get() {
           const image = this.getDataValue('image');
@@ -324,6 +333,14 @@ function defineModel() {
         type: DataTypes.STRING,
         validate: {
           isUrl: true,
+          isValidImage(url) {
+            // Only validate for new images
+            if (!url || url === this.backgroundImage) {
+              return;
+            } else if (!isValidUploadedImage(url, { allowTrustedThirdPartyImages: true })) {
+              throw new Error('The background image URL is not valid');
+            }
+          },
         },
         get() {
           return this.getDataValue('backgroundImage');


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-api/pull/3797

This time we're validating the images:
- Only when they change (to not break updating collectives that have an invalid image setup)
- With a list of trusted hosts (Twitter, Github, etc) to handle these cases until we have a more future-proof solution (https://github.com/opencollective/opencollective/issues/3098)