### PR TITLE
Use fixed version for Maildev

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,3 +228,10 @@ jobs:
         run: ./scripts/run_e2e_tests.sh
         env:
           CYPRESS_TEST_FILES: ${{ matrix.files }}
+
+      - name: Archive test screenshots
+        uses: actions/upload-artifact@v3
+        with:
+          name: screenshots
+          path: opencollective-frontend/test/cypress/screenshots
+        if: ${{ failure() }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8650,7 +8650,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "geoip-lite": "^1.4.2",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.4",
-    "maildev": "^1.1.0",
+    "maildev": "1.1.0",
     "markdown-table": "^2.0.0",
     "mocha": "^9.0.0",
     "nock": "^13.1.0",


### PR DESCRIPTION
Updated version seems to break our E2E tests:

```
   Running:  08-user.change-email.test.js                                                  (12 of 13)
[6326:0330/080152.797597:ERROR:bus.cc(392)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")


  Users can change their email address
error: GraphQL error: A user with that email already exists
error: {"locations":[{"line":2,"column":3}],"path":["updateUserEmail"]}
    ✓ uses a form in advanced settings (7594ms)
    1) sends a confirmation email to confirm the change
error: GraphQL error: Invalid email confirmation token
error: {"locations":[{"line":2,"column":3}],"path":["confirmUserEmail"]}
    ✓ shows an error if validation link is invalid/expired (703ms)
    2) can re-send the confirmation email


  2 passing (40s)
  2 failing

  1) Users can change their email address
       sends a confirmation email to confirm the change:
     AssertionError: Timed out retrying after 15000ms: Expected to find content: 'Confirm Email' within the selector: 'a' but never did.
      at Context.eval (http://localhost:3000/__cypress/tests?p=test/cypress/integration/08-user.change-email.test.js:975:8)

  2) Users can change their email address
       can re-send the confirmation email:
     AssertionError: Timed out retrying after 15000ms: Expected to find element: `[data-cy=EditUserEmailForm] input[name=email]`, but never found it.
      at Context.eval (http://localhost:3000/__cypress/tests?p=test/cypress/integration/08-user.change-email.test.js:991:8)
```