### PR TITLE
Ignore some commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# style: eslint --fix and prettier
+bd115f4eed74484ab4cee076711c027eab7b1a05


### PR DESCRIPTION
`.git-blame-ignore-revs` is now [officially supported](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) on Github, this will make our lives easier when trying to find the origin of a change.

Ignored:
- https://github.com/opencollective/opencollective-api/pull/1450/commits/bd115f4eed74484ab4cee076711c027eab7b1a05