### PR TITLE
Emails: add `link-collective` partial

### DIFF
--- a/server/lib/emailTemplates.ts
+++ b/server/lib/emailTemplates.ts
@@ -119,6 +119,7 @@ const eventsnippet = fs.readFileSync(`${templatesPath}/partials/eventsnippet.hbs
 const expenseItems = fs.readFileSync(`${templatesPath}/partials/expense-items.hbs`, 'utf8');
 const eventdata = fs.readFileSync(`${templatesPath}/partials/eventdata.hbs`, 'utf8');
 const collectivecard = fs.readFileSync(`${templatesPath}/partials/collectivecard.hbs`, 'utf8');
+const linkCollective = fs.readFileSync(`${templatesPath}/partials/link-collective.hbs`, 'utf8');
 const chargeDateNotice = fs.readFileSync(`${templatesPath}/partials/charge_date_notice.hbs`, 'utf8');
 const mthReportFooter = fs.readFileSync(`${templatesPath}/partials/monthlyreport.footer.hbs`, 'utf8');
 const mthReportSubscription = fs.readFileSync(`${templatesPath}/partials/monthlyreport.subscription.hbs`, 'utf8');
@@ -127,6 +128,7 @@ handlebars.registerPartial('header', header);
 handlebars.registerPartial('footer', footer);
 handlebars.registerPartial('toplogo', toplogo);
 handlebars.registerPartial('collectivecard', collectivecard);
+handlebars.registerPartial('linkCollective', linkCollective);
 handlebars.registerPartial('eventsnippet', eventsnippet);
 handlebars.registerPartial('expenseItems', expenseItems);
 handlebars.registerPartial('eventdata', eventdata);

--- a/templates/emails/collective.apply.hbs
+++ b/templates/emails/collective.apply.hbs
@@ -5,7 +5,7 @@ Subject: Thanks for applying to {{host.name}}
 <div class="hidden">Your application is pending.</div>
 
 <p>Oh hey {{user.collective.name}} 👋 </p>
-<p>Thank you for applying to <a href="{{config.host.website}}/{{host.slug}}">{{host.name}}</a> to host <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a>.</p>
+<p>Thank you for applying to <a href="{{config.host.website}}/{{host.slug}}">{{host.name}}</a> to host {{> linkCollective collective=collective}}.</p>
 <p>Please make sure that your <a href="{{config.host.website}}/{{collective.slug}}">Collective page</a> describes your purpose and activities as accurately as possible, as we will look at this info when reviewing your application.</p>
 
 <p>If you have any questions, feel free to respond to this email.</p>

--- a/templates/emails/collective.comment.created.hbs
+++ b/templates/emails/collective.comment.created.hbs
@@ -14,21 +14,21 @@ Subject: {{{collective.name}}}: New comment
   <p style="padding: 1em;">
     Hi,
     <br /><br />
-    <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
+    {{> linkCollective collective=fromCollective}} just posted
     a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:
   </p>
 {{else if conversation}}
   <p style="font-size: 17px; padding: 1em;">
     Hi {{collective.name}},
     <br /><br />
-    <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
+    {{> linkCollective collective=fromCollective}} just posted
     a new comment on a Conversation, <a href="{{config.host.website}}{{path}}">{{conversation.title}}</a>:
   </p>
 {{else if update}}
   <p style="font-size: 17px; padding: 1em;">
     Hi {{collective.name}},
     <br /><br />
-    <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
+    {{> linkCollective collective=fromCollective}} just posted
     a new comment on an Update, <a href="{{config.host.website}}{{path}}">{{update.title}}</a>:
   </p>
 {{/if}}

--- a/templates/emails/collective.contact.hbs
+++ b/templates/emails/collective.contact.hbs
@@ -5,7 +5,7 @@ Subject: New message from {{{fromCollective.name}}} on Open Collective{{#if subj
 <p style="font-size: 17px; padding: 1em;">
   Hi {{collective.name}},
   <br /><br />
-  <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just sent you a message on Open
+  {{> linkCollective collective=fromCollective}} just sent you a message on Open
   Collective. Simply reply to this email to reply to the sender.
 </p>
 

--- a/templates/emails/collective.conversation.created.hbs
+++ b/templates/emails/collective.conversation.created.hbs
@@ -5,7 +5,7 @@ Subject: New Conversation on {{{collective.name}}}: "{{{escapeForSubject convers
 <p style="padding: 1em;">
   Hi {{collective.name}},
   <br /><br />
-  <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just started
+  {{> linkCollective collective=fromCollective}} just started
   a new Conversation: <a href="{{config.host.website}}/{{collective.slug}}/conversations/{{conversation.slug}}-{{conversation.hashId}}">{{conversation.title}}</a>
 </p>
 

--- a/templates/emails/collective.expense.approved.for.host.hbs
+++ b/templates/emails/collective.expense.approved.for.host.hbs
@@ -11,7 +11,7 @@ Subject: New expense approved on {{{collective.name}}}: {{currency expense.amoun
 <br />
 
 <table>
-  <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
+  <tr><th>Submitted by:</th><td>{{> linkCollective collective=fromCollective}}</td></tr>
   <tr><th>Payout method:</th><td>{{expense.payoutMethodLabel}}</td></tr>
   {{#if expense.privateMessage}}
     <tr><th valign="top">Private note:</th><td>{{{expense.privateMessage}}}</td></tr>

--- a/templates/emails/collective.expense.approved.hbs
+++ b/templates/emails/collective.expense.approved.hbs
@@ -3,7 +3,7 @@ Subject: Your expense to {{{collective.name}}} for {{currency expense.amount cur
 {{> header}}
 
 <p>Your expense, <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a>, has been approved.</p>
-<p>Most payments are processed within a few days, but the timing will depend on the available budget of <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a>, the payment method, and other factors.</p>
+<p>Most payments are processed within a few days, but the timing will depend on the available budget of {{> linkCollective collective=collective}}, the payment method, and other factors.</p>
 <p>If you have any questions related to this expense, please post a comment on <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">the expense page</a>.</p>
 <center>
   <h1><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{currency expense.amount currency=expense.currency}}</a></h1>
@@ -14,7 +14,7 @@ Subject: Your expense to {{{collective.name}}} for {{currency expense.amount cur
 <br />
 
 <table>
-  <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
+  <tr><th>Submitted by:</th><td>{{> linkCollective collective=fromCollective}}</td></tr>
   <tr><th>Payout method:</th><td>{{expense.payoutMethodLabel}}</td></tr>
   {{#if expense.privateMessage}}
     <tr><th valign="top">Private note:</th><td>{{{expense.privateMessage}}}</td></tr>

--- a/templates/emails/collective.expense.invite.drafted.hbs
+++ b/templates/emails/collective.expense.invite.drafted.hbs
@@ -9,7 +9,7 @@ Subject: {{{collective.name}}} wants to pay you
   </h1>
 </center>
 <p>
-  This means <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a> wants to pay you. You need to confirm some details so your payment can be processed.
+  This means {{> linkCollective collective=collective}} wants to pay you. You need to confirm some details so your payment can be processed.
 </p>
 
 
@@ -19,7 +19,7 @@ Subject: {{{collective.name}}} wants to pay you
 <table>
   <tr>
     <th>Requested by </th>
-    <td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td>
+    <td>{{> linkCollective collective=fromCollective}}</td>
   </tr>
   {{#if recipientNote}}
   <tr>

--- a/templates/emails/collective.expense.paid.hbs
+++ b/templates/emails/collective.expense.paid.hbs
@@ -12,7 +12,7 @@ Subject: {{#ifCond expense.currency '===' 'USD'}}💵 {{/ifCond}}{{#ifCond expen
 <center>
   <h3>Hi there!</h3>
   <p>
-    Your expense, <b><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b>, submitted to <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a> on {{moment expense.createdAt}} has been paid.
+    Your expense, <b><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b>, submitted to {{> linkCollective collective=collective}} on {{moment expense.createdAt}} has been paid.
     {{#if expense.payoutMethod}}
       {{#ifCond expense.payoutMethod.type '===' 'BANK_ACCOUNT'}}
         The money can take a few days to arrive, depending on the bank.

--- a/templates/emails/collective.expense.processing.hbs
+++ b/templates/emails/collective.expense.processing.hbs
@@ -6,7 +6,7 @@ Subject: Payment being processed: {{{expense.description}}} for {{{collective.na
   <h3>Hi there!</h3>
   <p>
     Your expense, <b><a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a></b>,
-    submitted to <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a> on {{moment expense.createdAt}}, is currently being processed by Wise and should be paid soon.
+    submitted to {{> linkCollective collective=collective}} on {{moment expense.createdAt}}, is currently being processed by Wise and should be paid soon.
   </p>
 </center>
 

--- a/templates/emails/collective.expense.rejected.hbs
+++ b/templates/emails/collective.expense.rejected.hbs
@@ -5,7 +5,7 @@ Subject: Expense rejected: {{currency expense.amount currency=expense.currency}}
 <p>Your expense, <a href="{{config.host.website}}/{{collective.slug}}/expenses/{{expense.id}}">{{expense.description}}</a>, has been rejected.</p>
 
 <table>
-  <tr><th>Submitted by:</th><td><a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></td></tr>
+  <tr><th>Submitted by:</th><td>{{> linkCollective collective=fromCollective}}</td></tr>
   {{#if expense.privateMessage}}
     <tr><th valign="top">Note:</th><td>{{{expense.privateMessage}}}</td></tr>
   {{/if}}

--- a/templates/emails/collective.update.published.hbs
+++ b/templates/emails/collective.update.published.hbs
@@ -81,7 +81,7 @@ Subject: {{{escapeForSubject update.title}}}
 <br />
 
 <h2>{{{update.title}}}</h2>
-<div class="byline">by <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a></div>
+<div class="byline">by {{> linkCollective collective=fromCollective}}</div>
 
 <div class="updateHtml">
   {{{update.html}}}

--- a/templates/emails/conversation.comment.created.hbs
+++ b/templates/emails/conversation.comment.created.hbs
@@ -5,7 +5,7 @@ Subject: New comment from {{{fromCollective.name}}} on "{{{escapeForSubject conv
 <p style="font-size: 17px; padding: 1em;">
   Hi {{collective.name}},
   <br /><br />
-  <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
+  {{> linkCollective collective=fromCollective}} just posted
   a new comment on a Conversation, <a href="{{config.host.website}}{{path}}">{{conversation.title}}</a>:
 </p>
 

--- a/templates/emails/expense.comment.created.hbs
+++ b/templates/emails/expense.comment.created.hbs
@@ -5,7 +5,7 @@ Subject: {{{collective.name}}}: New comment on expense {{{escapeForSubject expen
 <p style="padding: 1em;">
   Hi,
   <br /><br />
-  <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
+  {{> linkCollective collective=fromCollective}} just posted
   a new comment on an Expense, <a href="{{config.host.website}}{{path}}">{{expense.description}}</a>:
 </p>
 

--- a/templates/emails/github.signup.hbs
+++ b/templates/emails/github.signup.hbs
@@ -53,7 +53,7 @@ h3 {
       <td valign="top" width="50"><img src="{{config.host.website}}/static/images/email/vertical-line-green.png" width="30" /></td>
       <td valign="top">
         <h3 class="grey">Create</h3>
-        <p class="grey">Your Collective <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a> has been created. Share this link and start accepting financial contributions: <a href="{{config.host.website}}/{{collective.slug}}">{{config.host.website}}/{{collective.slug}}</a></p>
+        <p class="grey">Your Collective {{> linkCollective collective=collective}} has been created. Share this link and start accepting financial contributions: <a href="{{config.host.website}}/{{collective.slug}}">{{config.host.website}}/{{collective.slug}}</a></p>
       </td>
       <td valign="top">
         <img src="{{config.host.website}}/static/images/email/github.signup.step1.png" width="180" />

--- a/templates/emails/member.invitation.hbs
+++ b/templates/emails/member.invitation.hbs
@@ -10,9 +10,9 @@ Subject: Invitation to join {{{collective.name}}} on Open Collective
 
 <p>
   {{#if skipDefaultAdmin}}
-    You were just invited you to the role of {{role}} of <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a> on Open Collective.
+    You were just invited you to the role of {{role}} of {{> linkCollective collective=collective}} on Open Collective.
   {{else}}
-    <a href="{{config.host.website}}/{{invitedByUser.collective.slug}}">{{invitedByUser.collective.name}}</a> just invited you to the role of {{role}} of <a href="{{config.host.website}}/{{collective.slug}}">{{collective.name}}</a> on Open Collective.
+    <a href="{{config.host.website}}/{{invitedByUser.collective.slug}}">{{invitedByUser.collective.name}}</a> just invited you to the role of {{role}} of {{> linkCollective collective=collective}} on Open Collective.
   {{/if}}
 </p>
 

--- a/templates/emails/member.invitation.hbs
+++ b/templates/emails/member.invitation.hbs
@@ -10,7 +10,7 @@ Subject: Invitation to join {{{collective.name}}} on Open Collective
 
 <p>
   {{#if skipDefaultAdmin}}
-    You were just invited you to the role of {{role}} of {{> linkCollective collective=collective}} on Open Collective.
+    You were just invited to the role of {{role}} of {{> linkCollective collective=collective}} on Open Collective.
   {{else}}
     <a href="{{config.host.website}}/{{invitedByUser.collective.slug}}">{{invitedByUser.collective.name}}</a> just invited you to the role of {{role}} of {{> linkCollective collective=collective}} on Open Collective.
   {{/if}}

--- a/templates/emails/update.comment.created.hbs
+++ b/templates/emails/update.comment.created.hbs
@@ -6,7 +6,7 @@ Subject: New comment from {{{fromCollective.name}}} on "{{{escapeForSubject upda
 <p style="font-size: 17px; padding: 1em;">
   Hi {{collective.name}},
   <br /><br />
-  <a href="{{config.host.website}}/{{fromCollective.slug}}">{{fromCollective.name}}</a> just posted
+  {{> linkCollective collective=fromCollective}} just posted
   a new comment on an Update, <a href="{{config.host.website}}{{path}}">{{update.title}}</a>:
 </p>
 

--- a/templates/partials/link-collective.hbs
+++ b/templates/partials/link-collective.hbs
@@ -1,0 +1,1 @@
+<a href="{{config.host.website}}/{{collective.slug}}">{{#if text}}{{text}}{{else if collective.name}}{{{collective.name}}}{{else}}{{collective.slug}}{{/if}}</a>

--- a/test/templates/partials/link-collective.test.ts
+++ b/test/templates/partials/link-collective.test.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+
+import handlebars from '../../../server/lib/handlebars';
+import { fakeCollective } from '../../test-helpers/fake-data';
+
+const template = handlebars.compile('{{> linkCollective collective=collective}}');
+
+const DEFAULT_CONTEXT = { config: { host: { website: 'https://opencollective.com' } } };
+
+describe('templates/partials/link-collective', () => {
+  it('should render a link to a collective', async () => {
+    const collective = (await fakeCollective({ name: 'Test Collective' })).activity;
+    const result = template({ ...DEFAULT_CONTEXT, collective });
+    expect(result).to.eq(`<a href="https://opencollective.com/${collective.slug}">Test Collective</a>`);
+  });
+
+  it('should render a link to a collective with a custom text', async () => {
+    const collective = (await fakeCollective({ name: 'Test Collective' })).activity;
+    const result = template({ ...DEFAULT_CONTEXT, collective, text: 'Hello World' });
+    expect(result).to.eq(`<a href="https://opencollective.com/${collective.slug}">Hello World</a>`);
+  });
+});


### PR DESCRIPTION
https://github.com/opencollective/opencollective-api/pull/7934 reminded me of an old change I had in my local stash to add a partial to link accounts more easily in emails. I completed the feature & added a test.

The main goals here are:
1. to make it easier to link a collective
2. to prevent typos in the URL
3. to increase our use of partials to better re-use code (same spirit as https://github.com/opencollective/opencollective/issues/5872)
4. for the future, to make sure all collectives with a parent get the proper link set directly

This PR should also fix some occurrences of https://github.com/opencollective/opencollective/issues/4758.