### PR TITLE
ChronologicalOrderInput: make fields non-null

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -1967,12 +1967,12 @@ input ChronologicalOrderInput {
   """
   Field to chronologically order by.
   """
-  field: DateTimeField = CREATED_AT
+  field: DateTimeField! = CREATED_AT
 
   """
   Ordering direction.
   """
-  direction: OrderDirection = DESC
+  direction: OrderDirection! = DESC
 }
 
 """

--- a/server/graphql/v2/enum/OrderByFieldType.ts
+++ b/server/graphql/v2/enum/OrderByFieldType.ts
@@ -6,6 +6,7 @@ export enum ORDER_BY_PSEUDO_FIELDS {
   CREATED_AT = 'CREATED_AT',
 }
 
+// TODO: This should be called "AccountOrderByField", as the fields are only available for accounts
 export const OrderByFieldType = new GraphQLEnumType({
   name: 'OrderByFieldType',
   description: 'Possible fields you can use to order by',

--- a/server/graphql/v2/input/ChronologicalOrderInput.js
+++ b/server/graphql/v2/input/ChronologicalOrderInput.js
@@ -1,4 +1,4 @@
-import { GraphQLInputObjectType } from 'graphql';
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
 
 import { DateTimeField } from '../enum/DateTimeField';
 import { OrderDirectionType } from '../enum/OrderDirectionType';
@@ -10,12 +10,12 @@ export const ChronologicalOrderInput = new GraphQLInputObjectType({
     field: {
       description: 'Field to chronologically order by.',
       defaultValue: 'createdAt',
-      type: DateTimeField,
+      type: new GraphQLNonNull(DateTimeField),
     },
     direction: {
       description: 'Ordering direction.',
       defaultValue: 'DESC',
-      type: OrderDirectionType,
+      type: new GraphQLNonNull(OrderDirectionType),
     },
   }),
 });

--- a/server/graphql/v2/input/OrderByInput.ts
+++ b/server/graphql/v2/input/OrderByInput.ts
@@ -5,6 +5,7 @@ import { OrderDirectionType } from '../enum/OrderDirectionType';
 
 export { ORDER_BY_PSEUDO_FIELDS };
 
+// TODO: This should be called "AccountOrderInput", as the fields are only available for accounts
 export const OrderByInput = new GraphQLInputObjectType({
   name: 'OrderByInput',
   description: 'Input to order results',


### PR DESCRIPTION
They have default values so this will not cause any regression. Queries like this:

```gql
{
  expenses(orderBy: {field: null, direction: null}) {
    nodes {
      id
    }
  }
}
```

Were resulting in messy Sequelize or SQL errors like:

```
{
  "errors": [
    {
      "message": "Cannot read properties of null (reading '_modelAttribute')",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "expenses"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR"
      }
    }
  ],
  "data": null
}
```