### PR TITLE
Expose organization emails on GQLV2

### DIFF
--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -19,7 +19,7 @@ import { createDataLoaderWithOptions, sortResults, sortResultsSimple } from './h
 import { generateCollectivePayoutMethodsLoader, generateCollectivePaypalPayoutMethodsLoader } from './payout-method';
 import * as transactionLoaders from './transactions';
 import updatesLoader from './updates';
-import { generateCanSeeUserPrivateInfoLoader, generateUserByCollectiveIdLoader } from './user';
+import { generateCanSeeAccountPrivateInfoLoader, generateUserByCollectiveIdLoader } from './user';
 import { generateCollectiveVirtualCardLoader, generateHostCollectiveVirtualCardLoader } from './virtual-card';
 
 export const loaders = req => {
@@ -66,7 +66,7 @@ export const loaders = req => {
   context.loaders.VirtualCard.byHostCollectiveId = generateHostCollectiveVirtualCardLoader(req, cache);
 
   // User
-  context.loaders.User.canSeeUserPrivateInfo = generateCanSeeUserPrivateInfoLoader(req, cache);
+  context.loaders.User.canSeeAccountPrivateInfo = generateCanSeeAccountPrivateInfoLoader(req, cache);
   context.loaders.User.byCollectiveId = generateUserByCollectiveIdLoader(req, cache);
 
   /** *** Collective *****/

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -910,7 +910,10 @@ const CollectiveFields = () => {
 
         // If the profile is incognito, remoteUser must be allowed to see its `createdByUser`
         const user = await req.loaders.User.byId.load(collective.CreatedByUserId);
-        if (user && (!collective.isIncognito || (await req.loaders.User.canSeeUserPrivateInfo.load(user)))) {
+        if (
+          user &&
+          (!collective.isIncognito || (await req.loaders.User.canSeeAccountPrivateInfo.load(user.CollectiveId)))
+        ) {
           return user;
         } else {
           return {};
@@ -1965,7 +1968,7 @@ export const UserCollectiveType = new GraphQLObjectType({
               ? req.loaders.User.byId.load(userCollective.CreatedByUserId) // TODO: Should rely on Member
               : req.loaders.User.byCollectiveId.load(userCollective.id));
 
-            if (user && (await req.loaders.User.canSeeUserPrivateInfo.load(user))) {
+            if (user && (await req.loaders.User.canSeeAccountPrivateInfo.load(user.CollectiveId))) {
               return user.email;
             }
           }

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -182,7 +182,7 @@ export const UserType = new GraphQLObjectType({
       email: {
         type: GraphQLString,
         async resolve(user, args, req) {
-          if (req.remoteUser && (await req.loaders.User.canSeeUserPrivateInfo.load(user))) {
+          if (req.remoteUser && (await req.loaders.User.canSeeAccountPrivateInfo.load(user.CollectiveId))) {
             return user.email;
           }
         },
@@ -190,7 +190,7 @@ export const UserType = new GraphQLObjectType({
       emailWaitingForValidation: {
         type: GraphQLString,
         async resolve(user, args, req) {
-          if (req.remoteUser && (await req.loaders.User.canSeeUserPrivateInfo.load(user))) {
+          if (req.remoteUser && (await req.loaders.User.canSeeAccountPrivateInfo.load(user.CollectiveId))) {
             return user.emailWaitingForValidation;
           }
         },

--- a/server/graphql/v2/object/Individual.js
+++ b/server/graphql/v2/object/Individual.js
@@ -34,7 +34,7 @@ export const Individual = new GraphQLObjectType({
             ? req.loaders.User.byId.load(userCollective.CreatedByUserId) // TODO: Should rely on Member
             : req.loaders.User.byCollectiveId.load(userCollective.id));
 
-          if (user && (await req.loaders.User.canSeeUserPrivateInfo.load(user))) {
+          if (user && (await req.loaders.User.canSeeAccountPrivateInfo.load(user.CollectiveId))) {
             return user.email;
           }
         },

--- a/test/server/graphql/loaders/user.test.js
+++ b/test/server/graphql/loaders/user.test.js
@@ -1,10 +1,15 @@
 import { expect } from 'chai';
 
-import { generateCanSeeUserPrivateInfoLoader } from '../../../../server/graphql/loaders/user.ts';
+import { generateCanSeeAccountPrivateInfoLoader } from '../../../../server/graphql/loaders/user.ts';
 import { fakeCollective, fakeMember, fakeUser } from '../../../test-helpers/fake-data';
+import { resetTestDB } from '../../../utils';
 
 describe('server/graphql/loaders/user', () => {
-  describe('canSeeUserPrivateInfoLoader', () => {
+  before(async () => {
+    await resetTestDB();
+  });
+
+  describe('canSeeAccountPrivateInfoLoader', () => {
     describe('User info', () => {
       let userWithPrivateInfo, randomUser, collectiveAdmin, hostAdmin;
 
@@ -21,32 +26,32 @@ describe('server/graphql/loaders/user', () => {
       });
 
       it('Cannot see infos as unauthenticated', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: null });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: null });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.false;
       });
 
       it('Cannot see infos as a random user', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: randomUser });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: randomUser });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.false;
       });
 
       it('Can see infos if self', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: userWithPrivateInfo });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: userWithPrivateInfo });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.true;
       });
 
       it('Can see infos if collective admin', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: collectiveAdmin });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: collectiveAdmin });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.true;
       });
 
       it('Can see infos if host admin', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: hostAdmin });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: hostAdmin });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.true;
       });
     });
@@ -77,32 +82,32 @@ describe('server/graphql/loaders/user', () => {
       });
 
       it('Cannot see infos as unauthenticated', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: null });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: null });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.false;
       });
 
       it('Cannot see infos as a random user', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: randomUser });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: randomUser });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.false;
       });
 
       it('Can see infos if self', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: userWithPrivateInfo });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: userWithPrivateInfo });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.true;
       });
 
       it('Cannot see infos if collective admin', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: collectiveAdmin });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: collectiveAdmin });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.false;
       });
 
       it('Cannot see infos if host admin', async () => {
-        const loader = generateCanSeeUserPrivateInfoLoader({ remoteUser: hostAdmin });
-        const result = await loader.load(userWithPrivateInfo);
+        const loader = generateCanSeeAccountPrivateInfoLoader({ remoteUser: hostAdmin });
+        const result = await loader.load(userWithPrivateInfo.CollectiveId);
         expect(result).to.be.false;
       });
     });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3415

Breaking down the implementation in multiple commits:
- https://github.com/opencollective/opencollective-api/commit/cc6af6da4aac3e11c81facb12653a72792586f15: just a refactor to check the private info permission on accounts rather than users. Should not have any impact.
- TODO: ___