### PR TITLE
InviteMembers: use transaction and add test

### DIFF
--- a/server/graphql/common/members.ts
+++ b/server/graphql/common/members.ts
@@ -43,15 +43,15 @@ export async function editPublicMessage(_, { fromAccount, toAccount, FromCollect
 }
 
 export async function processInviteMembersInput(
-  args: { collective; inviteMembers: [{ memberAccount?; memberInfo?; role; description?; since? }]; skipDefaultAdmin },
-  options: { transaction?; supportedRoles?: [string]; collective?; user? },
+  collective: typeof models.Collective,
+  inviteMemberInputs: [{ memberAccount?; memberInfo?; role; description?; since? }],
+  options: { skipDefaultAdmin?; transaction?; supportedRoles?: [string]; user? },
 ) {
-  const collective = options.collective || (await fetchAccountWithReference(args.collective));
-  if (args.inviteMembers.length > 30) {
+  if (inviteMemberInputs.length > 30) {
     throw new Error('You exceeded the maximum number of invitations allowed at Collective creation.');
   }
 
-  for (const inviteMember of args.inviteMembers) {
+  for (const inviteMember of inviteMemberInputs) {
     if (!options.supportedRoles?.includes(inviteMember.role)) {
       throw new Forbidden('You can only invite accountants, admins, or members.');
     }
@@ -78,7 +78,7 @@ export async function processInviteMembersInput(
     };
     await models.MemberInvitation.invite(collective, memberParams, {
       transaction: options.transaction,
-      skipDefaultAdmin: args.skipDefaultAdmin,
+      skipDefaultAdmin: options.skipDefaultAdmin,
     });
   }
 }

--- a/server/graphql/v2/mutation/CreateCollectiveMutation.js
+++ b/server/graphql/v2/mutation/CreateCollectiveMutation.js
@@ -128,10 +128,10 @@ async function createCollective(_, args, req) {
       }
 
       if (args.inviteMembers && args.inviteMembers.length) {
-        await processInviteMembersInput(args, {
+        await processInviteMembersInput(collective, args.inviteMembers, {
+          skipDefaultAdmin: args.skipDefaultAdmin,
           transaction,
           supportedRoles: MEMBER_INVITATION_SUPPORTED_ROLES,
-          collective,
           user,
         });
       }

--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -90,9 +90,8 @@ const HostApplicationMutations = {
       });
 
       if (args.inviteMembers && args.inviteMembers.length) {
-        await processInviteMembersInput(args, {
+        await processInviteMembersInput(collective, args.inviteMembers, {
           supportedRoles: [MemberRoles.ADMIN],
-          collective,
           user: req.remoteUser,
         });
       }

--- a/server/models/MemberInvitation.js
+++ b/server/models/MemberInvitation.js
@@ -253,16 +253,19 @@ function defineModel() {
       invitation.collective = collective;
 
       if (MEMBER_INVITATION_SUPPORTED_ROLES.includes(memberParams.role)) {
-        const member = await models.Collective.findByPk(memberParams.MemberCollectiveId);
-        await models.Activity.create({
-          type: ActivityTypes.COLLECTIVE_CORE_MEMBER_INVITED,
-          CollectiveId: collective.id,
-          data: {
-            notify: false,
-            memberCollective: member.activity,
-            collective: collective.activity,
+        const memberCollective = await models.Collective.findByPk(memberParams.MemberCollectiveId, sequelizeParams);
+        await models.Activity.create(
+          {
+            type: ActivityTypes.COLLECTIVE_CORE_MEMBER_INVITED,
+            CollectiveId: collective.id,
+            data: {
+              notify: false,
+              memberCollective: memberCollective.activity,
+              collective: collective.activity,
+            },
           },
-        });
+          sequelizeParams,
+        );
       }
     }
 

--- a/test/server/graphql/v2/mutation/CreateCollectiveMutations.test.js
+++ b/test/server/graphql/v2/mutation/CreateCollectiveMutations.test.js
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 import gqlV2 from 'fake-tag';
 import nock from 'nock';
 
+import { activities } from '../../../../../server/constants';
 import models from '../../../../../server/models';
+import { randEmail } from '../../../../stores';
+import { fakeUser } from '../../../../test-helpers/fake-data';
 import * as utils from '../../../../utils';
 
 const createCollectiveMutation = gqlV2/* GraphQL */ `
@@ -10,11 +13,25 @@ const createCollectiveMutation = gqlV2/* GraphQL */ `
     $collective: CollectiveCreateInput!
     $host: AccountReferenceInput
     $automateApprovalWithGithub: Boolean
+    $inviteMembers: [InviteMemberInput]
   ) {
-    createCollective(collective: $collective, host: $host, automateApprovalWithGithub: $automateApprovalWithGithub) {
+    createCollective(
+      collective: $collective
+      host: $host
+      automateApprovalWithGithub: $automateApprovalWithGithub
+      inviteMembers: $inviteMembers
+    ) {
       name
       slug
       tags
+      isActive
+      ... on AccountWithHost {
+        isApproved
+        host {
+          id
+          slug
+        }
+      }
     }
   }
 `;
@@ -67,6 +84,65 @@ describe('server/graphql/v2/mutation/CreateCollectiveMutations', () => {
       expect(result.data.createCollective.name).to.equal(newCollectiveData.name);
       expect(result.data.createCollective.slug).to.equal(newCollectiveData.slug);
       expect(result.data.createCollective.tags).to.deep.equal(newCollectiveData.tags);
+    });
+
+    it('invite members', async () => {
+      const user = await models.User.createUserWithCollective(utils.data('user2'));
+      const existingUserToInvite = await fakeUser();
+      const result = await utils.graphqlQueryV2(
+        createCollectiveMutation,
+        {
+          collective: newCollectiveData,
+          inviteMembers: [
+            // Existing user
+            {
+              memberAccount: { slug: existingUserToInvite.collective.slug },
+              role: 'ADMIN',
+              description: 'An admin with existing account',
+            },
+            // New user
+            {
+              memberInfo: { name: 'Another admin', email: randEmail() },
+              role: 'ADMIN',
+              description: 'An admin with a new account',
+            },
+          ],
+        },
+        user,
+      );
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+
+      const resultAccount = result.data.createCollective;
+      expect(resultAccount.name).to.equal(newCollectiveData.name);
+      expect(resultAccount.slug).to.equal(newCollectiveData.slug);
+      expect(resultAccount.tags).to.deep.equal(newCollectiveData.tags);
+
+      const collective = await models.Collective.findOne({ where: { slug: resultAccount.slug } });
+
+      // Check that no-one was added directly as an admin
+      const admins = await collective.getAdmins();
+      expect(admins).to.have.length(1);
+      expect(admins[0].id).to.eq(user.CollectiveId);
+
+      // Check that the other admins were invited
+      const invitedAdmins = await models.MemberInvitation.findAll({
+        order: [['id', 'ASC']],
+        where: { CollectiveId: collective.id },
+        include: [{ association: 'memberCollective' }],
+      });
+
+      expect(invitedAdmins).to.have.length(2);
+      expect(invitedAdmins[0].memberCollective.slug).to.eq(existingUserToInvite.collective.slug);
+      expect(invitedAdmins[1].memberCollective.name).to.eq('Another admin');
+      const memberInvitationActivities = await models.Activity.findAll({
+        order: [['id', 'ASC']],
+        where: { type: activities.COLLECTIVE_CORE_MEMBER_INVITED, CollectiveId: collective.id },
+      });
+
+      expect(memberInvitationActivities).to.have.length(2);
+      expect(memberInvitationActivities[0].data.memberCollective.slug).to.eq(existingUserToInvite.collective.slug);
+      expect(memberInvitationActivities[1].data.memberCollective.name).to.eq('Another admin');
     });
   });
 


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-api/pull/7511

Create collective form was broken when inviting new admins because we were not passing the SQL transaction down.

I also made a few changes:
- Add test for `applyToHost`
- Add test for `createCollective`
- `processInviteMembersInput`: make the function signature clearer by:
  - making `collective` a positional param (since it's required)
  - making `inviteMemberInputs` a positional param that matched the GraphQL `MemberInvitationInput`
  - Moving everything else to `options`

![image](https://user-images.githubusercontent.com/1556356/173805820-6f3e539a-dafb-4250-a354-1d961016efb1.png)

![image](https://user-images.githubusercontent.com/1556356/173804702-ebbbcc7f-9e11-4a9c-9d18-7981e302213e.png)
