### PR TITLE
Add Accountants as recipients of the Collective Report

### DIFF
--- a/cron/monthly/collective-report.js
+++ b/cron/monthly/collective-report.js
@@ -6,6 +6,7 @@ import config from 'config';
 import { omit, pick } from 'lodash';
 import moment from 'moment';
 
+import { roles } from '../../server/constants';
 import ActivityTypes from '../../server/constants/activities';
 import { TransactionKind } from '../../server/constants/transaction-kind';
 import { generateHostFeeAmountForTransactionLoader } from '../../server/graphql/loaders/transactions';
@@ -142,7 +143,7 @@ const processCollective = async collective => {
   ];
 
   let emailData = {};
-  const options = { attachments: [] };
+  const options = { attachments: [], roles: [roles.ADMIN, roles.ACCOUNTANT] };
   const csvFilename = `${collective.slug}-${moment(d).format(dateFormat)}-transactions.csv`;
 
   return Promise.all(promises)

--- a/cron/monthly/collective-report.js
+++ b/cron/monthly/collective-report.js
@@ -143,7 +143,7 @@ const processCollective = async collective => {
   ];
 
   let emailData = {};
-  const options = { attachments: [], roles: [roles.ADMIN, roles.ACCOUNTANT] };
+  const options = { attachments: [], role: [roles.ADMIN, roles.ACCOUNTANT] };
   const csvFilename = `${collective.slug}-${moment(d).format(dateFormat)}-transactions.csv`;
 
   return Promise.all(promises)


### PR DESCRIPTION
Realized in https://github.com/opencollective/opencollective/issues/5755 that we never added accountants as recipients of this email. 

@kewitz tagging you on the review to make sure I'm using this in the right way :wink: 