### PR TITLE
Fix `isApproved` for independant accounts

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1282,6 +1282,8 @@ function defineModel() {
   Collective.prototype.isApproved = function () {
     if (this.type === types.EVENT) {
       throw new Error("isApproved must be called on event's parent collective");
+    } else if (this.id === this.HostCollectiveId) {
+      return true;
     } else {
       return Boolean(this.HostCollectiveId && this.isActive && this.approvedAt);
     }


### PR DESCRIPTION
Would resolve https://github.com/opencollective/opencollective/issues/5577

If we go with this solution, we should remove the duplicate checks in the frontend, like https://github.com/opencollective/opencollective-frontend/blob/5605fe280f0d8b3f81df4e8e1bc74d6deca815d7/components/expenses/ExpenseInfoSidebar.js#L67 