### PR TITLE
Allow filtering for untagged expenses

### DIFF
--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -222,6 +222,8 @@ const ExpensesCollectionQuery = {
     }
     if (args.tag || args.tags) {
       where['tags'] = { [Op.contains]: args.tag || args.tags };
+    } else if (args.tag === null || args.tags === null) {
+      where['tags'] = { [Op.is]: null };
     }
     if (args.minAmount) {
       where['amount'] = { [Op.gte]: args.minAmount };


### PR DESCRIPTION
API fix for https://github.com/opencollective/opencollective/issues/5889

This allows filtering for untagged expenses when setting `tag` or `tags` to `null` as [per this comment](https://github.com/opencollective/opencollective/issues/5889#issuecomment-1223619272):
> We already support passing `null` as a tag to the API. I suggest that when making such a query:
> 
> ```graphql
> {
>   expenses(tag: null) {
>     totalCount
>   }
> }
> ```
> 
> We return all expenses without tags.
> 
> For the frontend, @alanna's solution above sounds ideal to me.


