### PR TITLE
Fix user object used in sendOrderConfirmedEmail

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -603,10 +603,28 @@ const validatePayment = payment => {
   }
 };
 
+// For legacy purpose, we want to get a single user that we will use for:
+// - authentication with the PDF service
+// - constructing notification/activity objects
+// We can't rely on createdByUser because they have moved out of the Organization, Collective, etc ...
+const getUserForOrder = async order => {
+  if (order.fromCollective.type !== 'USER') {
+    const admins = await order.fromCollective.getAdmins();
+    if (admins.length > 0) {
+      const firstAdminUser = await admins[0].getUser();
+      if (firstAdminUser) {
+        return firstAdminUser;
+      }
+    }
+  }
+
+  return order.createdByUser;
+};
+
 const sendOrderConfirmedEmail = async (order, transaction) => {
   const attachments = [];
   const { collective, tier, interval, fromCollective, paymentMethod } = order;
-  const user = order.createdByUser;
+  const user = await getUserForOrder(order);
   const host = await collective.getHostCollective();
 
   if (tier && tier.type === tiers.TICKET) {


### PR DESCRIPTION
- If the `createdByUser` is no longer admin of the Organization, PDF could not be fetched.
- If the `createdByUser` opted out the `thankyou` email, the email would not be sent to current admins.

```
SELECT *
FROM "Orders" o
LEFT JOIN "Collectives" c ON c."id" = o."FromCollectiveId"
LEFT JOIN "Users" u ON u."id" = o."CreatedByUserId"
WHERE c."type" != 'USER' AND o."status" = 'ACTIVE'
AND NOT EXISTS (
    SELECT * FROM "Members"
    WHERE "deletedAt" IS NULL
    AND "CollectiveId" = c."id"
    AND "role" = 'ADMIN'
    AND "MemberCollectiveId" = u."CollectiveId"
)
```