### PR TITLE
Revert "Guest: Don't change slug when validating the account"

### DIFF
--- a/server/lib/guest-accounts.ts
+++ b/server/lib/guest-accounts.ts
@@ -137,6 +137,7 @@ export const confirmGuestAccount = async (
   const newName = userCollective.name !== DEFAULT_GUEST_NAME ? userCollective.name : 'Incognito';
   userCollective = await userCollective.update({
     name: newName,
+    slug: newName === 'Incognito' ? `user-${uuid().split('-')[0]}` : await models.Collective.generateSlug([newName]),
     data: { ...userCollective.data, isGuest: false, wasGuest: true },
   });
 

--- a/test/server/lib/guest-accounts.test.ts
+++ b/test/server/lib/guest-accounts.test.ts
@@ -95,7 +95,7 @@ describe('server/lib/guest-accounts.ts', () => {
       await user.reload({ include: [{ association: 'collective' }] });
       expect(user.confirmedAt).to.not.be.null;
       expect(user.collective.name).to.eq('Incognito');
-      expect(user.collective.slug).to.include('guest-'); // slug doesn't get updated
+      expect(user.collective.slug).to.include('user-');
     });
 
     it('verifies the account and updates the profile for users that already filled their profiles', async () => {
@@ -107,7 +107,7 @@ describe('server/lib/guest-accounts.ts', () => {
       await user.reload({ include: [{ association: 'collective' }] });
       expect(user.confirmedAt).to.not.be.null;
       expect(user.collective.name).to.eq('Zappa');
-      expect(user.collective.slug).to.include('guest'); // slug doesn't get updated
+      expect(user.collective.slug).to.include('zappa');
     });
   });
 });


### PR DESCRIPTION
Reverts opencollective/opencollective-api#6468
Resolve https://github.com/opencollective/opencollective/issues/4876