### PR TITLE
Remove `setupModel` calls

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # .git-blame-ignore-revs
 # style: eslint --fix and prettier
 bd115f4eed74484ab4cee076711c027eab7b1a05
+# Remove `setupModel` calls
+2630abeb6c5b540c6d13b7c8afcc74a57ec58fcf

--- a/server/models/Activity.ts
+++ b/server/models/Activity.ts
@@ -16,80 +16,74 @@ export class Activity extends Model<InferAttributes<Activity>, InferCreationAttr
   public declare createdAt: CreationOptional<Date>;
 }
 
-function setupModel() {
-  Activity.init(
-    {
-      id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
-        autoIncrement: true,
-      },
-      type: DataTypes.STRING,
+Activity.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    type: DataTypes.STRING,
 
-      data: DataTypes.JSONB,
+    data: DataTypes.JSONB,
 
-      CollectiveId: {
-        type: DataTypes.INTEGER,
-        references: {
-          model: 'Collectives',
-          key: 'id',
-        },
-      },
-
-      UserId: {
-        type: DataTypes.INTEGER,
-        references: {
-          model: 'Users',
-          key: 'id',
-        },
-      },
-
-      UserTokenId: {
-        type: DataTypes.INTEGER,
-        references: {
-          model: 'UserTokens',
-          key: 'id',
-        },
-      },
-
-      TransactionId: {
-        type: DataTypes.INTEGER,
-        references: {
-          model: 'Transactions',
-          key: 'id',
-        },
-      },
-
-      ExpenseId: {
-        type: DataTypes.INTEGER,
-        references: {
-          model: 'Expenses',
-          key: 'id',
-        },
-      },
-
-      createdAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
+    CollectiveId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Collectives',
+        key: 'id',
       },
     },
-    {
-      sequelize,
-      updatedAt: false,
-      hooks: {
-        afterCreate(activity) {
-          if (activity.data?.notify !== false) {
-            dispatch(activity); // intentionally no return statement, needs to be async
-          }
-          return Promise.resolve();
-        },
+
+    UserId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Users',
+        key: 'id',
       },
     },
-  );
-}
 
-// We're using the setupModel function to keep the indentation and have a clearer git history.
-// Please consider this if you plan to refactor.
-setupModel();
+    UserTokenId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'UserTokens',
+        key: 'id',
+      },
+    },
+
+    TransactionId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Transactions',
+        key: 'id',
+      },
+    },
+
+    ExpenseId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Expenses',
+        key: 'id',
+      },
+    },
+
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+    updatedAt: false,
+    hooks: {
+      afterCreate(activity) {
+        if (activity.data?.notify !== false) {
+          dispatch(activity); // intentionally no return statement, needs to be async
+        }
+        return Promise.resolve();
+      },
+    },
+  },
+);
 
 export default Activity;

--- a/server/models/CurrencyExchangeRate.ts
+++ b/server/models/CurrencyExchangeRate.ts
@@ -14,6 +14,8 @@ export class CurrencyExchangeRate extends Model<
   public declare from: string;
   public declare to: string;
   public declare createdAt: Date;
+  public declare updatedAt: Date;
+  public declare deletedAt: Date;
 
   static getMany(
     fromCurrency: string,
@@ -43,49 +45,43 @@ export class CurrencyExchangeRate extends Model<
   }
 }
 
-function setupModel(CurrencyExchangeRate) {
-  // Link the model to database fields
-  CurrencyExchangeRate.init(
-    {
-      id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
-        autoIncrement: true,
-      },
-      rate: {
-        type: DataTypes.FLOAT,
-        allowNull: false,
-      },
-      from: {
-        type: DataTypes.STRING,
-        allowNull: false,
-      },
-      to: {
-        type: DataTypes.STRING,
-        allowNull: false,
-      },
-      createdAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
-        allowNull: false,
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-      },
+// Link the model to database fields
+CurrencyExchangeRate.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
     },
-    {
-      sequelize,
-      tableName: 'CurrencyExchangeRates',
+    rate: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
     },
-  );
-}
-
-// We're using the setupModel function to keep the indentation and have a clearer git history.
-// Please consider this if you plan to refactor.
-setupModel(CurrencyExchangeRate);
+    from: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    to: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'CurrencyExchangeRates',
+  },
+);
 
 export default CurrencyExchangeRate;

--- a/server/models/ExpenseAttachedFile.ts
+++ b/server/models/ExpenseAttachedFile.ts
@@ -48,55 +48,49 @@ export class ExpenseAttachedFile extends Model {
   };
 }
 
-function setupModel(ExpenseAttachedFile) {
-  // Link the model to database fields
-  ExpenseAttachedFile.init(
-    {
-      id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
-        autoIncrement: true,
-      },
-      ExpenseId: {
-        type: DataTypes.INTEGER,
-        references: { model: 'Expenses', key: 'id' },
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE',
-        allowNull: false,
-      },
-      CreatedByUserId: {
-        type: DataTypes.INTEGER,
-        references: { key: 'id', model: 'Users' },
-        onDelete: 'SET NULL',
-        onUpdate: 'CASCADE',
-        allowNull: false,
-      },
-      url: {
-        type: DataTypes.STRING,
-        allowNull: false,
-        validate: {
-          isValid(url: string): void {
-            if (url && !isValidUploadedImage(url) && !url.startsWith(config.host.rest)) {
-              throw new Error('The attached file URL is not valid');
-            }
-          },
+// Link the model to database fields
+ExpenseAttachedFile.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    ExpenseId: {
+      type: DataTypes.INTEGER,
+      references: { model: 'Expenses', key: 'id' },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+    },
+    CreatedByUserId: {
+      type: DataTypes.INTEGER,
+      references: { key: 'id', model: 'Users' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+    },
+    url: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        isValid(url: string): void {
+          if (url && !isValidUploadedImage(url) && !url.startsWith(config.host.rest)) {
+            throw new Error('The attached file URL is not valid');
+          }
         },
       },
-      createdAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
-        allowNull: false,
-      },
     },
-    {
-      sequelize,
-      tableName: 'ExpenseAttachedFiles',
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
     },
-  );
-}
-
-// We're using the setupModel function to keep the indentation and have a clearer git history.
-// Please consider this if you plan to refactor.
-setupModel(ExpenseAttachedFile);
+  },
+  {
+    sequelize,
+    tableName: 'ExpenseAttachedFiles',
+  },
+);
 
 export default ExpenseAttachedFile;

--- a/server/models/ExpenseItem.ts
+++ b/server/models/ExpenseItem.ts
@@ -86,92 +86,86 @@ const descriptionSanitizerOptions = buildSanitizerOptions({
   links: true,
 });
 
-function setupModel(ExpenseItem) {
-  // Link the model to database fields
-  ExpenseItem.init(
-    {
-      id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
-        autoIncrement: true,
+// Link the model to database fields
+ExpenseItem.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      validate: {
+        min: 1,
       },
-      amount: {
-        type: DataTypes.INTEGER,
-        allowNull: false,
-        validate: {
-          min: 1,
-        },
+    },
+    url: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      set(value: string | null): void {
+        // Make sure empty strings are converted to null
+        this.setDataValue('url', value || null);
       },
-      url: {
-        type: DataTypes.STRING,
-        allowNull: true,
-        set(value: string | null): void {
-          // Make sure empty strings are converted to null
-          this.setDataValue('url', value || null);
-        },
-        validate: {
-          isUrl: true,
-          isValidImage(url: string): void {
-            if (url && !isValidUploadedImage(url)) {
-              throw new Error('The attached file URL is not valid');
-            }
-          },
-        },
-      },
-      description: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-        set(value) {
-          if (value) {
-            this.setDataValue('description', sanitizeHTML(value, descriptionSanitizerOptions));
-          } else {
-            this.setDataValue('description', null);
+      validate: {
+        isUrl: true,
+        isValidImage(url: string): void {
+          if (url && !isValidUploadedImage(url)) {
+            throw new Error('The attached file URL is not valid');
           }
         },
       },
-      createdAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
-        allowNull: false,
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
-        allowNull: false,
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-      },
-      incurredAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
-        allowNull: false,
-      },
-      ExpenseId: {
-        type: DataTypes.INTEGER,
-        references: { model: 'Expenses', key: 'id' },
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE',
-        allowNull: false,
-      },
-      CreatedByUserId: {
-        type: DataTypes.INTEGER,
-        references: { key: 'id', model: 'Users' },
-        onDelete: 'SET NULL',
-        onUpdate: 'CASCADE',
-        allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      set(value: string | null) {
+        if (value) {
+          this.setDataValue('description', sanitizeHTML(value, descriptionSanitizerOptions));
+        } else {
+          this.setDataValue('description', null);
+        }
       },
     },
-    {
-      sequelize,
-      paranoid: true,
-      tableName: 'ExpenseItems',
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
     },
-  );
-}
-
-// We're using the setupModel function to keep the indentation and have a clearer git history.
-// Please consider this if you plan to refactor.
-setupModel(ExpenseItem);
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+    },
+    incurredAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    ExpenseId: {
+      type: DataTypes.INTEGER,
+      references: { model: 'Expenses', key: 'id' },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+    },
+    CreatedByUserId: {
+      type: DataTypes.INTEGER,
+      references: { key: 'id', model: 'Users' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    paranoid: true,
+    tableName: 'ExpenseItems',
+  },
+);
 
 export default ExpenseItem;

--- a/server/models/HostApplication.ts
+++ b/server/models/HostApplication.ts
@@ -82,77 +82,76 @@ export class HostApplication extends Model<InferAttributes<HostApplication>, Inf
   }
 }
 
-function setupModel(HostApplication) {
-  // Link the model to database fields
-  HostApplication.init(
-    {
-      id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
-        autoIncrement: true,
-      },
-      CollectiveId: {
-        type: DataTypes.INTEGER,
-        references: { key: 'id', model: 'Collectives' },
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE',
-        allowNull: false,
-      },
-      HostCollectiveId: {
-        type: DataTypes.INTEGER,
-        references: { key: 'id', model: 'Collectives' },
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE',
-        allowNull: false,
-      },
-      CreatedByUserId: {
-        type: DataTypes.INTEGER,
-        references: { key: 'id', model: 'Users' },
-        onDelete: 'SET NULL',
-        onUpdate: 'CASCADE',
-        allowNull: true,
-      },
-      status: {
-        type: DataTypes.ENUM(...Object.values(HostApplicationStatus)),
-        allowNull: false,
-        validate: {
-          isIn: {
-            args: [Object.values(HostApplicationStatus)],
-            msg: `Must be one of: ${Object.values(HostApplicationStatus)}`,
-          },
+// Link the model to database fields
+HostApplication.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    CollectiveId: {
+      type: DataTypes.INTEGER,
+      references: { key: 'id', model: 'Collectives' },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+    },
+    HostCollectiveId: {
+      type: DataTypes.INTEGER,
+      references: { key: 'id', model: 'Collectives' },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+    },
+    CreatedByUserId: {
+      type: DataTypes.INTEGER,
+      references: { key: 'id', model: 'Users' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+      allowNull: true,
+    },
+    status: {
+      type: DataTypes.ENUM(...Object.values(HostApplicationStatus)),
+      allowNull: false,
+      validate: {
+        isIn: {
+          args: [Object.values(HostApplicationStatus)],
+          msg: `Must be one of: ${Object.values(HostApplicationStatus)}`,
         },
       },
-      message: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-        validate: {
-          len: [0, 3000],
-        },
-      },
-      customData: {
-        type: DataTypes.JSONB,
-        allowNull: true,
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        defaultValue: DataTypes.NOW,
-        allowNull: false,
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
+    },
+    message: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      validate: {
+        len: [0, 3000],
       },
     },
-    {
-      sequelize,
-      tableName: 'HostApplications',
-      paranoid: true,
+    customData: {
+      type: DataTypes.JSONB,
+      allowNull: true,
     },
-  );
-}
-
-// We're using the setupModel function to keep the indentation and have a clearer git history.
-// Please consider this if you plan to refactor.
-setupModel(HostApplication);
+    createdAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'HostApplications',
+    paranoid: true,
+  },
+);
 
 export default HostApplication;


### PR DESCRIPTION
While looking at a model, I realized Typescript was missing some errors; it somehow failed to infer the type from inside the function, probably because the argument passed to `setupModel` (the model itself) was not typed.

I figured that, since we have `.git-blame-ignore-revs` now, we could get rid of them and ignore the commit in the history.

This is best reviewed with "Ignore whitespace changes": https://github.com/opencollective/opencollective-api/pull/7814/files?diff=split&w=1