### PR TITLE
Add Support to Search Parts of Strings in `/search`

### DIFF
--- a/server/graphql/v2/query/collection/TagStatsCollectionQuery.js
+++ b/server/graphql/v2/query/collection/TagStatsCollectionQuery.js
@@ -1,7 +1,7 @@
 import { GraphQLInt, GraphQLNonNull, GraphQLString } from 'graphql';
 import { pick } from 'lodash';
 
-import rawQueries from '../../../../lib/queries';
+import { getTagFrequencies } from '../../../../lib/search';
 import { TagStatsCollection } from '../../collection/TagStatsCollection';
 
 const TagStatsCollectionQuery = {
@@ -15,7 +15,7 @@ const TagStatsCollectionQuery = {
     offset: { type: new GraphQLNonNull(GraphQLInt), defaultValue: 0 },
   },
   async resolve(_, args) {
-    const tagFrequencies = await rawQueries.getTagFrequencies({
+    const tagFrequencies = await getTagFrequencies({
       ...pick(args, ['searchTerm', 'limit', 'offset']),
     });
 

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1161,16 +1161,16 @@ const getTagFrequencies = async args => {
   let searchTermFragment = '';
   let term = args.searchTerm;
   // Cleanup term
+  term = sanitizeSearchTermForILike(trimSearchTerm(term));
   if (term && term.length > 0) {
-    term = sanitizeSearchTermForILike(trimSearchTerm(term));
     if (term[0] === '@') {
       // When the search starts with a `@`, we search by slug only
       term = term.replace(/^@+/, '');
       searchTermFragment = `AND slug ILIKE '%' || :term || '%' `;
     } else {
-      searchTermFragment = `
-        AND ("searchTsVector" @@ plainto_tsquery('english', :vectorizedTerm)
-        OR "searchTsVector" @@ plainto_tsquery('simple', :vectorizedTerm))`;
+      searchTermFragment += `
+        AND ("searchTsVector" @@ to_tsquery('english', :vectorizedTerm':*')
+        OR "searchTsVector" @@ to_tsquery('simple', :vectorizedTerm':*'))`;
     }
   } else {
     term = '';

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1160,9 +1160,10 @@ const getTransactionsTimeSeries = async (
 const getTagFrequencies = async args => {
   let searchTermFragment = '';
   let term = args.searchTerm;
-  // Cleanup term
-  term = sanitizeSearchTermForILike(trimSearchTerm(term));
+
   if (term && term.length > 0) {
+    // Cleanup term
+    term = sanitizeSearchTermForILike(trimSearchTerm(term));
     if (term[0] === '@') {
       // When the search starts with a `@`, we search by slug only
       term = term.replace(/^@+/, '');

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -155,9 +155,9 @@ export const searchCollectivesInDB = async (
     dynamicConditions += `AND "tags" @> (:searchedTags) `;
   }
 
-  // Cleanup term
-  term = sanitizeSearchTermForILike(trimSearchTerm(term));
   if (term && term.length > 0) {
+    // Cleanup term
+    term = sanitizeSearchTermForILike(trimSearchTerm(term));
     if (term[0] === '@') {
       // When the search starts with a `@`, we search by slug only
       term = term.replace(/^@+/, '');


### PR DESCRIPTION
We need to give ability for users to search part of text in the `/search` page. For example if there's a collective called with text `jhipster` included in one of it's fields it should appear when a user searches for `jhips` or `jhipste` etc. This PR solves that. 

Related Discussion: https://github.com/opencollective/opencollective-api/pull/7376#discussion_r844297165 