### PR TITLE
Fix GQL cache key variables for budget section query

### DIFF
--- a/server/graphql/cache.js
+++ b/server/graphql/cache.js
@@ -40,6 +40,7 @@ function getCacheKeyForBudgetOrTransactionsSections(req, queryHash) {
     req.body.variables.kind &&
     !isEqual(req.body.variables.kind.sort(), [
       TransactionKind.ADDED_FUNDS,
+      TransactionKind.BALANCE_TRANSFER,
       TransactionKind.CONTRIBUTION,
       TransactionKind.EXPENSE,
       TransactionKind.PLATFORM_TIP,


### PR DESCRIPTION
Also added a warning in https://github.com/opencollective/opencollective-frontend/pull/7655