### PR TITLE
Fix ExpensesQuery CREDIT_CARD payout method resolver

### DIFF
--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -219,7 +219,7 @@ const ExpensesCollectionQuery = {
     }
 
     if (args.payoutMethodType === 'CREDIT_CARD') {
-      where[Op.and].push(sequelize.literal(`("VirtualCardId" IS NOT NULL)`));
+      where[Op.and].push({ VirtualCardId: { [Op.not]: null } });
     } else if (args.payoutMethodType) {
       include.push({
         association: 'PayoutMethod',

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -217,7 +217,10 @@ const ExpensesCollectionQuery = {
       where['createdAt'] = where['createdAt'] || {};
       where['createdAt'][Op.lte] = args.dateTo;
     }
-    if (args.payoutMethodType) {
+
+    if (args.payoutMethodType === 'CREDIT_CARD') {
+      where[Op.and].push(sequelize.literal(`("VirtualCardId" IS NOT NULL)`));
+    } else if (args.payoutMethodType) {
       include.push({
         association: 'PayoutMethod',
         attributes: [],


### PR DESCRIPTION
Since there's no CREDIT_CARD Payout Method whatsoever, we should either get rid of this option in the filter or implement a compatible logic in the resolver.

Considering we're displaying the CREDIT_CARD as the Payout Method on the Expense page, and we have no other place to display that information, I'm picking the former and implementing a special condition in the resolver for now.