### PR TITLE
Refactor Wise: throw pre-check errors synchronously

### DIFF
--- a/server/graphql/errors.ts
+++ b/server/graphql/errors.ts
@@ -87,7 +87,9 @@ export class PlanLimit extends ApolloError {
 export class TransferwiseError extends ApolloError {
   constructor(message?: string, code?: string, additionalProperties?: Record<string, unknown>) {
     super(
-      message || 'An unknown error happened with TransferWise. Please contact support@opencollective.com.',
+      message
+        ? `Wise: ${message}`
+        : 'An unknown error happened with TransferWise. Please contact support@opencollective.com.',
       code || 'transferwise.error.default',
       additionalProperties,
     );


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/5253

I'm moving some Wise `createTransaction` pre-checks outside the try/catch that reports errors asynchronously.

I think there's still value in moving the Expense to error and generating activity with more information for the user, but this pre-check is mainly related to the Host and it makes more sense to deliver the error synchronously as a toast to the host admin paying/scheduling the expense.