### PR TITLE
Make `ExpensePermissions` fields non-nullable

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -2181,18 +2181,18 @@ type ExpensePermissions {
   Whether the current user can unschedule this expense payment
   """
   canUnschedulePayment: Boolean!
-  edit: Permission
-  editTags: Permission
-  delete: Permission
-  seeInvoiceInfo: Permission
-  pay: Permission
-  approve: Permission
-  unapprove: Permission
-  reject: Permission
-  markAsSpam: Permission
-  markAsUnpaid: Permission
-  comment: Permission
-  unschedulePayment: Permission
+  edit: Permission!
+  editTags: Permission!
+  delete: Permission!
+  seeInvoiceInfo: Permission!
+  pay: Permission!
+  approve: Permission!
+  unapprove: Permission!
+  reject: Permission!
+  markAsSpam: Permission!
+  markAsUnpaid: Permission!
+  comment: Permission!
+  unschedulePayment: Permission!
 }
 
 type Permission {

--- a/server/graphql/v2/object/ExpensePermissions.ts
+++ b/server/graphql/v2/object/ExpensePermissions.ts
@@ -108,51 +108,51 @@ const ExpensePermissions = new GraphQLObjectType({
     },
     // Extended permissions
     edit: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canEditExpense),
     },
     editTags: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canEditExpenseTags),
     },
     delete: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canDeleteExpense),
     },
     seeInvoiceInfo: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canSeeExpenseInvoiceInfo),
     },
     pay: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canPayExpense),
     },
     approve: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canApprove),
     },
     unapprove: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canUnapprove),
     },
     reject: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canReject),
     },
     markAsSpam: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canMarkAsSpam),
     },
     markAsUnpaid: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canMarkAsUnpaid),
     },
     comment: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canComment),
     },
     unschedulePayment: {
-      type: Permission,
+      type: new GraphQLNonNull(Permission),
       resolve: parsePermissionFromEvaluator(ExpenseLib.canUnschedulePayment),
     },
   }),


### PR DESCRIPTION
It looks like we're never going to return null, and the frontend is not setup to handle this case.