### PR TITLE
Misc improvements on multi-currency expenses FX rate

### DIFF
--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -53,6 +53,8 @@ export const loaders = req => {
     cache,
   );
   context.loaders.Expense.requiredLegalDocuments = expenseLoaders.requiredLegalDocuments(req, cache);
+  context.loaders.Expense.expenseToHostTransactionFxRateLoader =
+    expenseLoaders.generateExpenseToHostTransactionFxRateLoader(req, cache);
 
   // Payout method
   context.loaders.PayoutMethod.paypalByCollectiveId = generateCollectivePaypalPayoutMethodsLoader(req, cache);

--- a/server/lib/transactions.ts
+++ b/server/lib/transactions.ts
@@ -183,7 +183,7 @@ export async function createTransactionsFromPaidExpense(
     FromCollectiveId: expense.FromCollectiveId,
     HostCollectiveId: host.id,
     PaymentMethodId: paymentMethod ? paymentMethod.id : null,
-    data: transactionData,
+    data: set(transactionData || {}, 'expenseToHostFxRate', expenseToHostFxRate),
   };
 
   // If the payee is assuming the fees, we adapt the amounts

--- a/test/test-helpers/fake-data.js
+++ b/test/test-helpers/fake-data.js
@@ -301,6 +301,9 @@ export const fakeExpense = async (expenseData = {}) => {
   }
 
   expense.User = await models.User.findByPk(expense.UserId);
+  expense.collective = await models.Collective.findByPk(expense.CollectiveId, {
+    include: [{ association: 'host' }],
+  });
   return expense;
 };
 


### PR DESCRIPTION
- Mark rates as not approximate when retrieved from Wise/PayPal payments info
- Store/fetch rates in transactions as not approximate values