### PR TITLE
Fix unreliable SPAM test

### DIFF
--- a/test/server/models/RecurringExpense.test.ts
+++ b/test/server/models/RecurringExpense.test.ts
@@ -43,7 +43,7 @@ describe('server/models/RecurringExpense', () => {
     expect(newExpense.status).to.eq('DRAFT');
     expect(newExpense).to.have.nested.property('data.draftKey');
     expect(newExpense).to.have.nested.property('data.items');
-    expect(newExpense.data.items[0].amount).to.eq(expense.items[0].amount);
+    expect(newExpense.data.items.map(i => i.amount)).to.deep.eqInAnyOrder(expense.items.map(i => i.amount));
   });
 
   it('should mail the user notifying about a new draft', async () => {


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective-api/pull/7820

We had many failures like the one below on CI, the root cause being that randomly generated strings sometimes contained suspicious keywords like `cbd`.

```
 1) server/lib/spam
       collectiveSpamCheck
         is ok with legit domains:

      AssertionError: expected { …(7) } to deeply equal { score: +0, keywords: [], …(5) }
      + expected - actual

           "website": "https://example.com/cb677aa7-1aea-47a9-9023-9d63cbd16380"
         }
         "date": "2020-01-01T00:00:00.000Z"
         "domains": []
      -  "keywords": [
      -    "cbd"
      -  ]
      -  "score": 0.3
      +  "keywords": []
      +  "score": 0
       }
      
      at Context.<anonymous> (test/server/lib/spam.test.js:106:61)
      at Generator.next (<anonymous>)
      at Generator.tryCatcher (node_modules/bluebird/js/release/util.js:16:23)
      at PromiseSpawn._promiseFulfilled (node_modules/bluebird/js/release/generators.js:97:49)
      at Promise._settlePromise (node_modules/bluebird/js/release/promise.js:609:26)
      at Promise._settlePromise0 (node_modules/bluebird/js/release/promise.js:649:10)
      at Promise._settlePromises (node_modules/bluebird/js/release/promise.js:729:18)
      at _drainQueueStep (node_modules/bluebird/js/release/async.js:93:12)
      at _drainQueue (node_modules/bluebird/js/release/async.js:86:9)
      at Async._drainQueues (node_modules/bluebird/js/release/async.js:102:5)
      at Immediate.Async.drainQueues [as _onImmediate] (node_modules/bluebird/js/release/async.js:15:14)
      at processImmediate (node:internal/timers:466:21)
```