### PR TITLE
Send an email notification when an application is connected through OAuth

### DIFF
--- a/server/constants/activities.ts
+++ b/server/constants/activities.ts
@@ -62,6 +62,7 @@ enum ActivityTypes {
   WEBHOOK_PAYPAL_RECEIVED = 'webhook.paypal.received',
   COLLECTIVE_MONTHLY = 'collective.monthly',
   ORDER_CANCELED_ARCHIVED_COLLECTIVE = 'order.canceled.archived.collective',
+  OAUTH_APPLICATION_AUTHORIZED = 'oauth.application.authorized',
   ORDER_PROCESSING = 'order.processing',
   ORDER_PROCESSING_CRYPTO = 'order.processing.crypto',
   ORDER_PENDING_CONTRIBUTION_NEW = 'order.new.pendingFinancialContribution',
@@ -106,6 +107,7 @@ export const TransactionalActivities = [
   ActivityTypes.COLLECTIVE_EXPENSE_INVITE_DRAFTED,
   ActivityTypes.COLLECTIVE_EXPENSE_RECURRING_DRAFTED,
   ActivityTypes.HOST_APPLICATION_CONTACT,
+  ActivityTypes.OAUTH_APPLICATION_AUTHORIZED,
 ];
 
 export enum ActivityClasses {

--- a/server/lib/emailTemplates.ts
+++ b/server/lib/emailTemplates.ts
@@ -52,6 +52,7 @@ export const templateNames = [
   'host.application.contact',
   'host.report',
   'member.invitation',
+  'oauth.application.authorized',
   'onboarding.day2',
   'onboarding.day2.foundation',
   'onboarding.day2.opensource',

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -129,6 +129,7 @@ export const notifyByEmail = async (activity: Activity) => {
       await notify.collective(activity);
       break;
 
+    case ActivityTypes.OAUTH_APPLICATION_AUTHORIZED:
     case ActivityTypes.ORGANIZATION_COLLECTIVE_CREATED:
     case ActivityTypes.TAXFORM_REQUEST:
     case ActivityTypes.USER_CARD_CLAIMED:

--- a/server/lib/oauth/model.ts
+++ b/server/lib/oauth/model.ts
@@ -18,6 +18,7 @@ import {
 import config from 'config';
 import debugLib from 'debug';
 
+import activities from '../../constants/activities';
 import models from '../../models';
 import type OAuthAuthorizationCode from '../../models/OAuthAuthorizationCode';
 import UserToken, { TokenType } from '../../models/UserToken';
@@ -146,13 +147,25 @@ const model: OauthModel = {
   ): Promise<AuthorizationCode> {
     debug('model.saveAuthorizationCode', code, client);
     const application = await models.Application.findOne({ where: { clientId: client.id } });
+
+    const scope = Array.isArray(code.scope) ? code.scope : code.scope?.split(',');
+
     const authorization = await models.OAuthAuthorizationCode.create({
       ApplicationId: application.id,
       UserId: user.id,
       code: code.authorizationCode,
       expiresAt: code.expiresAt,
       redirectUri: code.redirectUri,
-      scope: Array.isArray(code.scope) ? code.scope : code.scope?.split(','),
+      scope,
+    });
+
+    await models.Activity.create({
+      type: activities.OAUTH_APPLICATION_AUTHORIZED,
+      UserId: user.id,
+      data: {
+        application: application.publicInfo,
+        scope,
+      },
     });
 
     authorization.application = application;

--- a/server/lib/oauth/model.ts
+++ b/server/lib/oauth/model.ts
@@ -147,7 +147,7 @@ const model: OauthModel = {
   ): Promise<AuthorizationCode> {
     debug('model.saveAuthorizationCode', code, client);
     const application = await models.Application.findOne({ where: { clientId: client.id } });
-
+    const collective = await user.getCollective();
     const scope = Array.isArray(code.scope) ? code.scope : code.scope?.split(',');
 
     const authorization = await models.OAuthAuthorizationCode.create({
@@ -162,8 +162,10 @@ const model: OauthModel = {
     await models.Activity.create({
       type: activities.OAUTH_APPLICATION_AUTHORIZED,
       UserId: user.id,
+      CollectiveId: user.CollectiveId,
       data: {
         application: application.publicInfo,
+        collective: collective.minimal,
         scope,
       },
     });

--- a/server/models/Application.js
+++ b/server/models/Application.js
@@ -92,6 +92,19 @@ function defineModel() {
             callbackUrl: this.callbackUrl,
           };
         },
+        publicInfo() {
+          return {
+            id: this.id,
+            name: this.name,
+            description: this.description,
+            type: this.type,
+            CreatedByUserId: this.CreatedByUserId,
+            CollectiveId: this.CollectiveId,
+            createdAt: this.createdAt,
+            updatedAt: this.updatedAt,
+            deletedAt: this.deletedAt,
+          };
+        },
       },
     },
   );

--- a/templates/emails/oauth.application.authorized.hbs
+++ b/templates/emails/oauth.application.authorized.hbs
@@ -1,0 +1,25 @@
+Subject: Open Collective: A third-party OAuth application has been added to your account
+
+{{> header}}
+
+<br />
+Hi,
+<br />
+<br />
+A third-party OAuth application ({{application.name}}) was recently authorized to access your account.
+
+{{#if scope.length}}
+<br />
+<br />
+Scopes:
+<br />
+<ul>
+    {{#each scope}}
+    <li>{{this}}</li>
+    {{/each}}
+</ul>
+{{/if}}
+<br />
+<br />
+
+{{> footer}}

--- a/templates/emails/oauth.application.authorized.hbs
+++ b/templates/emails/oauth.application.authorized.hbs
@@ -2,24 +2,29 @@ Subject: Open Collective: A third-party OAuth application has been added to your
 
 {{> header}}
 
-<br />
-Hi,
-<br />
-<br />
-A third-party OAuth application ({{application.name}}) was recently authorized to access your account.
+<p>
+    Hi,
+    <br />
+    <br />
+    A third-party OAuth application ({{application.name}}) was recently authorized to access your account.
+</p>
 
-{{#if scope.length}}
-<br />
-<br />
-Scopes:
-<br />
-<ul>
-    {{#each scope}}
-    <li>{{this}}</li>
-    {{/each}}
-</ul>
-{{/if}}
-<br />
-<br />
+    {{#if scope.length}}
+    <br />
+    <br />
+    Scopes:
+    <br />
+    <ul>
+        {{#each scope}}
+        <li>{{this}}</li>
+        {{/each}}
+    </ul>
+    {{/if}}
+    <br />
+    <br />
+
+<p>
+    You can manage authorized OAuth applications from the <a href="{{config.host.website}}/{{collective.slug}}/admin/for-developers">For Developers</a> section of your settings.
+</p>
 
 {{> footer}}


### PR DESCRIPTION
Moved from @hdiniz's fork (https://github.com/opencollective/opencollective-api/pull/7737) to our main repo
Resolves https://github.com/opencollective/opencollective/issues/5614

# Email for new oauth application authorized
![Screenshot from 2022-07-11 14-29-31](https://user-images.githubusercontent.com/5448927/178332881-e4a0b89d-459b-4f76-9434-7b83777f5866.png)

# Email for new oauth application authorized with scopes
![Screenshot from 2022-07-11 14-28-59](https://user-images.githubusercontent.com/5448927/178332966-f155052a-5a79-4d5e-932e-7d2cce076306.png)

There is a refactor of the notifications flow on https://github.com/opencollective/opencollective-api/pull/7713 close to being merged, when that happens I will rebase this change.

