### PR TITLE
Cancel PayPal subscriptions when archiving

### DIFF
--- a/cron/hourly/70-cancel-archived-accounts-subscriptions.ts
+++ b/cron/hourly/70-cancel-archived-accounts-subscriptions.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import '../../server/env';
+
+import { groupBy, size } from 'lodash';
+
+import { activities } from '../../server/constants';
+import logger from '../../server/lib/logger';
+import { reportErrorToSentry } from '../../server/lib/sentry';
+import { sleep } from '../../server/lib/utils';
+import models, { Op } from '../../server/models';
+
+/**
+ * Since the collective has been archived, its HostCollectiveId has been set to null.
+ * We need some more logic to make sure we're loading the right host.
+ */
+const getHostFromOrder = async order => {
+  const transactions = await order.getTransactions({
+    attributes: ['HostCollectiveId'],
+    group: ['HostCollectiveId'],
+    where: { type: 'CREDIT', kind: 'CONTRIBUTION', HostCollectiveId: { [Op.ne]: null } },
+  });
+
+  if (transactions.length !== 1) {
+    throw new Error(`Could not find the host for order ${order.id}`);
+  }
+
+  return models.Collective.findByPk(transactions[0].HostCollectiveId);
+};
+
+/**
+ * When archiving collectives. we need to make sure subscriptions managed externally are properly cancelled
+ * by calling the right service method (PayPal). We do this asynchronously to properly deal with rate limiting and
+ * performance constraints.
+ */
+export async function run() {
+  const orphanOrders = await models.Order.findAll({
+    include: [
+      {
+        model: models.Subscription,
+        required: true,
+        where: { isManagedExternally: true, isActive: true },
+      },
+      {
+        association: 'collective',
+        required: true,
+        where: { deactivatedAt: { [Op.not]: null }, isActive: false },
+      },
+      { association: 'fromCollective' },
+      { association: 'paymentMethod' },
+    ],
+  });
+
+  if (!orphanOrders.length) {
+    return;
+  }
+
+  const groupedOrders = groupBy(orphanOrders, 'CollectiveId');
+  logger.info(`Found ${orphanOrders.length} recurring contributions to cancel across ${size(groupedOrders)} accounts`);
+
+  for (const accountOrders of Object.values(groupedOrders)) {
+    const collectiveHandle = accountOrders[0].collective.slug;
+    const reason = `@${collectiveHandle} archived their account`;
+    logger.info(`Cancelling ${accountOrders.length} subscriptions for @${collectiveHandle}`);
+    for (const order of accountOrders) {
+      const host = await getHostFromOrder(order);
+      logger.debug(`Cancelling order ${order.id} for @${collectiveHandle} (host: ${host.slug})`);
+      if (!process.env.DRY) {
+        await order.Subscription.deactivate(reason, host);
+        await order.update({ status: 'CANCELLED' });
+        await models.Activity.create({
+          type: activities.SUBSCRIPTION_CANCELED,
+          CollectiveId: order.CollectiveId,
+          FromCollectiveId: order.FromCollectiveId,
+          HostCollectiveId: order.collective.HostCollectiveId,
+          OrderId: order.id,
+          UserId: order.CreatedByUserId,
+          data: {
+            subscription: order.Subscription,
+            collective: order.collective.minimal,
+            fromCollective: order.fromCollective.minimal,
+            reasonCode: 'ARCHIVED_ACCOUNT',
+            reason: reason,
+          },
+        });
+        await sleep(500); // To prevent rate-limiting issues when calling 3rd party payment processor APIs
+      }
+    }
+  }
+}
+
+if (require.main === module) {
+  run()
+    .then(() => process.exit(0))
+    .catch(e => {
+      logger.error('Error while cancelling archived accounts subscriptions');
+      console.error(e);
+      reportErrorToSentry(e);
+      process.exit(1);
+    });
+}

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -7,7 +7,6 @@ import { v4 as uuid } from 'uuid';
 import activities from '../../../constants/activities';
 import { types } from '../../../constants/collectives';
 import FEATURE from '../../../constants/feature';
-import OrderStatuses from '../../../constants/order_status';
 import roles from '../../../constants/roles';
 import { purgeCacheForCollective } from '../../../lib/cache';
 import * as collectivelib from '../../../lib/collectivelib';
@@ -489,21 +488,6 @@ export async function archiveCollective(_, args, req) {
       throw new Error('Cannot archive collective with balance > 0');
     }
   }
-
-  // We need to cancel all active recurring contributions managed externally
-  const childrenIds = (await collective.getChildren({ attributes: ['id'] })).map(c => c.id);
-  const orders = await models.Order.findAll({
-    where: { CollectiveId: [collective.id, ...childrenIds] },
-    includes: [{ model: models.Subscription, required: true, isManagedExternally: true, isActive: true }],
-  });
-
-  // There's a risk of having a timeout or rate limiting if we cancel too many subscriptions at once. We need a better solution, such as making the archive job asynchronous.
-  // See https://github.com/opencollective/opencollective/issues/5962
-  if (orders.length > 20) {
-    throw new Error('Too many recurring contributions attached to this profile, please contact support');
-  }
-
-  // TODO: Cancel all subscriptions
 
   // Trigger archive
   const membership = await models.Member.findOne({

--- a/server/models/Subscription.js
+++ b/server/models/Subscription.js
@@ -65,12 +65,12 @@ function defineModel() {
     return this.save();
   };
 
-  Subscription.prototype.deactivate = async function (reason) {
+  Subscription.prototype.deactivate = async function (reason, host) {
     // If subscription exists on a third party, cancel it there
     if (this.paypalSubscriptionId) {
       const order = await this.getOrder();
       order.Subscription = this;
-      await cancelPaypalSubscription(order, reason);
+      await cancelPaypalSubscription(order, reason, host);
     }
 
     return this.update({ isActive: false, deactivatedAt: new Date() });

--- a/server/paymentProviders/paypal/subscription.ts
+++ b/server/paymentProviders/paypal/subscription.ts
@@ -15,9 +15,13 @@ import { PaymentProviderService } from '../types';
 import { paypalRequest } from './api';
 import { refundPaypalCapture } from './payment';
 
-export const cancelPaypalSubscription = async (order: typeof models.Order, reason = undefined): Promise<void> => {
+export const cancelPaypalSubscription = async (
+  order: typeof models.Order,
+  reason = undefined,
+  host: typeof models.Collective = undefined,
+): Promise<void> => {
   const collective = order.collective || (await order.getCollective());
-  const hostCollective = await collective.getHostCollective();
+  const hostCollective = host || (await collective.getHostCollective());
   const subscription = order.Subscription || (await order.getSubscription());
   await paypalRequest(`billing/subscriptions/${subscription.paypalSubscriptionId}/cancel`, { reason }, hostCollective);
 };

--- a/test/cron/hourly/70-cancel-archived-accounts-subscriptions.test.ts
+++ b/test/cron/hourly/70-cancel-archived-accounts-subscriptions.test.ts
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import { assert, createSandbox } from 'sinon';
+
+import { run as runCronJob } from '../../../cron/hourly/70-cancel-archived-accounts-subscriptions';
+import * as PaypalAPI from '../../../server/paymentProviders/paypal/api';
+import {
+  fakeCollective,
+  fakeConnectedAccount,
+  fakeHost,
+  fakeOrder,
+  fakePaymentMethod,
+  randStr,
+} from '../../test-helpers/fake-data';
+import { resetTestDB } from '../../utils';
+
+const fakePayPalSubscriptionOrder = async collective => {
+  const paypalSubscriptionId = randStr();
+  const paymentMethod = await fakePaymentMethod({
+    service: 'paypal',
+    type: 'subscription',
+    token: paypalSubscriptionId,
+  });
+  return fakeOrder(
+    {
+      CollectiveId: collective.id,
+      interval: 'month',
+      status: 'ACTIVE',
+      TierId: null,
+      totalAmount: 1000,
+      subscription: { paypalSubscriptionId, isActive: true, isManagedExternally: true },
+      PaymentMethodId: paymentMethod.id,
+    },
+    {
+      withSubscription: true,
+      withTransactions: true,
+    },
+  );
+};
+
+describe('cron/hourly/70-cancel-archived-accounts-subscriptions', () => {
+  let sandbox, host;
+
+  before(async () => {
+    await resetTestDB();
+    host = await fakeHost();
+    await fakeConnectedAccount({ service: 'paypal', clientId: randStr(), token: randStr(), CollectiveId: host.id });
+    sandbox = createSandbox();
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('does nothing if there is no order to cancel', async () => {
+    // Active collective with active subscriptions...
+    const collective = await fakeCollective({ isActive: true, deactivatedAt: null });
+    const order = await fakePayPalSubscriptionOrder(collective);
+    await runCronJob();
+
+    // ... should not trigger any change
+    await order.reload();
+    expect(order.status).to.eq('ACTIVE');
+    expect(order.Subscription.isActive).to.be.true;
+  });
+
+  it('cancels active recurring PayPal contributions', async () => {
+    const host = await fakeHost();
+    const collective = await fakeCollective({
+      isActive: true,
+      deactivatedAt: null,
+      HostCollectiveId: host.id,
+      slug: 'test-collective',
+    });
+    const order = await fakePayPalSubscriptionOrder(collective);
+
+    // PayPal API stubs
+    const paypalRequestStub = sandbox.stub(PaypalAPI, 'paypalRequest');
+    const subscriptionUrl = `billing/subscriptions/${order.paymentMethod.token}`;
+    paypalRequestStub.resolves();
+
+    // Archived collective with active subscriptions...
+    await collective.update({ isActive: false, deactivatedAt: Date.now(), approvedAt: null, HostCollectiveId: null });
+    await runCronJob();
+
+    // ... should trigger the cancellation
+    assert.calledOnce(paypalRequestStub);
+    const paypalRequest = paypalRequestStub.getCall(0);
+    expect(paypalRequest.args[0]).to.eq(`${subscriptionUrl}/cancel`);
+    expect(paypalRequest.args[1].reason).to.eq(`@test-collective archived their account`);
+    expect(paypalRequest.args[2].id).to.eq(host.id);
+
+    await order.reload();
+    await order.Subscription.reload();
+    expect(order.status).to.eq('CANCELLED');
+    expect(order.Subscription.isActive).to.be.false;
+  });
+});

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -495,13 +495,16 @@ export const fakeOrder = async (
       fakeTransaction({
         OrderId: order.id,
         type: 'CREDIT',
+        kind: 'CONTRIBUTION',
         FromCollectiveId: order.FromCollectiveId,
         CollectiveId: order.CollectiveId,
+        HostCollectiveId: collective.HostCollectiveId,
         amount: order.totalAmount,
       }),
       fakeTransaction({
         OrderId: order.id,
         type: 'DEBIT',
+        kind: 'CONTRIBUTION',
         CollectiveId: order.FromCollectiveId,
         FromCollectiveId: order.CollectiveId,
         amount: -order.totalAmount,


### PR DESCRIPTION
This will make sure that we cancel PayPal subscriptions (asynchronously) when archiving a collective.