### PR TITLE
Add a script for manual PayPal refunds

### DIFF
--- a/scripts/paypal/payment-reconciliator.ts
+++ b/scripts/paypal/payment-reconciliator.ts
@@ -107,7 +107,8 @@ const markOrderAsError = async order => {
   await order.update({ status: OrderStatus.ERROR });
 };
 
-const findOrdersWithErroneousStatus = async options => {
+const findOrdersWithErroneousStatus = async (_, commander) => {
+  const options = commander.optsWithGlobals();
   const hostSlugs = await getHostsSlugsFromOptions(options);
   for (const hostSlug of hostSlugs) {
     console.log(`\nChecking host ${hostSlug} for erroneous order statuses...`);
@@ -132,7 +133,8 @@ const findOrdersWithErroneousStatus = async options => {
   }
 };
 
-const findOrphanSubscriptions = async options => {
+const findOrphanSubscriptions = async (_, commander) => {
+  const options = commander.optsWithGlobals();
   const reason = `Some PayPal subscriptions were previously not cancelled properly. Please contact support@opencollective.com for any question.`;
   const hostSlugs = await getHostsSlugsFromOptions(options);
   const allHosts = await models.Collective.findAll({ where: { slug: hostSlugs } });
@@ -252,7 +254,8 @@ const findOrphanSubscriptions = async options => {
   }
 };
 
-const findMissingPaypalTransactions = async options => {
+const findMissingPaypalTransactions = async (_, commander) => {
+  const options = commander.optsWithGlobals();
   const hostSlugs = await getHostsSlugsFromOptions(options);
   for (const hostSlug of hostSlugs) {
     console.log(`\nChecking host ${hostSlug} for missing transactions...`);
@@ -328,7 +331,8 @@ const getRefundedTransactionsFromPaypal = async (host, startDate, endDate) => {
   return response['transaction_details'];
 };
 
-const findRefundedContributions = async options => {
+const findRefundedContributions = async (_, commander) => {
+  const options = commander.optsWithGlobals();
   const hostSlugs = await getHostsSlugsFromOptions(options);
   for (const hostSlug of hostSlugs) {
     console.log(`\nChecking host ${hostSlug} for refunded contributions not marked as such in our ledger...`);

--- a/scripts/paypal/refund.ts
+++ b/scripts/paypal/refund.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+
+import '../../server/env';
+
+import { Command } from 'commander';
+
+import logger from '../../server/lib/logger';
+import { sleep } from '../../server/lib/utils';
+import { findTransactionByPaypalId, refundPaypalCapture } from '../../server/paymentProviders/paypal/payment';
+
+const main = async () => {
+  const program = new Command();
+  program.showSuggestionAfterError();
+
+  const commaSeparatedArgs = list => list.split(',');
+
+  // General options
+  program.option('--captures <captureIds>', 'List of PayPal capture/transaction ids', commaSeparatedArgs);
+  program.option('--reason <reason>', 'Why is this refunded? (sent to refundees)');
+
+  // Parse arguments
+  program.parse();
+  const options = program.opts();
+  const captureIds = options['captures'];
+  if (!captureIds?.length) {
+    program.help({ error: true });
+  } else {
+    for (const captureId of captureIds) {
+      const ledgerTransaction = await findTransactionByPaypalId(captureId);
+      if (!ledgerTransaction) {
+        logger.warn(`No transaction found for PayPal capture ${captureId}`);
+      } else {
+        try {
+          logger.info(`Refunding PayPal capture ${captureId} (order #${ledgerTransaction.OrderId})`);
+          await refundPaypalCapture(ledgerTransaction, captureId, null, options['reason']);
+        } catch (e) {
+          logger.warn(`Could not refund PayPal transaction ${captureId}`, e);
+        }
+        sleep(1000); // To prevent rate-limiting issues with PayPal
+      }
+    }
+  }
+};
+
+main()
+  .then(() => process.exit())
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
A few transactions were missed by the payment reconciliation because of rate limiting. This script will address them