### PR TITLE
Use float for Amount's valueInCents

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -4669,7 +4669,7 @@ A financial amount.
 type Amount {
   value: Float
   currency: Currency
-  valueInCents: Int
+  valueInCents: Float
 
   """
   If the amount was generated from a currency conversion, this field contains details about the conversion

--- a/server/graphql/v2/object/Amount.js
+++ b/server/graphql/v2/object/Amount.js
@@ -1,4 +1,4 @@
-import { GraphQLFloat, GraphQLInt, GraphQLObjectType } from 'graphql';
+import { GraphQLFloat, GraphQLObjectType } from 'graphql';
 import { isNil } from 'lodash';
 
 import { Currency } from '../enum/Currency';
@@ -26,7 +26,7 @@ export const Amount = new GraphQLObjectType({
       },
     },
     valueInCents: {
-      type: GraphQLInt,
+      type: GraphQLFloat,
       resolve(amount) {
         if (isNil(amount.value)) {
           return null;


### PR DESCRIPTION
An attempt at fixing https://github.com/opencollective/opencollective/issues/5452

I tried with the [GraphQLBigInt](https://www.the-guild.dev/graphql/scalars/docs/scalars/big-int) scalar, but it requires an additional dependency (https://github.com/ardatan/json-bigint-patch) which seems to be causing breaking changes as numbers are then parsed as big ints:

> AssertionError: expected 0n to equal +0

Returning as `float` should be safe a backward-compatible. 