### PR TITLE
Search: Order by transactions count rather than sum

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -169,7 +169,7 @@ export const searchCollectivesInDB = async (
 
   const sortSubqueries = {
     ACTIVITY: `
-      SELECT COALESCE(SUM(ABS("netAmountInCollectiveCurrency")), 0)
+      SELECT COUNT(t.id)
       FROM "Transactions" t
       WHERE t."CollectiveId" = c.id
       AND t."deletedAt" IS NULL`,


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-api/pull/7351/files#r852615373

According to [Sentry](https://sentry.io/organizations/open-collective/issues/3056282096/), we got a lot of errors on the search page this weekend because malicious users added funds with crazy amounts that were bugging the `GraphQLInt` limits. Since the search page ordered by summing the total amount, these people were arriving at the top of the results.

It's easier to fake amounts than the number of transactions, therefore using `COUNT` instead of `SUM` should make it more difficult for people to trick this query. Moreover, it seems to me that the number of interactions is a better definition of "Activity" than the strength of these interactions.