### PR TITLE
Change search by slug logic to "startsWith" instead of "contains"

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -103,7 +103,7 @@ const getSearchTermSQLConditions = (term, collectiveTable) => {
     if (term[0] === '@' && splitTerm.length === 1) {
       // When the search starts with a `@`, we search by slug only
       sanitizedTerm = sanitizeSearchTermForILike(removeDiacritics(trimmedTerm).replace(/^@+/, ''));
-      sqlConditions = `AND ${collectiveTable ? `${collectiveTable}.` : ''}"slug" ILIKE '%' || :sanitizedTerm || '%' `;
+      sqlConditions = `AND ${collectiveTable ? `${collectiveTable}.` : ''}"slug" ILIKE :sanitizedTerm || '%' `;
     } else {
       sanitizedTerm = splitTerm.length === 1 ? sanitizeSearchTermForTSQuery(trimmedTerm) : trimmedTerm;
       if (sanitizedTerm) {


### PR DESCRIPTION
This changes the search by slug (which we do by prefixing the search term by `@` sign) to `startWith` the given string instead of returning everything that `contains` the given search string. 

Related to comment; https://github.com/opencollective/opencollective/issues/5434#issuecomment-1098832658
 
![image](https://user-images.githubusercontent.com/12435965/172778434-bfa48118-5545-4e39-9476-dbf7cd0f55fe.png)

Previously we had,

![image](https://user-images.githubusercontent.com/12435965/172778598-dfe73892-8572-423c-b8cc-3b7e4f8a5326.png)
