### PR TITLE
test: add tests for MemberInvitation mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "test:update": "TZ=UTC CHAI_JEST_SNAPSHOT_UPDATE_ALL=true nyc mocha",
     "test:clean": "rm -rf .nyc_output coverage",
     "test:coverage": "codecov",
-    "test:graphql": "npm run test test/server/graphql",
+    "test:graphql": "npm run test test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts",
     "test:lib": "npm run test test/server/lib",
     "test:models": "npm run test test/server/models",
     "test:payment-providers": "npm run test test/server/paymentProviders",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "test:update": "TZ=UTC CHAI_JEST_SNAPSHOT_UPDATE_ALL=true nyc mocha",
     "test:clean": "rm -rf .nyc_output coverage",
     "test:coverage": "codecov",
-    "test:graphql": "npm run test test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts",
+    "test:graphql": "npm run test test/server/graphql",
     "test:lib": "npm run test test/server/lib",
     "test:models": "npm run test test/server/models",
     "test:payment-providers": "npm run test test/server/paymentProviders",

--- a/server/constants/activities.js
+++ b/server/constants/activities.js
@@ -35,6 +35,7 @@ export default {
   COLLECTIVE_MEMBER_CREATED: 'collective.member.created',
   COLLECTIVE_CORE_MEMBER_ADDED: 'collective.core.member.added',
   COLLECTIVE_CORE_MEMBER_INVITED: 'collective.core.member.invited',
+  COLLECTIVE_CORE_MEMBER_INVITATION_DECLINED: 'collective.core.member.invitation.declined',
   COLLECTIVE_CORE_MEMBER_REMOVED: 'collective.core.member.removed',
   COLLECTIVE_CORE_MEMBER_EDITED: 'collective.core.member.edited',
   COLLECTIVE_TRANSACTION_CREATED: 'collective.transaction.created',

--- a/server/models/MemberInvitation.js
+++ b/server/models/MemberInvitation.js
@@ -160,7 +160,18 @@ function defineModel() {
   };
 
   MemberInvitation.prototype.decline = async function () {
-    return this.destroy();
+    await this.destroy();
+    const collective = this.collective || (await this.getCollective());
+    const memberCollective = this.memberCollective || (await this.getMemberCollective());
+    await models.Activity.create({
+      type: ActivityTypes.COLLECTIVE_CORE_MEMBER_INVITATION_DECLINED,
+      CollectiveId: this.CollectiveId,
+      data: {
+        notify: false,
+        memberCollective: memberCollective?.activity,
+        collective: collective?.activity,
+      },
+    });
   };
 
   MemberInvitation.prototype.sendEmail = async function (remoteUser, skipDefaultAdmin = false, sequelizeParams = null) {

--- a/server/models/MemberInvitation.js
+++ b/server/models/MemberInvitation.js
@@ -143,7 +143,7 @@ function defineModel() {
       purgeCacheForCollective(collective.slug);
     }
 
-    if ([roles.ACCOUNTANT, roles.ADMIN, roles.MEMBER].includes(this.role)) {
+    if (MEMBER_INVITATION_SUPPORTED_ROLES.includes(this.role)) {
       const member = await models.Collective.findByPk(this.MemberCollectiveId);
       await models.Activity.create({
         type: ActivityTypes.COLLECTIVE_CORE_MEMBER_ADDED,
@@ -241,7 +241,7 @@ function defineModel() {
       invitation = await MemberInvitation.create({ ...memberParams, CollectiveId: collective.id }, sequelizeParams);
       invitation.collective = collective;
 
-      if ([roles.ACCOUNTANT, roles.ADMIN, roles.MEMBER].includes(this.role)) {
+      if (MEMBER_INVITATION_SUPPORTED_ROLES.includes(memberParams.role)) {
         const member = await models.Collective.findByPk(memberParams.MemberCollectiveId);
         await models.Activity.create({
           type: ActivityTypes.COLLECTIVE_CORE_MEMBER_INVITED,

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -3,6 +3,7 @@ import gqlV2 from 'fake-tag';
 import { describe, it } from 'mocha';
 import { createSandbox } from 'sinon';
 
+import ActivityTypes from '../../../../../server/constants/activities';
 import roles from '../../../../../server/constants/roles';
 import { idEncode, IDENTIFIER_TYPES } from '../../../../../server/graphql/v2/identifiers';
 import emailLib from '../../../../../server/lib/email';
@@ -93,8 +94,17 @@ describe('MemberInvitationMutations', () => {
         user1,
       );
 
+      const activity = await models.Activity.findAll({
+        where: {
+          type: ActivityTypes.COLLECTIVE_CORE_MEMBER_INVITED,
+          CollectiveId: collective1.id,
+        },
+      });
       const createdMemberInvitation = result.data.inviteMember;
+
       expect(result.errors).to.not.exist;
+      expect(activity.length).to.equal(1);
+      expect(activity[0].data.memberCollective.id).to.equal(user2.id);
       expect(createdMemberInvitation.role).to.equal(roles.MEMBER);
       expect(createdMemberInvitation.description).to.equal('new user 2 as MEMBER');
       expect(createdMemberInvitation.since.toISOString()).to.equal(new Date('01 January 2022').toISOString());
@@ -362,6 +372,14 @@ describe('MemberInvitationMutations', () => {
         },
         user3,
       );
+      const activity = await models.Activity.findAll({
+        where: {
+          type: ActivityTypes.COLLECTIVE_CORE_MEMBER_ADDED,
+          CollectiveId: collective1.id,
+        },
+      });
+      expect(activity.length).to.equal(1);
+      expect(activity[0].data.memberCollective.id).to.equal(user3.id);
       expect(result.errors).to.not.exist;
       expect(result.data.replyToMemberInvitation).to.equal(true);
     });

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -85,7 +85,7 @@ describe('MemberInvitationMutations', () => {
         {
           memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
           account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user 2 as ADMIN',
+          description: 'new user 2 as MEMBER',
           role: roles.MEMBER,
           since: new Date('01 January 2022').toISOString(),
         },
@@ -95,7 +95,7 @@ describe('MemberInvitationMutations', () => {
       const createdMemberInvitation = result.data.inviteMember;
       expect(result.errors).to.not.exist;
       expect(createdMemberInvitation.role).to.equal(roles.MEMBER);
-      expect(createdMemberInvitation.description).to.equal('new user 2 as ADMIN');
+      expect(createdMemberInvitation.description).to.equal('new user 2 as MEMBER');
       expect(createdMemberInvitation.since.toISOString()).to.equal(new Date('01 January 2022').toISOString());
       expect(sendEmailSpy.callCount).to.equal(1);
       expect(sendEmailSpy.args[0][0]).to.equal(user2.email);
@@ -212,11 +212,51 @@ describe('MemberInvitationMutations', () => {
     });
   });
 
-  //   describe('editMemberInvitation', () => {
-  //     it('should edit the role, description and since and document the changes in an activity', () => {});
-  //     it('must be authenticated as an admin of the collective', () => {});
-  //     it('can only update role to accountant, admin or member', () => {});
-  //   });
+  describe('editMemberInvitation', () => {
+    const editMemberInvitationMutation = gqlV2/* GraphQL */ `
+      mutation EditMemberInvitation(
+        $memberAccount: AccountReferenceInput!
+        $account: AccountReferenceInput!
+        $role: MemberRole
+        $description: String
+        $since: DateTime
+      ) {
+        editMemberInvitation(
+          memberAccount: $memberAccount
+          account: $account
+          role: $role
+          description: $description
+          since: $since
+        ) {
+          id
+          role
+          description
+          since
+        }
+      }
+    `;
+    it('should edit the role, description, and since and document the changes in an activity', async () => {
+      const result = await utils.graphqlQueryV2(
+        editMemberInvitationMutation,
+        {
+          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 2 with role changed from MEMBER to ADMIN',
+          role: roles.ADMIN,
+          since: new Date('01 February 2022').toISOString(),
+        },
+        user1,
+      );
+
+      const editedMemberInvitation = result.data.editMemberInvitation;
+      expect(result.errors).to.not.exist;
+      expect(editedMemberInvitation.role).to.equal(roles.ADMIN);
+      expect(editedMemberInvitation.description).to.equal('new user 2 with role changed from MEMBER to ADMIN');
+      expect(editedMemberInvitation.since.toISOString()).to.equal(new Date('01 February 2022').toISOString());
+    });
+    //   it('must be authenticated as an admin of the collective', async () => {});
+    //   it('can only update role to accountant, admin or member', async () => {});
+  });
 
   //   describe('replyToMemberInvitation', () => {
   //     it('can accept the invitation and document the changes in an activity', () => {});

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -314,7 +314,7 @@ describe('MemberInvitationMutations', () => {
           memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
           account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'role changed to MEMBER',
-          role: roles.ADMIN,
+          role: roles.MEMBER,
           since: new Date('01 February 2022').toISOString(),
         },
         user1,

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -8,124 +8,92 @@ import roles from '../../../../../server/constants/roles';
 import { idEncode, IDENTIFIER_TYPES } from '../../../../../server/graphql/v2/identifiers';
 import emailLib from '../../../../../server/lib/email';
 import models from '../../../../../server/models';
+import { fakeCollective, fakeUser } from '../../../../test-helpers/fake-data';
 import * as utils from '../../../../utils';
 
-let host, user1, user2, user3, user4, user5, user6, collective1, collective2;
-let createdMemberInvitationId1, createdMemberInvitationId2, createdMemberInvitationId3;
+let collectiveAdminUser, collective;
 let sandbox, sendEmailSpy;
 
 describe('MemberInvitationMutations', () => {
-  /* SETUP
-    - collective1: host, user1 as admin
-    - user2, user3, ... user6
-    - collective2: user2 as admin
-  */
-  before(() => {
+  before(async () => {
+    await utils.resetTestDB();
     sandbox = createSandbox();
     sendEmailSpy = sandbox.spy(emailLib, 'sendMessage');
+    collectiveAdminUser = await fakeUser();
+    collective = await fakeCollective({ name: 'webpack test collective', admin: collectiveAdminUser });
   });
-
   after(() => sandbox.restore());
-  before(() => utils.resetTestDB());
-  before(async () => {
-    user1 = await models.User.createUserWithCollective(utils.data('user1'));
-  });
-  before(async () => {
-    host = await models.User.createUserWithCollective(utils.data('host1'));
-  });
-  before(async () => {
-    user2 = await models.User.createUserWithCollective(utils.data('user2'));
-  });
-  before(async () => {
-    user3 = await models.User.createUserWithCollective(utils.data('user3'));
-  });
-  before(async () => {
-    user4 = await models.User.createUserWithCollective(utils.data('user4'));
-  });
-  before(async () => {
-    user5 = await models.User.createUserWithCollective(utils.data('user5'));
-  });
-  before(async () => {
-    user6 = await models.User.createUserWithCollective(utils.data('user6'));
-  });
-  before(async () => {
-    collective1 = await models.Collective.create(utils.data('collective1'));
-  });
-  before(async () => {
-    collective2 = await models.Collective.create(utils.data('collective2'));
-  });
-  before(() => collective1.addUserWithRole(host, roles.HOST));
-  before(() => collective1.addUserWithRole(user1, roles.ADMIN));
-  before(() => collective2.addUserWithRole(host, roles.HOST));
-  before(() => collective2.addUserWithRole(user2, roles.ADMIN));
+
+  const inviteMemberMutation = gqlV2/* GraphQL */ `
+    mutation InviteMember(
+      $memberAccount: AccountReferenceInput!
+      $account: AccountReferenceInput!
+      $role: MemberRole!
+      $description: String
+      $since: DateTime
+    ) {
+      inviteMember(
+        memberAccount: $memberAccount
+        account: $account
+        role: $role
+        description: $description
+        since: $since
+      ) {
+        id
+        role
+        description
+        since
+      }
+    }
+  `;
 
   describe('inviteMember', () => {
-    const inviteMemberMutation = gqlV2/* GraphQL */ `
-      mutation InviteMember(
-        $memberAccount: AccountReferenceInput!
-        $account: AccountReferenceInput!
-        $role: MemberRole!
-        $description: String
-        $since: DateTime
-      ) {
-        inviteMember(
-          memberAccount: $memberAccount
-          account: $account
-          role: $role
-          description: $description
-          since: $since
-        ) {
-          id
-          role
-          description
-          since
-        }
-      }
-    `;
     it('should create a new member invitation and its related activity', async () => {
       sendEmailSpy.resetHistory();
+      const randomUserToInvite = await fakeUser();
       const result = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInvite.collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 2 as MEMBER',
           role: roles.MEMBER,
           since: new Date('01 January 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
 
       const activity = await models.Activity.findAll({
         where: {
           type: ActivityTypes.COLLECTIVE_CORE_MEMBER_INVITED,
-          CollectiveId: collective1.id,
+          CollectiveId: collective.id,
         },
       });
       const createdMemberInvitation = result.data.inviteMember;
 
       expect(result.errors).to.not.exist;
       expect(activity.length).to.equal(1);
-      expect(activity[0].data.memberCollective.id).to.equal(user2.id);
+      expect(activity[0].data.memberCollective.id).to.equal(randomUserToInvite.collective.id);
       expect(createdMemberInvitation.role).to.equal(roles.MEMBER);
       expect(createdMemberInvitation.description).to.equal('new user 2 as MEMBER');
       expect(createdMemberInvitation.since.toISOString()).to.equal(new Date('01 January 2022').toISOString());
       expect(sendEmailSpy.callCount).to.equal(1);
-      expect(sendEmailSpy.args[0][0]).to.equal(user2.email);
-      expect(sendEmailSpy.args[0][1]).to.equal("Invitation to join Scouts d'Arlon on Open Collective");
+      expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
     });
     it('must be authenticated as an admin of the collective', async () => {
       sendEmailSpy.resetHistory();
+      const randomUser = await fakeUser();
+      const anotherRandomUser = await fakeUser();
       const result = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(user3.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user 2 as ADMIN',
+          memberAccount: { id: idEncode(anotherRandomUser.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 2 as MEMBER',
           role: roles.MEMBER,
           since: new Date('01 January 2022').toISOString(),
         },
-        user2,
+        randomUser,
       );
       expect(sendEmailSpy.callCount).to.equal(0);
       expect(result.errors).to.have.length(1);
@@ -134,76 +102,77 @@ describe('MemberInvitationMutations', () => {
     it('can only add with role accountant, admin, or member', async () => {
       // Able to add ACCOUNTANT Role
       sendEmailSpy.resetHistory();
+      const randomUserToInviteAsAccountant = await fakeUser();
       const result1 = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(user3.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInviteAsAccountant.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 3 as ACCOUNTANT',
           role: roles.ACCOUNTANT,
           since: new Date('01 January 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
-      createdMemberInvitationId1 = result1.data.inviteMember.id;
       expect(result1.errors).to.not.exist;
       expect(result1.data.inviteMember.role).to.equal(roles.ACCOUNTANT);
       expect(result1.data.inviteMember.description).to.equal('new user 3 as ACCOUNTANT');
       expect(sendEmailSpy.callCount).to.equal(1);
-      expect(sendEmailSpy.args[0][0]).to.equal(user3.email);
+      expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
 
       // Able to add ADMIN Role
       sendEmailSpy.resetHistory();
+      const randomUserToInviteAsAdmin = await fakeUser();
       const result2 = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(user4.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInviteAsAdmin.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 4 as ADMIN',
           role: roles.ADMIN,
           since: new Date('01 January 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
-      createdMemberInvitationId2 = result2.data.inviteMember.id;
       expect(result2.errors).to.not.exist;
       expect(result2.data.inviteMember.role).to.equal(roles.ADMIN);
       expect(result2.data.inviteMember.description).to.equal('new user 4 as ADMIN');
       expect(sendEmailSpy.callCount).to.equal(1);
-      expect(sendEmailSpy.args[0][0]).to.equal(user4.email);
+      expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
 
       // Able to add MEMBER Role
       sendEmailSpy.resetHistory();
+      const randomUserToInviteAsMember = await fakeUser();
       const result3 = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(user5.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInviteAsMember.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 5 as MEMBER',
           role: roles.MEMBER,
           since: new Date('01 January 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
-      createdMemberInvitationId3 = result3.data.inviteMember.id;
       expect(result3.errors).to.not.exist;
       expect(result3.data.inviteMember.role).to.equal(roles.MEMBER);
       expect(result3.data.inviteMember.description).to.equal('new user 5 as MEMBER');
       expect(sendEmailSpy.callCount).to.equal(1);
-      expect(sendEmailSpy.args[0][0]).to.equal(user5.email);
+      expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
 
       // Throw error wihle adding other roles
       sendEmailSpy.resetHistory();
+      const randomUserToInviteAsBacker = await fakeUser();
       const result4 = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(user6.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInviteAsBacker.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 6 as BACKER',
           role: roles.BACKER,
           since: new Date('01 January 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
       expect(sendEmailSpy.callCount).to.equal(0);
       expect(result4.errors).to.have.length(1);
@@ -211,16 +180,17 @@ describe('MemberInvitationMutations', () => {
     });
     it('can only add with a user account', async () => {
       sendEmailSpy.resetHistory();
+      const randomCollective = await fakeCollective({ admin: collectiveAdminUser });
       const result = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(collective2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomCollective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'not a user acccount',
           role: roles.MEMBER,
           since: new Date('01 January 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
       expect(sendEmailSpy.callCount).to.equal(0);
       expect(result.errors).to.have.length(1);
@@ -228,7 +198,7 @@ describe('MemberInvitationMutations', () => {
     });
   });
 
-  describe('editMemberInvitation', () => {
+  describe('editMemberInvitation', async () => {
     const editMemberInvitationMutation = gqlV2/* GraphQL */ `
       mutation EditMemberInvitation(
         $memberAccount: AccountReferenceInput!
@@ -251,17 +221,34 @@ describe('MemberInvitationMutations', () => {
         }
       }
     `;
+
+    let randomUserToInvite;
+    before(async () => {
+      randomUserToInvite = await fakeUser();
+      await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user as MEMBER',
+          role: roles.MEMBER,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        collectiveAdminUser,
+      );
+    });
+
     it('should edit the role, description, and since', async () => {
       const result = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
-          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 2 with role changed from MEMBER to ADMIN',
           role: roles.ADMIN,
           since: new Date('01 February 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
 
       const editedMemberInvitation = result.data.editMemberInvitation;
@@ -271,16 +258,17 @@ describe('MemberInvitationMutations', () => {
       expect(editedMemberInvitation.since.toISOString()).to.equal(new Date('01 February 2022').toISOString());
     });
     it('must be authenticated as an admin of the collective', async () => {
+      const randomUser = await fakeUser();
       const result = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
-          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'role changed to MEMBER',
           role: roles.MEMBER,
           since: new Date('01 February 2022').toISOString(),
         },
-        user3,
+        randomUser,
       );
 
       expect(result.errors).to.have.length(1);
@@ -291,13 +279,13 @@ describe('MemberInvitationMutations', () => {
       const result1 = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
-          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'role changed to ACCOUNTANT',
           role: roles.ACCOUNTANT,
           since: new Date('01 February 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
 
       const editedMemberInvitation1 = result1.data.editMemberInvitation;
@@ -309,13 +297,13 @@ describe('MemberInvitationMutations', () => {
       const result2 = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
-          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'role changed to ADMIN',
           role: roles.ADMIN,
           since: new Date('01 February 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
 
       const editedMemberInvitation2 = result2.data.editMemberInvitation;
@@ -327,13 +315,13 @@ describe('MemberInvitationMutations', () => {
       const result3 = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
-          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'role changed to MEMBER',
           role: roles.MEMBER,
           since: new Date('01 February 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
 
       const editedMemberInvitation3 = result3.data.editMemberInvitation;
@@ -345,13 +333,13 @@ describe('MemberInvitationMutations', () => {
       const result4 = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
-          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'role changed to BACKER',
           role: roles.BACKER,
           since: new Date('01 February 2022').toISOString(),
         },
-        user1,
+        collectiveAdminUser,
       );
 
       expect(result4.errors).to.have.length(1);
@@ -365,49 +353,85 @@ describe('MemberInvitationMutations', () => {
                 replyToMemberInvitation(invitation: $invitation, accept: $accept)
             }
         `;
+
+    let randomUserToAcceptInvite, randomUserToDeclineInvite;
+    let createdInvitationToAccept,
+      createdInvitationToAcceptId,
+      createdInvitationToDecline,
+      createdInvitationToDeclineId;
+
+    before(async () => {
+      randomUserToAcceptInvite = await fakeUser();
+      randomUserToDeclineInvite = await fakeUser();
+      createdInvitationToAccept = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(randomUserToAcceptInvite.collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user as ACCOUNTANT',
+          role: roles.ACCOUNTANT,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        collectiveAdminUser,
+      );
+      createdInvitationToAcceptId = createdInvitationToAccept.data.inviteMember.id;
+      createdInvitationToDecline = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(randomUserToDeclineInvite.collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user as ACCOUNTANT',
+          role: roles.ACCOUNTANT,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        collectiveAdminUser,
+      );
+      createdInvitationToDeclineId = createdInvitationToDecline.data.inviteMember.id;
+    });
+
     it('can accept the invitation and document the changes in an activity', async () => {
       const result = await utils.graphqlQueryV2(
         replyToMemberInvitationMutation,
         {
-          invitation: { id: createdMemberInvitationId1 },
+          invitation: { id: createdInvitationToAcceptId },
           accept: true,
         },
-        user3,
+        randomUserToAcceptInvite,
       );
       const activity = await models.Activity.findAll({
         where: {
           type: ActivityTypes.COLLECTIVE_CORE_MEMBER_ADDED,
-          CollectiveId: collective1.id,
+          CollectiveId: collective.id,
         },
       });
       expect(activity.length).to.equal(1);
-      expect(activity[0].data.memberCollective.id).to.equal(user3.id);
+      expect(activity[0].data.memberCollective.id).to.equal(randomUserToAcceptInvite.collective.id);
       expect(result.errors).to.not.exist;
       expect(result.data.replyToMemberInvitation).to.equal(true);
-    });
-    it('can decline the invitation', async () => {
-      const result = await utils.graphqlQueryV2(
-        replyToMemberInvitationMutation,
-        {
-          invitation: { id: createdMemberInvitationId2 },
-          accept: false,
-        },
-        user4,
-      );
-      expect(result.errors).to.not.exist;
-      expect(result.data.replyToMemberInvitation).to.equal(false);
     });
     it('must be authenticated as the invited user', async () => {
       const result = await utils.graphqlQueryV2(
         replyToMemberInvitationMutation,
         {
-          invitation: { id: createdMemberInvitationId3 },
+          invitation: { id: createdInvitationToDeclineId },
           accept: true,
         },
-        user2,
+        randomUserToAcceptInvite,
       );
       expect(result.errors).to.have.length(1);
       expect(result.errors[0].message).to.equal('Only an admin of the invited account can reply to the invitation');
+    });
+    it('can decline the invitation', async () => {
+      const result = await utils.graphqlQueryV2(
+        replyToMemberInvitationMutation,
+        {
+          invitation: { id: createdInvitationToDeclineId },
+          accept: false,
+        },
+        randomUserToDeclineInvite,
+      );
+      expect(result.errors).to.not.exist;
+      expect(result.data.replyToMemberInvitation).to.equal(false);
     });
   });
 });

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -17,8 +17,8 @@ let sandbox, sendEmailSpy;
 describe('MemberInvitationMutations', () => {
   /* SETUP
     - collective1: host, user1 as admin
-    - user2
-    - user3
+    - user2, user3, ... user6
+    - collective2: user2 as admin
   */
   before(() => {
     sandbox = createSandbox();
@@ -56,6 +56,8 @@ describe('MemberInvitationMutations', () => {
   });
   before(() => collective1.addUserWithRole(host, roles.HOST));
   before(() => collective1.addUserWithRole(user1, roles.ADMIN));
+  before(() => collective2.addUserWithRole(host, roles.HOST));
+  before(() => collective2.addUserWithRole(user2, roles.ADMIN));
 
   describe('inviteMember', () => {
     const inviteMemberMutation = gqlV2/* GraphQL */ `
@@ -249,7 +251,7 @@ describe('MemberInvitationMutations', () => {
         }
       }
     `;
-    it('should edit the role, description, and since and document the changes in an activity', async () => {
+    it('should edit the role, description, and since', async () => {
       const result = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
@@ -383,7 +385,7 @@ describe('MemberInvitationMutations', () => {
       expect(result.errors).to.not.exist;
       expect(result.data.replyToMemberInvitation).to.equal(true);
     });
-    it('can decline the invitation and document the changes in an activity', async () => {
+    it('can decline the invitation', async () => {
       const result = await utils.graphqlQueryV2(
         replyToMemberInvitationMutation,
         {

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -1,0 +1,226 @@
+import { expect } from 'chai';
+import gqlV2 from 'fake-tag';
+import { describe, it } from 'mocha';
+import { createSandbox } from 'sinon';
+
+import roles from '../../../../../server/constants/roles';
+import { idEncode, IDENTIFIER_TYPES } from '../../../../../server/graphql/v2/identifiers';
+import emailLib from '../../../../../server/lib/email';
+import models from '../../../../../server/models';
+import * as utils from '../../../../utils';
+
+let host, user1, user2, user3, user4, user5, user6, collective1, collective2;
+let sandbox, sendEmailSpy;
+
+describe('MemberInvitationMutations', () => {
+  /* SETUP
+    - collective1: host, user1 as admin
+    - user2
+    - user3
+  */
+  before(() => {
+    sandbox = createSandbox();
+    sendEmailSpy = sandbox.spy(emailLib, 'sendMessage');
+  });
+
+  after(() => sandbox.restore());
+  before(() => utils.resetTestDB());
+  before(async () => {
+    user1 = await models.User.createUserWithCollective(utils.data('user1'));
+  });
+  before(async () => {
+    host = await models.User.createUserWithCollective(utils.data('host1'));
+  });
+  before(async () => {
+    user2 = await models.User.createUserWithCollective(utils.data('user2'));
+  });
+  before(async () => {
+    user3 = await models.User.createUserWithCollective(utils.data('user3'));
+  });
+  before(async () => {
+    user4 = await models.User.createUserWithCollective(utils.data('user4'));
+  });
+  before(async () => {
+    user5 = await models.User.createUserWithCollective(utils.data('user5'));
+  });
+  before(async () => {
+    user6 = await models.User.createUserWithCollective(utils.data('user6'));
+  });
+  before(async () => {
+    collective1 = await models.Collective.create(utils.data('collective1'));
+  });
+  before(async () => {
+    collective2 = await models.Collective.create(utils.data('collective2'));
+  });
+  before(() => collective1.addUserWithRole(host, roles.HOST));
+  before(() => collective1.addUserWithRole(user1, roles.ADMIN));
+
+  describe('inviteMember', () => {
+    const inviteMemberMutation = gqlV2/* GraphQL */ `
+      mutation InviteMember(
+        $memberAccount: AccountReferenceInput!
+        $account: AccountReferenceInput!
+        $role: MemberRole!
+        $description: String
+        $since: DateTime
+      ) {
+        inviteMember(
+          memberAccount: $memberAccount
+          account: $account
+          role: $role
+          description: $description
+          since: $since
+        ) {
+          id
+          role
+          description
+          since
+        }
+      }
+    `;
+    it('should create a new member invitation and its related activity', async () => {
+      sendEmailSpy.resetHistory();
+      const result = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(user2.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 2 as ADMIN',
+          role: roles.MEMBER,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        user1,
+      );
+
+      const createdMemberInvitation = result.data.inviteMember;
+      expect(result.errors).to.not.exist;
+      expect(createdMemberInvitation.role).to.equal(roles.MEMBER);
+      expect(createdMemberInvitation.description).to.equal('new user 2 as ADMIN');
+      expect(createdMemberInvitation.since.toISOString()).to.equal(new Date('01 January 2022').toISOString());
+      expect(sendEmailSpy.callCount).to.equal(1);
+      expect(sendEmailSpy.args[0][0]).to.equal(user2.email);
+      expect(sendEmailSpy.args[0][1]).to.equal("Invitation to join Scouts d'Arlon on Open Collective");
+    });
+    it('must be authenticated as an admin of the collective', async () => {
+      sendEmailSpy.resetHistory();
+      const result = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(user3.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 2 as ADMIN',
+          role: roles.MEMBER,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        user2,
+      );
+      expect(sendEmailSpy.callCount).to.equal(0);
+      expect(result.errors).to.have.length(1);
+      expect(result.errors[0].message).to.equal('Only admins can send an invitation.');
+    });
+    it('can only add with role accountant, admin, or member', async () => {
+      // Able to add ACCOUNTANT Role
+      sendEmailSpy.resetHistory();
+      const result1 = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(user3.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 3 as ACCOUNTANT',
+          role: roles.ACCOUNTANT,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        user1,
+      );
+      expect(result1.errors).to.not.exist;
+      expect(result1.data.inviteMember.role).to.equal(roles.ACCOUNTANT);
+      expect(result1.data.inviteMember.description).to.equal('new user 3 as ACCOUNTANT');
+      expect(sendEmailSpy.callCount).to.equal(1);
+      expect(sendEmailSpy.args[0][0]).to.equal(user3.email);
+
+      // Able to add ADMIN Role
+      sendEmailSpy.resetHistory();
+      const result2 = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(user4.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 4 as ADMIN',
+          role: roles.ADMIN,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        user1,
+      );
+      expect(result2.errors).to.not.exist;
+      expect(result2.data.inviteMember.role).to.equal(roles.ADMIN);
+      expect(result2.data.inviteMember.description).to.equal('new user 4 as ADMIN');
+      expect(sendEmailSpy.callCount).to.equal(1);
+      expect(sendEmailSpy.args[0][0]).to.equal(user4.email);
+
+      // Able to add MEMBER Role
+      sendEmailSpy.resetHistory();
+      const result3 = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(user5.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 5 as MEMBER',
+          role: roles.MEMBER,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        user1,
+      );
+      expect(result3.errors).to.not.exist;
+      expect(result3.data.inviteMember.role).to.equal(roles.MEMBER);
+      expect(result3.data.inviteMember.description).to.equal('new user 5 as MEMBER');
+      expect(sendEmailSpy.callCount).to.equal(1);
+      expect(sendEmailSpy.args[0][0]).to.equal(user5.email);
+
+      // Throw error wihle adding other roles
+      sendEmailSpy.resetHistory();
+      const result4 = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(user6.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 6 as BACKER',
+          role: roles.BACKER,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        user1,
+      );
+      expect(sendEmailSpy.callCount).to.equal(0);
+      expect(result4.errors).to.have.length(1);
+      expect(result4.errors[0].message).to.equal('You can only invite accountants, admins, or members.');
+    });
+    it('can only add with a user account', async () => {
+      sendEmailSpy.resetHistory();
+      const result = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(collective2.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective1.id, IDENTIFIER_TYPES.ACCOUNT) },
+          description: 'new user 6 as BACKER',
+          role: roles.MEMBER,
+          since: new Date('01 January 2022').toISOString(),
+        },
+        user1,
+      );
+      expect(sendEmailSpy.callCount).to.equal(0);
+      expect(result.errors).to.have.length(1);
+      expect(result.errors[0].message).to.equal('You can only invite users.');
+    });
+  });
+
+  //   describe('editMemberInvitation', () => {
+  //     it('should edit the role, description and since and document the changes in an activity', () => {});
+  //     it('must be authenticated as an admin of the collective', () => {});
+  //     it('can only update role to accountant, admin or member', () => {});
+  //   });
+
+  //   describe('replyToMemberInvitation', () => {
+  //     it('can accept the invitation and document the changes in an activity', () => {});
+  //     it('can decline the invitation and document the changes in an activity', () => {});
+  //     it('must be authenticated as the invited user', () => {});
+  //   });
+});

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import gqlV2 from 'fake-tag';
+import { omit } from 'lodash';
 import { describe, it } from 'mocha';
 import { createSandbox } from 'sinon';
 
@@ -8,7 +9,7 @@ import roles from '../../../../../server/constants/roles';
 import { idEncode, IDENTIFIER_TYPES } from '../../../../../server/graphql/v2/identifiers';
 import emailLib from '../../../../../server/lib/email';
 import models from '../../../../../server/models';
-import { fakeCollective, fakeUser } from '../../../../test-helpers/fake-data';
+import { fakeCollective, fakeMemberInvitation, fakeUser } from '../../../../test-helpers/fake-data';
 import * as utils from '../../../../utils';
 
 let collectiveAdminUser, collective;
@@ -22,7 +23,12 @@ describe('MemberInvitationMutations', () => {
     collectiveAdminUser = await fakeUser();
     collective = await fakeCollective({ name: 'webpack test collective', admin: collectiveAdminUser });
   });
+
   after(() => sandbox.restore());
+
+  afterEach(() => {
+    sendEmailSpy.resetHistory();
+  });
 
   const inviteMemberMutation = gqlV2/* GraphQL */ `
     mutation InviteMember(
@@ -49,7 +55,6 @@ describe('MemberInvitationMutations', () => {
 
   describe('inviteMember', () => {
     it('should create a new member invitation and its related activity', async () => {
-      sendEmailSpy.resetHistory();
       const randomUserToInvite = await fakeUser();
       const result = await utils.graphqlQueryV2(
         inviteMemberMutation,
@@ -80,14 +85,14 @@ describe('MemberInvitationMutations', () => {
       expect(sendEmailSpy.callCount).to.equal(1);
       expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
     });
+
     it('must be authenticated as an admin of the collective', async () => {
-      sendEmailSpy.resetHistory();
       const randomUser = await fakeUser();
       const anotherRandomUser = await fakeUser();
       const result = await utils.graphqlQueryV2(
         inviteMemberMutation,
         {
-          memberAccount: { id: idEncode(anotherRandomUser.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(anotherRandomUser.CollectiveId, IDENTIFIER_TYPES.ACCOUNT) },
           account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 2 as MEMBER',
           role: roles.MEMBER,
@@ -99,87 +104,53 @@ describe('MemberInvitationMutations', () => {
       expect(result.errors).to.have.length(1);
       expect(result.errors[0].message).to.equal('Only admins can send an invitation.');
     });
+
     it('can only add with role accountant, admin, or member', async () => {
-      // Able to add ACCOUNTANT Role
-      sendEmailSpy.resetHistory();
-      const randomUserToInviteAsAccountant = await fakeUser();
-      const result1 = await utils.graphqlQueryV2(
-        inviteMemberMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInviteAsAccountant.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user 3 as ACCOUNTANT',
-          role: roles.ACCOUNTANT,
-          since: new Date('01 January 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-      expect(result1.errors).to.not.exist;
-      expect(result1.data.inviteMember.role).to.equal(roles.ACCOUNTANT);
-      expect(result1.data.inviteMember.description).to.equal('new user 3 as ACCOUNTANT');
-      expect(sendEmailSpy.callCount).to.equal(1);
-      expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
+      const validRoles = [roles.ADMIN, roles.MEMBER, roles.ACCOUNTANT];
+      for (const role of validRoles) {
+        const invitedUser = await fakeUser();
+        const result = await utils.graphqlQueryV2(
+          inviteMemberMutation,
+          {
+            memberAccount: { id: idEncode(invitedUser.CollectiveId, IDENTIFIER_TYPES.ACCOUNT) },
+            account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+            description: 'new user description',
+            since: new Date('01 January 2022').toISOString(),
+            role,
+          },
+          collectiveAdminUser,
+        );
 
-      // Able to add ADMIN Role
-      sendEmailSpy.resetHistory();
-      const randomUserToInviteAsAdmin = await fakeUser();
-      const result2 = await utils.graphqlQueryV2(
-        inviteMemberMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInviteAsAdmin.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user 4 as ADMIN',
-          role: roles.ADMIN,
-          since: new Date('01 January 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-      expect(result2.errors).to.not.exist;
-      expect(result2.data.inviteMember.role).to.equal(roles.ADMIN);
-      expect(result2.data.inviteMember.description).to.equal('new user 4 as ADMIN');
-      expect(sendEmailSpy.callCount).to.equal(1);
-      expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
+        expect(result.errors).to.not.exist;
+        expect(result.data.inviteMember.role).to.equal(role);
+        expect(result.data.inviteMember.description).to.equal('new user description');
+        expect(sendEmailSpy.callCount).to.equal(1);
+        expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
+        sendEmailSpy.resetHistory();
+      }
 
-      // Able to add MEMBER Role
-      sendEmailSpy.resetHistory();
-      const randomUserToInviteAsMember = await fakeUser();
-      const result3 = await utils.graphqlQueryV2(
-        inviteMemberMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInviteAsMember.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user 5 as MEMBER',
-          role: roles.MEMBER,
-          since: new Date('01 January 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-      expect(result3.errors).to.not.exist;
-      expect(result3.data.inviteMember.role).to.equal(roles.MEMBER);
-      expect(result3.data.inviteMember.description).to.equal('new user 5 as MEMBER');
-      expect(sendEmailSpy.callCount).to.equal(1);
-      expect(sendEmailSpy.args[0][1]).to.equal('Invitation to join webpack test collective on Open Collective');
-
-      // Throw error wihle adding other roles
-      sendEmailSpy.resetHistory();
-      const randomUserToInviteAsBacker = await fakeUser();
-      const result4 = await utils.graphqlQueryV2(
-        inviteMemberMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInviteAsBacker.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user 6 as BACKER',
-          role: roles.BACKER,
-          since: new Date('01 January 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-      expect(sendEmailSpy.callCount).to.equal(0);
-      expect(result4.errors).to.have.length(1);
-      expect(result4.errors[0].message).to.equal('You can only invite accountants, admins, or members.');
+      // Throw error if adding other roles
+      const invalidRoles = Object.values(omit(roles, [...validRoles, 'CONNECTED_COLLECTIVE']));
+      for (const role of invalidRoles) {
+        const invitedUser = await fakeUser();
+        const result = await utils.graphqlQueryV2(
+          inviteMemberMutation,
+          {
+            memberAccount: { id: idEncode(invitedUser.id, IDENTIFIER_TYPES.ACCOUNT) },
+            account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+            description: 'new user 6 as BACKER',
+            since: new Date('01 January 2022').toISOString(),
+            role,
+          },
+          collectiveAdminUser,
+        );
+        expect(sendEmailSpy.callCount).to.equal(0);
+        expect(result.errors).to.have.length(1);
+        expect(result.errors[0].message).to.equal('You can only invite accountants, admins, or members.');
+      }
     });
+
     it('can only add with a user account', async () => {
-      sendEmailSpy.resetHistory();
       const randomCollective = await fakeCollective({ admin: collectiveAdminUser });
       const result = await utils.graphqlQueryV2(
         inviteMemberMutation,
@@ -222,27 +193,22 @@ describe('MemberInvitationMutations', () => {
       }
     `;
 
-    let randomUserToInvite;
+    let invitation;
+
     before(async () => {
-      randomUserToInvite = await fakeUser();
-      await utils.graphqlQueryV2(
-        inviteMemberMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user as MEMBER',
-          role: roles.MEMBER,
-          since: new Date('01 January 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
+      invitation = await fakeMemberInvitation({
+        CollectiveId: collective.id,
+        description: 'new user as MEMBER',
+        role: roles.MEMBER,
+        since: new Date('01 January 2022').toISOString(),
+      });
     });
 
     it('should edit the role, description, and since', async () => {
       const result = await utils.graphqlQueryV2(
         editMemberInvitationMutation,
         {
-          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
+          memberAccount: { id: idEncode(invitation.MemberCollectiveId, IDENTIFIER_TYPES.ACCOUNT) },
           account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
           description: 'new user 2 with role changed from MEMBER to ADMIN',
           role: roles.ADMIN,
@@ -257,146 +223,84 @@ describe('MemberInvitationMutations', () => {
       expect(editedMemberInvitation.description).to.equal('new user 2 with role changed from MEMBER to ADMIN');
       expect(editedMemberInvitation.since.toISOString()).to.equal(new Date('01 February 2022').toISOString());
     });
+
     it('must be authenticated as an admin of the collective', async () => {
       const randomUser = await fakeUser();
-      const result = await utils.graphqlQueryV2(
-        editMemberInvitationMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'role changed to MEMBER',
-          role: roles.MEMBER,
-          since: new Date('01 February 2022').toISOString(),
-        },
-        randomUser,
-      );
+      const invitedUser = await invitation.memberCollective.getUser();
+      for (const user of [randomUser, invitedUser]) {
+        const result = await utils.graphqlQueryV2(
+          editMemberInvitationMutation,
+          {
+            memberAccount: { id: idEncode(invitation.MemberCollectiveId, IDENTIFIER_TYPES.ACCOUNT) },
+            account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+            description: 'role changed to MEMBER',
+            role: roles.MEMBER,
+            since: new Date('01 February 2022').toISOString(),
+          },
+          user,
+        );
 
-      expect(result.errors).to.have.length(1);
-      expect(result.errors[0].message).to.equal('Only admins can edit members.');
+        expect(result.errors).to.have.length(1);
+        expect(result.errors[0].message).to.equal('Only admins can edit members.');
+      }
     });
+
     it('can only update role to accountant, admin or member', async () => {
-      // update role to ACCOUNTANT
-      const result1 = await utils.graphqlQueryV2(
-        editMemberInvitationMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'role changed to ACCOUNTANT',
-          role: roles.ACCOUNTANT,
-          since: new Date('01 February 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
+      const validRoles = [roles.ADMIN, roles.MEMBER, roles.ACCOUNTANT];
+      for (const role of validRoles) {
+        const result = await utils.graphqlQueryV2(
+          editMemberInvitationMutation,
+          {
+            memberAccount: { id: idEncode(invitation.MemberCollectiveId, IDENTIFIER_TYPES.ACCOUNT) },
+            account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+            description: `role changed to ${role}`,
+            since: new Date('01 February 2022').toISOString(),
+            role,
+          },
+          collectiveAdminUser,
+        );
 
-      const editedMemberInvitation1 = result1.data.editMemberInvitation;
-      expect(result1.errors).to.not.exist;
-      expect(editedMemberInvitation1.role).to.equal(roles.ACCOUNTANT);
-      expect(editedMemberInvitation1.description).to.equal('role changed to ACCOUNTANT');
-
-      // update role to ADMIN
-      const result2 = await utils.graphqlQueryV2(
-        editMemberInvitationMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'role changed to ADMIN',
-          role: roles.ADMIN,
-          since: new Date('01 February 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-
-      const editedMemberInvitation2 = result2.data.editMemberInvitation;
-      expect(result2.errors).to.not.exist;
-      expect(editedMemberInvitation2.role).to.equal(roles.ADMIN);
-      expect(editedMemberInvitation2.description).to.equal('role changed to ADMIN');
-
-      // update role to MEMBER
-      const result3 = await utils.graphqlQueryV2(
-        editMemberInvitationMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'role changed to MEMBER',
-          role: roles.MEMBER,
-          since: new Date('01 February 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-
-      const editedMemberInvitation3 = result3.data.editMemberInvitation;
-      expect(result3.errors).to.not.exist;
-      expect(editedMemberInvitation3.role).to.equal(roles.MEMBER);
-      expect(editedMemberInvitation3.description).to.equal('role changed to MEMBER');
+        expect(result.errors).to.not.exist;
+        const editedMemberInvitation = result.data.editMemberInvitation;
+        expect(editedMemberInvitation.role).to.equal(role);
+        expect(editedMemberInvitation.description).to.equal(`role changed to ${role}`);
+      }
 
       // Throw error if updating to any other role
-      const result4 = await utils.graphqlQueryV2(
-        editMemberInvitationMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToInvite.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'role changed to BACKER',
-          role: roles.BACKER,
-          since: new Date('01 February 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
+      const invalidRoles = Object.values(omit(roles, [...validRoles, 'CONNECTED_COLLECTIVE']));
+      for (const role of invalidRoles) {
+        const result = await utils.graphqlQueryV2(
+          editMemberInvitationMutation,
+          {
+            memberAccount: { id: idEncode(invitation.MemberCollectiveId, IDENTIFIER_TYPES.ACCOUNT) },
+            account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+            description: 'role changed to BACKER',
+            since: new Date('01 February 2022').toISOString(),
+            role,
+          },
+          collectiveAdminUser,
+        );
 
-      expect(result4.errors).to.have.length(1);
-      expect(result4.errors[0].message).to.equal('You can only edit accountants, admins, or members.');
+        expect(result.errors).to.have.length(1);
+        expect(result.errors[0].message).to.equal('You can only edit accountants, admins, or members.');
+      }
     });
   });
 
   describe('replyToMemberInvitation', () => {
     const replyToMemberInvitationMutation = gqlV2`
-            mutation ReplyToMemberInvitation($invitation: MemberInvitationReferenceInput!, $accept: Boolean!) {
-                replyToMemberInvitation(invitation: $invitation, accept: $accept)
-            }
-        `;
-
-    let randomUserToAcceptInvite, randomUserToDeclineInvite;
-    let createdInvitationToAccept,
-      createdInvitationToAcceptId,
-      createdInvitationToDecline,
-      createdInvitationToDeclineId;
-
-    before(async () => {
-      randomUserToAcceptInvite = await fakeUser();
-      randomUserToDeclineInvite = await fakeUser();
-      createdInvitationToAccept = await utils.graphqlQueryV2(
-        inviteMemberMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToAcceptInvite.collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user as ACCOUNTANT',
-          role: roles.ACCOUNTANT,
-          since: new Date('01 January 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-      createdInvitationToAcceptId = createdInvitationToAccept.data.inviteMember.id;
-      createdInvitationToDecline = await utils.graphqlQueryV2(
-        inviteMemberMutation,
-        {
-          memberAccount: { id: idEncode(randomUserToDeclineInvite.collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
-          description: 'new user as ACCOUNTANT',
-          role: roles.ACCOUNTANT,
-          since: new Date('01 January 2022').toISOString(),
-        },
-        collectiveAdminUser,
-      );
-      createdInvitationToDeclineId = createdInvitationToDecline.data.inviteMember.id;
-    });
+      mutation ReplyToMemberInvitation($invitation: MemberInvitationReferenceInput!, $accept: Boolean!) {
+          replyToMemberInvitation(invitation: $invitation, accept: $accept)
+      }
+    `;
 
     it('can accept the invitation and document the changes in an activity', async () => {
+      const invitation = await fakeMemberInvitation({ CollectiveId: collective.id, role: roles.ADMIN });
+      const invitedUser = await invitation.memberCollective.getUser();
       const result = await utils.graphqlQueryV2(
         replyToMemberInvitationMutation,
-        {
-          invitation: { id: createdInvitationToAcceptId },
-          accept: true,
-        },
-        randomUserToAcceptInvite,
+        { invitation: { id: idEncode(invitation.id, IDENTIFIER_TYPES.MEMBER_INVITATION) }, accept: true },
+        invitedUser,
       );
       const activity = await models.Activity.findAll({
         where: {
@@ -405,33 +309,56 @@ describe('MemberInvitationMutations', () => {
         },
       });
       expect(activity.length).to.equal(1);
-      expect(activity[0].data.memberCollective.id).to.equal(randomUserToAcceptInvite.collective.id);
+      expect(activity[0].data.memberCollective.id).to.equal(invitation.MemberCollectiveId);
       expect(result.errors).to.not.exist;
       expect(result.data.replyToMemberInvitation).to.equal(true);
     });
-    it('must be authenticated as the invited user', async () => {
-      const result = await utils.graphqlQueryV2(
-        replyToMemberInvitationMutation,
-        {
-          invitation: { id: createdInvitationToDeclineId },
-          accept: true,
-        },
-        randomUserToAcceptInvite,
-      );
-      expect(result.errors).to.have.length(1);
-      expect(result.errors[0].message).to.equal('Only an admin of the invited account can reply to the invitation');
-    });
+
     it('can decline the invitation', async () => {
+      const invitation = await fakeMemberInvitation({ CollectiveId: collective.id, role: roles.ADMIN });
+      const invitedUser = await invitation.memberCollective.getUser();
       const result = await utils.graphqlQueryV2(
         replyToMemberInvitationMutation,
-        {
-          invitation: { id: createdInvitationToDeclineId },
-          accept: false,
-        },
-        randomUserToDeclineInvite,
+        { invitation: { id: idEncode(invitation.id, IDENTIFIER_TYPES.MEMBER_INVITATION) }, accept: false },
+        invitedUser,
       );
       expect(result.errors).to.not.exist;
       expect(result.data.replyToMemberInvitation).to.equal(false);
+
+      const activity = await models.Activity.findAll({
+        where: {
+          type: ActivityTypes.COLLECTIVE_CORE_MEMBER_INVITATION_DECLINED,
+          CollectiveId: collective.id,
+          data: { memberCollective: { id: invitation.MemberCollectiveId } },
+        },
+      });
+
+      expect(activity.length).to.equal(1);
+    });
+
+    it('must be authenticated as the invited user', async () => {
+      // Must be authenticated
+      const invitation = await fakeMemberInvitation({ CollectiveId: collective.id, role: roles.ADMIN });
+      const resultUnauthenticated = await utils.graphqlQueryV2(replyToMemberInvitationMutation, {
+        invitation: { id: idEncode(invitation.id, IDENTIFIER_TYPES.MEMBER_INVITATION) },
+        accept: true,
+      });
+
+      expect(resultUnauthenticated.errors).to.have.length(1);
+      expect(resultUnauthenticated.errors[0].message).to.equal('You need to be authenticated to perform this action');
+
+      // Must be invited user
+      const randomUser = await fakeUser();
+      for (const user of [collectiveAdminUser, randomUser]) {
+        const result = await utils.graphqlQueryV2(
+          replyToMemberInvitationMutation,
+          { invitation: { id: idEncode(invitation.id, IDENTIFIER_TYPES.MEMBER_INVITATION) }, accept: true },
+          user,
+        );
+
+        expect(result.errors).to.have.length(1);
+        expect(result.errors[0].message).to.equal('Only an admin of the invited account can reply to the invitation');
+      }
     });
   });
 });

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -654,6 +654,28 @@ export const fakeMember = async (data: Record<string, unknown> = {}) => {
   return member;
 };
 
+/**
+ * Creates a fake member invitation
+ */
+export const fakeMemberInvitation = async (data: Record<string, unknown> = {}) => {
+  const collective = data.CollectiveId ? await models.Collective.findByPk(data.CollectiveId) : await fakeCollective();
+  const memberCollective = data.MemberCollectiveId
+    ? await models.Collective.findByPk(data.MemberCollectiveId)
+    : (await fakeUser()).collective;
+  const member = await models.MemberInvitation.create({
+    ...data,
+    CollectiveId: collective.id,
+    MemberCollectiveId: memberCollective.id,
+    role: data.role || roles.ADMIN,
+    CreatedByUserId: collective.CreatedByUserId,
+  });
+
+  // Attach associations
+  member.collective = collective;
+  member.memberCollective = memberCollective;
+  return member;
+};
+
 const fakePaymentMethodToken = (service, type) => {
   if (service === 'stripe' && type === 'creditcard') {
     return `pm_${randStrOfLength(24)}`;


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5605

> **Note**
>
> The following cases (Editining an invitation and declining an invitation) actually don't document changes in an activity.

`it('should edit the role, description and since and document the changes in an activity', () => {});`
` it('can decline the invitation and document the changes in an activity', () => {});`

https://github.com/opencollective/opencollective-api/blob/8916c35847d63b40a167dce4a8d2944d8b4c25aa/server/models/MemberInvitation.js#L162-L165
https://github.com/opencollective/opencollective-api/blob/8916c35847d63b40a167dce4a8d2944d8b4c25aa/server/models/MemberInvitation.js#L228-L231