### PR TITLE
Ability to sort Updates by publication date

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -569,7 +569,7 @@ interface Account {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -2915,7 +2915,7 @@ type Host implements Account & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -3803,6 +3803,36 @@ type UpdateAudienceStats {
   The total number of emails to send
   """
   total: Int!
+}
+
+"""
+Input to order updates chronologically
+"""
+input UpdateChronologicalOrderInput {
+  """
+  Field to chronologically order by.
+  """
+  field: UpdateDateTimeField! = CREATED_AT
+
+  """
+  Ordering direction.
+  """
+  direction: OrderDirection! = DESC
+}
+
+"""
+All possible DateTime fields for an update
+"""
+enum UpdateDateTimeField {
+  """
+  The creation time
+  """
+  CREATED_AT
+
+  """
+  The creation time
+  """
+  PUBLISHED_AT
 }
 
 """
@@ -4951,7 +4981,7 @@ type Bot implements Account {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -5447,7 +5477,7 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -6271,7 +6301,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -6878,7 +6908,7 @@ type Individual implements Account {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -7464,7 +7494,7 @@ type Organization implements Account & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -8082,7 +8112,7 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -10638,7 +10668,7 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -11234,7 +11264,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 

--- a/server/graphql/v2/enum/UpdateDateTimeField.ts
+++ b/server/graphql/v2/enum/UpdateDateTimeField.ts
@@ -1,0 +1,16 @@
+import { GraphQLEnumType } from 'graphql';
+
+export const UpdateDateTimeField = new GraphQLEnumType({
+  name: 'UpdateDateTimeField',
+  description: 'All possible DateTime fields for an update',
+  values: {
+    CREATED_AT: {
+      value: 'createdAt',
+      description: 'The creation time',
+    },
+    PUBLISHED_AT: {
+      value: 'publishedAt',
+      description: 'The creation time',
+    },
+  },
+});

--- a/server/graphql/v2/input/UpdateChronologicalOrderInput.ts
+++ b/server/graphql/v2/input/UpdateChronologicalOrderInput.ts
@@ -1,0 +1,31 @@
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
+
+import { OrderDirectionType } from '../enum/OrderDirectionType';
+import { UpdateDateTimeField } from '../enum/UpdateDateTimeField';
+
+export const UpdateChronologicalOrderInput = new GraphQLInputObjectType({
+  name: 'UpdateChronologicalOrderInput',
+  description: 'Input to order updates chronologically',
+  fields: () => ({
+    field: {
+      description: 'Field to chronologically order by.',
+      defaultValue: 'createdAt',
+      type: new GraphQLNonNull(UpdateDateTimeField),
+    },
+    direction: {
+      description: 'Ordering direction.',
+      defaultValue: 'DESC',
+      type: new GraphQLNonNull(OrderDirectionType),
+    },
+  }),
+});
+
+export const UPDATE_CHRONOLOGICAL_ORDER_INPUT_DEFAULT_VALUE = Object.entries(
+  UpdateChronologicalOrderInput.getFields(),
+).reduce(
+  (values, [key, value]) => ({
+    ...values,
+    [key]: value.defaultValue,
+  }),
+  {},
+);

--- a/test/server/graphql/v2/query/AccountQuery.test.js
+++ b/test/server/graphql/v2/query/AccountQuery.test.js
@@ -1,14 +1,21 @@
 import { expect } from 'chai';
 import gqlV2 from 'fake-tag';
-import { times } from 'lodash';
+import { shuffle, times } from 'lodash';
 
 import { roles } from '../../../../../server/constants';
 import { randEmail } from '../../../../stores';
-import { fakeCollective, fakeHost, fakeOrganization, fakeUser, multiple } from '../../../../test-helpers/fake-data';
+import {
+  fakeCollective,
+  fakeHost,
+  fakeOrganization,
+  fakeUpdate,
+  fakeUser,
+  multiple,
+} from '../../../../test-helpers/fake-data';
 import { graphqlQueryV2, resetTestDB } from '../../../../utils';
 
 const accountQuery = gqlV2/* GraphQL */ `
-  query Account($slug: String!) {
+  query Account($slug: String!, $updatesOrder: UpdateChronologicalOrderInput) {
     account(slug: $slug) {
       id
       legalName
@@ -24,6 +31,14 @@ const accountQuery = gqlV2/* GraphQL */ `
             id
             slug
           }
+        }
+      }
+      updates(orderBy: $updatesOrder) {
+        totalCount
+        nodes {
+          id
+          createdAt
+          publishedAt
         }
       }
     }
@@ -324,6 +339,39 @@ describe('server/graphql/v2/query/AccountQuery', () => {
       expect(resultUnauthenticated.data.account.emails).to.be.null;
       expect(resultRandomUser.data.account.emails).to.be.null;
       expect(resultAdmin.data.account.emails).to.deep.eq([adminUser.email, adminUser2.email]);
+    });
+  });
+
+  describe('updates', () => {
+    let collective, admin;
+
+    before(async () => {
+      admin = await fakeUser(); // creating an admins as we need one to fetch unpublished updates
+      collective = await fakeCollective({ admin });
+      const CollectiveId = collective.id;
+      await Promise.all(
+        // Shuffle the array to make sure insertion order doesn't matter
+        shuffle([
+          fakeUpdate({ CollectiveId, createdAt: new Date('2020-01-01'), publishedAt: null }),
+          fakeUpdate({ CollectiveId, createdAt: new Date('2020-07-01'), publishedAt: null }),
+          fakeUpdate({ CollectiveId, createdAt: new Date('2020-01-01'), publishedAt: new Date('2020-01-01') }),
+          fakeUpdate({ CollectiveId, createdAt: new Date('2020-05-01'), publishedAt: new Date('2020-02-01') }),
+          fakeUpdate({ CollectiveId, createdAt: new Date('2020-01-01'), publishedAt: new Date('2020-03-01') }),
+        ]),
+      );
+    });
+
+    it('sort by publishedAt (with a fallback on createdAt)', async () => {
+      const updatesOrder = { field: 'PUBLISHED_AT', direction: 'DESC' };
+      const result = await graphqlQueryV2(accountQuery, { slug: collective.slug, updatesOrder }, admin);
+      const updates = result.data.account.updates.nodes;
+
+      expect(updates.length).to.eq(5);
+      expect(updates[0]).to.containSubset({ publishedAt: null, createdAt: new Date('2020-07-01') });
+      expect(updates[1]).to.containSubset({ publishedAt: null, createdAt: new Date('2020-01-01') });
+      expect(updates[2]).to.containSubset({ publishedAt: new Date('2020-03-01'), createdAt: new Date('2020-01-01') });
+      expect(updates[3]).to.containSubset({ publishedAt: new Date('2020-02-01'), createdAt: new Date('2020-05-01') });
+      expect(updates[4]).to.containSubset({ publishedAt: new Date('2020-01-01'), createdAt: new Date('2020-01-01') });
     });
   });
 });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5690
Goes with https://github.com/opencollective/opencollective-frontend/pull/7944

Order updates by `publishedAt` instead of `createdAt`