### PR TITLE
Search: Term with spaces returns spaceless results

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -96,6 +96,7 @@ const getSearchTermSQLConditions = (term, collectiveTable) => {
   let tsQueryFunc, tsQueryArg;
   let sqlConditions = '';
   let sanitizedTerm = '';
+  let sanitizedTermNoWhitespaces = '';
   const trimmedTerm = trimSearchTerm(term);
   if (trimmedTerm?.length > 0) {
     // Cleanup term
@@ -106,17 +107,41 @@ const getSearchTermSQLConditions = (term, collectiveTable) => {
       sqlConditions = `AND ${collectiveTable ? `${collectiveTable}.` : ''}"slug" ILIKE :sanitizedTerm || '%' `;
     } else {
       sanitizedTerm = splitTerm.length === 1 ? sanitizeSearchTermForTSQuery(trimmedTerm) : trimmedTerm;
+      sanitizedTermNoWhitespaces = sanitizedTerm.replace(/ /g, '');
+      // Only search for existing term
       if (sanitizedTerm) {
-        tsQueryFunc = splitTerm.length === 1 ? 'to_tsquery' : ' websearch_to_tsquery';
-        tsQueryArg = tsQueryFunc === 'to_tsquery' ? `concat(:sanitizedTerm, ':*')` : ':sanitizedTerm';
-        sqlConditions = `
-        AND (${collectiveTable ? `${collectiveTable}.` : ''}"searchTsVector" @@ ${tsQueryFunc}('english', ${tsQueryArg})
-        OR ${collectiveTable ? `${collectiveTable}.` : ''}"searchTsVector" @@ ${tsQueryFunc}('simple', ${tsQueryArg}))`;
+        if (splitTerm.length === 1) {
+          sqlConditions = `
+          AND (${
+            collectiveTable ? `${collectiveTable}.` : ''
+          }"searchTsVector" @@ to_tsquery('english', concat(:sanitizedTerm, ':*'))
+          OR ${
+            collectiveTable ? `${collectiveTable}.` : ''
+          }"searchTsVector" @@ to_tsquery('simple', concat(:sanitizedTerm, ':*')))`;
+        } else {
+          // Search terms with more than word (seperated by spaces) should be searched for
+          // both with and without the spaces.
+          // Eg. The collective named BossaNova should be able to be found by searching
+          // either "BossaNova" OR "Bossa Nova"
+          sqlConditions = `
+          AND (${
+            collectiveTable ? `${collectiveTable}.` : ''
+          }"searchTsVector" @@ websearch_to_tsquery('english', :sanitizedTerm)
+          OR ${
+            collectiveTable ? `${collectiveTable}.` : ''
+          }"searchTsVector" @@ websearch_to_tsquery('simple', :sanitizedTerm)
+          OR ${
+            collectiveTable ? `${collectiveTable}.` : ''
+          }"searchTsVector" @@ websearch_to_tsquery('english', :sanitizedTermNoWhitespaces)
+          OR ${
+            collectiveTable ? `${collectiveTable}.` : ''
+          }"searchTsVector" @@ websearch_to_tsquery('simple', :sanitizedTermNoWhitespaces))`;
+        }
       }
     }
   }
 
-  return { sqlConditions, tsQueryArg, tsQueryFunc, sanitizedTerm };
+  return { sqlConditions, tsQueryArg, tsQueryFunc, sanitizedTerm, sanitizedTermNoWhitespaces };
 };
 
 const getSortSubQuery = (searchTermConditions, orderBy = null) => {
@@ -252,6 +277,7 @@ export const searchCollectivesInDB = async (
         term: term,
         slugifiedTerm: term ? slugify(term) : '',
         sanitizedTerm: searchTermConditions.sanitizedTerm,
+        sanitizedTermNoWhitespaces: searchTermConditions.sanitizedTermNoWhitespaces,
         searchedTags,
         countryCodes,
         offset,
@@ -374,6 +400,7 @@ export const getTagFrequencies = async args => {
       type: sequelize.QueryTypes.SELECT,
       replacements: {
         sanitizedTerm: searchConditions.sanitizedTerm,
+        sanitizedTermNoWhitespaces: searchConditions.sanitizedTermNoWhitespaces,
         limit: args.limit,
         offset: args.offset,
       },

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -107,10 +107,12 @@ const getSearchTermSQLConditions = (term, collectiveTable) => {
       sqlConditions = `AND ${collectiveTable ? `${collectiveTable}.` : ''}"slug" ILIKE :sanitizedTerm || '%' `;
     } else {
       sanitizedTerm = splitTerm.length === 1 ? sanitizeSearchTermForTSQuery(trimmedTerm) : trimmedTerm;
-      sanitizedTermNoWhitespaces = sanitizedTerm.replace(/ /g, '');
+      sanitizedTermNoWhitespaces = sanitizedTerm.replace(/\s/g, '');
       // Only search for existing term
       if (sanitizedTerm) {
         if (splitTerm.length === 1) {
+          tsQueryFunc = 'to_tsquery';
+          tsQueryArg = `concat(:sanitizedTerm, ':*')`;
           sqlConditions = `
           AND (${
             collectiveTable ? `${collectiveTable}.` : ''
@@ -123,6 +125,8 @@ const getSearchTermSQLConditions = (term, collectiveTable) => {
           // both with and without the spaces.
           // Eg. The collective named BossaNova should be able to be found by searching
           // either "BossaNova" OR "Bossa Nova"
+          tsQueryFunc = 'websearch_to_tsquery';
+          tsQueryArg = ':sanitizedTerm';
           sqlConditions = `
           AND (${
             collectiveTable ? `${collectiveTable}.` : ''

--- a/test/server/lib/search.test.js
+++ b/test/server/lib/search.test.js
@@ -33,11 +33,27 @@ describe('server/lib/search', () => {
       expect(results.find(collective => collective.id === userCollective.id)).to.exist;
     });
 
-    it('By name', async () => {
-      const name = 'AVeryUniqueName ThatNoOneElseHas';
-      const { userCollective } = await newUser(name);
-      const [results] = await searchCollectivesInDB(name);
-      expect(results.find(collective => collective.id === userCollective.id)).to.exist;
+    describe('By name', () => {
+      it('matches with the exact search term', async () => {
+        const name = 'AVeryUniqueName ThatNoOneElseHas';
+        const { userCollective } = await newUser(name);
+        const [results] = await searchCollectivesInDB(name);
+        expect(results.find(collective => collective.id === userCollective.id)).to.exist;
+      });
+
+      it('matches when spaces are included in search term and not in name', async () => {
+        const name = 'SomethingNew';
+        const { userCollective } = await newUser(name);
+        const [results] = await searchCollectivesInDB('Something New');
+        expect(results.find(collective => collective.id === userCollective.id)).to.exist;
+      });
+
+      it('does not match when spaces are not included in search term and are in name', async () => {
+        const name = 'Something New';
+        const { userCollective } = await newUser(name);
+        const [results] = await searchCollectivesInDB('SomethingNew');
+        expect(results.find(collective => collective.id === userCollective.id)).to.not.exist;
+      });
     });
 
     describe('By tag', () => {


### PR DESCRIPTION
Related Issue: https://github.com/opencollective/opencollective/issues/5811

This PR adds changes to the search functionality such a collective named "TestCollective" can be searched for and found using a search term with spaces like "Test Collective".