### PR TITLE
Fix memberOf query when `includeIncognito` is true

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1331,15 +1331,15 @@ const CollectiveFields = () => {
         if (roles && roles.length > 0) {
           where.role = { [Op.in]: roles };
         }
-        const collectiveConditions = { deletedAt: null, isIncognito: false };
+        const collectiveConditions = {};
         if (args.type) {
           collectiveConditions.type = args.type;
         }
         if (args.onlyActiveCollectives) {
           collectiveConditions.isActive = true;
         }
-        if (args.includeIncognito && (req.remoteUser?.isAdmin(collective.id) || req.remoteUser?.isRoot())) {
-          collectiveConditions.isIncognito = true;
+        if (!args.includeIncognito || !(req.remoteUser?.isAdmin(collective.id) || req.remoteUser?.isRoot())) {
+          collectiveConditions.isIncognito = false; // only admins can see incognito profiles
         }
         return models.Member.findAll({
           where,


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5311
Introduced in https://github.com/opencollective/opencollective-api/pull/7023

Some queries were broken by the update in https://github.com/opencollective/opencollective-api/pull/7023 that invalidly filtered results to get only the incognito profiles.