### PR TITLE
Correct some typos in virtual card suspended email

### DIFF
--- a/templates/emails/collective.virtualcard.suspended.hbs
+++ b/templates/emails/collective.virtualcard.suspended.hbs
@@ -11,8 +11,8 @@ Subject: ⚠ {{collective.name}}'s {{virtualCard.last4}} card was suspended
 
 {{#if expenses}}
 <p>
-  {{virtualCard.name}} ({{virtualCard.last4}}) card has been suspended due to missing receipts, receipts must be uploaded with 30 days for all transactions.
-  <br/>
+  {{virtualCard.name}} ({{virtualCard.last4}}) card has been suspended due to missing receipts. Receipts must be uploaded within 30 days for all transactions.
+  <br/><br/>
   The following charges are missing receipts:
 </p>
 


### PR DESCRIPTION
Currently the virtual card suspended email look like this. 

![image](https://user-images.githubusercontent.com/12435965/190841755-056363b0-0462-47d1-85d3-4afe2935cabf.png)

Note the typos. With this change it looks like,

![image](https://user-images.githubusercontent.com/12435965/190841793-8cd91267-0fbd-465a-b3a8-608c9a8b8069.png)
