### PR TITLE
Remove getDecodedId helper

### DIFF
--- a/server/graphql/v2/identifiers.js
+++ b/server/graphql/v2/identifiers.js
@@ -86,12 +86,3 @@ export const getIdEncodeResolver =
   (type, idField = 'id') =>
   entity =>
     idEncode(entity[idField], type);
-
-/**
- * Resolve original id by decoding if string, otherwise return as is.
- * @param {number|string} id - id to decode
- * @returns {number} decoded id
- */
-export function getDecodedId(id) {
-  return isNaN(id) && typeof id === 'string' ? idDecode(id) : id;
-}

--- a/server/graphql/v2/input/OrderReferenceInput.js
+++ b/server/graphql/v2/input/OrderReferenceInput.js
@@ -23,9 +23,9 @@ export const OrderReferenceInput = new GraphQLInputObjectType({
  *
  * @param {object} input - id of the order
  */
-export const fetchOrderWithReference = async input => {
+export const fetchOrderWithReference = async (input, { include, throwIfMissing = true } = {}) => {
   const loadOrderById = id => {
-    return models.Order.findByPk(id);
+    return models.Order.findByPk(id, { include });
   };
 
   let order;
@@ -37,7 +37,7 @@ export const fetchOrderWithReference = async input => {
   } else {
     throw new Error('Please provide an id');
   }
-  if (!order) {
+  if (!order && throwIfMissing) {
     throw new NotFound('Order Not Found');
   }
   return order;

--- a/server/graphql/v2/mutation/CommentMutations.js
+++ b/server/graphql/v2/mutation/CommentMutations.js
@@ -2,7 +2,7 @@ import { GraphQLNonNull, GraphQLString } from 'graphql';
 
 import { mustBeLoggedInTo } from '../../../lib/auth';
 import { createComment, deleteComment, editComment } from '../../common/comment';
-import { getDecodedId, idDecode, IDENTIFIER_TYPES } from '../identifiers';
+import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
 import { CommentCreateInput } from '../input/CommentCreateInput';
 import { CommentUpdateInput } from '../input/CommentUpdateInput';
 import { getConversationDatabaseIdFromReference } from '../input/ConversationReferenceInput';
@@ -20,7 +20,7 @@ const commentMutations = {
       },
     },
     resolve(_, { comment }, req) {
-      const commentToEdit = { ...comment, id: getDecodedId(comment.id) };
+      const commentToEdit = { ...comment, id: idDecode(comment.id, IDENTIFIER_TYPES.COMMENT) };
       return editComment(commentToEdit, req);
     },
   },
@@ -32,7 +32,7 @@ const commentMutations = {
       },
     },
     resolve(_, { id }, req) {
-      const decodedId = getDecodedId(id);
+      const decodedId = idDecode(id, IDENTIFIER_TYPES.COMMENT);
       return deleteComment(decodedId, req);
     },
   },

--- a/test/server/graphql/v2/identifiers.test.js
+++ b/test/server/graphql/v2/identifiers.test.js
@@ -1,16 +1,9 @@
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 
 import * as identifiers from '../../../../server/graphql/v2/identifiers';
 
 describe('server/graphql/v2/identifiers', () => {
-  it('returns same value if number', () => {
-    const id = 10;
-    expect(identifiers.getDecodedId(id)).to.be.eq(id);
-  });
-  it('returns decode id', () => {
-    const id = 155;
-    const encodedId = identifiers.idEncode(155);
-    assert.notEqual(id, encodedId);
-    expect(identifiers.getDecodedId(encodedId)).to.be.eq(id);
+  it('encodes then decodes a numerical id', () => {
+    expect(identifiers.idDecode(identifiers.idEncode(10, 'transaction'), 'transaction')).to.equal(10);
   });
 });


### PR DESCRIPTION
This helper was introduced in https://github.com/opencollective/opencollective-api/pull/2869, but its purpose is unclear:
- We want all IDs to be generated for a specific type (comment, expense, etc) so having a generic function doesn't make sense
- It's unclear what is expected from this helper, and ID V2 ? V1 ?
- It was confusing for some developers who used that instead of `idDecode` (see https://github.com/opencollective/opencollective-api/pull/7932#discussion_r969194402) 
