### PR TITLE
Add mutation to un-host a collective by host admins

### DIFF
--- a/server/constants/activities.ts
+++ b/server/constants/activities.ts
@@ -13,6 +13,7 @@ enum ActivityTypes {
   COLLECTIVE_CREATED = 'collective.created',
   COLLECTIVE_EDITED = 'collective.edited',
   COLLECTIVE_DELETED = 'collective.deleted',
+  COLLECTIVE_UNHOSTED = 'collective.unhosted',
   ORGANIZATION_COLLECTIVE_CREATED = 'organization.collective.created',
   // Freezing collectives
   COLLECTIVE_FROZEN = 'collective.frozen',
@@ -155,6 +156,7 @@ export const ActivitiesPerClass: Record<ActivityClasses, ActivityTypes[]> = {
     ActivityTypes.COLLECTIVE_REJECTED,
     ActivityTypes.COLLECTIVE_FROZEN,
     ActivityTypes.COLLECTIVE_UNFROZEN,
+    ActivityTypes.COLLECTIVE_UNHOSTED,
     ActivityTypes.ORGANIZATION_COLLECTIVE_CREATED,
     ActivityTypes.DEACTIVATED_COLLECTIVE_AS_HOST,
     ActivityTypes.ACTIVATED_COLLECTIVE_AS_HOST,

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -12432,13 +12432,14 @@ type Mutation {
   ): ProcessHostApplicationResponse!
 
   """
-  [Root only] Removes the host for an account
+  Removes the host for an account
   """
   removeHost(
     """
     The account to unhost
     """
     account: AccountReferenceInput!
+    message: String
   ): Account!
 
   """

--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -181,6 +181,10 @@ const HostApplicationMutations = {
       checkRemoteUserCanUseHost(req);
 
       const account = await fetchAccountWithReference(args.account, { throwIfMissing: true });
+      if (account.ParentCollectiveId) {
+        throw new ValidationFailed(`Cannot unhost projects/events with a parent. Please unhost the parent instead.`);
+      }
+
       const host = await req.loaders.Collective.host.load(account.id);
       if (!host) {
         return account;

--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -15,12 +15,8 @@ import { stripHTML } from '../../../lib/sanitize-html';
 import models, { sequelize } from '../../../models';
 import { HostApplicationStatus } from '../../../models/HostApplication';
 import { processInviteMembersInput } from '../../common/members';
-import {
-  checkRemoteUserCanRoot,
-  checkRemoteUserCanUseAccount,
-  checkRemoteUserCanUseHost,
-} from '../../common/scope-check';
-import { Forbidden, NotFound, ValidationFailed } from '../../errors';
+import { checkRemoteUserCanUseAccount, checkRemoteUserCanUseHost, checkScope } from '../../common/scope-check';
+import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../../errors';
 import { ProcessHostApplicationAction } from '../enum/ProcessHostApplicationAction';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { InviteMemberInput } from '../input/InviteMemberInput';
@@ -171,23 +167,43 @@ const HostApplicationMutations = {
   },
   removeHost: {
     type: new GraphQLNonNull(Account),
-    description: '[Root only] Removes the host for an account',
+    description: 'Removes the host for an account',
     args: {
       account: {
         type: new GraphQLNonNull(AccountReferenceInput),
         description: 'The account to unhost',
       },
+      message: {
+        type: GraphQLString,
+      },
     },
     resolve: async (_, args, req: express.Request): Promise<Record<string, unknown>> => {
-      checkRemoteUserCanRoot(req);
+      checkRemoteUserCanUseHost(req);
 
       const account = await fetchAccountWithReference(args.account, { throwIfMissing: true });
       const host = await req.loaders.Collective.host.load(account.id);
       if (!host) {
-        throw new ValidationFailed('This account has no host');
+        return account;
+      }
+      if (!req.remoteUser.isAdminOfCollective(host) && !(req.remoteUser.isRoot() && checkScope(req, 'root'))) {
+        throw new Unauthorized();
       }
 
       await account.changeHost(null);
+
+      await models.Activity.create({
+        type: activities.COLLECTIVE_UNHOSTED,
+        UserId: req.remoteUser?.id,
+        UserTokenId: req.userToken?.id,
+        CollectiveId: account.id,
+        HostCollectiveId: host.id,
+        data: {
+          collective: account.info,
+          host: host.info,
+          message: args.message,
+        },
+      });
+
       await Promise.all([purgeAllCachesForAccount(account), purgeAllCachesForAccount(host)]);
       return account.reload();
     },

--- a/server/lib/emailTemplates.ts
+++ b/server/lib/emailTemplates.ts
@@ -23,6 +23,7 @@ export const templateNames = [
   'collective.contact',
   'collective.frozen',
   'collective.unfrozen',
+  'collective.unhosted',
   'collective.created.opensource',
   'collective.expense.approved',
   'collective.expense.approved.for.host',

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -133,6 +133,7 @@ export const notifyByEmail = async (activity: Activity) => {
     case ActivityTypes.COLLECTIVE_EXPENSE_CREATED:
     case ActivityTypes.COLLECTIVE_FROZEN:
     case ActivityTypes.COLLECTIVE_UNFROZEN:
+    case ActivityTypes.COLLECTIVE_UNHOSTED:
     case ActivityTypes.PAYMENT_CREDITCARD_EXPIRING:
       await notify.collective(activity);
       break;

--- a/templates/emails/collective.unhosted.hbs
+++ b/templates/emails/collective.unhosted.hbs
@@ -1,0 +1,21 @@
+Subject: Important: {{{collective.name}}} has been un-hosted by {{{host.name}}}
+
+{{> header}}
+
+<p style="font-size: 17px; padding: 1em;">
+  Hi {{collective.name}},
+  <br /><br />
+  Your fiscal host, <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a>, has un-hosted your Collective.
+  <br/><br/>
+  If you have additional questions about this, please <a href="{{config.host.website}}/{{host.slug}}/contact">contact</a> your fiscal host.
+  {{#if message}}
+    <br /><br />
+    <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a> included the following message:
+  {{/if}}
+</p>
+
+{{#if message}}
+  <blockquote style="color: #6a737d;font-size: 16px;text-align: left;padding: 0.5em 0.75em;margin: 0 24px;border-left: 3px solid #e4e4e4;white-space: pre-line;font-style: italic;">{{message}}</blockquote>
+{{/if}}
+
+{{> footer}}

--- a/templates/emails/collective.unhosted.hbs
+++ b/templates/emails/collective.unhosted.hbs
@@ -5,12 +5,12 @@ Subject: Important: {{{collective.name}}} has been un-hosted by {{{host.name}}}
 <p style="font-size: 17px; padding: 1em;">
   Hi {{collective.name}},
   <br /><br />
-  Your fiscal host, <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a>, has un-hosted your Collective.
+  Your fiscal host, {{> linkCollective collective=host}}, has un-hosted your Collective.
   <br/><br/>
   If you have additional questions about this, please <a href="{{config.host.website}}/{{host.slug}}/contact">contact</a> your fiscal host.
   {{#if message}}
     <br /><br />
-    <a href="{{config.host.website}}/{{host.slug}}">{{{host.name}}}</a> included the following message:
+    {{> linkCollective collective=host}} included the following message:
   {{/if}}
 </p>
 

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -436,6 +436,27 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       expect(unhostingActivity.data.host.id).to.eq(host.id);
     });
 
+    it('validates if collective does not have a parent account', async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ HostCollectiveId: host.id });
+      const event = await fakeEvent({ ParentCollectiveId: collective.id });
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: {
+            legacyId: event.id,
+          },
+          message: 'root user',
+        },
+        rootUser,
+      );
+
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(
+        'Cannot unhost projects/events with a parent. Please unhost the parent instead.',
+      );
+    });
+
     it('does not remove the the host from a hosted collective with non-zero balance', async () => {
       const host = await fakeHost();
       const collective = await fakeCollective({ HostCollectiveId: host.id });

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
 import gqlV2 from 'fake-tag';
+import moment from 'moment';
 import { createSandbox } from 'sinon';
 
-import { activities } from '../../../../../server/constants';
+import { activities, roles } from '../../../../../server/constants';
+import { TransactionKind } from '../../../../../server/constants/transaction-kind';
 import { ProcessHostApplicationAction } from '../../../../../server/graphql/v2/enum';
 import emailLib from '../../../../../server/lib/email';
 import models from '../../../../../server/models';
@@ -12,7 +14,9 @@ import {
   fakeEvent,
   fakeHost,
   fakeHostApplication,
+  fakeMember,
   fakeProject,
+  fakeTransaction,
   fakeUser,
 } from '../../../../test-helpers/fake-data';
 import { graphqlQueryV2, resetTestDB, waitForCondition } from '../../../../utils';
@@ -77,9 +81,31 @@ const PROCESS_HOST_APPLICATION_MUTATION = gqlV2/* GraphQL */ `
   }
 `;
 
+const REMOVE_HOST_MUTATION = gqlV2/* GraphQL */ `
+  mutation UnhostAccount($account: AccountReferenceInput!, $message: String) {
+    removeHost(account: $account, message: $message) {
+      id
+      slug
+      name
+      ... on AccountWithHost {
+        host {
+          id
+        }
+      }
+    }
+  }
+`;
+
 describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
+  let rootUser;
+
   before(async () => {
     await resetTestDB();
+  });
+
+  before(async () => {
+    rootUser = await fakeUser();
+    await fakeMember({ CollectiveId: rootUser.id, MemberCollectiveId: 1, role: roles.ADMIN });
   });
 
   describe('processHostApplication', () => {
@@ -333,6 +359,162 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       expect(memberInvitationActivities).to.have.length(2);
       expect(memberInvitationActivities[0].data.memberCollective.slug).to.eq(existingUserToInvite.collective.slug);
       expect(memberInvitationActivities[1].data.memberCollective.name).to.eq('Another admin');
+    });
+  });
+
+  describe('removeHost', () => {
+    it('requires an account reference input', async () => {
+      const result = await graphqlQueryV2(REMOVE_HOST_MUTATION, {});
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(
+        'Variable "$account" of required type "AccountReferenceInput!" was not provided.',
+      );
+    });
+
+    it('requires token with host scope', async () => {
+      const result = await graphqlQueryV2(REMOVE_HOST_MUTATION, {
+        account: {
+          id: 'some id',
+        },
+      });
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal('You need to be logged in to manage hosted accounts.');
+    });
+
+    it('results in error if account does not exist', async () => {
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: {
+            legacyId: -1,
+          },
+        },
+        rootUser,
+      );
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal('Account Not Found');
+    });
+
+    it('is successful if account already does not have a host', async () => {
+      const collective = await fakeCollective({ HostCollectiveId: null });
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: {
+            legacyId: collective.id,
+          },
+        },
+        rootUser,
+      );
+      expect(result.errors).to.not.exist;
+      expect(result.data.removeHost.host).to.be.null;
+    });
+
+    it('removes the host from a hosted collective using a root user', async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ HostCollectiveId: host.id });
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: {
+            legacyId: collective.id,
+          },
+          message: 'root user',
+        },
+        rootUser,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.removeHost.host).to.be.null;
+
+      const unhostingActivity = await models.Activity.findOne({
+        where: { type: activities.COLLECTIVE_UNHOSTED, CollectiveId: collective.id },
+      });
+      expect(unhostingActivity).to.exist;
+      expect(unhostingActivity.data.message).to.eq('root user');
+      expect(unhostingActivity.data.collective.id).to.eq(collective.id);
+      expect(unhostingActivity.data.host.id).to.eq(host.id);
+    });
+
+    it('does not remove the the host from a hosted collective with non-zero balance', async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ HostCollectiveId: host.id });
+
+      const transactionProps = {
+        type: 'CREDIT',
+        kind: TransactionKind.CONTRIBUTION,
+        CollectiveId: collective.id,
+        currency: 'USD',
+        hostCurrency: 'USD',
+        HostCollectiveId: host.id,
+        createdAt: moment.utc(),
+      };
+
+      await fakeTransaction({
+        ...transactionProps,
+        kind: TransactionKind.CONTRIBUTION,
+        amount: 3000,
+        hostFeeInHostCurrency: -600,
+      });
+
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: {
+            legacyId: collective.id,
+          },
+          message: 'non-zero balance',
+        },
+        rootUser,
+      );
+
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal('Unable to change host: you still have a balance of $30.00');
+    });
+
+    it('validates if user is admin of target host collective', async () => {
+      const user = await fakeUser();
+      await fakeCollective({ admin: user });
+
+      const collectiveToBeUnhosted = await fakeCollective();
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: {
+            legacyId: collectiveToBeUnhosted.id,
+          },
+          message: 'not admin of host',
+        },
+        user,
+      );
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal('You need to be authenticated to perform this action');
+    });
+
+    it('removes the host from a hosted collective using host admin', async () => {
+      const user = await fakeUser();
+      const host = await fakeHost({ admin: user });
+      const collective = await fakeCollective({ HostCollectiveId: host.id });
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: {
+            legacyId: collective.id,
+          },
+          message: 'using host admin',
+        },
+        user,
+      );
+      expect(result.errors).to.not.exist;
+      expect(result.data.removeHost.host).to.be.null;
+
+      const unhostingActivity = await models.Activity.findOne({
+        where: { type: activities.COLLECTIVE_UNHOSTED, CollectiveId: collective.id },
+      });
+      expect(unhostingActivity).to.exist;
+      expect(unhostingActivity.data.message).to.eq('using host admin');
+      expect(unhostingActivity.data.collective.id).to.eq(collective.id);
+      expect(unhostingActivity.data.host.id).to.eq(host.id);
     });
   });
 });


### PR DESCRIPTION
Relates to https://github.com/opencollective/opencollective/issues/3330

The removeHost mutation is available both by root actions and by host admins. When successful, an activy is logged and an email email notification is sent to the collective admins with an optional message.

The collective balance must be zero for this mutation to succeed.

![image](https://user-images.githubusercontent.com/5448927/191728364-a13858f6-10c7-4a26-98cc-05d9485bf5ef.png)

