### PR TITLE
Create greeting partial

### DIFF
--- a/server/lib/emailTemplates.ts
+++ b/server/lib/emailTemplates.ts
@@ -117,6 +117,7 @@ const templatesPath = `${__dirname}/../../templates`;
 
 // Register partials
 const header = fs.readFileSync(`${templatesPath}/partials/header.hbs`, 'utf8');
+const greeting = fs.readFileSync(`${templatesPath}/partials/greeting.hbs`, 'utf8');
 const footer = fs.readFileSync(`${templatesPath}/partials/footer.hbs`, 'utf8');
 const toplogo = fs.readFileSync(`${templatesPath}/partials/toplogo.hbs`, 'utf8');
 const eventsnippet = fs.readFileSync(`${templatesPath}/partials/eventsnippet.hbs`, 'utf8');
@@ -129,6 +130,7 @@ const mthReportFooter = fs.readFileSync(`${templatesPath}/partials/monthlyreport
 const mthReportSubscription = fs.readFileSync(`${templatesPath}/partials/monthlyreport.subscription.hbs`, 'utf8');
 
 handlebars.registerPartial('header', header);
+handlebars.registerPartial('greeting', greeting);
 handlebars.registerPartial('footer', footer);
 handlebars.registerPartial('toplogo', toplogo);
 handlebars.registerPartial('collectivecard', collectivecard);

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -45,6 +45,8 @@ export const notify = {
   ) {
     const userId = options?.user?.id || options?.userId || activity.UserId;
     const user = options?.user || (await models.User.findByPk(userId, { include: [models.Collective] }));
+
+    // TODO We're not using the `unsubscribed` option here, we should
     const unsubscribed = await models.Notification.getUnsubscribers({
       type: activity.type,
       UserId: user.id,

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -50,6 +50,11 @@ export const notify = {
       CollectiveId: options?.collective?.id || activity.CollectiveId,
     });
 
+    if (!activity.data.recipientName) {
+      const userCollective = await models.Collective.findByPk(user.CollectiveId);
+      activity.data.recipientName = userCollective.name;
+    }
+
     const isTransactional = TransactionalActivities.includes(activity.type);
     if (unsubscribed.length === 0) {
       debug('notifying.user', user.id, user && user.email, activity.type);
@@ -116,6 +121,8 @@ export const notify = {
           CollectiveId: collective.ParentCollectiveId ? [collective.ParentCollectiveId, collective.id] : collective.id,
           role,
         });
+
+    activity.data.recipientName = activity.data.fromCollective ? activity.data.fromCollective : collective.name;
 
     return notify.users(users, activity, { ...options, collective });
   },

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -52,7 +52,7 @@ export const notify = {
 
     if (!activity.data.recipientName) {
       const userCollective = await models.Collective.findByPk(user.CollectiveId);
-      activity.data.recipientName = userCollective.name;
+      activity.data.recipientName = userCollective.name || userCollective.legalName;
     }
 
     const isTransactional = TransactionalActivities.includes(activity.type);

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1952,9 +1952,6 @@ Collective.prototype.sendNewMemberEmail = async function (user, role, member, se
         name: this.name,
         type: lowercaseType,
       },
-      recipient: {
-        collective: memberUser.collective.activity,
-      },
       loginLink: `${config.host.website}/signin?next=/${memberUser.collective.slug}/admin`,
     },
     { bcc: remoteUser.email },

--- a/templates/emails/activated.collective.as.host.hbs
+++ b/templates/emails/activated.collective.as.host.hbs
@@ -2,7 +2,7 @@ Subject: Fiscal Host Activated — Welcome!
 
 {{> header}}
 
-<p>Hi!</p>
+{{> greeting}}
 
 <p>I’m Pía, co-founder of Open Collective. Thank you for becoming a Fiscal Host, a company or individual who holds funds for Collectives. It’s a great way to help your community be sustainable.</p>
 

--- a/templates/emails/activated.collective.as.host.hbs
+++ b/templates/emails/activated.collective.as.host.hbs
@@ -2,7 +2,7 @@ Subject: Fiscal Host Activated — Welcome!
 
 {{> header}}
 
-{{> greeting}}
+<p>{{> greeting}}</p>
 
 <p>I’m Pía, co-founder of Open Collective. Thank you for becoming a Fiscal Host, a company or individual who holds funds for Collectives. It’s a great way to help your community be sustainable.</p>
 

--- a/templates/emails/activated.collective.as.independent.hbs
+++ b/templates/emails/activated.collective.as.independent.hbs
@@ -2,7 +2,7 @@ Subject: Independent Collective Activated — Welcome!
 
 {{> header}}
 
-<p>Hi {{collective.name}} 👋</p>
+<p>{{> greeting}} 👋</p>
 
 <p>You've activated your Independent Collective and you're ready to start receiving contributions. That's great! Here are some useful tips to help you get started.</p>
 

--- a/templates/emails/activated.collective.as.independent.hbs
+++ b/templates/emails/activated.collective.as.independent.hbs
@@ -2,7 +2,7 @@ Subject: Independent Collective Activated — Welcome!
 
 {{> header}}
 
-<p>{{> greeting}} 👋</p>
+<p>Hi {{collective.name}} 👋</p>
 
 <p>You've activated your Independent Collective and you're ready to start receiving contributions. That's great! Here are some useful tips to help you get started.</p>
 

--- a/templates/emails/collective.comment.created.hbs
+++ b/templates/emails/collective.comment.created.hbs
@@ -12,19 +12,22 @@ Subject: {{{collective.name}}}: New comment
 
 {{#if expense}}
   <p style="padding: 1em;">
-    {{> greeting}}
+    Hi,
+    <br /><br />
     {{> linkCollective collective=fromCollective}} just posted
     a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:
   </p>
 {{else if conversation}}
   <p style="font-size: 17px; padding: 1em;">
-    {{> greeting}}
+    Hi {{collective.name}},
+    <br /><br />
     {{> linkCollective collective=fromCollective}} just posted
     a new comment on a Conversation, <a href="{{config.host.website}}{{path}}">{{conversation.title}}</a>:
   </p>
 {{else if update}}
   <p style="font-size: 17px; padding: 1em;">
-    {{> greeting}}
+    Hi {{collective.name}},
+    <br /><br />
     {{> linkCollective collective=fromCollective}} just posted
     a new comment on an Update, <a href="{{config.host.website}}{{path}}">{{update.title}}</a>:
   </p>

--- a/templates/emails/collective.comment.created.hbs
+++ b/templates/emails/collective.comment.created.hbs
@@ -12,22 +12,19 @@ Subject: {{{collective.name}}}: New comment
 
 {{#if expense}}
   <p style="padding: 1em;">
-    Hi,
-    <br /><br />
+    {{> greeting}}
     {{> linkCollective collective=fromCollective}} just posted
     a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:
   </p>
 {{else if conversation}}
   <p style="font-size: 17px; padding: 1em;">
-    Hi {{collective.name}},
-    <br /><br />
+    {{> greeting}}
     {{> linkCollective collective=fromCollective}} just posted
     a new comment on a Conversation, <a href="{{config.host.website}}{{path}}">{{conversation.title}}</a>:
   </p>
 {{else if update}}
   <p style="font-size: 17px; padding: 1em;">
-    Hi {{collective.name}},
-    <br /><br />
+    {{> greeting}}
     {{> linkCollective collective=fromCollective}} just posted
     a new comment on an Update, <a href="{{config.host.website}}{{path}}">{{update.title}}</a>:
   </p>

--- a/templates/emails/collective.contact.hbs
+++ b/templates/emails/collective.contact.hbs
@@ -3,8 +3,7 @@ Subject: New message from {{{fromCollective.name}}} on Open Collective{{#if subj
 {{> header}}
 
 <p style="font-size: 17px; padding: 1em;">
-  Hi {{collective.name}},
-  <br /><br />
+  {{> greeting}}
   {{> linkCollective collective=fromCollective}} just sent you a message on Open
   Collective. Simply reply to this email to reply to the sender.
 </p>

--- a/templates/emails/collective.contact.hbs
+++ b/templates/emails/collective.contact.hbs
@@ -4,7 +4,8 @@ Subject: New message from {{{fromCollective.name}}} on Open Collective{{#if subj
 
 <p style="font-size: 17px; padding: 1em;">
   {{> greeting}}
-  {{> linkCollective collective=fromCollective}} just sent you a message on Open
+  <br /><br />
+  {{> linkCollective collective=fromCollective}} just sent a message to {{> linkCollective collective=collective}} on Open
   Collective. Simply reply to this email to reply to the sender.
 </p>
 

--- a/templates/emails/collective.conversation.created.hbs
+++ b/templates/emails/collective.conversation.created.hbs
@@ -4,8 +4,9 @@ Subject: New Conversation on {{{collective.name}}}: "{{{escapeForSubject convers
 
 <p style="padding: 1em;">
   {{> greeting}}
+  <br /><br />
   {{> linkCollective collective=fromCollective}} just started
-  a new Conversation: <a href="{{config.host.website}}/{{collective.slug}}/conversations/{{conversation.slug}}-{{conversation.hashId}}">{{conversation.title}}</a>
+  a new Conversation on {{collective.name}}: <a href="{{config.host.website}}/{{collective.slug}}/conversations/{{conversation.slug}}-{{conversation.hashId}}">{{conversation.title}}</a>
 </p>
 
 <table style="width: 100%; margin-bottom: 30px;">

--- a/templates/emails/collective.conversation.created.hbs
+++ b/templates/emails/collective.conversation.created.hbs
@@ -3,8 +3,7 @@ Subject: New Conversation on {{{collective.name}}}: "{{{escapeForSubject convers
 {{> header}}
 
 <p style="padding: 1em;">
-  Hi {{collective.name}},
-  <br /><br />
+  {{> greeting}}
   {{> linkCollective collective=fromCollective}} just started
   a new Conversation: <a href="{{config.host.website}}/{{collective.slug}}/conversations/{{conversation.slug}}-{{conversation.hashId}}">{{conversation.title}}</a>
 </p>

--- a/templates/emails/collective.expense.error.hbs
+++ b/templates/emails/collective.expense.error.hbs
@@ -3,7 +3,7 @@ Subject: Payment from {{{collective.name}}} for {{{escapeForSubject expense.desc
 {{> header}}
 
 <center>
-  <h3>Hi there!</h3>
+  <h3>{{> greeting}}</h3>
   <p>
     The payout for your expense, <b><a
         href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b>, which

--- a/templates/emails/collective.expense.paid.hbs
+++ b/templates/emails/collective.expense.paid.hbs
@@ -10,7 +10,7 @@ Subject: {{#ifCond expense.currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond expen
 </style>
 
 <center>
-  <h3>Hi there!</h3>
+  <h3>{{> greeting}}</h3>
   <p>
     Your expense, <b><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b>, submitted to {{> linkCollective collective=collective}} on {{moment expense.createdAt}} has been paid.
     {{#if expense.payoutMethod}}

--- a/templates/emails/collective.expense.processing.hbs
+++ b/templates/emails/collective.expense.processing.hbs
@@ -3,7 +3,7 @@ Subject: Payment being processed: {{{expense.description}}} for {{{collective.na
 {{> header}}
 
 <center>
-  <h3>Hi there!</h3>
+  <h3>{{> greeting}}</h3>
   <p>
     Your expense, <b><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b>,
     submitted to {{> linkCollective collective=collective}} on {{moment expense.createdAt}}, is currently being processed by Wise and should be paid soon.

--- a/templates/emails/collective.frozen.hbs
+++ b/templates/emails/collective.frozen.hbs
@@ -3,7 +3,8 @@ Subject: Important: {{{collective.name}}} has been frozen by {{{host.name}}}
 {{> header}}
 
 <p style="font-size: 17px; padding: 1em;">
-  {{> greeting}}
+  Hi {{collective.name}},
+  <br /><br />
   Your fiscal host, <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a>, has frozen your Collective.
   In other words, they have temporarily limited what you (and your connected Projects & Events) can and cannot do on the platform.
   <br/><br/>

--- a/templates/emails/collective.frozen.hbs
+++ b/templates/emails/collective.frozen.hbs
@@ -3,8 +3,7 @@ Subject: Important: {{{collective.name}}} has been frozen by {{{host.name}}}
 {{> header}}
 
 <p style="font-size: 17px; padding: 1em;">
-  Hi {{collective.name}},
-  <br /><br />
+  {{> greeting}}
   Your fiscal host, <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a>, has frozen your Collective.
   In other words, they have temporarily limited what you (and your connected Projects & Events) can and cannot do on the platform.
   <br/><br/>

--- a/templates/emails/collective.member.created.hbs
+++ b/templates/emails/collective.member.created.hbs
@@ -4,7 +4,7 @@ Subject: New financial contributor to {{{collective.name}}}: {{{member.memberCol
 
 <h1>🎉 New financial contributor</h1>
 
-{{> greeting}}
+<p>{{> greeting }}</p>
 
 <p>{{#if member.memberCollective.isIncognito}}Someone (incognito){{else}}<a
     href="{{config.host.website}}/{{member.memberCollective.slug}}">{{member.memberCollective.name}}</a>{{/if}} has become a new financial contributor to

--- a/templates/emails/collective.member.created.hbs
+++ b/templates/emails/collective.member.created.hbs
@@ -4,11 +4,7 @@ Subject: New financial contributor to {{{collective.name}}}: {{{member.memberCol
 
 <h1>🎉 New financial contributor</h1>
 
-{{#if recipient.collective.name}}
-<p>{{recipient.collective.name}},</p>
-{{else}}
-<p>Hi,</p>
-{{/if}}
+{{> greeting}}
 
 <p>{{#if member.memberCollective.isIncognito}}Someone (incognito){{else}}<a
     href="{{config.host.website}}/{{member.memberCollective.slug}}">{{member.memberCollective.name}}</a>{{/if}} has become a new financial contributor to

--- a/templates/emails/collective.newmember.hbs
+++ b/templates/emails/collective.newmember.hbs
@@ -4,11 +4,7 @@ Subject: {{{remoteUser.collective.name}}} added you as {{{collective.name}}} {{r
 
 {{> toplogo}}
 
-{{#if recipient.collective.name}}
-<p>{{recipient.collective.name}},</p>
-{{else}}
-<p>Hi,</p>
-{{/if}}
+{{> greeting}}
 
 <p>{{remoteUser.collective.name}} (cced) added you to <a href="https://opencollective.com/{{collective.slug}}">{{collective.name}}</a> as {{role}} on Open Collective.</p>
 

--- a/templates/emails/collective.newmember.hbs
+++ b/templates/emails/collective.newmember.hbs
@@ -4,7 +4,7 @@ Subject: {{{remoteUser.collective.name}}} added you as {{{collective.name}}} {{r
 
 {{> toplogo}}
 
-{{> greeting}}
+<p>{{> greeting}}</p>
 
 <p>{{remoteUser.collective.name}} (cced) added you to <a href="https://opencollective.com/{{collective.slug}}">{{collective.name}}</a> as {{role}} on Open Collective.</p>
 
@@ -36,5 +36,6 @@ Subject: {{{remoteUser.collective.name}}} added you as {{{collective.name}}} {{r
 
 <a href="{{{loginLink}}}" class="btn blue">
   <div>Log in</div>
+</a>
 
 {{> footer}}

--- a/templates/emails/collective.unfrozen.hbs
+++ b/templates/emails/collective.unfrozen.hbs
@@ -3,7 +3,8 @@ Subject: Important: {{{collective.name}}} has been unfrozen by {{{host.name}}}
 {{> header}}
 
 <p style="font-size: 17px; padding: 1em;">
-  {{> greeting}}
+  Hi {{collective.name}},
+  <br /><br />
   Your fiscal host, <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a>, has unfrozen your Collective.
   In other words, they have reactivated any features that were previously limited while frozen.
   <br/><br/>

--- a/templates/emails/collective.unfrozen.hbs
+++ b/templates/emails/collective.unfrozen.hbs
@@ -3,8 +3,7 @@ Subject: Important: {{{collective.name}}} has been unfrozen by {{{host.name}}}
 {{> header}}
 
 <p style="font-size: 17px; padding: 1em;">
-  Hi {{collective.name}},
-  <br /><br />
+  {{> greeting}}
   Your fiscal host, <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a>, has unfrozen your Collective.
   In other words, they have reactivated any features that were previously limited while frozen.
   <br/><br/>

--- a/templates/emails/conversation.comment.created.hbs
+++ b/templates/emails/conversation.comment.created.hbs
@@ -3,8 +3,7 @@ Subject: New comment from {{{fromCollective.name}}} on "{{{escapeForSubject conv
 {{> header}}
 
 <p style="font-size: 17px; padding: 1em;">
-  Hi {{collective.name}},
-  <br /><br />
+  {{> greeting}}
   {{> linkCollective collective=fromCollective}} just posted
   a new comment on a Conversation, <a href="{{config.host.website}}{{path}}">{{conversation.title}}</a>:
 </p>

--- a/templates/emails/conversation.comment.created.hbs
+++ b/templates/emails/conversation.comment.created.hbs
@@ -4,6 +4,7 @@ Subject: New comment from {{{fromCollective.name}}} on "{{{escapeForSubject conv
 
 <p style="font-size: 17px; padding: 1em;">
   {{> greeting}}
+  <br /><br />
   {{> linkCollective collective=fromCollective}} just posted
   a new comment on a Conversation, <a href="{{config.host.website}}{{path}}">{{conversation.title}}</a>:
 </p>

--- a/templates/emails/deactivated.collective.as.host.hbs
+++ b/templates/emails/deactivated.collective.as.host.hbs
@@ -2,7 +2,7 @@ Subject: Fiscal Host Deactivated
 
 {{> header}}
 
-<p>Hi,</p>
+{{> greeting}}
 
 <p>You have successfully deactivated {{collective.name}} as a Fiscal Host. It can no longer receive and disburse funds for Collectives. The Host Dashboard has also been deactivated.</p>
 

--- a/templates/emails/expense.comment.created.hbs
+++ b/templates/emails/expense.comment.created.hbs
@@ -4,6 +4,7 @@ Subject: {{{collective.name}}}: New comment on expense {{{escapeForSubject expen
 
 <p style="padding: 1em;">
   {{> greeting}}
+   <br /><br />
   {{> linkCollective collective=fromCollective}} just posted
   a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:
 </p>

--- a/templates/emails/expense.comment.created.hbs
+++ b/templates/emails/expense.comment.created.hbs
@@ -3,8 +3,7 @@ Subject: {{{collective.name}}}: New comment on expense {{{escapeForSubject expen
 {{> header}}
 
 <p style="padding: 1em;">
-  Hi,
-  <br /><br />
+  {{> greeting}}
   {{> linkCollective collective=fromCollective}} just posted
   a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:
 </p>

--- a/templates/emails/host.application.contact.hbs
+++ b/templates/emails/host.application.contact.hbs
@@ -3,8 +3,7 @@ Subject: New message from {{{host.name}}} on Open Collective{{#if subject}} {{/i
 {{> header}}
 
 <p style="font-size: 17px; padding: 1em;">
-  Hi {{collective.name}},
-  <br /><br />
+  {{> greeting}}
   The Fiscal Host you applied to, <a href="{{config.host.website}}/{{host.slug}}">{{host.name}}</a>, just sent you a message on Open Collective:
 </p>
 

--- a/templates/emails/host.report.hbs
+++ b/templates/emails/host.report.hbs
@@ -85,7 +85,7 @@ Subject: {{#if erratumMessage}}Erratum{{#if erratumNumber}} {{erratumNumber}}{{/
       <strong>Erratum:</strong> <span style="white-space: pre-wrap;">{{erratumMessage}}</span>
     </p>
   {{/if}}
-  {{> greeting}}
+  <p>{{> greeting}}</p>
   <p>Here is your {{#if month}}monthly{{else}}yearly{{/if}} stats report, from {{moment startDate}} to
     {{moment endDateIncluded}}.</p>
   <center>

--- a/templates/emails/host.report.hbs
+++ b/templates/emails/host.report.hbs
@@ -85,7 +85,7 @@ Subject: {{#if erratumMessage}}Erratum{{#if erratumNumber}} {{erratumNumber}}{{/
       <strong>Erratum:</strong> <span style="white-space: pre-wrap;">{{erratumMessage}}</span>
     </p>
   {{/if}}
-  <p>Hi {{recipient.name}}!</p>
+  {{> greeting}}
   <p>Here is your {{#if month}}monthly{{else}}yearly{{/if}} stats report, from {{moment startDate}} to
     {{moment endDateIncluded}}.</p>
   <center>

--- a/templates/emails/member.invitation.hbs
+++ b/templates/emails/member.invitation.hbs
@@ -2,11 +2,7 @@ Subject: Invitation to join {{{collective.name}}} on Open Collective
 
 {{> header}}
 
-{{#if memberCollective.name}}
-<p>Dear {{memberCollective.name}},</p>
-{{else}}
-<p>Hi,</p>
-{{/if}}
+{{> greeting}}
 
 <p>
   {{#if skipDefaultAdmin}}

--- a/templates/emails/member.invitation.hbs
+++ b/templates/emails/member.invitation.hbs
@@ -2,7 +2,7 @@ Subject: Invitation to join {{{collective.name}}} on Open Collective
 
 {{> header}}
 
-{{> greeting}}
+<p>{{> greeting recipient=memberCollective}}</p>
 
 <p>
   {{#if skipDefaultAdmin}}

--- a/templates/emails/oauth.application.authorized.hbs
+++ b/templates/emails/oauth.application.authorized.hbs
@@ -3,9 +3,7 @@ Subject: Open Collective: A third-party OAuth application has been added to your
 {{> header}}
 
 <p>
-    Hi,
-    <br />
-    <br />
+    {{> greeting}}
     A third-party OAuth application ({{application.name}}) was recently authorized to access your account.
 </p>
 

--- a/templates/emails/oauth.application.authorized.hbs
+++ b/templates/emails/oauth.application.authorized.hbs
@@ -4,6 +4,8 @@ Subject: Open Collective: A third-party OAuth application has been added to your
 
 <p>
     {{> greeting}}
+    <br />
+    <br />
     A third-party OAuth application ({{application.name}}) was recently authorized to access your account.
 </p>
 

--- a/templates/emails/onboarding.day2.organization.hbs
+++ b/templates/emails/onboarding.day2.organization.hbs
@@ -2,9 +2,9 @@ Subject: Help us improve the Sponsor experience
 
 {{> header}}
 
-<h1>Hello {{collective.name}} 👋</h1>
+<h1>{{> greeting}} 👋</h1>
 
-<p>Hi! Thanks again for signing up your Organization to Open Collective.</p>
+<p>Thanks again for signing up your Organization to Open Collective.</p>
 
 <p>We’re always seeking to improve our platform, so we're interested in your feedback!</p>
 

--- a/templates/emails/onboarding.day2.organization.hbs
+++ b/templates/emails/onboarding.day2.organization.hbs
@@ -2,7 +2,7 @@ Subject: Help us improve the Sponsor experience
 
 {{> header}}
 
-<h1>{{> greeting}} 👋</h1>
+<h1>Hello {{collective.name}} 👋</h1>
 
 <p>Thanks again for signing up your Organization to Open Collective.</p>
 

--- a/templates/emails/onboarding.day3.opensource.hbs
+++ b/templates/emails/onboarding.day3.opensource.hbs
@@ -2,7 +2,7 @@ Subject: More revenue streams for your Collective
 
 {{> header}}
 
-<h1>{{> greeting}}</h1>
+<h1>{{> greeting collective=collective}}</h1>
 
 <p>Have you customized <a href="https://opencollective.com/{{collective.slug}}/admin/tiers">your contribution tiers</a>? Think about how to entice financial contributors by giving them some options!</p>
 

--- a/templates/emails/onboarding.day3.opensource.hbs
+++ b/templates/emails/onboarding.day3.opensource.hbs
@@ -2,7 +2,7 @@ Subject: More revenue streams for your Collective
 
 {{> header}}
 
-<h1>Hi {{collective.name}}</h1>
+<h1>{{> greeting}}</h1>
 
 <p>Have you customized <a href="https://opencollective.com/{{collective.slug}}/admin/tiers">your contribution tiers</a>? Think about how to entice financial contributors by giving them some options!</p>
 

--- a/templates/emails/order.pending.crypto.hbs
+++ b/templates/emails/order.pending.crypto.hbs
@@ -14,11 +14,7 @@ Subject: Your {{pledgeAmount}} {{pledgeCurrency}} {{order.type}} to {{{collectiv
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Hi {{fromCollective.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+{{> greeting}}
 
 <p>Thank you for your crypto contribution to {{collective.name}} in the amount of {{pledgeAmount}} {{pledgeCurrency}}, made on
   {{moment order.createdAt}}.</p>

--- a/templates/emails/order.processing.hbs
+++ b/templates/emails/order.processing.hbs
@@ -5,11 +5,7 @@ currency=order.currency}}} {{order.type}} to {{collective.name}} is being proces
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Hi {{fromCollective.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+{{> greeting}}
 
 <p>Thank you for your contribution to {{collective.name}} in the amount of {{currency order.totalAmount currency=order.currency}}, made on {{moment order.createdAt}}.</p>
 

--- a/templates/emails/order.thankyou.foundation.hbs
+++ b/templates/emails/order.thankyou.foundation.hbs
@@ -4,11 +4,7 @@ Subject: Thank you for your contribution to {{{collective.name}}}
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Dear {{fromCollective.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+{{> greeting}}
 
 {{#if interval}}
   {{#if firstPayment }}

--- a/templates/emails/order.thankyou.hbs
+++ b/templates/emails/order.thankyou.hbs
@@ -4,11 +4,7 @@ Subject: Thank you for your contribution to {{{collective.name}}}
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Dear {{fromCollective.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+{{> greeting}}
 
 {{#if interval}}
   {{#if firstPayment }}

--- a/templates/emails/order.thankyou.opensource.hbs
+++ b/templates/emails/order.thankyou.opensource.hbs
@@ -4,11 +4,7 @@ Subject: Thank you for your contribution to {{{collective.name}}}
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Dear {{fromCollective.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+{{> greeting}}
 
 {{#if interval}}
   {{#if firstPayment }}

--- a/templates/emails/order.thankyou.wwcode.hbs
+++ b/templates/emails/order.thankyou.wwcode.hbs
@@ -8,11 +8,7 @@ Subject: Thank you for your {{currency order.totalAmount currency=order.currency
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>{{fromCollective.name}},</p>
-{{else}}
-<p>Hi,</p>
-{{/if}}
+{{> greeting}}
 
 {{#if interval}}
   {{#if firstPayment}}

--- a/templates/emails/organization.newmember.hbs
+++ b/templates/emails/organization.newmember.hbs
@@ -4,7 +4,7 @@ Subject: {{{remoteUser.collective.name}}} added you as {{role}} to {{{collective
 
 {{> toplogo}}
 
-{{> greeting}}
+<p>{{> greeting}}</p>
 
 <p>{{remoteUser.collective.name}} (cced) added you as {{role}} for <a href="https://opencollective.com/{{collective.slug}}">{{collective.name}}</a> on Open Collective.</p>
 

--- a/templates/emails/organization.newmember.hbs
+++ b/templates/emails/organization.newmember.hbs
@@ -4,11 +4,7 @@ Subject: {{{remoteUser.collective.name}}} added you as {{role}} to {{{collective
 
 {{> toplogo}}
 
-{{#if recipient.collective.name}}
-<p>{{recipient.collective.name}},</p>
-{{else}}
-<p>Hi,</p>
-{{/if}}
+{{> greeting}}
 
 <p>{{remoteUser.collective.name}} (cced) added you as {{role}} for <a href="https://opencollective.com/{{collective.slug}}">{{collective.name}}</a> on Open Collective.</p>
 

--- a/templates/emails/payment.creditcard.confirmation.hbs
+++ b/templates/emails/payment.creditcard.confirmation.hbs
@@ -4,11 +4,7 @@ Subject: Confirm your credit card to continue supporting {{{collective.name}}}
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Dear {{fromCollective.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+{{> greeting}}
 
 <p>To comply with banking regulations, we are required to confirm your credit card in order to process your payment of {{currency order.totalAmount currency=order.currency}} to {{collective.name}}.</p>
 

--- a/templates/emails/payment.creditcard.expiring.hbs
+++ b/templates/emails/payment.creditcard.expiring.hbs
@@ -16,12 +16,7 @@ Subject: Your {{brand}} card ending in {{name}} is about to expire
 
 {{> header}}
 
-{{#if collectiveName}}
-<p>Hi {{collectiveName}},</p>
-{{else}}
-<p>Hello,</p>
-{{/if}}
-
+{{> greeting}}
 
 {{#if reminder}}
 <p>

--- a/templates/emails/payment.failed.hbs
+++ b/templates/emails/payment.failed.hbs
@@ -17,11 +17,7 @@ Subject: Payment failed: Update info to keep supporting {{{collective.name}}}
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Hi {{fromCollective.name}},</p>
-{{else}}
-<p>Hello,</p>
-{{/if}}
+{{> greeting}}
 
 {{#if lastAttempt}}
 

--- a/templates/emails/subscription.canceled.hbs
+++ b/templates/emails/subscription.canceled.hbs
@@ -4,11 +4,7 @@ Subject: Contribution cancelled to {{{collective.name}}}
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Hi {{fromCollective.name}},</p>
-{{else}}
-<p>Hello</p>
-{{/if}}
+{{> greeting}}
 
 <p>Your recurring contribution to {{collective.name}} (cced) for {{currency subscription.amount currency=subscription.currency}}/{{subscription.interval}} has been cancelled.</p>
 

--- a/templates/emails/taxform.request.hbs
+++ b/templates/emails/taxform.request.hbs
@@ -2,11 +2,7 @@ Subject: Action required: Submit tax form for {{{accountName}}}
 
 {{> header}}
 
-{{#if recipientName}}
-<p>Hi {{recipientName}},</p>
-{{else}}
-<p>Hi,</p>
-{{/if}}
+{{> greeting}}
 
 <p>
   US regulations require US entities to collect certain information about payees for tax reporting purposes. The button below will take you to HelloWorks, the service we use to collect your tax information securely.

--- a/templates/emails/ticket.confirmed.hbs
+++ b/templates/emails/ticket.confirmed.hbs
@@ -5,11 +5,7 @@ Subject: {{ order.quantity }} {{pluralize "ticket" n=order.quantity}} confirmed 
 
 {{> toplogo}}
 
-{{#if recipient.name}}
-<p>Hi {{recipient.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+{{> greeting}}
 
 <p>You have booked {{ order.quantity }} {{pluralize "ticket" n=order.quantity}} to {{ event.name }}{{#if order.totalAmount}} for a total of {{currency order.totalAmount currency=order.currency}}{{/if}}.</p>
 

--- a/templates/emails/ticket.confirmed.open-2020.hbs
+++ b/templates/emails/ticket.confirmed.open-2020.hbs
@@ -1,6 +1,6 @@
 Subject: Thanks for buying a ticket to OPEN 2020
 
-<p>Hi,</p>
+{{> greeting}}
 
 <p>Thanks for buying a ticket to OPEN 2020</p>
 

--- a/templates/emails/update.comment.created.hbs
+++ b/templates/emails/update.comment.created.hbs
@@ -5,6 +5,7 @@ Subject: New comment from {{{fromCollective.name}}} on "{{{escapeForSubject upda
 
 <p style="font-size: 17px; padding: 1em;">
   {{> greeting}}
+  <br /><br />
   {{> linkCollective collective=fromCollective}} just posted
   a new comment on an Update, <a href="{{config.host.website}}{{path}}">{{update.title}}</a>:
 </p>

--- a/templates/emails/update.comment.created.hbs
+++ b/templates/emails/update.comment.created.hbs
@@ -4,8 +4,7 @@ Subject: New comment from {{{fromCollective.name}}} on "{{{escapeForSubject upda
 
 
 <p style="font-size: 17px; padding: 1em;">
-  Hi {{collective.name}},
-  <br /><br />
+  {{> greeting}}
   {{> linkCollective collective=fromCollective}} just posted
   a new comment on an Update, <a href="{{config.host.website}}{{path}}">{{update.title}}</a>:
 </p>

--- a/templates/emails/user.changeEmail.hbs
+++ b/templates/emails/user.changeEmail.hbs
@@ -9,8 +9,7 @@ Subject: Confirm your email {{user.emailWaitingForValidation}} on Open Collectiv
 <br />
 <br />
 <p>
-  Hi,
-  <br/><br/>
+  {{> greeting}}
   It looks like you changed your email address on Open Collective.
   <br/><br/>
   We need to verify that <strong>{{user.emailWaitingForValidation}}</strong> is correct by clicking this button:

--- a/templates/emails/user.monthlyreport.hbs
+++ b/templates/emails/user.monthlyreport.hbs
@@ -219,7 +219,7 @@ Subject: {{capitalize month}} Open Collective Report
       <a class="ContainerLogo" href="//opencollective.com"></a>
       <div class="ContainerLogoName"></div>
       <div class="Section Intro">
-        <h2>Hi {{fromCollective.name}} 👋</h2>
+        <h2>{{> greeting}}👋</h2>
         <ul class="intro">
           <li>In {{month}}, you have backed {{stats.collectives}} {{pluralize "collective" n=stats.collectives}} for a total of {{stats.totalDonatedString}}. Thank you for your {{pluralize "contribution" n=stats.collectives}}! 🙌
           {{#if stats.expenses}}<br />These Collectives have spent a total of {{stats.totalSpentString}} in expenses.{{/if}}

--- a/templates/emails/user.yearlyreport.hbs
+++ b/templates/emails/user.yearlyreport.hbs
@@ -74,7 +74,7 @@ Subject: 🏅Your year on Open Collective
 
 
 <p>
-  Hi {{collective.name}}!
+  {{> greeting}}
 </p>
 
 <p>

--- a/templates/partials/greeting.hbs
+++ b/templates/partials/greeting.hbs
@@ -1,0 +1,5 @@
+{{#if recipientName ~}}
+<p>Hi {{recipientName}},</p>
+{{else ~}}
+<p>Hi,</p>
+{{/if ~}}

--- a/templates/partials/greeting.hbs
+++ b/templates/partials/greeting.hbs
@@ -1,4 +1,6 @@
-{{#if recipientName ~}}
+{{#if recipient ~}}
+Hi{{#if recipient.name}} {{recipient.name}}{{/if}},
+{{else if recipientName ~}}
 Hi {{recipientName}},
 {{else ~}}
 Hi,

--- a/templates/partials/greeting.hbs
+++ b/templates/partials/greeting.hbs
@@ -1,5 +1,5 @@
 {{#if recipientName ~}}
-<p>Hi {{recipientName}},</p>
+Hi {{recipientName}},
 {{else ~}}
-<p>Hi,</p>
+Hi,
 {{/if ~}}

--- a/test/templates/partials/greeting.test.ts
+++ b/test/templates/partials/greeting.test.ts
@@ -12,15 +12,8 @@ describe('templates/partials/greeting', () => {
   });
 
   it('should render a collective name in greeting', async () => {
-    const collective = await fakeCollective({ name: 'Test Collective' });
-    const result = template({ recipientName: collective.name });
+    const result = template({ recipientName: 'Test Collective' });
     expect(result).to.eq(`<p>Hi Test Collective,</p>\n`);
   });
 
-  it('should render a user name in greeting', async () => {
-    const user = await fakeUser();
-    const result = template({ recipientName: user.collective.name });
-    // The fake user has a randomly generated name, so we don't attempt full equality.
-    expect(result).to.include(`<p>Hi User`);
-  });
 });

--- a/test/templates/partials/greeting.test.ts
+++ b/test/templates/partials/greeting.test.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+
+import handlebars from '../../../server/lib/handlebars';
+import { fakeCollective, fakeUser } from '../../test-helpers/fake-data';
+
+const template = handlebars.compile('{{> greeting}}');
+
+describe('templates/partials/greeting', () => {
+  it('should render a generic greeting without a recipient', async () => {
+    const result = template({});
+    expect(result).to.eq(`<p>Hi,</p>\n`);
+  });
+
+  it('should render a collective name in greeting', async () => {
+    const collective = await fakeCollective({ name: 'Test Collective' });
+    const result = template({ recipientName: collective.name });
+    expect(result).to.eq(`<p>Hi Test Collective,</p>\n`);
+  });
+
+  it('should render a user name in greeting', async () => {
+    const user = await fakeUser();
+    const result = template({ recipientName: user.collective.name });
+    // The fake user has a randomly generated name, so we don't attempt full equality.
+    expect(result).to.include(`<p>Hi User`);
+  });
+});


### PR DESCRIPTION
Addresses: https://github.com/opencollective/opencollective/issues/5872

This will allow more flexible greetings in email templates. A recipient name is used, if provided.

If a collective - wide notification is sent that collective name will be used rather than individual names.

Caveat: I have not tested this locally. I'm not quite at the point where I am able to do that. So there is some small risk, I think. If you are able to verify this change first, that would be good.