### PR TITLE
OAuth -> lastUsedAt: provide UserId for faster Activities fetch

### DIFF
--- a/server/graphql/v2/mutation/OAuthAuthorizationMutations.js
+++ b/server/graphql/v2/mutation/OAuthAuthorizationMutations.js
@@ -35,6 +35,7 @@ const oAuthAuthorizationMutations = {
         expiresAt: userToken.accessTokenExpiresAt,
         createdAt: userToken.createdAt,
         updatedAt: userToken.updatedAt,
+        user: req.remoteUser,
       };
     },
   },

--- a/server/graphql/v2/object/Application.js
+++ b/server/graphql/v2/object/Application.js
@@ -98,6 +98,7 @@ export const Application = new GraphQLObjectType({
             createdAt: userToken.createdAt,
             updatedAt: userToken.updatedAt,
             scope: userToken.scope,
+            user: req.remoteUser,
           };
         }
       },

--- a/server/graphql/v2/object/Individual.js
+++ b/server/graphql/v2/object/Individual.js
@@ -161,6 +161,7 @@ export const Individual = new GraphQLObjectType({
               createdAt: row.createdAt,
               updatedAt: row.updatedAt,
               scope: row.scope,
+              user,
             };
           });
 

--- a/server/graphql/v2/object/OAuthAuthorization.js
+++ b/server/graphql/v2/object/OAuthAuthorization.js
@@ -47,6 +47,7 @@ export const OAuthAuthorization = new GraphQLObjectType({
           const activity = await models.Activity.findOne({
             attributes: ['createdAt'],
             where: {
+              UserId: authorization.user.id,
               UserTokenId: authorization.id,
             },
             order: [['createdAt', 'DESC']],


### PR DESCRIPTION
This query is super-slow in prod due to the number of `Activities`. Since `UserId` is indexed, we can take advantage of it.