### PR TITLE
Enhancement on Activity types

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -8466,9 +8466,9 @@ type Query {
     dateTo: DateTime = null
 
     """
-    Only return activities that are of this type
+    Only return activities that are of this class/type
     """
-    type: [ActivityAndClassesType] = null
+    type: [ActivityAndClassesType!] = null
   ): ActivityCollection!
   application(
     """

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -8468,7 +8468,7 @@ type Query {
     """
     Only return activities that are of this type
     """
-    activityType: [ActivityAndClassesType] = null
+    type: [ActivityAndClassesType] = null
   ): ActivityCollection!
   application(
     """

--- a/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
@@ -2,7 +2,7 @@ import { GraphQLList, GraphQLNonNull } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 import { Order } from 'sequelize';
 
-import { ActivitiesPerClass } from '../../../../constants/activities';
+import ActivityTypes, { ActivitiesPerClass } from '../../../../constants/activities';
 import models, { Op } from '../../../../models';
 import { checkRemoteUserCanUseAccount } from '../../../common/scope-check';
 import { ActivityCollection } from '../../collection/ActivityCollection';
@@ -81,7 +81,8 @@ const ActivitiesCollectionQuery = {
       where['createdAt'] = Object.assign({}, where['createdAt'], { [Op.lte]: args.dateTo });
     }
     if (args.type) {
-      where['type'] = { [Op.in]: ActivitiesPerClass[args.activityType] };
+      const ignoredActivities = [ActivityTypes.COLLECTIVE_TRANSACTION_CREATED]; // This activity is creating a lot of noise, is usually covered already by orders/expenses activities and is not properly categorized (see https://github.com/opencollective/opencollective/issues/5903)
+      where['type'] = { [Op.in]: ActivitiesPerClass[args.activityType].filter(t => !ignoredActivities.includes(t)) };
     }
 
     const order: Order = [['createdAt', 'DESC']];

--- a/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
@@ -32,8 +32,7 @@ const ActivitiesCollectionArgs = {
     defaultValue: null,
     description: 'Only return activities that were created before this date',
   },
-  // TODO: No need to repeat "activity" in the name of the field, we should call it "type"
-  activityType: {
+  type: {
     type: new GraphQLList(ActivityAndClassesType),
     defaultValue: null,
     description: 'Only return activities that are of this type',
@@ -81,7 +80,7 @@ const ActivitiesCollectionQuery = {
     if (args.dateTo) {
       where['createdAt'] = Object.assign({}, where['createdAt'], { [Op.lte]: args.dateTo });
     }
-    if (args.activityType) {
+    if (args.type) {
       where['type'] = { [Op.in]: ActivitiesPerClass[args.activityType] };
     }
 


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-frontend/pull/8131

This is a breaking change, but since the feature is not released publicly that should be fine.

- Rename `activityType` arg to `type`, make list elements non-nullable
- Update type filter to support passing activities directly (it was previously crashing the query).
- Ignore `COLLECTIVE_TRANSACTION_CREATED` activity, see https://github.com/opencollective/opencollective/issues/5903

