### PR TITLE
PayPal: add script command to get payout info

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -224,6 +224,10 @@ export function setupModels() {
     foreignKey: 'FromCollectiveId',
     as: 'fromCollective',
   });
+  m.Expense.belongsTo(m.Collective, {
+    foreignKey: 'HostCollectiveId',
+    as: 'host',
+  });
   m.Expense.belongsTo(m.VirtualCard, {
     foreignKey: 'VirtualCardId',
     as: 'virtualCard',


### PR DESCRIPTION
PayPal has strange conditions to sign-in. Implementing a script so we don't have to rely on their clanky web interface to get more information about a transaction.