### PR TITLE
Deprecate GQLV1 `createCollectiveFromGithub` mutation

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -3551,6 +3551,7 @@ This is the root mutation
 type Mutation {
   createCollective(collective: CollectiveInputType!): CollectiveInterface
   createCollectiveFromGithub(collective: CollectiveInputType!): CollectiveInterface
+    @deprecated(reason: "2022-05-03: This mutation is deprecated and can only be used in test environments.")
   editCollective(collective: CollectiveInputType!): CollectiveInterface
   deleteCollective(id: Int!): CollectiveInterface
   deleteUserCollective(id: Int!): CollectiveInterface

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -64,6 +64,7 @@ const mutations = {
   },
   createCollectiveFromGithub: {
     type: CollectiveInterfaceType,
+    deprecationReason: '2022-05-03: This mutation is deprecated and can only be used in test environments.',
     args: {
       collective: { type: new GraphQLNonNull(CollectiveInputType) },
     },

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -180,6 +180,10 @@ export async function createCollectiveFromGithub(_, args, req) {
     throw new ValidationFailed('collective.name required');
   }
 
+  if (config.env === 'production') {
+    throw new Error('This mutation is not allowed in production');
+  }
+
   let collective;
   const user = req.remoteUser;
   const githubHandle = args.collective.githubHandle;
@@ -268,6 +272,9 @@ export async function createCollectiveFromGithub(_, args, req) {
 
   const data = { collective: collective.info };
 
+  // !!!
+  //  Remember to remove this email template when removing this mutation, it's not used elsewhere
+  // !!!
   await emailLib.send('github.signup', user.email, data);
 
   models.Activity.create({


### PR DESCRIPTION
Goes with https://github.com/opencollective/opencollective-frontend/pull/7749

This will now throw an error if called from production environments