### PR TITLE
Wise: Use new BalancesV4 endpoint and remove deprecated Borderless Account endpoint request

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -290,7 +290,7 @@ export const Host = new GraphQLObjectType({
           if (transferwiseAccount) {
             return TransferwiseLib.getAccountBalances(transferwiseAccount).then(balances => {
               return balances.map(balance => ({
-                value: Math.round((balance.amount.value - Math.abs(balance.reservedAmount?.value || 0)) * 100),
+                value: Math.round(balance.amount.value * 100),
                 currency: balance.amount.currency,
               }));
             });

--- a/server/lib/transferwise.ts
+++ b/server/lib/transferwise.ts
@@ -13,8 +13,8 @@ import { isNull, omitBy, pick, startCase, toInteger, toUpper } from 'lodash';
 import { TransferwiseError } from '../graphql/errors';
 import {
   AccessToken,
+  BalanceV4,
   BatchGroup,
-  BorderlessAccount,
   CurrencyPair,
   Profile,
   QuoteV2,
@@ -361,16 +361,15 @@ export const getCurrencyPairs = async (token: string): Promise<{ sourceCurrencie
   );
 };
 
-export const getBorderlessAccount = async (token: string, profileId: string | number): Promise<BorderlessAccount> => {
+export const listBalancesAccount = async (
+  token: string,
+  profileId: string | number,
+  types = 'STANDARD',
+): Promise<BalanceV4[]> => {
   try {
-    const accounts: BorderlessAccount[] = await requestDataAndThrowParsedError(
-      axios.get,
-      `/v1/borderless-accounts?profileId=${profileId}`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    );
-    return accounts.find(a => a.profileId === profileId);
+    return requestDataAndThrowParsedError(axios.get, `/v4/profiles/${profileId}/balances?types=${types}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
   } catch (e) {
     logger.error(e);
     reportErrorToSentry(e, { feature: FEATURE.TRANSFERWISE });

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -18,7 +18,7 @@ import models, { sequelize } from '../../models';
 import PayoutMethod from '../../models/PayoutMethod';
 import { ConnectedAccount } from '../../types/ConnectedAccount';
 import {
-  Balance,
+  BalanceV4,
   BatchGroup,
   QuoteV2,
   QuoteV2PaymentOption,
@@ -524,11 +524,10 @@ async function getRequiredBankInformation(
   return requiredFields;
 }
 
-async function getAccountBalances(connectedAccount: ConnectedAccount): Promise<Balance[]> {
+async function getAccountBalances(connectedAccount: ConnectedAccount): Promise<BalanceV4[]> {
   await populateProfileId(connectedAccount);
   const token = await getToken(connectedAccount);
-  const account = await transferwise.getBorderlessAccount(token, <number>connectedAccount.data.id);
-  return account?.balances || [];
+  return transferwise.listBalancesAccount(token, <number>connectedAccount.data.id);
 }
 
 const oauth = {

--- a/server/types/transferwise.ts
+++ b/server/types/transferwise.ts
@@ -260,15 +260,29 @@ export type Balance = {
   };
 };
 
-export type BorderlessAccount = {
+export type BalanceV4 = {
   id: number;
-  profileId: number;
-  recipientId: number;
+  currency: string;
+  type: 'STANDARD' | 'SAVINGS';
+  amount: {
+    value: number;
+    currency: string;
+  };
+  reservedAmount: {
+    value: number;
+    currency: string;
+  };
+  cashAmount: {
+    value: number;
+    currency: string;
+  };
+  totalWorth: {
+    value: number;
+    currency: string;
+  };
   creationTime: string;
   modificationTime: string;
-  active: boolean;
-  eligible: boolean;
-  balances: Balance[];
+  visible: boolean;
 };
 
 export type AccessToken = {

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -54,7 +54,6 @@ describe('server/paymentProviders/transferwise/index', () => {
     fundTransfer,
     getAccountRequirements,
     cacheSpy,
-    getBorderlessAccount,
     validateAccountRequirements,
     createBatchGroup,
     completeBatchGroup,
@@ -67,14 +66,6 @@ describe('server/paymentProviders/transferwise/index', () => {
   before(utils.resetTestDB);
   before(() => {
     createQuote = sandbox.stub(transferwiseLib, 'createQuote').resolves(quote);
-    getBorderlessAccount = sandbox.stub(transferwiseLib, 'getBorderlessAccount').resolves({
-      balances: [
-        {
-          currency: 'USD',
-          amount: { value: 100000 },
-        },
-      ],
-    });
     sandbox.stub(transferwiseLib, 'getTemporaryQuote').resolves(quote);
     sandbox.stub(transferwiseLib, 'getProfiles').resolves([
       {
@@ -256,14 +247,6 @@ describe('server/paymentProviders/transferwise/index', () => {
       createBatchGroup.resolves({ id: batchGroupId });
       getBatchGroup.resolves({ id: batchGroupId, version: 1, transferIds: [800], status: 'NEW' });
       createBatchGroupTransfer.resolves({ id: 800 });
-      getBorderlessAccount.resolves({
-        balances: [
-          {
-            currency: 'USD',
-            amount: { value: 100000 },
-          },
-        ],
-      });
       await transferwise.scheduleExpenseForPayment(expense);
     });
 
@@ -395,14 +378,6 @@ describe('server/paymentProviders/transferwise/index', () => {
       getBatchGroup.resolves({ id: batchGroupId, version: 1, transferIds: [800], status: 'NEW' });
       createBatchGroupTransfer.resolves({ id: 800 });
       completeBatchGroup.resolves({ id: batchGroupId, version: 2, status: 'COMPLETED' });
-      getBorderlessAccount.resolves({
-        balances: [
-          {
-            currency: 'USD',
-            amount: { value: 100000 },
-          },
-        ],
-      });
       response = await transferwise.payExpensesBatchGroup(host, [expense]);
     });
 


### PR DESCRIPTION
Based on https://api-docs.wise.com/#balance-account-deprecated.

Just to make sure we don't end up with balances missing again. Types were updated, and I also tested locally.