### PR TITLE
Handle null collective in `user.isAdminOfCollective`

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -315,7 +315,9 @@ function defineModel() {
 
   // Slightly better API than the former
   User.prototype.isAdminOfCollective = function (collective) {
-    if (collective.type === 'EVENT' || collective.type === 'PROJECT') {
+    if (!collective) {
+      return false;
+    } else if (collective.type === 'EVENT' || collective.type === 'PROJECT') {
       return this.isAdmin(collective.id) || this.isAdmin(collective.ParentCollectiveId);
     } else {
       return this.isAdmin(collective.id);


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/3275588026

Consistent with what we do in `isAdminOfCollectiveOrHost` and other permissions helpers.