### PR TITLE
Unified search helper between orders/expenses/transactions

### DIFF
--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -178,6 +178,7 @@ const ExpensesCollectionQuery = {
       idFields: ['id'],
       slugFields: ['$fromCollective.slug$', '$User.collective.slug$'],
       textFields: ['$fromCollective.name$', '$User.collective.name$', 'description'],
+      amountFields: ['amount'],
       stringArrayFields: ['tags'],
       stringArrayTransformFn: (str: string) => str.toLowerCase(), // expense tags are stored lowercase
     });

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -7,6 +7,7 @@ import { expenseStatus } from '../../../../constants';
 import EXPENSE_TYPE from '../../../../constants/expense_type';
 import { getBalancesWithBlockedFunds } from '../../../../lib/budget';
 import queries from '../../../../lib/queries';
+import { buildSearchConditions } from '../../../../lib/search';
 import models, { Op, sequelize } from '../../../../models';
 import { PayoutMethodTypes } from '../../../../models/PayoutMethod';
 import { ExpenseCollection } from '../../collection/ExpenseCollection';
@@ -172,29 +173,21 @@ const ExpensesCollectionQuery = {
     }
 
     // Add search filter
-    if (args.searchTerm) {
-      const sanitizedTerm = args.searchTerm.replace(/(_|%|\\)/g, '\\$1');
-      const ilikeQuery = `%${sanitizedTerm}%`;
-      where[Op.or] = [
-        { description: { [Op.iLike]: ilikeQuery } },
-        { tags: { [Op.overlap]: [args.searchTerm.toLowerCase()] } },
-        { '$fromCollective.slug$': { [Op.iLike]: ilikeQuery } },
-        { '$fromCollective.name$': { [Op.iLike]: ilikeQuery } },
-        { '$User.collective.slug$': { [Op.iLike]: ilikeQuery } },
-        { '$User.collective.name$': { [Op.iLike]: ilikeQuery } },
-        // { '$items.description$': { [Op.iLike]: ilikeQuery } },
-      ];
+    // Not searching in items yet because one-to-many relationships with limits are broken in Sequelize. Could be fixed by https://github.com/sequelize/sequelize/issues/4376
+    const searchTermConditions = buildSearchConditions(args.searchTerm, {
+      idFields: ['id'],
+      slugFields: ['$fromCollective.slug$', '$User.collective.slug$'],
+      textFields: ['$fromCollective.name$', '$User.collective.name$', 'description'],
+      stringArrayFields: ['tags'],
+      stringArrayTransformFn: (str: string) => str.toLowerCase(), // expense tags are stored lowercase
+    });
 
+    if (searchTermConditions.length) {
+      where[Op.or] = searchTermConditions;
       include.push(
         { association: 'fromCollective', attributes: [] },
         { association: 'User', attributes: [], include: [{ association: 'collective', attributes: [] }] },
-        // One-to-many relationships with limits are broken in Sequelize. Could be fixed by https://github.com/sequelize/sequelize/issues/4376
-        // { association: 'items', duplicating: false, attributes: [], separate: true },
       );
-
-      if (!isNaN(args.searchTerm)) {
-        where[Op.or].push({ id: args.searchTerm });
-      }
     }
 
     // Add filters

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -156,6 +156,9 @@ export const OrdersCollectionResolver = async (args, req: express.Request) => {
     idFields: ['id'],
     slugFields: ['$fromCollective.slug$', '$collective.slug$'],
     textFields: ['$fromCollective.name$', '$collective.name$', 'description'],
+    amountFields: ['totalAmount'],
+    stringArrayFields: ['tags'],
+    stringArrayTransformFn: (str: string) => str.toLowerCase(), // expense tags are stored lowercase
   });
 
   if (searchTermConditions.length) {

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -3,6 +3,7 @@ import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString 
 import { GraphQLDateTime } from 'graphql-scalars';
 import { Includeable } from 'sequelize';
 
+import { buildSearchConditions } from '../../../../lib/search';
 import models, { Op } from '../../../../models';
 import { NotFound } from '../../../errors';
 import { OrderCollection } from '../../collection/OrderCollection';
@@ -151,28 +152,14 @@ export const OrdersCollectionResolver = async (args, req: express.Request) => {
   }
 
   // Add search filter
-  if (args.searchTerm) {
-    const searchConditions = [];
-    const searchedId = args.searchTerm.match(/^#?(\d+)$/)?.[1];
+  const searchTermConditions = buildSearchConditions(args.searchTerm, {
+    idFields: ['id'],
+    slugFields: ['$fromCollective.slug$', '$collective.slug$'],
+    textFields: ['$fromCollective.name$', '$collective.name$', 'description'],
+  });
 
-    // If search term starts with a `#`, only search by ID
-    if (args.searchTerm[0] !== '#' || !searchedId) {
-      const sanitizedTerm = args.searchTerm.replace(/(_|%|\\)/g, '\\$1');
-      const ilikeQuery = `%${sanitizedTerm}%`;
-      searchConditions.push(
-        { description: { [Op.iLike]: ilikeQuery } },
-        { '$fromCollective.slug$': { [Op.iLike]: ilikeQuery } },
-        { '$fromCollective.name$': { [Op.iLike]: ilikeQuery } },
-        { '$collective.slug$': { [Op.iLike]: ilikeQuery } },
-        { '$collective.name$': { [Op.iLike]: ilikeQuery } },
-      );
-    }
-
-    if (searchedId) {
-      searchConditions.push({ id: parseInt(searchedId) });
-    }
-
-    where[Op.and].push({ [Op.or]: searchConditions });
+  if (searchTermConditions.length) {
+    where[Op.and].push({ [Op.or]: searchTermConditions });
   }
 
   // Add filters

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -230,6 +230,7 @@ export const TransactionsCollectionResolver = async (args, req: express.Request)
     idFields: ['id'],
     slugFields: ['$fromCollective.slug$', '$collective.slug$'],
     textFields: ['$fromCollective.name$', '$collective.name$', 'description'],
+    amountFields: ['amount', 'netAmountInHostCurrency'],
   });
 
   if (searchTermConditions.length) {

--- a/test/server/lib/search.test.js
+++ b/test/server/lib/search.test.js
@@ -2,7 +2,13 @@ import { expect } from 'chai';
 import config from 'config';
 
 import { CollectiveType } from '../../../server/graphql/v1/CollectiveInterface';
-import { searchCollectivesByEmail, searchCollectivesInDB } from '../../../server/lib/search';
+import {
+  buildSearchConditions,
+  parseSearchTerm,
+  searchCollectivesByEmail,
+  searchCollectivesInDB,
+} from '../../../server/lib/search';
+import { Op } from '../../../server/models';
 import { newUser } from '../../stores';
 import { fakeCollective, fakeUser } from '../../test-helpers/fake-data';
 import { resetTestDB } from '../../utils';
@@ -87,6 +93,131 @@ describe('server/lib/search', () => {
       const [results, count] = await searchCollectivesByEmail(user.email, user);
       expect(count).to.eq(1);
       expect(results.find(collective => collective.id === userCollective.id)).to.exist;
+    });
+  });
+
+  describe('parseSearchTerm', () => {
+    it('detects IDs', () => {
+      expect(parseSearchTerm('#123')).to.deep.equal({ type: 'id', term: 123 });
+    });
+
+    it('detects slugs', () => {
+      expect(parseSearchTerm('@test')).to.deep.equal({ type: 'slug', term: 'test' });
+      expect(parseSearchTerm('@test-hyphen')).to.deep.equal({ type: 'slug', term: 'test-hyphen' });
+    });
+
+    it('detects numbers', () => {
+      expect(parseSearchTerm('42')).to.deep.equal({ type: 'number', term: 42, isFloat: false });
+      expect(parseSearchTerm('42.')).to.deep.equal({ type: 'number', term: 42, isFloat: true });
+      expect(parseSearchTerm('42.64')).to.deep.equal({ type: 'number', term: 42.64, isFloat: true });
+    });
+
+    it('goes back to text for everything else', () => {
+      expect(parseSearchTerm('')).to.deep.equal({ type: 'text', term: '' });
+      expect(parseSearchTerm('test')).to.deep.equal({ type: 'text', term: 'test' });
+      expect(parseSearchTerm('test-hyphen')).to.deep.equal({ type: 'text', term: 'test-hyphen' });
+      expect(parseSearchTerm('#4242 not an id')).to.deep.equal({ type: 'text', term: '#4242 not an id' });
+      expect(parseSearchTerm('@slug not a slug')).to.deep.equal({ type: 'text', term: '@slug not a slug' });
+    });
+  });
+
+  describe('buildSearchConditions', () => {
+    const TEST_FIELDS_CONFIGURATION = {
+      slugFields: ['slug', '$fromCollective.slug$'],
+      idFields: ['id', '$fromCollective.id$'],
+      textFields: ['name', '$fromCollective.name$'],
+      amountFields: ['amount', '$order.totalAmount$'],
+      stringArrayFields: ['tags'],
+    };
+
+    const testBuildSearchConditionsWithCustomConfig = (searchTerm, fieldsConfig, options) => {
+      const conditions = buildSearchConditions(searchTerm, fieldsConfig, options);
+      conditions.forEach(condition => {
+        Object.keys(condition).forEach(field => {
+          // We must operators like the ILIKE operator, as toString/expect is not parsing these flag
+          if (condition[field][Op.iLike]) {
+            condition[field]['ILIKE'] = condition[field][Op.iLike];
+          }
+          if (condition[field][Op.overlap]) {
+            condition[field]['OVERLAP'] = condition[field][Op.overlap];
+          }
+        });
+      });
+
+      return conditions;
+    };
+
+    const testBuildSearchConditions = (searchTerm, expectedResults) => {
+      return testBuildSearchConditionsWithCustomConfig(
+        searchTerm,
+        TEST_FIELDS_CONFIGURATION,
+        undefined,
+        expectedResults,
+      );
+    };
+
+    it('returns no condition for an empty search', () => {
+      expect(testBuildSearchConditions('')).to.deep.eq([]);
+    });
+
+    it('build conditions for IDs', () => {
+      expect(testBuildSearchConditions('#4242')).to.deep.eq([{ id: 4242 }, { '$fromCollective.id$': 4242 }]);
+    });
+
+    it('build conditions for slugs', () => {
+      expect(testBuildSearchConditions('@betree')).to.deep.eq([
+        { slug: 'betree' },
+        { '$fromCollective.slug$': 'betree' },
+      ]);
+    });
+
+    it('build conditions for numbers', () => {
+      expect(testBuildSearchConditions('4242')).to.deep.eq([
+        { slug: { ILIKE: '%4242%' } },
+        { '$fromCollective.slug$': { ILIKE: '%4242%' } },
+        { name: { ILIKE: '%4242%' } },
+        { '$fromCollective.name$': { ILIKE: '%4242%' } },
+        { tags: { OVERLAP: ['4242'] } },
+        { id: 4242 },
+        { '$fromCollective.id$': 4242 },
+        { amount: 424200 },
+        { '$order.totalAmount$': 424200 },
+      ]);
+
+      expect(testBuildSearchConditions('4242.66')).to.deep.eq([
+        { slug: { ILIKE: '%4242.66%' } },
+        { '$fromCollective.slug$': { ILIKE: '%4242.66%' } },
+        { name: { ILIKE: '%4242.66%' } },
+        { '$fromCollective.name$': { ILIKE: '%4242.66%' } },
+        { tags: { OVERLAP: ['4242.66'] } },
+        { amount: 424266 },
+        { '$order.totalAmount$': 424266 },
+      ]);
+    });
+
+    it('build conditions for full text', () => {
+      expect(testBuildSearchConditions('   hello world   ')).to.deep.eq([
+        { slug: { ILIKE: '%hello world%' } },
+        { '$fromCollective.slug$': { ILIKE: '%hello world%' } },
+        { name: { ILIKE: '%hello world%' } },
+        { '$fromCollective.name$': { ILIKE: '%hello world%' } },
+        { tags: { OVERLAP: ['hello world'] } },
+      ]);
+    });
+
+    it('can transform text for string arrays', () => {
+      const fieldsConfig = { stringArrayFields: ['tags'] };
+
+      // No transform: will only trim
+      expect(testBuildSearchConditionsWithCustomConfig('   hello   WorlD   ', fieldsConfig)).to.deep.eq([
+        { tags: { OVERLAP: ['hello WorlD'] } },
+      ]);
+
+      // Uppercase
+      const options = { stringArrayTransformFn: value => value.toUpperCase() };
+      expect(testBuildSearchConditionsWithCustomConfig('   hello   WorlD   ', fieldsConfig, options)).to.deep.eq([
+        { tags: { OVERLAP: ['HELLO WORLD'] } },
+      ]);
     });
   });
 });


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5362

Introduced a common helper to have the same behavior when searching for expenses/transactions/orders. It fixes the abovementioned issue, but the search behavior itself should have no change.