### PR TITLE
Deprecate `supportedPaymentMethodService`

### DIFF
--- a/server/graphql/v2/query/collection/AccountsQuery.ts
+++ b/server/graphql/v2/query/collection/AccountsQuery.ts
@@ -40,6 +40,7 @@ const AccountsQuery = {
     supportedPaymentMethodService: {
       type: new GraphQLList(PaymentMethodService),
       description: 'Only accounts that support one of these payment services will be returned',
+      deprecationReason: '2022-04-22: Introduced for Hacktoberfest and not used anymore.',
     },
     skipRecentAccounts: {
       type: GraphQLBoolean,


### PR DESCRIPTION
We need to deprecate `supportedPaymentMethodService` field first before removing it. 

Related https://github.com/opencollective/opencollective-api/pull/7411