### PR TITLE
Fix transaction links in Host Report

### DIFF
--- a/templates/emails/host.report.hbs
+++ b/templates/emails/host.report.hbs
@@ -432,7 +432,7 @@ Subject: {{#if erratumMessage}}Erratum{{#if erratumNumber}} {{erratumNumber}}{{/
     {{#each transactions}}
     <tr>
       <td valign="top"><a
-          href="{{@root.config.host.website}}/{{collective.slug}}/expenses/{{id}}">{{moment
+          href="{{@root.config.host.website}}/{{collective.slug}}/transactions?searchTerm=%23{{id}}&kind=ALL">{{moment
           createdAt format="MM/DD"}}</a>
       </td>
       <td valign="top"><a href="{{@root.config.host.website}}/{{collective.slug}}">{{collective.shortSlug}}</a></td>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5821

Require https://github.com/opencollective/opencollective-frontend/pull/8066 to add `ALL` support for `kind`. This is to make sure the transaction is always visible, as the default kinds may filter it if it's a settlement for example.