### PR TITLE
feat: Create greeting partial. (#5872)

### DIFF
--- a/server/lib/emailTemplates.ts
+++ b/server/lib/emailTemplates.ts
@@ -113,6 +113,7 @@ const templatesPath = `${__dirname}/../../templates`;
 
 // Register partials
 const header = fs.readFileSync(`${templatesPath}/partials/header.hbs`, 'utf8');
+const greeting = fs.readFileSync(`${templatesPath}/partials/greeting.hbs`, 'utf8');
 const footer = fs.readFileSync(`${templatesPath}/partials/footer.hbs`, 'utf8');
 const toplogo = fs.readFileSync(`${templatesPath}/partials/toplogo.hbs`, 'utf8');
 const eventsnippet = fs.readFileSync(`${templatesPath}/partials/eventsnippet.hbs`, 'utf8');
@@ -124,6 +125,7 @@ const mthReportFooter = fs.readFileSync(`${templatesPath}/partials/monthlyreport
 const mthReportSubscription = fs.readFileSync(`${templatesPath}/partials/monthlyreport.subscription.hbs`, 'utf8');
 
 handlebars.registerPartial('header', header);
+handlebars.registerPartial('greeting', greeting);
 handlebars.registerPartial('footer', footer);
 handlebars.registerPartial('toplogo', toplogo);
 handlebars.registerPartial('collectivecard', collectivecard);

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -311,6 +311,7 @@ export const notifyByEmail = async (activity: Activity) => {
       activity.data.path = `/${activity.data.collective.slug}/expenses/${activity.data.expense.id}`;
 
       // Notify the admins of the collective
+      activity.data.recipientName = collective.name;
       await notify.collective(activity, {
         from: config.email.noReply,
         exclude: [activity.UserId, activity.data.UserId], // Don't notify the person who commented nor the expense author
@@ -318,6 +319,8 @@ export const notifyByEmail = async (activity: Activity) => {
 
       // Notify the admins of the host (if any)
       const HostCollectiveId = await collective.getHostCollectiveId();
+      const hostCollective = await models.Collective.findByPk(HostCollectiveId);
+      activity.data.recipientName = hostCollective.name;
       if (HostCollectiveId) {
         await notify.collective(activity, {
           from: config.email.noReply,
@@ -327,6 +330,7 @@ export const notifyByEmail = async (activity: Activity) => {
       }
 
       // Notify the author of the expense
+      activity.data.recipientName = activity.data.UserId;
       if (activity.UserId !== activity.data.UserId) {
         await notify.user(activity, {
           userId: activity.data.UserId,

--- a/templates/emails/expense.comment.created.hbs
+++ b/templates/emails/expense.comment.created.hbs
@@ -3,8 +3,7 @@ Subject: {{{collective.name}}}: New comment on expense {{{escapeForSubject expen
 {{> header}}
 
 <p style="padding: 1em;">
-  Hi,
-  <br /><br />
+  {{> greeting}}
   <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
   a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:
 </p>

--- a/templates/partials/greeting.hbs
+++ b/templates/partials/greeting.hbs
@@ -1,0 +1,5 @@
+{{#if recipientName}}
+<p>Hi {{{recipientName}}},</p>
+{{else}}
+<p>Hi,</p>
+{{/if}}


### PR DESCRIPTION
This will allow more flexible greetings in email templates. A recipient name is used, if provided.

As a first example, the expense comment activity notification is used since it has three recipients.

If this looks like the right approach, I could add recipientNames for each email notification, into this PR.