### PR TITLE
Fix tiers frequency resolver

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -544,6 +544,10 @@ enum OrderByFieldType {
   CREATED_AT
   MEMBER_COUNT
   TOTAL_CONTRIBUTED
+
+  """
+  The financial activity of the collective (number of transactions)
+  """
   ACTIVITY
   RANK
 }
@@ -2207,7 +2211,7 @@ type Tier {
   amount: Amount!
   type: TierType!
   interval: TierInterval @deprecated(reason: "2020-08-24: Please use \"frequency\"")
-  frequency: ContributionFrequency
+  frequency: TierFrequency!
   presets: [Int]
   maxQuantity: Int
 
@@ -2244,6 +2248,13 @@ enum TierInterval {
   month
   year
   flexible
+}
+
+enum TierFrequency {
+  MONTHLY
+  YEARLY
+  ONETIME
+  FLEXIBLE
 }
 
 enum TierAmountType {
@@ -7315,7 +7326,9 @@ type Query {
     Only accounts that support one of these payment services will be returned
     """
     supportedPaymentMethodService: [PaymentMethodService]
-      @deprecated(reason: "2022-04-22: Introduced for Hacktoberfest and not used anymore.")
+      @deprecated(
+        reason: "2022-04-22: Introduced for Hacktoberfest. Reference: https://github.com/opencollective/opencollective-api/pull/7440#issuecomment-1121504508"
+      )
 
     """
     Whether to skip recent suspicious accounts (48h)
@@ -7328,7 +7341,7 @@ type Query {
     country: [CountryISO]
 
     """
-    The order of results
+    The order of results. Defaults to [RANK, DESC] (or [CREATED_AT, DESC] if `supportedPaymentMethodService` is provided)
     """
     orderBy: OrderByInput
   ): AccountCollection!

--- a/server/graphql/v2/enum/TierFrequency.ts
+++ b/server/graphql/v2/enum/TierFrequency.ts
@@ -1,0 +1,42 @@
+import { GraphQLEnumType } from 'graphql';
+import { invert } from 'lodash';
+
+import INTERVALS from '../../../constants/intervals';
+
+enum TierFrequencyKey {
+  MONTHLY = 'MONTHLY',
+  YEARLY = 'YEARLY',
+  ONETIME = 'ONETIME',
+  FLEXIBLE = 'FLEXIBLE',
+}
+
+export const TierFrequency = new GraphQLEnumType({
+  name: 'TierFrequency',
+  values: Object.keys(TierFrequencyKey).reduce((values, key) => {
+    return { ...values, [key]: {} };
+  }, {}),
+});
+
+const TIER_FREQUENCY_TO_INTERVAL: Record<TierFrequencyKey, INTERVALS | null> = {
+  MONTHLY: INTERVALS.MONTH,
+  YEARLY: INTERVALS.YEAR,
+  FLEXIBLE: INTERVALS.FLEXIBLE,
+  ONETIME: null,
+};
+
+const TIER_INTERVAL_TO_FREQUENCY = <Record<INTERVALS | null, TierFrequencyKey>>invert(TIER_FREQUENCY_TO_INTERVAL);
+
+/**
+ * From a tier frequency provided as `TierFrequency` GQLV2 enum, returns an interval
+ * as we use it in the DB (ie. MONTHLY => month)
+ */
+export const getIntervalFromTierFrequency = (input: TierFrequencyKey): INTERVALS | null => {
+  return TIER_FREQUENCY_TO_INTERVAL[input];
+};
+
+/**
+ * From a tier interval from the DB, returns a `TierFrequency` GQLV2 enum (ie. month => MONTHLY)
+ */
+export const getTierFrequencyFromInterval = (input: INTERVALS): TierFrequencyKey => {
+  return TIER_INTERVAL_TO_FREQUENCY[input];
+};

--- a/server/graphql/v2/enum/TierInterval.js
+++ b/server/graphql/v2/enum/TierInterval.js
@@ -2,6 +2,7 @@ import { GraphQLEnumType } from 'graphql';
 
 export const TierInterval = new GraphQLEnumType({
   name: 'TierInterval',
+  deprecationReason: '2022-05-12: Deprecating in favor of TierFrequency',
   values: {
     month: {},
     year: {},

--- a/server/graphql/v2/object/Tier.js
+++ b/server/graphql/v2/object/Tier.js
@@ -4,7 +4,8 @@ import { GraphQLJSON } from 'graphql-type-json';
 
 import models, { Op } from '../../../models';
 import { OrderCollection } from '../collection/OrderCollection';
-import { ContributionFrequency, OrderStatus, TierAmountType, TierInterval, TierType } from '../enum';
+import { OrderStatus, TierAmountType, TierInterval, TierType } from '../enum';
+import { getTierFrequencyFromInterval, TierFrequency } from '../enum/TierFrequency';
 import { idEncode } from '../identifiers';
 
 import { Amount } from './Amount';
@@ -74,7 +75,10 @@ export const Tier = new GraphQLObjectType({
         deprecationReason: '2020-08-24: Please use "frequency"',
       },
       frequency: {
-        type: ContributionFrequency,
+        type: new GraphQLNonNull(TierFrequency),
+        resolve(tier) {
+          return getTierFrequencyFromInterval(tier.interval);
+        },
       },
       presets: {
         type: new GraphQLList(GraphQLInt),


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5548

Introducing a new `TierFrequency` type because:
- It differs from `ContributionFrequency`, which does not support `flexible`
- `TierInterval` values are lowercase, and the latest agreement on wording was to use the word "frequency"