### PR TITLE
WIP: Rename `types` to `collectiveTypes` in `constants/collectives`

### DIFF
--- a/server/constants/collectives.ts
+++ b/server/constants/collectives.ts
@@ -1,6 +1,6 @@
 import config from 'config';
 
-export enum types {
+export enum CollectiveType {
   COLLECTIVE = 'COLLECTIVE',
   EVENT = 'EVENT',
   USER = 'USER',
@@ -11,7 +11,7 @@ export enum types {
   VENDOR = 'VENDOR',
 }
 
-export const CollectiveTypesList = Object.values(types);
+export const CollectiveTypesList = Object.values(CollectiveType);
 
 export const DEFAULT_BACKGROUND_IMG = `${config.host.website}/public/images/collectives/default-header-bg.jpg`;
 


### PR DESCRIPTION
Renaming `types` to `CollectiveType` to satisfy https://github.com/opencollective/opencollective/issues/5611.