### PR TITLE
Fix: Virtual Card Auto-Pause card suspension notification multiple times

### DIFF
--- a/cron/daily/50-check-virtual-cards-missing-receipts.ts
+++ b/cron/daily/50-check-virtual-cards-missing-receipts.ts
@@ -37,7 +37,8 @@ const processVirtualCard = async (expenses: Array<typeof models.Expense>) => {
   } else if (
     virtualCard.provider === VirtualCardProviders.STRIPE &&
     host.settings?.virtualcards?.autopause &&
-    maxDaysPending >= 31
+    maxDaysPending >= 31 &&
+    virtualCard.isActive()
   ) {
     logger.info(`Virtual Card ${virtualCard.id} is being suspended due to pending expenses without receipts...`);
     await virtualCard.pause();


### PR DESCRIPTION
Small fix that will prevent the auto-pause worker from suspending and notifying the same card multiple times.