### PR TITLE
Better errors for blocking users when creating orders

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -356,7 +356,7 @@ export async function createOrder(order, req) {
   let remoteUser = req.remoteUser;
 
   if (remoteUser && !canUseFeature(remoteUser, FEATURE.ORDER)) {
-    return new FeatureNotAllowedForUser();
+    throw new FeatureNotAllowedForUser();
   } else if (!remoteUser) {
     await checkGuestContribution(order, loaders);
   }
@@ -514,6 +514,10 @@ export async function createOrder(order, req) {
         const creationRequest = { ip: reqIp, userAgent, mask: reqMask };
         captchaResponse = await checkCaptcha(order, remoteUser, reqIp);
         const guestProfile = await getOrCreateGuestProfile(order.guestInfo, creationRequest);
+        if (!canUseFeature(guestProfile.user, FEATURE.ORDER)) {
+          throw new FeatureNotAllowedForUser();
+        }
+
         remoteUser = guestProfile.user;
         fromCollective = guestProfile.collective;
         isGuest = true;


### PR DESCRIPTION
- Fix the error message by using `throw` instead of `return`
- Adds the ability to block a guest user (aka. block their emails)