### PR TITLE
Record multi-currency expenses in the ledger

### DIFF
--- a/scripts/add_transactions_for_paid_expenses.js
+++ b/scripts/add_transactions_for_paid_expenses.js
@@ -12,7 +12,7 @@ process.exit();
 /*
 
 import models, { sequelize } from '../server/models';
-import { createFromPaidExpense as createTransactionFromPaidExpense } from '../server/lib/transactions';
+import { createTransactionsFromPaidExpense } from '../server/lib/transactions';
 
 const done = err => {
   if (err) console.log('err', err);
@@ -62,7 +62,7 @@ function run() {
           expense = e;
           return e.collective.getHostCollective();
         })
-        .then(host => createTransactionFromPaidExpense(host, null, expense, null, expense.UserId))
+        .then(host => createTransactionsFromPaidExpense(host, null, expense, null, expense.UserId))
         .then(() => expensesFixed.push(expenseId));
     })
     .then(() => console.log('Expenses fixed: ', expensesFixed.length))

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1353,7 +1353,7 @@ const checkHasBalanceToPayExpense = async (
 
   // Ensure the collective has enough funds to pay the expense, with an error margin of 20% of the expense amount
   // to account for fluctuating rates. Example: to pay for a $100 expense in euros, the collective needs to have at least $120.
-  const getMinExpectedBalance = amountToPay => (isSameCurrency ? amountToPay : amountToPay * 1.2);
+  const getMinExpectedBalance = amountToPay => (isSameCurrency ? amountToPay : Math.round(amountToPay * 1.2));
 
   // Check base balance before fees
   if (balanceInExpenseCurrency < getMinExpectedBalance(expense.amount)) {

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1199,8 +1199,8 @@ export async function createTransferWiseTransactionsAndUpdateExpense({ host, exp
     fees.paymentProcessorFeeInHostCurrency.fees = Math.round(data.paymentOption.fee.total * 100);
   }
 
-  const fxRate = 1; // TODO
-  await createTransactionsFromPaidExpense(host, expense, fees, fxRate, data);
+  const expenseToHostFxRate = (expense.currency !== host.currency && data.quote.rate) || 1;
+  await createTransactionsFromPaidExpense(host, expense, fees, expenseToHostFxRate, data);
   await expense.createActivity(activities.COLLECTIVE_EXPENSE_PROCESSING, remoteUser);
   await expense.setProcessing(remoteUser.id);
   return expense;

--- a/server/lib/transactions.ts
+++ b/server/lib/transactions.ts
@@ -142,7 +142,7 @@ export async function createTransactionsFromPaidExpense(
   fees: FEES_IN_HOST_CURRENCY = DEFAULT_FEES,
   /** Set this to a different value if the expense was paid in a currency that differs form the host's */
   expenseToHostFxRateConfig: number | 'auto',
-  /** Will be store in transaction.data */
+  /** Will be stored in transaction.data */
   transactionData: Record<string, unknown> = null,
   /** @deprecated Only used for paypal adaptive, to link the payment method */
   paymentMethod = null,

--- a/server/lib/transactions.ts
+++ b/server/lib/transactions.ts
@@ -151,12 +151,10 @@ export async function createTransactionsFromPaidExpense(
   expense.collective = expense.collective || (await models.Collective.findByPk(expense.CollectiveId));
 
   // Get the right FX rate for the expense
-  let expenseToHostFxRate;
-  if (expenseToHostFxRateConfig === 'auto') {
-    expenseToHostFxRate = await getFxRate(expense.currency, host.currency, expense.incurredAt || expense.createdAt);
-  } else {
-    expenseToHostFxRate = expenseToHostFxRateConfig;
-  }
+  const expenseToHostFxRate =
+    expenseToHostFxRateConfig === 'auto'
+      ? await getFxRate(expense.currency, host.currency, expense.incurredAt || expense.createdAt)
+      : expenseToHostFxRateConfig;
 
   // To group all the info we retrieved from the payment. All amounts are expected to be in expense currency
   const { paymentProcessorFeeInHostCurrency, hostFeeInHostCurrency, platformFeeInHostCurrency } = fees;

--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -100,7 +100,7 @@ export const checkBatchItemStatus = async (
           const paymentProcessorFeeInExpenseCurrency = floatAmountToCents(toNumber(item.payout_item_fee.value));
           fees['paymentProcessorFeeInHostCurrency'] = Math.round(paymentProcessorFeeInExpenseCurrency * fxRate);
           if (item.payout_item_fee.currency !== expense.currency) {
-            // payout_item_fee is always supposed to be in currency_conversion.to_amount.currency. This is a sanitiy check just in case
+            // payout_item_fee is always supposed to be in currency_conversion.to_amount.currency. This is a sanity check just in case
             logger.error(`Payout item fee currency does not match expense #${expense.id} currency`);
           }
         }

--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -2,13 +2,14 @@
 
 import { createHash } from 'crypto';
 
-import { isNil, round } from 'lodash';
+import { isNil, round, toNumber } from 'lodash';
 
 import activities from '../../constants/activities';
 import status from '../../constants/expense_status';
 import logger from '../../lib/logger';
+import { floatAmountToCents } from '../../lib/math';
 import * as paypal from '../../lib/paypal';
-import { createFromPaidExpense as createTransactionFromPaidExpense } from '../../lib/transactions';
+import { createTransactionsFromPaidExpense } from '../../lib/transactions';
 import models from '../../models';
 import { PayoutItemDetails } from '../../types/paypal';
 
@@ -27,7 +28,7 @@ export const payExpensesBatch = async (expenses: typeof models.Expense[]): Promi
 
   const host = await firstExpense.collective.getHostCollective();
   if (!host) {
-    throw new Error(`Could not find the host embursing the expense.`);
+    throw new Error(`Could not find the host reimbursing the expense.`);
   }
 
   const connectedAccount = await host.getAccountForPaymentProvider(providerName);
@@ -93,7 +94,18 @@ export const checkBatchItemStatus = async (
   switch (item.transaction_status) {
     case 'SUCCESS':
       if (expense.status !== status.PAID) {
-        await createTransactionFromPaidExpense(host, null, expense, null, expense.UserId, 0, 0, 0, item);
+        const fees = {};
+        const fxRate = 1 / (toNumber(item.currency_conversion?.exchange_rate) || 1);
+        if (item.payout_item_fee) {
+          const paymentProcessorFeeInExpenseCurrency = floatAmountToCents(toNumber(item.payout_item_fee.value));
+          fees['paymentProcessorFeeInHostCurrency'] = Math.round(paymentProcessorFeeInExpenseCurrency * fxRate);
+          if (item.payout_item_fee.currency !== expense.currency) {
+            // payout_item_fee is always supposed to be in currency_conversion.to_amount.currency. This is a sanitiy check just in case
+            logger.error(`Payout item fee currency does not match expense #${expense.id} currency`);
+          }
+        }
+
+        await createTransactionsFromPaidExpense(host, expense, fees, fxRate, item);
         await expense.setPaid(expense.lastEditedById);
         const user = await models.User.findByPk(expense.lastEditedById);
         await expense.createActivity(activities.COLLECTIVE_EXPENSE_PAID, user);

--- a/server/types/paypal.ts
+++ b/server/types/paypal.ts
@@ -62,6 +62,11 @@ export type PayoutItemDetails = {
     sender_item_id: string;
   };
   time_processed: string;
+  currency_conversion?: {
+    to_amount: { value: number; currency: string };
+    from_amount: { value: number; currency: string };
+    exchange_rate: string;
+  };
   errors?: {
     name: string;
     debug_id: string;

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -1386,8 +1386,10 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         it('Pays the expense manually', async () => {
           const paymentProcessorFee = 100; // Expressed in collective currency
           const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
+          const payee = await fakeCollective({ name: 'Payee', HostCollectiveId: null });
           const expense = await fakeExpense({
             amount: 1000,
+            FromCollectiveId: payee.id,
             CollectiveId: collective.id,
             status: 'APPROVED',
             PayoutMethodId: payoutMethod.id,
@@ -1454,8 +1456,8 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         it('Records a manual payment with an active account', async () => {
           const paymentProcessorFee = 100; // Expressed in collective currency
           const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
-          const payeeHost = await fakeHost({ currency: 'NZD' });
-          const payee = await fakeCollective({ HostCollectiveId: payeeHost.id });
+          const payeeHost = await fakeHost({ currency: 'NZD', name: 'PayeeHost' });
+          const payee = await fakeCollective({ name: 'Payee', HostCollectiveId: payeeHost.id });
           const expense = await fakeExpense({
             amount: 1000,
             FromCollectiveId: payee.id,

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js.snap
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`server/graphql/v2/mutation/ExpenseMutations processExpense PAY Multi-currency expense Pays the expense manually 1`] = `
+"
+| type   | amount | netAmountInCollectiveCurrency | paymentFee | currency | hostCurrency | hostCurrencyFxRate | To                | From              | Host | isRefund |
+| ------ | ------ | ----------------------------- | ---------- | -------- | ------------ | ------------------ | ----------------- | ----------------- | ---- | -------- |
+| CREDIT | 1200   | 1100                          | -100       | USD      | USD          | 1                  | User Namee9d4b7cb | Babel             | NULL | false    |
+| DEBIT  | -1100  | -1200                         | -100       | USD      | USD          | 1                  | Babel             | User Namee9d4b7cb | OSC  | false    |"
+`;
+
+exports[`server/graphql/v2/mutation/ExpenseMutations processExpense PAY Multi-currency expense Records a manual payment with an active account 1`] = `
+"
+| type   | amount | netAmountInCollectiveCurrency | paymentFee | currency | hostCurrency | hostCurrencyFxRate | To                       | From                     | Host               | isRefund |
+| ------ | ------ | ----------------------------- | ---------- | -------- | ------------ | ------------------ | ------------------------ | ------------------------ | ------------------ | -------- |
+| CREDIT | 1200   | 1100                          | -110       | USD      | NZD          | 1.1                | Test Collective c022fe84 | Babel                    | Test Host f3175a47 | false    |
+| DEBIT  | -1100  | -1200                         | -100       | USD      | USD          | 1                  | Babel                    | Test Collective c022fe84 | OSC                | false    |"
+`;
+
 exports[`server/graphql/v2/mutation/ExpenseMutations processExpense PAY pays 100% of the balance by putting the fees on the payee 1`] = `
 "
 | type   | kind    | isRefund | To       | From     | amount | amountInHostCurrency | paymentFee | netAmountInCollectiveCurrency |

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js.snap
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js.snap
@@ -2,18 +2,18 @@
 
 exports[`server/graphql/v2/mutation/ExpenseMutations processExpense PAY Multi-currency expense Pays the expense manually 1`] = `
 "
-| type   | amount | netAmountInCollectiveCurrency | paymentFee | currency | hostCurrency | hostCurrencyFxRate | To                | From              | Host | isRefund |
-| ------ | ------ | ----------------------------- | ---------- | -------- | ------------ | ------------------ | ----------------- | ----------------- | ---- | -------- |
-| CREDIT | 1200   | 1100                          | -100       | USD      | USD          | 1                  | User Namee9d4b7cb | Babel             | NULL | false    |
-| DEBIT  | -1100  | -1200                         | -100       | USD      | USD          | 1                  | Babel             | User Namee9d4b7cb | OSC  | false    |"
+| type   | amount | netAmountInCollectiveCurrency | paymentFee | currency | hostCurrency | hostCurrencyFxRate | To    | From  | Host | isRefund |
+| ------ | ------ | ----------------------------- | ---------- | -------- | ------------ | ------------------ | ----- | ----- | ---- | -------- |
+| CREDIT | 1200   | 1100                          | -100       | USD      | USD          | 1                  | Payee | Babel | NULL | false    |
+| DEBIT  | -1100  | -1200                         | -100       | USD      | USD          | 1                  | Babel | Payee | OSC  | false    |"
 `;
 
 exports[`server/graphql/v2/mutation/ExpenseMutations processExpense PAY Multi-currency expense Records a manual payment with an active account 1`] = `
 "
-| type   | amount | netAmountInCollectiveCurrency | paymentFee | currency | hostCurrency | hostCurrencyFxRate | To                       | From                     | Host               | isRefund |
-| ------ | ------ | ----------------------------- | ---------- | -------- | ------------ | ------------------ | ------------------------ | ------------------------ | ------------------ | -------- |
-| CREDIT | 1200   | 1100                          | -110       | USD      | NZD          | 1.1                | Test Collective c022fe84 | Babel                    | Test Host f3175a47 | false    |
-| DEBIT  | -1100  | -1200                         | -100       | USD      | USD          | 1                  | Babel                    | Test Collective c022fe84 | OSC                | false    |"
+| type   | amount | netAmountInCollectiveCurrency | paymentFee | currency | hostCurrency | hostCurrencyFxRate | To    | From  | Host      | isRefund |
+| ------ | ------ | ----------------------------- | ---------- | -------- | ------------ | ------------------ | ----- | ----- | --------- | -------- |
+| CREDIT | 1200   | 1100                          | -110       | USD      | NZD          | 1.1                | Payee | Babel | PayeeHost | false    |
+| DEBIT  | -1100  | -1200                         | -100       | USD      | USD          | 1                  | Babel | Payee | OSC       | false    |"
 `;
 
 exports[`server/graphql/v2/mutation/ExpenseMutations processExpense PAY pays 100% of the balance by putting the fees on the payee 1`] = `

--- a/test/server/paymentProviders/paypal/payouts.test.js
+++ b/test/server/paymentProviders/paypal/payouts.test.js
@@ -188,7 +188,7 @@ describe('paymentMethods/paypal/payouts.js', () => {
 
       expect(paypalLib.getBatchInfo.getCall(0)).to.have.property('lastArg', 'fake-batch-id-eur');
       expect(expense).to.have.property('status', 'PAID');
-      expect(transaction).to.have.property('paymentProcessorFeeInHostCurrency', -150);
+      expect(transaction).to.have.property('paymentProcessorFeeInHostCurrency', -150); // 1.20 / 0.8
       expect(transaction).to.have.property('amountInHostCurrency', -12500);
       expect(transaction).to.have.property('hostCurrency', 'USD');
       expect(transaction).to.have.property('netAmountInCollectiveCurrency', -10120);

--- a/test/server/paymentProviders/paypal/payouts.test.js
+++ b/test/server/paymentProviders/paypal/payouts.test.js
@@ -8,7 +8,13 @@ import status from '../../../../server/constants/expense_status';
 import * as paypalLib from '../../../../server/lib/paypal';
 import { PayoutMethodTypes } from '../../../../server/models/PayoutMethod';
 import * as paypalPayouts from '../../../../server/paymentProviders/paypal/payouts';
-import { fakeCollective, fakeConnectedAccount, fakeExpense, fakePayoutMethod } from '../../../test-helpers/fake-data';
+import {
+  fakeCollective,
+  fakeConnectedAccount,
+  fakeExpense,
+  fakeHost,
+  fakePayoutMethod,
+} from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
 describe('paymentMethods/paypal/payouts.js', () => {
@@ -21,14 +27,14 @@ describe('paymentMethods/paypal/payouts.js', () => {
   describe('payExpensesBatch', () => {
     let expense, host, collective, payoutMethod;
     beforeEach(async () => {
-      host = await fakeCollective({ isHostAccount: true });
+      host = await fakeHost({ currency: 'USD' });
       await fakeConnectedAccount({
         CollectiveId: host.id,
         service: 'paypal',
         clientId: 'fake',
         token: 'fake',
       });
-      collective = await fakeCollective({ HostCollectiveId: host.id });
+      collective = await fakeCollective({ HostCollectiveId: host.id, currency: 'USD' });
       payoutMethod = await fakePayoutMethod({
         type: PayoutMethodTypes.PAYPAL,
         data: {
@@ -144,6 +150,54 @@ describe('paymentMethods/paypal/payouts.js', () => {
     });
 
     it('work with cross-currency collectives', async () => {
+      const collectiveInEur = await fakeCollective({ currency: 'EUR', HostCollectiveId: host.id });
+      const expense = await fakeExpense({
+        status: status.PROCESSING,
+        amount: 10000,
+        CollectiveId: collectiveInEur.id,
+        currency: 'EUR',
+        PayoutMethodId: payoutMethod.id,
+        category: 'Engineering',
+        type: 'INVOICE',
+        description: 'May Invoice',
+        data: { payout_batch_id: 'fake-batch-id-eur' },
+      });
+      expense.collective = collectiveInEur;
+
+      paypalLib.getBatchInfo.resolves({
+        items: [
+          {
+            transaction_status: 'SUCCESS',
+            payout_item: { sender_item_id: expense.id.toString() },
+            payout_batch_id: 'fake-batch-id-eur',
+            payout_item_fee: {
+              currency: 'EUR',
+              value: '1.20',
+            },
+            currency_conversion: {
+              to_amount: { value: '100.00', currency: 'EUR' },
+              from_amount: { value: '125.00', currency: 'USD' },
+              exchange_rate: '0.80',
+            },
+          },
+        ],
+      });
+
+      await paypalPayouts.checkBatchStatus([expense]);
+      const [transaction] = await expense.getTransactions({ where: { type: 'DEBIT' } });
+
+      expect(paypalLib.getBatchInfo.getCall(0)).to.have.property('lastArg', 'fake-batch-id-eur');
+      expect(expense).to.have.property('status', 'PAID');
+      expect(transaction).to.have.property('paymentProcessorFeeInHostCurrency', -150);
+      expect(transaction).to.have.property('amountInHostCurrency', -12500);
+      expect(transaction).to.have.property('hostCurrency', 'USD');
+      expect(transaction).to.have.property('netAmountInCollectiveCurrency', -10120);
+      expect(transaction).to.have.property('currency', collectiveInEur.currency); // EUR
+      expect(transaction).to.have.property('amount', -10000); // EUR
+    });
+
+    it("work with cross-currency expense (but collective's still using host currency)", async () => {
+      // Here expense=EUR, collective=USD, host=USD
       const expense = await fakeExpense({
         status: status.PROCESSING,
         amount: 10000,
@@ -168,24 +222,32 @@ describe('paymentMethods/paypal/payouts.js', () => {
               value: '1.20',
             },
             currency_conversion: {
-              to_amount: { value: '99.312', currency: 'EUR' },
-              from_amount: { value: '124.14', currency: 'USD' },
+              to_amount: { value: '100.00', currency: 'EUR' },
+              from_amount: { value: '125.00', currency: 'USD' },
               exchange_rate: '0.80',
             },
           },
         ],
       });
 
+      const paymentProcessorFeeInExpenseCurrency = 120; // As defined in the mock
+      const paymentProcessorFeeInHostCurrency = paymentProcessorFeeInExpenseCurrency / 0.8;
+      const expenseAmountInHostCurrency = expense.amount / 0.8;
+
       await paypalPayouts.checkBatchStatus([expense]);
       const [transaction] = await expense.getTransactions({ where: { type: 'DEBIT' } });
 
       expect(paypalLib.getBatchInfo.getCall(0)).to.have.property('lastArg', 'fake-batch-id-eur');
       expect(expense).to.have.property('status', 'PAID');
-      expect(transaction).to.have.property('paymentProcessorFeeInHostCurrency', -150);
+      expect(transaction).to.have.property('paymentProcessorFeeInHostCurrency', -paymentProcessorFeeInHostCurrency);
       expect(transaction).to.have.property('amountInHostCurrency', -12500);
       expect(transaction).to.have.property('hostCurrency', 'USD');
-      expect(transaction).to.have.property('netAmountInCollectiveCurrency', -10120);
-      expect(transaction).to.have.property('currency', 'EUR');
+      expect(transaction).to.have.property('currency', collective.currency); // USD
+      expect(transaction).to.have.property('amount', -12500); // USD
+      expect(transaction).to.have.property(
+        'netAmountInCollectiveCurrency',
+        -expenseAmountInHostCurrency - paymentProcessorFeeInHostCurrency,
+      );
     });
 
     const failedStatuses = ['FAILED', 'BLOCKED', 'REFUNDED', 'RETURNED', 'REVERSED'];


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-frontend/pull/7520
Part of https://github.com/opencollective/opencollective/issues/5146#issuecomment-1023321220

This PR includes a refactor of the way we record paid expenses.

**Why**
While implementing support for multi-currency expenses, I realized that the code supposed to check for the payment response (to get the fees and FX rate) was split in multiple places. Some of it was living under the payment provider libraries, and some of it was living under `server/lib/transactions.js` > `createFromPaidExpense`. [Here](https://github.com/opencollective/opencollective-api/blob/a486075c7ebd7a5ac9620e78f51c1765e8fac6fa/server/lib/transactions.js#L93) for example, we were parsing PayPal response, it seems out of the responsibility scope for a function that's supposed to "create transactions from paid expenses".

Multi-currency expenses required some changes in the way we handle these amounts (especially regarding FX rates) and my first implementation quickly became messy, with duplicated code in multiple places.

**How**
Though affecting multiple places, the refactor described below is quite simple in its essence: make `createTransactionsFromPaidExpense` agnostic of the payout method service. Its purpose should be solely about creating transactions from a paid expense, and the responsibility of parsing the payout provider response should be in the code of the payout providers libraries calling it.