### PR TITLE
Fix Wise webhook response time

### DIFF
--- a/server/paymentProviders/transferwise/webhook.ts
+++ b/server/paymentProviders/transferwise/webhook.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express';
+import { toString } from 'lodash';
 import moment from 'moment';
 import { Op } from 'sequelize';
 
@@ -9,10 +10,10 @@ import { verifyEvent } from '../../lib/transferwise';
 import models from '../../models';
 import { TransferStateChangeEvent } from '../../types/transferwise';
 
-async function handleTransferStateChange(event: TransferStateChangeEvent): Promise<void> {
+export async function handleTransferStateChange(event: TransferStateChangeEvent): Promise<void> {
   const transaction = await models.Transaction.findOne({
     where: {
-      data: { transfer: { id: event.data.resource.id } },
+      data: { transfer: { id: toString(event.data.resource.id) } },
       updatedAt: {
         [Op.gte]: moment().subtract(10, 'days').toDate(),
       },


### PR DESCRIPTION
It turns out the problem wasn't the index but the way Sequelize would build up the query.

Originally, Sequelize would cast the ID number to double-precision, effectively bypassing our index:
```
WHERE ("Transaction"."deletedAt" IS NULL
AND (CAST(("Transaction"."data"#>>'{transfer,id}') AS DOUBLE PRECISION) = 392897660
AND "Transaction"."updatedAt" >= '2022-03-28 00:59:24.757 +00:00')) LIMIT 1;
```

With this update, we get rid of that forced casting and we end up hitting the index when analyzing the query:
```
WHERE ("Transaction"."deletedAt" IS NULL
AND (("Transaction"."data"#>>'{transfer,id}') = '392897660'
AND "Transaction"."updatedAt" >= '2022-03-28 01:07:05.081 +00:00')) LIMIT 1;
```