### PR TITLE
Ignore transaction FX rate when collective change their currencies

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1923,9 +1923,10 @@ export const getExpenseAmountInDifferentCurrency = async (expense, toCurrency, r
   // TODO: Can we retrieve something for virtual cards?
 
   if (expense.status === 'PAID') {
-    const rate = await req.loaders.Expense.expenseToHostTransactionFxRateLoader.load(expense.id);
-    if (rate !== null) {
-      return buildAmount(rate, OPENCOLLECTIVE, false, expense.createdAt);
+    const result = await req.loaders.Expense.expenseToHostTransactionFxRateLoader.load(expense.id);
+    // If collective changed their currency since the expense was paid, we can't rely on transaction.currency
+    if (result.rate !== null && (!expense.collective || expense.collective.currency === result.currency)) {
+      return buildAmount(result.rate, OPENCOLLECTIVE, false, expense.createdAt);
     }
   }
 


### PR DESCRIPTION
Should resolve https://opencollective.freshdesk.com/a/tickets/84305

Transactions currency is always set to `collective.currency` when paying expenses. But we should not rely on the value from the transaction if the collective has changed its currency since, as the assumption that `transaction.currency` === `collective.currency` is not true anymore, leading to something that looks like this:

![image](https://user-images.githubusercontent.com/1556356/169564495-98be9bd5-29f1-4f7e-846f-7d70bdcc3f2f.png)

This PR will display the amount with the current collective currency using the closest FX rate, clearly stating that it's an approximation:
![image](https://user-images.githubusercontent.com/1556356/169566577-bb604740-bf31-403c-b258-207edb912a29.png)

![image](https://user-images.githubusercontent.com/1556356/169566831-b6034bb1-9c34-4ad4-966d-51b91d436dec.png)
