### PR TITLE
Move `geoLocationLatLong` to JSONB

### DIFF
--- a/migrations/20220426103129-move-coordinates-to-jsonb.js
+++ b/migrations/20220426103129-move-coordinates-to-jsonb.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "CollectiveHistories"
+      ALTER COLUMN "geoLocationLatLong" TYPE JSONB
+      USING JSONB("geoLocationLatLong")
+    `);
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Collectives"
+      ALTER COLUMN "geoLocationLatLong" TYPE JSONB
+      USING JSONB("geoLocationLatLong")
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Collectives"
+      ALTER COLUMN "geoLocationLatLong" TYPE GEOMETRY('POINT')
+      USING ST_POINT(
+        ("geoLocationLatLong" -> 'coordinates' ->> 0)::float,
+        ("geoLocationLatLong" -> 'coordinates' ->> 1)::float
+      )
+    `);
+  },
+};

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -365,7 +365,20 @@ function defineModel() {
         },
       },
 
-      geoLocationLatLong: DataTypes.GEOMETRY('POINT'),
+      geoLocationLatLong: {
+        type: DataTypes.JSONB,
+        validate: {
+          validate(data) {
+            if (!data) {
+              return;
+            } else if (data.type !== 'Point' || !data.coordinates || data.coordinates.length !== 2) {
+              throw new Error('Invalid GeoLocation');
+            } else if (typeof data.coordinates[0] !== 'number' || typeof data.coordinates[1] !== 'number') {
+              throw new Error('Invalid latitude/longitude');
+            }
+          },
+        },
+      },
 
       settings: {
         type: DataTypes.JSONB,

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -1254,4 +1254,21 @@ describe('server/models/Collective', () => {
       expect(collective.hasPolicy('FAKE_POLICY')).to.be.false;
     });
   });
+
+  describe('location', () => {
+    it('validates latitude/longitude', async () => {
+      // Invalid
+      await expect(fakeCollective({ geoLocationLatLong: 42 })).to.be.rejected;
+      await expect(fakeCollective({ geoLocationLatLong: 'nope' })).to.be.rejected;
+      await expect(fakeCollective({ geoLocationLatLong: {} })).to.be.rejected;
+      await expect(fakeCollective({ geoLocationLatLong: { type: 'Point' } })).to.be.rejected;
+      await expect(fakeCollective({ geoLocationLatLong: { type: 'Point', coordinates: 42 } })).to.be.rejected;
+      await expect(fakeCollective({ geoLocationLatLong: { type: 'Point', coordinates: [55] } })).to.be.rejected;
+      await expect(fakeCollective({ geoLocationLatLong: { type: 'TOTO', coordinates: [55, -66] } })).to.be.rejected;
+
+      // Valid
+      await expect(fakeCollective({ geoLocationLatLong: null })).to.be.fulfilled;
+      await expect(fakeCollective({ geoLocationLatLong: { type: 'Point', coordinates: [55, -66] } })).to.be.fulfilled;
+    });
+  });
 });


### PR DESCRIPTION
As per https://github.com/opencollective/opencollective/issues/3171, this removes the dependency on Postgis.

Sequelize was converting all `GEOMETRY(POINT)` to objects like `{ type: 'POINT', coordinates: [0, 0] }` (basically what we get by calling `st_asgeojson`). Storing the JSONB directly seems to have the exact same effect regarding the model usage. Since no query depends on it, it seems that there's nothing more to do.
