### PR TITLE
fix: update `nextChargeDate` while updating recurring contribution interval

### DIFF
--- a/server/lib/subscriptions.ts
+++ b/server/lib/subscriptions.ts
@@ -151,6 +151,25 @@ export const updateSubscriptionDetails = async (
     newSubscriptionData['interval'] = tier.interval;
   }
 
+  // Update next charge date
+  if (newOrderData['interval']) {
+    const previousInterval = order.interval;
+    const newInterval = newOrderData['interval'];
+    const previousNextChargeDate = moment(order.Subscription.nextChargeDate);
+    let nextChargeDate;
+
+    if (previousInterval === 'month' && newInterval === 'year') {
+      nextChargeDate = moment().add(1, 'years').startOf('year');
+    } else if (previousInterval === 'year' && newInterval === 'month') {
+      nextChargeDate = getNextChargeDateForUpdateFromExternalToInternal(previousNextChargeDate);
+    }
+
+    if (nextChargeDate) {
+      newSubscriptionData['nextChargeDate'] = nextChargeDate.toDate();
+      newSubscriptionData['nextPeriodStart'] = nextChargeDate.toDate();
+    }
+  }
+
   // Update order's Tier
   const newTierId = tier?.id || null;
   if (newTierId !== order.TierId) {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5297

- [x] When updating from monthly to yearly: next charge date should be set to 1st January of next year
- [x] When updating from yearly to monthly
  - If the last charge was before the 15th of the month: the next charge date should be set to the 1st of next month
  - If the last charge was after the 15th of the month: the next charge date should be set to the 1st of the month after next month