### PR TITLE
Add Slight Adjustments to Styles in Custom Email Template Body

### DIFF
--- a/templates/emails/thankyou.hbs
+++ b/templates/emails/thankyou.hbs
@@ -30,7 +30,8 @@ Subject: Thank you for your contribution to {{collective.name}}
 {{#if customMessage}}
 <p>A message from {{collective.name}}:</p>
 
-<div style="color: #494B4D; font-size: 14px; line-height: 18px; padding-left: 10px; border-left: 5px solid #F1F2F3">{{{customMessage}}}</div>
+<img width="40" height="33" src="{{config.host.website}}/static/images/email/quotation-custom-email.png" />
+<div style="color: #494B4D; font-size: 14px; line-height: 18px; padding-left: 10px; margin-top: 10px; border-left: 5px solid #F1F2F3">{{{customMessage}}}</div>
 {{/if}}
 
 <h2>Help us raise more money!</h2>


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/2682

⚠️ Requires: https://github.com/opencollective/opencollective-frontend/pull/8019

I noticed that there were some slight discrepancy in the styles of the custom email template string. What we have currently,

![image](https://user-images.githubusercontent.com/12435965/178357570-85a47a03-f5e2-49e4-ab9a-4481ff1c0347.png)

In this PR I've changed this to the following which I think better represents what's given in the [design preview](https://www.figma.com/file/ZQBMWhnGGtRWeIZknFW1eP/%5BOC-Design%5D-Production-Ready-%E2%9C%85?node-id=17991%3A193953),

![image](https://user-images.githubusercontent.com/12435965/178357315-8c60b044-5dd7-4e6e-9954-e7a0468d5fce.png)
