### PR TITLE
enhancement(transactions): Store PayoutMethodId on Transaction

### DIFF
--- a/migrations/20220824153704-add-payout-method-id-to-transaction.js
+++ b/migrations/20220824153704-add-payout-method-id-to-transaction.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, DataTypes) {
+    await queryInterface.addColumn('Transactions', 'PayoutMethodId', {
+      type: DataTypes.INTEGER,
+      references: { key: 'id', model: 'PayoutMethods' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Transactions', 'PayoutMethodId');
+  },
+};

--- a/server/graphql/v2/interface/Transaction.js
+++ b/server/graphql/v2/interface/Transaction.js
@@ -25,6 +25,7 @@ import { Amount } from '../object/Amount';
 import { Expense } from '../object/Expense';
 import { Order } from '../object/Order';
 import { PaymentMethod } from '../object/PaymentMethod';
+import PayoutMethod from '../object/PayoutMethod';
 import { TaxInfo } from '../object/TaxInfo';
 
 import { Account } from './Account';
@@ -184,6 +185,9 @@ const transactionFieldsDefinition = () => ({
   },
   paymentMethod: {
     type: PaymentMethod,
+  },
+  payoutMethod: {
+    type: PayoutMethod,
   },
   permissions: {
     type: TransactionPermissions,
@@ -472,6 +476,16 @@ export const TransactionFields = () => {
       resolve(transaction, _, req) {
         if (transaction.PaymentMethodId) {
           return req.loaders.PaymentMethod.byId.load(transaction.PaymentMethodId);
+        } else {
+          return null;
+        }
+      },
+    },
+    payoutMethod: {
+      type: PayoutMethod,
+      resolve(transaction, _, req) {
+        if (transaction.PayoutMethodId) {
+          return req.loaders.PayoutMethod.byId.load(transaction.PayoutMethodId);
         } else {
           return null;
         }

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -166,6 +166,7 @@ export const buildRefundForTransaction = (t, user, data, refundedPaymentProcesso
     'data.tax',
     'kind',
     'isDebt',
+    'PayoutMethodId',
   ]);
 
   refund.CreatedByUserId = user?.id || null;

--- a/server/lib/transactions.ts
+++ b/server/lib/transactions.ts
@@ -193,6 +193,7 @@ export async function createTransactionsFromPaidExpense(
     FromCollectiveId: expense.FromCollectiveId,
     HostCollectiveId: host.id,
     PaymentMethodId: paymentMethod ? paymentMethod.id : null,
+    PayoutMethodId: expense.PayoutMethodId,
     taxAmount: computeExpenseTaxes(expense),
     data: {
       ...(transactionData || {}),

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -191,6 +191,14 @@ function defineModel() {
         onUpdate: 'CASCADE',
       },
 
+      PayoutMethodId: {
+        type: DataTypes.INTEGER,
+        references: { key: 'id', model: 'PayoutMethods' },
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+        allowNull: true,
+      },
+
       isRefund: {
         type: DataTypes.BOOLEAN,
         defaultValue: false,

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -227,6 +227,8 @@ export function setupModels() {
     as: 'host',
   });
   m.Transaction.belongsTo(m.PaymentMethod);
+  m.Transaction.belongsTo(m.PayoutMethod);
+
   m.PaymentMethod.hasMany(m.Transaction);
 
   // Transaction settlements

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -1039,6 +1039,26 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         expect(membership).to.exist;
       });
 
+      it('attaches the PayoutMethod to the transaction itself', async () => {
+        const paymentProcessorFee = 100;
+        const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
+        const expense = await fakeExpense({
+          amount: 1000,
+          CollectiveId: collective.id,
+          status: 'APPROVED',
+          PayoutMethodId: payoutMethod.id,
+        });
+
+        const expensePlusFees = expense.amount + paymentProcessorFee;
+        await fakeTransaction({ type: 'CREDIT', CollectiveId: collective.id, amount: expensePlusFees });
+        const mutationParams = { expenseId: expense.id, action: 'PAY', paymentParams: { paymentProcessorFee } };
+        await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
+
+        const transactions = await models.Transaction.findAll({ where: { ExpenseId: expense.id } });
+
+        expect(transactions.every(tx => tx.PayoutMethodId === expense.PayoutMethodId)).to.equal(true);
+      });
+
       describe('With PayPal', () => {
         it('fails if not enough funds on the paypal preapproved key', async () => {
           const callPaypal = sandbox.stub(paypalAdaptive, 'callPaypal').callsFake(() => {
@@ -1216,6 +1236,17 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
           const [transaction] = await models.Transaction.findAll({ where: { ExpenseId: expense.id } });
 
           expect(transaction).to.have.nested.property('paymentProcessorFeeInHostCurrency').to.equal(0);
+        });
+
+        it('attaches the PayoutMethod to the associated Transactions', async () => {
+          await host.update({
+            settings: defaultsDeep(host.settings, { transferwise: { ignorePaymentProcessorFees: true } }),
+          });
+          const mutationParams = { expenseId: expense.id, action: 'PAY' };
+          await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
+          const transactions = await models.Transaction.findAll({ where: { ExpenseId: expense.id } });
+
+          expect(transactions.every(tx => tx.PayoutMethodId === expense.PayoutMethodId)).to.equal(true);
         });
       });
 
@@ -1803,6 +1834,37 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         expect(result.errors).to.exist;
         expect(result.errors[0].message).to.eq('Expense is already scheduled for payment');
       });
+    });
+
+    it('sets the PayoutMethodId on transactions correctly after editing the expense', async () => {
+      // Create a new collective to make sure the balance is empty
+      const testCollective = await fakeCollective({ HostCollectiveId: host.id, admin: collectiveAdmin.collective });
+      const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
+      const expense = await fakeExpense({
+        amount: 1000,
+        CollectiveId: testCollective.id,
+        status: 'APPROVED',
+        PayoutMethodId: payoutMethod.id,
+      });
+
+      // Updates the collective balance and pay the expense
+      await fakeTransaction({ type: 'CREDIT', CollectiveId: testCollective.id, amount: expense.amount });
+      await payExpense(makeRequest(hostAdmin), { id: expense.id });
+
+      const mutationParams = { expenseId: expense.id, action: 'MARK_AS_UNPAID' };
+      await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
+
+      const originalTransactions = await models.Transaction.findAll({ where: { ExpenseId: expense.id } });
+      expect(originalTransactions.every(tx => tx.PayoutMethodId === payoutMethod.id)).to.equal(true);
+
+      const newPayoutMethod = await fakePayoutMethod({ type: 'OTHER' });
+      await expense.update({ PayoutMethodId: newPayoutMethod.id });
+
+      await fakeTransaction({ type: 'CREDIT', CollectiveId: testCollective.id, amount: expense.amount });
+      await payExpense(makeRequest(hostAdmin), { id: expense.id });
+
+      const newTransactions = await models.Transaction.findAll({ where: { ExpenseId: expense.id } });
+      expect(newTransactions.slice(-2).every(tx => tx.PayoutMethodId === newPayoutMethod.id)).to.equal(true);
     });
   });
 

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -1039,7 +1039,7 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         expect(membership).to.exist;
       });
 
-      it('attaches the PayoutMethod to the transaction itself', async () => {
+      it('attaches the PayoutMethod to the associated Transactions', async () => {
         const paymentProcessorFee = 100;
         const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
         const expense = await fakeExpense({


### PR DESCRIPTION
Closes https://github.com/opencollective/opencollective/issues/5505

This PR adds a `PayoutMethodId` field to `Transaction` so that we keep track of the correct PayoutMethod over time.