### PR TITLE
fix: remove collective name from expense email

### DIFF
--- a/templates/emails/collective.comment.created.hbs
+++ b/templates/emails/collective.comment.created.hbs
@@ -10,9 +10,9 @@ Subject: {{{collective.name}}}: New comment
 
 {{> header}}
 
-{{#if expense }}
+{{#if expense}}
   <p style="padding: 1em;">
-    Hi {{collective.name}},
+    Hi,
     <br /><br />
     <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
     a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:

--- a/templates/emails/expense.comment.created.hbs
+++ b/templates/emails/expense.comment.created.hbs
@@ -3,7 +3,7 @@ Subject: {{{collective.name}}}: New comment on expense {{{escapeForSubject expen
 {{> header}}
 
 <p style="padding: 1em;">
-  Hi {{collective.name}},
+  Hi,
   <br /><br />
   <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
   a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:


### PR DESCRIPTION
As per https://github.com/opencollective/opencollective/issues/5207 the expense email comment notification goes to both the admin as well as the expense payee, so a singular greeting name doesn't work.

As a quick fix, remove the greeting name to make the email greeting generic for both recipients.