### PR TITLE
Revert "db_restore: edit MigrationLogs enum permissions"

### DIFF
--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -89,7 +89,6 @@ echo "DB restored to postgres://localhost/${LOCALDBNAME}"
   psql "${LOCALDBNAME}" -c "alter type \"enum_ExpenseHistories_type\" owner to ${LOCALDBUSER};"
   psql "${LOCALDBNAME}" -c "alter type \"enum_MemberInvitations_role\" owner to ${LOCALDBUSER};"
   psql "${LOCALDBNAME}" -c "alter type \"enum_PayoutMethods_type\" owner to ${LOCALDBUSER};"
-  psql "${LOCALDBNAME}" -c "alter type \"enum_MigrationLogs_type\" owner to ${LOCALDBUSER};"
 
   psql "${LOCALDBNAME}" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ${LOCALDBUSER};"
   psql "${LOCALDBNAME}" -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${LOCALDBUSER};"


### PR DESCRIPTION
Reverts opencollective/opencollective-api#7517

I just realized this is not part of the dev dump, which will cause issues for new devs using it. We'll bring that back after [updating the local dump](https://github.com/opencollective/opencollective/issues/3171#issuecomment-1109726932).