### PR TITLE
Add support to show multi currency expense amounts in emails

### DIFF
--- a/server/models/Expense.js
+++ b/server/models/Expense.js
@@ -347,6 +347,7 @@ function defineModel() {
         fromCollective: fromCollective.minimal,
         expense: this.info,
         transaction: transaction?.info,
+        amountInHostCurrency: Math.abs(transaction?.info?.amountInHostCurrency),
         payoutMethod: payoutMethod && pick(payoutMethod.dataValues, ['id', 'type', 'data']),
         items:
           !isEmpty(items) &&

--- a/templates/emails/collective.expense.paid.hbs
+++ b/templates/emails/collective.expense.paid.hbs
@@ -21,7 +21,7 @@ Subject: {{#ifCond expense.currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond expen
       The money can take a few days to arrive, depending on the payment processor.
     {{/if}}
   </p>
-  <h2><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{currency expense.amount currency=expense.currency}}</a></h2>
+  <h2><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{currency expense.amount currency=expense.currency}} {{#ifCond transaction.hostCurrency '!==' expense.currency}}({{currency amountInHostCurrency currency=transaction.hostCurrency}}){{/ifCond}}</a></h2>
   <div><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{transaction.description}}</a></div>
   <table>
     <tr>


### PR DESCRIPTION
https://github.com/opencollective/opencollective/issues/5272

![Screenshot 2022-07-15 at 10-58-33 MailDev ( 11)](https://user-images.githubusercontent.com/12435965/179284101-28bc5972-4dcd-4e87-8ca0-f0ceedece9b1.png)

And if the expense use the same currency as host,

![image](https://user-images.githubusercontent.com/12435965/179284155-62a16e69-584c-460b-af47-97a2268a2d43.png)


