### PR TITLE
Remove `customEmailMessage` field

### DIFF
--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -152,10 +152,7 @@ export function validateSettings(settings: any): string | boolean {
    * for the "div" tags that enclose the content <div>..<div/>. These divs are auto
    * added by the RichTextEditor.js
    */
-  if (
-    (settings.customEmailMessage && settings.customEmailMessage.length > 511) ||
-    (settings.customEmailMessage?.thankYou && settings.customEmailMessage.thankYou.length > 511)
-  ) {
+  if (settings.customEmailMessage?.thankYou && settings.customEmailMessage.thankYou.length > 511) {
     return 'Message should be less than 500 characters';
   }
 

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -614,10 +614,7 @@ const sendOrderConfirmedEmail = async (order, transaction) => {
   const host = await collective.getHostCollective();
   const parentCollective = await collective.getParentCollective();
   const customMessage =
-    collective.settings?.customEmailMessage ||
-    parentCollective?.settings?.customEmailMessage ||
-    collective.settings?.customEmailMessage?.thankYou ||
-    parentCollective?.settings?.customEmailMessage?.thankYou;
+    collective.settings?.customEmailMessage?.thankYou || parentCollective?.settings?.customEmailMessage?.thankYou;
 
   if (tier && tier.type === tiers.TICKET) {
     return models.Activity.create({

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -387,10 +387,7 @@ export async function sendThankYouEmail(order, transaction, isFirstPayment = fal
     interval: order.Subscription?.interval || order.interval,
     subscriptionsLink: getEditRecurringContributionsUrl(order.fromCollective),
     customMessage:
-      collective.settings?.customEmailMessage ||
-      parentCollective?.settings?.customEmailMessage ||
-      collective.settings?.customEmailMessage?.thankYou ||
-      parentCollective?.settings?.customEmailMessage?.thankYou,
+      collective.settings?.customEmailMessage?.thankYou || parentCollective?.settings?.customEmailMessage?.thankYou,
   };
 
   // hit PDF service and get PDF (unless payment method type is gift card)


### PR DESCRIPTION
Completely removes the old `settings.customEmailMessage` strings from the API. 

⚠️ Only merge after https://github.com/opencollective/opencollective-api/pull/7783