### PR TITLE
Fix cast in postgis removal migration

### DIFF
--- a/migrations/20220426103129-move-coordinates-to-jsonb.js
+++ b/migrations/20220426103129-move-coordinates-to-jsonb.js
@@ -5,13 +5,13 @@ module.exports = {
     await queryInterface.sequelize.query(`
       ALTER TABLE "CollectiveHistories"
       ALTER COLUMN "geoLocationLatLong" TYPE JSONB
-      USING JSONB("geoLocationLatLong")
+      USING st_asgeojson("geoLocationLatLong")::jsonb
     `);
 
     await queryInterface.sequelize.query(`
       ALTER TABLE "Collectives"
       ALTER COLUMN "geoLocationLatLong" TYPE JSONB
-      USING JSONB("geoLocationLatLong")
+      USING st_asgeojson("geoLocationLatLong")::jsonb
     `);
   },
 


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-api/pull/7457
Part of https://github.com/opencollective/opencollective/issues/3171

Postgres versions seem to not act the same way with this cast, staging failed with:

```
remote:        Loaded configuration file "config/sequelize-cli.js".
remote:        == 20220426103129-move-coordinates-to-jsonb: migrating =======
remote:        
remote:        ERROR: function jsonb(geometry) does not exist
remote:        
```