### PR TITLE
Improve performance of the tax form queries

### DIFF
--- a/migrations/20220518065001-add-tax-forms-expenses-indexes.js
+++ b/migrations/20220518065001-add-tax-forms-expenses-indexes.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addIndex('LegalDocuments', ['CollectiveId'], { concurrently: true });
+    await queryInterface.addIndex('Expenses', ['status'], { concurrently: true });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('LegalDocuments', ['CollectiveId']);
+    await queryInterface.removeIndex('Expenses', ['status']);
+  },
+};


### PR DESCRIPTION
Should resolve timeouts reported by OCF in https://opencollective.slack.com/archives/G46PNRCGP/p1652735758820559

## Add indexes

Investigation showed that we were spending most of the time in the tax form query. Breaking that down, the `JOIN` on `LegalDocuments` seemed to be the most expensive operation there. Adding an index on its `CollectiveId` will massively reduce the complexity. I also added an index on expense status, as we also use this field a lot for filtering expenses - both in this query and other places of the code.

![image](https://user-images.githubusercontent.com/1556356/168976799-e71f7c2c-2939-49d2-a76e-ebdbb2edb4b7.png)

##  Simplify/optimize ready to pay

- A previously implemented optimization (filtering on `type`) was not working
- There was unnecessary complexity in the code => simplified
- Don't check collective balances when there's a pending tax form for the expense 
- We now check `RequiredLegalDocuments` **before** triggering the tax form query. The tax form query for a host like `europe` was taking ~1.5s even though there's no tax form defined. The one to check whether we have a required legal document takes 0.02s (there are 4 rows in there)