### PR TITLE
Fix conflict between Pending Charge cron and Cancelled authorizations

### DIFF
--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -500,6 +500,7 @@ function defineModel() {
       where: {
         ...where,
         type: expenseType.CHARGE,
+        status: 'PAID',
         '$items.url$': { [Op.eq]: null },
       },
       include: [...include, { model: models.ExpenseItem, as: 'items', required: true }],

--- a/test/server/models/Expense.test.js
+++ b/test/server/models/Expense.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { pick } from 'lodash';
 
-import { expenseTypes } from '../../../server/constants';
+import { expenseStatus, expenseTypes } from '../../../server/constants';
 import models from '../../../server/models';
 import Expense from '../../../server/models/Expense';
 import { fakeCollective, fakeExpense, fakeExpenseItem, fakeUser } from '../../test-helpers/fake-data';
@@ -46,10 +46,10 @@ describe('test/server/models/Expense', () => {
     before(async () => {
       await resetTestDB();
 
-      pendingCharge = await fakeExpense({ type: expenseTypes.CHARGE });
+      pendingCharge = await fakeExpense({ type: expenseTypes.CHARGE, status: expenseStatus.PAID });
       await fakeExpenseItem({ ExpenseId: pendingCharge.id, url: null });
 
-      const completeCharge = await fakeExpense({ type: expenseTypes.CHARGE });
+      const completeCharge = await fakeExpense({ type: expenseTypes.CHARGE, status: expenseStatus.PAID });
       await fakeExpenseItem({ ExpenseId: completeCharge.id });
     });
 
@@ -60,7 +60,7 @@ describe('test/server/models/Expense', () => {
     });
 
     it('should return pending card charges for given attributes', async () => {
-      const newPendingCharge = await fakeExpense({ type: expenseTypes.CHARGE });
+      const newPendingCharge = await fakeExpense({ type: expenseTypes.CHARGE, status: expenseStatus.PAID });
       await fakeExpenseItem({ ExpenseId: newPendingCharge.id, url: null });
 
       const pendingCharges = await Expense.findPendingCardCharges({


### PR DESCRIPTION
#7425 added a new `canceled` expense status that is used to inform about card charges that were canceled.

This fix updates `Expense.findPendingCardCharges` to consider only PAID expenses as possibly missing a receipt so we don't pause Virtual Card due to missing receipts on a canceled charge.