### PR TITLE
Account permissions resolver

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -2944,6 +2944,11 @@ type Host implements Account & AccountWithContributions {
   ): WebhookCollection!
 
   """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
+
+  """
   Number of unique financial contributors.
   """
   totalFinancialContributors(
@@ -3878,6 +3883,18 @@ type Webhook {
   activityType: ActivityType
   webhookUrl: URL
   account: Account!
+}
+
+"""
+Fields for the user permissions on an account
+"""
+type AccountPermissions {
+  id: String!
+
+  """
+  Whether the current user can mark this order as expired
+  """
+  addFunds: Permission!
 }
 
 """
@@ -4901,6 +4918,11 @@ type Bot implements Account {
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 }
 
 """
@@ -5382,6 +5404,11 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Returns the Fiscal Host
@@ -6191,6 +6218,11 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
   ): WebhookCollection!
 
   """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
+
+  """
   Returns the Fiscal Host
   """
   host: Host
@@ -6783,6 +6815,11 @@ type Individual implements Account {
   ): WebhookCollection!
 
   """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
+
+  """
   Email for the account. For authenticated user: scope: "email".
   """
   email: String
@@ -7351,6 +7388,11 @@ type Organization implements Account & AccountWithContributions {
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Number of unique financial contributors.
@@ -7954,6 +7996,11 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Returns the Fiscal Host
@@ -10471,6 +10518,11 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   ): WebhookCollection!
 
   """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
+
+  """
   Returns the Fiscal Host
   """
   host: Host
@@ -11050,6 +11102,11 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Returns the Fiscal Host

--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -30,6 +30,7 @@ import { idEncode } from '../identifiers';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { ChronologicalOrderInput } from '../input/ChronologicalOrderInput';
 import { ORDER_BY_PSEUDO_FIELDS, OrderByInput } from '../input/OrderByInput';
+import AccountPermissions from '../object/AccountPermissions';
 import { AccountStats } from '../object/AccountStats';
 import { ConnectedAccount } from '../object/ConnectedAccount';
 import { Location } from '../object/Location';
@@ -854,6 +855,11 @@ export const AccountFields = {
     },
   },
   webhooks: accountWebhooks,
+  permissions: {
+    type: new GraphQLNonNull(AccountPermissions),
+    description: 'Logged-in user permissions on an account',
+    resolve: collective => collective, // Individual resolvers in `AccountPermissions`
+  },
 };
 
 export default Account;

--- a/server/graphql/v2/object/AccountPermissions.ts
+++ b/server/graphql/v2/object/AccountPermissions.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
+
+import { checkScope } from '../../common/scope-check';
+import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';
+
+import { Permission, PermissionFields } from './Permission';
+
+const AccountPermissions = new GraphQLObjectType({
+  name: 'AccountPermissions',
+  description: 'Fields for the user permissions on an account',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: getIdEncodeResolver(IDENTIFIER_TYPES.ACCOUNT),
+    },
+    addFunds: {
+      type: new GraphQLNonNull(Permission),
+      description: 'Whether the current user can mark this order as expired',
+      resolve(collective, _, req: express.Request): PermissionFields {
+        return { allowed: checkScope(req, 'host') && req.remoteUser.isHostAdmin(collective) };
+      },
+    },
+  }),
+});
+
+export default AccountPermissions;

--- a/server/graphql/v2/object/Permission.ts
+++ b/server/graphql/v2/object/Permission.ts
@@ -11,9 +11,11 @@ export const Permission = new GraphQLObjectType({
   }),
 });
 
+export type PermissionFields = { allowed: boolean; reason?: string };
+
 export const parsePermissionFromEvaluator =
   (fn: ExpenseLib.ExpensePermissionEvaluator) =>
-  (expense, _, req: express.Request): Promise<{ allowed: boolean; reason?: string }> => {
+  (expense, _, req: express.Request): Promise<PermissionFields> => {
     return fn(req, expense, { throw: true })
       .then(allowed => ({ allowed }))
       .catch(error => ({ allowed: false, reason: error?.extensions?.code }));


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/5658#issuecomment-1181678094

Similarily to the `expense.permissions` and `order.permissions` fields, this PR adds an `account.permissions` field to check remove user's permissions on this account.

It uses the latest pattern implemented by @kewitz where we return an object like `{ allowed, reason }` to optionally add more details when features are not accessible.