### PR TITLE
Extend search capacities for orders/transactions/expenses

### DIFF
--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -178,6 +178,7 @@ const ExpensesCollectionQuery = {
       idFields: ['id'],
       slugFields: ['$fromCollective.slug$', '$User.collective.slug$'],
       textFields: ['$fromCollective.name$', '$User.collective.name$', 'description'],
+      amountFields: ['amount'],
       stringArrayFields: ['tags'],
       stringArrayTransformFn: (str: string) => str.toLowerCase(), // expense tags are stored lowercase
     });

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -156,6 +156,9 @@ export const OrdersCollectionResolver = async (args, req: express.Request) => {
     idFields: ['id'],
     slugFields: ['$fromCollective.slug$', '$collective.slug$'],
     textFields: ['$fromCollective.name$', '$collective.name$', 'description'],
+    amountFields: ['totalAmount'],
+    stringArrayFields: ['tags'],
+    stringArrayTransformFn: (str: string) => str.toLowerCase(), // expense tags are stored lowercase
   });
 
   if (searchTermConditions.length) {

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -230,6 +230,7 @@ export const TransactionsCollectionResolver = async (args, req: express.Request)
     idFields: ['id'],
     slugFields: ['$fromCollective.slug$', '$collective.slug$'],
     textFields: ['$fromCollective.name$', '$collective.name$', 'description'],
+    amountFields: ['amount', 'netAmountInHostCurrency'],
   });
 
   if (searchTermConditions.length) {


### PR DESCRIPTION
Requires https://github.com/opencollective/opencollective-api/pull/7321

Examples:
- Searching for `20` will return all expenses where the amount is $20
- `hacktoberfest` will return all orders made for hacktoberfest