### PR TITLE
feat(MemberInvitation.js): resend invitation email

### DIFF
--- a/server/models/MemberInvitation.js
+++ b/server/models/MemberInvitation.js
@@ -149,32 +149,29 @@ function defineModel() {
     return this.destroy();
   };
 
-  MemberInvitation.prototype.sendEmail = async function (memberParams, sequelizeParams, collective, skipDefaultAdmin) {
-    // Load users
-    const memberUser = await models.User.findOne({
-      where: { CollectiveId: memberParams.MemberCollectiveId },
+  MemberInvitation.prototype.sendEmail = async function (remoteUser, skipDefaultAdmin = false, sequelizeParams = null) {
+    // Load invitee
+    const invitedUser = await models.User.findOne({
+      where: { CollectiveId: this.MemberCollectiveId },
       include: [{ model: models.Collective, as: 'collective' }],
       ...sequelizeParams,
     });
 
-    if (!memberUser) {
-      throw new Error('user not found');
+    if (!invitedUser) {
+      throw new Error('Cannot find invited user');
     }
 
-    // Determine collective creator
-    const createdByUser = await models.User.findByPk(memberParams.CreatedByUserId, {
-      include: [{ model: models.Collective, as: 'collective' }],
-      ...sequelizeParams,
-    });
+    // Load collective
+    const collective = this.collective || (await this.getCollective(sequelizeParams));
 
     // Send member invitation
-    await emailLib.send('member.invitation', memberUser.email, {
-      role: MemberRoleLabels[memberParams.role] || memberParams.role.toLowerCase(),
-      invitation: pick(this, 'id'),
-      collective: pick(collective, ['slug', 'name']),
-      memberCollective: pick(memberUser.collective, ['slug', 'name']),
-      invitedByUser: pick(createdByUser, ['collective.slug', 'collective.name']),
-      skipDefaultAdmin: skipDefaultAdmin || false,
+    await emailLib.send('member.invitation', invitedUser.email, {
+      role: MemberRoleLabels[this.role] || this.role.toLowerCase(),
+      invitation: pick(this, ['id', 'role', 'description', 'since']),
+      collective: pick(collective, ['id', 'slug', 'name']),
+      memberCollective: pick(invitedUser.collective, ['id', 'slug', 'name']),
+      invitedByUser: pick(remoteUser, ['collective.id', 'collective.slug', 'collective.name']),
+      skipDefaultAdmin: skipDefaultAdmin,
     });
   };
 
@@ -190,7 +187,7 @@ function defineModel() {
       throw new Error('Individual accounts do not support members');
     }
 
-    // Ensure the user is not already a member or invited as such
+    // Ensure the user is not already a member
     const existingMember = await models.Member.findOne({
       where: {
         CollectiveId: collective.id,
@@ -205,7 +202,8 @@ function defineModel() {
     }
 
     // Update the existing invitation if it exists
-    const existingInvitation = await models.MemberInvitation.findOne({
+    let invitation = await models.MemberInvitation.findOne({
+      include: [{ association: 'collective' }],
       where: {
         CollectiveId: collective.id,
         MemberCollectiveId: memberParams.MemberCollectiveId,
@@ -213,30 +211,31 @@ function defineModel() {
       ...sequelizeParams,
     });
 
-    if (existingInvitation) {
-      await existingInvitation.sendEmail(memberParams, sequelizeParams, collective, skipDefaultAdmin);
-      return existingInvitation.update(pick(memberParams, ['role', 'description', 'since']), sequelizeParams);
+    if (invitation) {
+      const updateData = pick(memberParams, ['role', 'description', 'since']);
+      await invitation.update(updateData, sequelizeParams);
+    } else {
+      // Ensure collective has not invited too many people
+      const memberCountWhere = { CollectiveId: collective.id, role: MEMBER_INVITATION_SUPPORTED_ROLES };
+      const nbMembers = await models.Member.count({ where: memberCountWhere, ...sequelizeParams });
+      const nbInvitations = await models.MemberInvitation.count({ where: memberCountWhere, ...sequelizeParams });
+      if (nbMembers + nbInvitations > config.limits.maxCoreContributorsPerAccount) {
+        throw new Error('You exceeded the maximum number of members for this account');
+      }
+
+      // Create new member invitation
+      invitation = await MemberInvitation.create({ ...memberParams, CollectiveId: collective.id }, sequelizeParams);
+      invitation.collective = collective;
     }
 
-    // Ensure collective has not invited too many people
-    const memberCountWhere = { CollectiveId: collective.id, role: MEMBER_INVITATION_SUPPORTED_ROLES };
-    const nbMembers = await models.Member.count({ where: memberCountWhere, ...sequelizeParams });
-    const nbInvitations = await models.MemberInvitation.count({ where: memberCountWhere, ...sequelizeParams });
-    if (nbMembers + nbInvitations > config.limits.maxCoreContributorsPerAccount) {
-      throw new Error('You exceeded the maximum number of members for this account');
-    }
+    // Load remote user
+    // TODO: We should make `createdByUser` a required param
+    const createdByUser = await models.User.findByPk(memberParams.CreatedByUserId, {
+      include: [{ association: 'collective' }],
+      ...sequelizeParams,
+    });
 
-    // Create new member invitation
-    const invitation = await MemberInvitation.create(
-      {
-        ...memberParams,
-        CollectiveId: collective.id,
-      },
-      sequelizeParams,
-    );
-
-    await invitation.sendEmail(memberParams, sequelizeParams, collective, skipDefaultAdmin);
-
+    await invitation.sendEmail(createdByUser, skipDefaultAdmin, sequelizeParams);
     return invitation;
   };
 

--- a/server/models/MemberInvitation.js
+++ b/server/models/MemberInvitation.js
@@ -149,9 +149,7 @@ function defineModel() {
     return this.destroy();
   };
 
-  // ---- Static methods ----
-
-  MemberInvitation.sendEmail = async (memberParams, sequelizeParams, collective, skipDefaultAdmin) => {
+  MemberInvitation.prototype.sendEmail = async function (memberParams, sequelizeParams, collective, skipDefaultAdmin) {
     // Load users
     const memberUser = await models.User.findOne({
       where: { CollectiveId: memberParams.MemberCollectiveId },
@@ -179,6 +177,8 @@ function defineModel() {
       skipDefaultAdmin: skipDefaultAdmin || false,
     });
   };
+
+  // ---- Static methods ----
 
   MemberInvitation.invite = async function (collective, memberParams, { transaction, skipDefaultAdmin } = {}) {
     const sequelizeParams = transaction ? { transaction } : undefined;
@@ -214,7 +214,7 @@ function defineModel() {
     });
 
     if (existingInvitation) {
-      await this.sendEmail(memberParams, sequelizeParams, collective, skipDefaultAdmin);
+      await existingInvitation.sendEmail(memberParams, sequelizeParams, collective, skipDefaultAdmin);
       return existingInvitation.update(pick(memberParams, ['role', 'description', 'since']), sequelizeParams);
     }
 
@@ -235,7 +235,7 @@ function defineModel() {
       sequelizeParams,
     );
 
-    await this.sendEmail(memberParams, sequelizeParams, collective, skipDefaultAdmin);
+    await invitation.sendEmail(memberParams, sequelizeParams, collective, skipDefaultAdmin);
 
     return invitation;
   };


### PR DESCRIPTION
When an invitation already exists, resend the invitation email on request from the frontend. This is done to enable a user-facing "Resend Invite" button, see opencollective/opencollective-frontend#7710.

Fixes opencollective/opencollective#5030