### PR TITLE
Add bridges for OAuth documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "deploy:production": "./scripts/pre-deploy.sh production && git push production main",
     "deploy:staging": "./scripts/pre-deploy.sh staging && git push -f staging main",
     "dev": "nodemon server/index.js -x \"babel-node --extensions .js,.ts\" . -e js,hbs,ts",
+    "docs:generate:oauth": "babel-node --extensions .js,.ts ./scripts/docs/oauth.ts",
     "export:csv": "babel-node --extensions .js,.ts cron/monthly/data-export.js",
     "forestadmin-schema:update": "npm run script scripts/forestadmin-schema-update && prettier .forestadmin-schema.json --write",
     "git:clean": "./scripts/git_clean.sh",

--- a/scripts/docs/oauth.ts
+++ b/scripts/docs/oauth.ts
@@ -1,0 +1,13 @@
+import { OAuthScope } from '../../server/graphql/v2/enum/OAuthScope';
+
+type FieldDefinition = { description: string; deprecationReason: string | null };
+const fieldsDefinition: Record<string, FieldDefinition> = OAuthScope['_nameLookup'];
+
+console.log('## Scopes');
+console.log('\n<!-- Use opencollective-api/scripts/docs/oauth.ts to update this section -->\n');
+Object.entries(fieldsDefinition).forEach(([key, { description, deprecationReason }]) => {
+  console.log(`- \`${key}\`: ${description}`);
+  if (deprecationReason) {
+    console.log(`  Deprecated: ${deprecationReason}`);
+  }
+});

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -72,7 +72,7 @@ class CustomOAuth2Server extends OAuth2Server {
     options = assign(
       {
         allowEmptyState: false,
-        authorizationCodeLifetime: 5 * 60, // 5 minutes.
+        authorizationCodeLifetime: 5 * 60, // 5 minutes. Update https://docs.opencollective.com/help/developers/oauth#users-are-redirected-back-to-your-site when changing this
       },
       this.options,
       options,


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/5586

The script produces something like that:

```markdown
## Scopes

<!-- Use opencollective-api/scripts/docs/oauth.ts to update this section -->

- `email`: Access your email address.
- `incognito`: Access your incognito account.
- `account`: Manage your account, collectives and organizations.
- `expenses`: Create and manage expenses, payout methods.
- `orders`: Create and manage contributions, payment methods.
- `transactions`: Refund and reject recorded transactions.
- `virtualCards`: Create and manage virtual cards.
- `updates`: Create and manage updates.
- `conversations`: Create and manage conversations.
- `webhooks`: Create and manage webhooks
- `host`: Administrate fiscal hosts.
- `applications`: Create and manage OAuth applications.
- `connectedAccounts`: Create and manage connected accounts.
- `root`: Perform critical administrative operations. 
```