### PR TITLE
Make GraphQL v2 endpoint the default

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -206,9 +206,9 @@ export default async app => {
   graphqlServerV2.applyMiddleware({ app, path: '/graphql/v2' });
 
   /**
-   * GraphQL default (v1)
+   * GraphQL default (v2)
    */
-  graphqlServerV1.applyMiddleware({ app, path: '/graphql' });
+  graphqlServerV2.applyMiddleware({ app, path: '/graphql' });
 
   /**
    * Webhooks that should bypass api key check


### PR DESCRIPTION
Will lead to shorter and simpler URL. Better for developer experience.