### PR TITLE
Remove the older `supportedPaymentMethodService` field and relavant logic

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -9563,14 +9563,6 @@ type Query {
     hasCustomContributionsEnabled: Boolean
 
     """
-    Only accounts that support one of these payment services will be returned
-    """
-    supportedPaymentMethodService: [PaymentMethodService]
-      @deprecated(
-        reason: "2022-04-22: Introduced for Hacktoberfest. Reference: https://github.com/opencollective/opencollective-api/pull/7440#issuecomment-1121504508"
-      )
-
-    """
     The order of results. Defaults to [RANK, DESC] (or [CREATED_AT, DESC] if `supportedPaymentMethodService` is provided)
     """
     orderBy: OrderByInput
@@ -13548,21 +13540,6 @@ type Mutation {
     Reference of the expense to process
     """
     expense: ExpenseReferenceInput!
-  ): Expense!
-
-  """
-  To verify and unverified expense. Scope: "expenses".
-  """
-  verifyExpense(
-    """
-    Reference of the expense to process
-    """
-    expense: ExpenseReferenceInput!
-
-    """
-    Expense draft key if invited to submit expense
-    """
-    draftKey: String
   ): Expense!
 
   """


### PR DESCRIPTION
Related to the discussion at, https://github.com/opencollective/opencollective-api/pull/7359#discussion_r849163069. We are not using `supportedPaymentMethodService` and we should be default use the `searchCollectivesInDB` when we are doing search. Thus I propose refactoring this part to remove the unnecessary logic. 