### PR TITLE
Search: store ts vectors in Collectives table

### DIFF
--- a/migrations/20220404194326-store-search-ts-vector.js
+++ b/migrations/20220404194326-store-search-ts-vector.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    // Drop the existing search index
+    console.log('Dropping index...');
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "collective_search_index"
+    `);
+
+    // Not adding the column to the model itself, so we don't need to add it to the history
+    console.log('Adding TS Vector column...');
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Collectives"
+      ADD COLUMN "searchTsVector" tsvector
+      GENERATED ALWAYS AS (
+        SETWEIGHT(to_tsvector('simple', "slug"), 'A')
+        || SETWEIGHT(to_tsvector('simple', "name"), 'B')
+        || SETWEIGHT(to_tsvector('english', "name"), 'B')
+        || SETWEIGHT(to_tsvector('english', COALESCE("description", '')), 'C')
+        || SETWEIGHT(to_tsvector('english', COALESCE("longDescription", '')), 'C')
+        || SETWEIGHT(to_tsvector('simple', array_to_string_immutable(COALESCE(tags, ARRAY[]::varchar[]), ' ')), 'C')
+      ) STORED
+    `);
+
+    // Add TS vectors index
+    console.log('Adding TS Vector index...');
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY collective_search_index
+      ON "Collectives"
+      USING GIN("searchTsVector")
+      WHERE "deletedAt" IS NULL
+      AND "deactivatedAt" IS NULL
+      AND ("data" ->> 'isGuest')::boolean IS NOT TRUE
+      AND ("data" ->> 'hideFromSearch')::boolean IS NOT TRUE
+      AND name != 'incognito'
+      AND name != 'anonymous'
+      AND "isIncognito" = FALSE
+    `);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "collective_search_index"
+    `);
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Collectives"
+      DROP COLUMN "searchTsVector"
+    `);
+  },
+};

--- a/test/server/graphql/v1/search.test.js
+++ b/test/server/graphql/v1/search.test.js
@@ -10,6 +10,7 @@ describe('server/graphql/v1/search', () => {
 
   before(async () => {
     await utils.resetTestDB();
+    await utils.runSearchTsVectorMigration();
     commonKeyword = randStr();
     collectives = await Promise.all([
       fakeCollective({ name: randStr(), description: `A common keyword: ${commonKeyword}` }),

--- a/test/server/lib/search.test.js
+++ b/test/server/lib/search.test.js
@@ -11,10 +11,13 @@ import {
 import { Op } from '../../../server/models';
 import { newUser } from '../../stores';
 import { fakeCollective, fakeUser } from '../../test-helpers/fake-data';
-import { resetTestDB } from '../../utils';
+import { resetTestDB, runSearchTsVectorMigration } from '../../utils';
 
 describe('server/lib/search', () => {
-  before(resetTestDB);
+  before(async () => {
+    await resetTestDB();
+    await runSearchTsVectorMigration();
+  });
 
   describe('Search in DB', () => {
     it('By slug', async () => {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3825 with an alternative approach

As a bonus, we're now indexing `longDescription`.

# Stats

### Migration time

12.855s against a local prod DB copy

### Rows update time

Since we have an auto-generated column, I wanted to make sure that the row's update times were not going up. Testing updates on 100000 collectives with the following query showed no significant difference:

```sql
BEGIN;
EXPLAIN ANALYZE
UPDATE "Collectives" SET name = 'UPDATED' WHERE id < 100000 RETURNING *;
ROLLBACK;
```

Both results in something like:
> Update on "Collectives"  (cost=2081.10..25556.00 rows=98152 width=2440) (actual time=5.985..1771.365 rows=98944 loops=1)

### Search performance

Average: -98% execution time

Details:
- `open source`:
  - Before: `Limit  (cost=445094.12..445117.05 rows=20 width=1933) (actual time=1089.901..1092.494 rows=20 loops=1)`
  - After: `Limit  (cost=76.23..76.25 rows=5 width=1965) (actual time=39.911..39.917 rows=20 loops=1)`
  - Change: Complexity divided by 5857 (-99.98%), execution time divided by 28 (-96.42%)
- `foundation`: 
  - Before: `Limit  (cost=446345.38..446345.43 rows=20 width=1933) (actual time=1036.212..1036.278 rows=20 loops=1)`
  - After: `Limit  (cost=3624.67..3624.72 rows=20 width=1965) (actual time=4.827..4.832 rows=20 loops=1)`
  - Change: Complexity divided by 123 (-99.19%), execution time divided by 259 (-99.61%)
- `javascript`: 
  - Before: `Limit  (cost=446345.38..446345.43 rows=20 width=1933) (actual time=1074.604..1074.683 rows=20 loops=1)`
  - After: `Limit  (cost=1933.89..1933.94 rows=20 width=1965) (actual time=7.044..7.048 rows=20 loops=1)`
  - Change: Complexity divided by 231 (-99.57%), execution time divided by 153 (-99.35%)

<details>

Helpers:

```es6
 getRate = (from, to) => (to - from) / from * 100
compute = (from, to, timeBefore, timeAfter) => console.log(`Complexity divided by ${(from / to).toFixed(0)} (${getRate(from, to).toFixed(2)}%), execution time divided by ${(timeBefore / timeAfter).toFixed(0)} (${getRate(timeBefore, timeAfter).toFixed(2)}%)`)
```

</details>