### PR TITLE
Show HTML content for expense private note in emails

### DIFF
--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -8,7 +8,7 @@ import expenseType from '../constants/expense_type';
 import { TransactionTypes } from '../constants/transactions';
 import { reduceArrayToCurrency } from '../lib/currency';
 import logger from '../lib/logger';
-import { buildSanitizerOptions, sanitizeHTML, stripHTML } from '../lib/sanitize-html';
+import { buildSanitizerOptions, sanitizeHTML } from '../lib/sanitize-html';
 import sequelize, { DataTypes, Op, QueryTypes } from '../lib/sequelize';
 import { sanitizeTags, validateTags } from '../lib/tags';
 import CustomDataTypes from '../models/DataTypes';
@@ -271,7 +271,7 @@ function defineModel() {
             tags: this.tags,
             legacyPayoutMethod: this.legacyPayoutMethod,
             vat: this.vat,
-            privateMessage: this.privateMessage && stripHTML(this.privateMessage),
+            privateMessage: this.privateMessage,
             lastEditedById: this.lastEditedById,
             status: this.status,
             incurredAt: this.incurredAt,
@@ -365,24 +365,6 @@ function defineModel() {
       this.user = await models.User.findByPk(this.UserId);
     }
     return this.user;
-  };
-
-  Expense.prototype.setApproved = function (lastEditedById) {
-    if (this.status === status.PAID) {
-      throw new Error("Can't approve an expense that is PAID");
-    }
-    this.status = status.APPROVED;
-    this.lastEditedById = lastEditedById;
-    return this.save();
-  };
-
-  Expense.prototype.setRejected = function (lastEditedById) {
-    if (this.status === status.PAID) {
-      throw new Error("Can't reject an expense that is PAID");
-    }
-    this.status = status.REJECTED;
-    this.lastEditedById = lastEditedById;
-    return this.save();
   };
 
   Expense.prototype.setPaid = async function (editedById) {

--- a/templates/emails/collective.expense.approved.for.host.hbs
+++ b/templates/emails/collective.expense.approved.for.host.hbs
@@ -14,7 +14,7 @@ Subject: New expense approved on {{{collective.name}}}: {{currency expense.amoun
   <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
   <tr><th>Payout method:</th><td>{{expense.payoutMethodLabel}}</td></tr>
   {{#if expense.privateMessage}}
-    <tr><th valign="top">Private note:</th><td>{{expense.privateMessage}}</td></tr>
+    <tr><th valign="top">Private note:</th><td>{{{expense.privateMessage}}}</td></tr>
   {{/if}}
 </table>
 

--- a/templates/emails/collective.expense.approved.hbs
+++ b/templates/emails/collective.expense.approved.hbs
@@ -17,7 +17,7 @@ Subject: Your expense to {{{collective.name}}} for {{currency expense.amount cur
   <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
   <tr><th>Payout method:</th><td>{{expense.payoutMethodLabel}}</td></tr>
   {{#if expense.privateMessage}}
-    <tr><th valign="top">Private note:</th><td>{{expense.privateMessage}}</td></tr>
+    <tr><th valign="top">Private note:</th><td>{{{expense.privateMessage}}}</td></tr>
   {{/if}}
 </table>
 

--- a/templates/emails/collective.expense.rejected.hbs
+++ b/templates/emails/collective.expense.rejected.hbs
@@ -7,7 +7,7 @@ Subject: Expense rejected: {{currency expense.amount currency=expense.currency}}
 <table>
   <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
   {{#if expense.privateMessage}}
-    <tr><th valign="top">Note:</th><td>{{expense.privateMessage}}</td></tr>
+    <tr><th valign="top">Note:</th><td>{{{expense.privateMessage}}}</td></tr>
   {{/if}}
 </table>
 


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5420

We introduced (sanitized) HTML for expenses private messages in https://github.com/opencollective/opencollective-api/pull/4137 but we did not output this content as HTML in the emails.

![image](https://user-images.githubusercontent.com/1556356/162899063-22a6a884-2a63-42d4-8122-7dd37f262f41.png)
