### PR TITLE
Fix: scheduleExpenseForPayment throw if PayPal is not connected

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -549,6 +549,10 @@ export const scheduleExpenseForPayment = async (
   if (payoutMethod.type === PayoutMethodTypes.BANK_ACCOUNT) {
     await paymentProviders.transferwise.scheduleExpenseForPayment(expense);
   }
+  // If PayPal, check if host is connected to PayPal
+  else if (payoutMethod.type === PayoutMethodTypes.PAYPAL) {
+    await host.getAccountForPaymentProvider('paypal');
+  }
 
   const updatedExpense = await expense.update({
     status: expenseStatus.SCHEDULED_FOR_PAYMENT,

--- a/server/graphql/common/features.ts
+++ b/server/graphql/common/features.ts
@@ -191,6 +191,15 @@ export const getFeatureStatusResolver =
           ? FEATURE_STATUS.ACTIVE // TODO: This flag is misused, there's a confusion between ACTIVE and AVAILABLE
           : FEATURE_STATUS.DISABLED;
       }
+      case FEATURE.PAYPAL_PAYOUTS: {
+        const hasConnectedAccount = await models.ConnectedAccount.count({
+          where: { service: 'paypal', CollectiveId: collective.id },
+          limit: 1,
+        });
+        return hasFeature(collective, FEATURE.PAYPAL_PAYOUTS) && hasConnectedAccount
+          ? FEATURE_STATUS.ACTIVE
+          : FEATURE_STATUS.DISABLED;
+      }
       default:
         return FEATURE_STATUS.ACTIVE;
     }

--- a/server/graphql/common/features.ts
+++ b/server/graphql/common/features.ts
@@ -196,9 +196,7 @@ export const getFeatureStatusResolver =
           where: { service: 'paypal', CollectiveId: collective.id },
           limit: 1,
         });
-        return hasFeature(collective, FEATURE.PAYPAL_PAYOUTS) && hasConnectedAccount
-          ? FEATURE_STATUS.ACTIVE
-          : FEATURE_STATUS.DISABLED;
+        return hasConnectedAccount ? FEATURE_STATUS.ACTIVE : FEATURE_STATUS.DISABLED;
       }
       default:
         return FEATURE_STATUS.ACTIVE;


### PR DESCRIPTION
Adding a check before allowing a Host to schedule an expense for payment.
This covers the edge case where the Host requests access to the PayPal Payouts feature but does not connect to PayPal.
Keep in mind that we still allow users to submit PayPal expenses because the PayPal Adaptive Payment does not require a connected account.