### PR TITLE
Improve history tracking for host applications 

### DIFF
--- a/migrations/20220601073830-add-index-activity-type.js
+++ b/migrations/20220601073830-add-index-activity-type.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.addIndex('Activities', ['type']);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeIndex('Activities', ['type']);
+  },
+};

--- a/migrations/20220601073835-add-created-by-user-id-to-host-applications.js
+++ b/migrations/20220601073835-add-created-by-user-id-to-host-applications.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('HostApplications', 'CreatedByUserId', {
+      type: Sequelize.INTEGER,
+      references: { key: 'id', model: 'Users' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('HostApplications', 'CreatedByUserId');
+  },
+};

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2252,7 +2252,7 @@ function defineModel() {
 
         // Record application
         promises.push(
-          models.HostApplication.recordApplication(hostCollective, this, {
+          models.HostApplication.recordApplication(hostCollective, this, creatorUser, {
             message: options?.message,
             customData: options?.applicationData,
           }),

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2261,6 +2261,7 @@ function defineModel() {
         if (!options?.skipCollectiveApplyActivity && !shouldAutomaticallyApprove) {
           promises.push(
             models.Activity.create({
+              UserId: creatorUser.id,
               CollectiveId: this.id,
               type: activities.COLLECTIVE_APPLY,
               data,


### PR DESCRIPTION
- (fix) Set missing activity.UserId for apply event
- Store the requesting user in `application.CreatedByUserId`
- Add an index on activity.type as it's tedious to query this field in prod