### PR TITLE
Fix check-pending-wise-transactions outdated Transfer Id bug

### DIFF
--- a/cron/daily/check-pending-transferwise-transactions.js
+++ b/cron/daily/check-pending-transferwise-transactions.js
@@ -29,7 +29,7 @@ async function processExpense(expense) {
     throw new Error(`Could not find any transactions associated with expense.`);
   }
   const token = await transferwise.getToken(connectedAccount);
-  const transfer = await transferwiseLib.getTransfer(token, transaction.data.transfer.id);
+  const transfer = await transferwiseLib.getTransfer(token, expense.data.transfer.id);
   if (transfer.status === 'processing') {
     console.warn(`Transfer is still being processed, nothing to do but wait.`);
   } else if (expense.status === status.PROCESSING && transfer.status === 'outgoing_payment_sent') {

--- a/test/cron/daily/check-pending-transferwise-transactions.test.js
+++ b/test/cron/daily/check-pending-transferwise-transactions.test.js
@@ -59,6 +59,9 @@ describe('cron/hourly/check-pending-transferwise-transactions.js', () => {
       category: 'Engineering',
       type: 'INVOICE',
       description: 'January Invoice',
+      data: {
+        transfer: { id: 1234 },
+      },
     });
     await fakeTransaction({
       type: 'DEBIT',


### PR DESCRIPTION
Just caught this bug while investigating a support ticket.
I'm still checking how we ended up in a corrupt state where past transactions weren't deleted, but I'm sure this patch can already mitigate this issue.

Moreover, we should expedite https://github.com/opencollective/opencollective/issues/5435 to reduce the complexity on the Wise logic.