### PR TITLE
Use less arbitrary rule in checkHasBalanceToPayExpense

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1626,7 +1626,7 @@ const generateInsufficientBalanceErrorMessage = ({
   }
 
   if (!isSameCurrency) {
-    msg += `. For expenses submitted in a different currency than the collective, an error margin of 2σ to the latest rate is applied. The maximum amount that can be paid is ${formatCurrency(
+    msg += `. For expenses submitted in a different currency than the collective, an error margin is applied to accommodate for fluctuations. The maximum amount that can be paid is ${formatCurrency(
       Math.round(balance * rate),
       expenseCurrency,
     )}`;

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -9,6 +9,7 @@ import {
   isBoolean,
   isEqual,
   isNil,
+  isNumber,
   keyBy,
   mapValues,
   omitBy,
@@ -1607,34 +1608,6 @@ export const getExpenseFees = async (
   return { feesInCollectiveCurrency: resultFees, feesInHostCurrency, feesInExpenseCurrency };
 };
 
-const generateInsufficientBalanceErrorMessage = ({
-  object,
-  balance,
-  currency,
-  expenseAmount,
-  expenseCurrency,
-  rate,
-  isSameCurrency,
-  fees = 0,
-  feesName = '',
-}) => {
-  let msg = `Collective does not have enough funds to ${object}.`;
-  msg += ` Current balance: ${formatCurrency(balance, currency)}`;
-  msg += `, Expense amount: ${formatCurrency(expenseAmount, expenseCurrency)}`;
-  if (fees) {
-    msg += `, Estimated ${feesName} fees: ${formatCurrency(fees, expenseCurrency)}`;
-  }
-
-  if (!isSameCurrency) {
-    msg += `. For expenses submitted in a different currency than the collective, an error margin is applied to accommodate for fluctuations. The maximum amount that can be paid is ${formatCurrency(
-      Math.round(balance * rate),
-      expenseCurrency,
-    )}`;
-  }
-
-  return msg;
-};
-
 /**
  * Check if the collective balance is enough to pay the expense. Throws if not.
  */
@@ -1651,26 +1624,50 @@ export const checkHasBalanceToPayExpense = async (
     !isSameCurrency && (await models.CurrencyExchangeRate.getPairStats(expense.collective.currency, expense.currency));
 
   // Ensure the collective has enough funds to pay the expense, with an error margin of 2σ (standard deviations) the exchange rate of past 5 days
-  // to account for fluctuating rates. (2σ counts for 95% of rates of the given period)
-  const getMinExpectedBalance = amountToPayInExpenseCurrency =>
-    isSameCurrency
-      ? amountToPayInExpenseCurrency
-      : Math.round(amountToPayInExpenseCurrency / (exchangeStats.latestRate - exchangeStats.stddev * 2));
+  // to account for fluctuating rates. If no exchange rate is available, fallback to the 20% rule.
+  const assertMinExpectedBalance = (amountToPayInExpenseCurrency, feesInExpenseCurrency?) => {
+    let defaultErrorMessage = `Collective does not have enough funds ${
+      feesInExpenseCurrency ? 'to cover for the fees of this payment method' : 'to pay this expense'
+    }. Current balance: ${formatCurrency(
+      balanceInCollectiveCurrency,
+      expense.collective.currency,
+    )}, Expense amount: ${formatCurrency(expense.amount, expense.currency)}`;
+    if (feesInExpenseCurrency) {
+      defaultErrorMessage += `, Estimated ${payoutMethodType} fees: ${formatCurrency(
+        feesInExpenseCurrency,
+        expense.currency,
+      )}`;
+    }
+    if (isSameCurrency) {
+      if (balanceInCollectiveCurrency < amountToPayInExpenseCurrency) {
+        throw new ValidationFailed(`${defaultErrorMessage}.`);
+      }
+    } else if (isNumber(exchangeStats?.latestRate)) {
+      const rate = exchangeStats.latestRate - exchangeStats.stddev * 2;
+      const safeAmount = Math.round(amountToPayInExpenseCurrency / rate);
+      if (balanceInCollectiveCurrency < safeAmount) {
+        throw new ValidationFailed(
+          `${defaultErrorMessage}. For expenses submitted in a different currency than the collective, an error margin is applied to accommodate for fluctuations. The maximum amount that can be paid is ${formatCurrency(
+            Math.round(balanceInCollectiveCurrency * rate),
+            expense.currency,
+          )}.`,
+        );
+      }
+    } else {
+      const safeAmount = Math.round(amountToPayInExpenseCurrency * 1.2);
+      if (balanceInCollectiveCurrency < safeAmount) {
+        throw new ValidationFailed(
+          `${defaultErrorMessage}. For expenses submitted in a different currency than the collective, an error margin is applied to accommodate for fluctuations. The maximum amount that can be paid is ${formatCurrency(
+            Math.round(balanceInCollectiveCurrency / 1.2),
+            expense.collective.currency,
+          )}.`,
+        );
+      }
+    }
+  };
 
   // Check base balance before fees
-  if (balanceInCollectiveCurrency < getMinExpectedBalance(expense.amount)) {
-    throw new Unauthorized(
-      generateInsufficientBalanceErrorMessage({
-        object: 'pay this expense',
-        balance: balanceInCollectiveCurrency,
-        currency: expense.collective.currency,
-        expenseCurrency: expense.currency,
-        expenseAmount: expense.amount,
-        rate: exchangeStats.latestRate && exchangeStats.latestRate - exchangeStats.stddev * 2,
-        isSameCurrency,
-      }),
-    );
-  }
+  assertMinExpectedBalance(expense.amount);
 
   const { feesInHostCurrency, feesInCollectiveCurrency, feesInExpenseCurrency } = await getExpenseFees(expense, host, {
     fees: manualFees,
@@ -1700,21 +1697,7 @@ export const checkHasBalanceToPayExpense = async (
 
   // Ensure the collective has enough funds to cover the fees for this expense, with an error margin of 20% of the expense amount
   // to account for fluctuating rates. Example: to pay for a $100 expense in euros, the collective needs to have at least $120.
-  if (balanceInCollectiveCurrency < getMinExpectedBalance(totalAmountToPay)) {
-    throw new Error(
-      generateInsufficientBalanceErrorMessage({
-        object: 'cover for the fees of this payment method',
-        balance: balanceInCollectiveCurrency,
-        currency: expense.collective.currency,
-        expenseAmount: expense.amount,
-        expenseCurrency: expense.currency,
-        isSameCurrency,
-        rate: exchangeStats.latestRate && exchangeStats.latestRate - exchangeStats.stddev * 2,
-        fees: feesInExpenseCurrency.paymentProcessorFee,
-        feesName: payoutMethodType,
-      }),
-    );
-  }
+  assertMinExpectedBalance(totalAmountToPay, feesInExpenseCurrency.paymentProcessorFee);
 
   return { feesInCollectiveCurrency, feesInExpenseCurrency, feesInHostCurrency, totalAmountToPay };
 };

--- a/server/models/CurrencyExchangeRate.ts
+++ b/server/models/CurrencyExchangeRate.ts
@@ -43,6 +43,22 @@ export class CurrencyExchangeRate extends Model<
       },
     );
   }
+
+  static async getPairStats(
+    from: string,
+    to: string,
+  ): Promise<{ from: string; to: string; stddev: number; latestRate: number }> {
+    const info = sequelize.query(
+      `
+      SELECT "from", "to", STDDEV("rate"), (ARRAY_AGG("rate" ORDER BY "createdAt" DESC))[1] as "latestRate"
+      FROM "CurrencyExchangeRates"
+      WHERE "from" = :from AND "to" = :to AND "createdAt" >= DATE_TRUNC('day', NOW() - INTERVAL '5 days')
+      GROUP BY "to", "from"
+    `,
+      { replacements: { from, to }, type: sequelize.QueryTypes.SELECT, raw: true, plain: true },
+    );
+    return info;
+  }
 }
 
 // Link the model to database fields

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import moment from 'moment';
 
 import { expenseStatus } from '../../../../server/constants';
 import { EXPENSE_PERMISSION_ERROR_CODES } from '../../../../server/constants/permissions';
@@ -18,12 +19,22 @@ import {
   canSeeExpensePayoutMethod,
   canUnapprove,
   canUnschedulePayment,
+  checkHasBalanceToPayExpense,
   getExpenseAmountInDifferentCurrency,
   isAccountHolderNameAndLegalNameMatch,
 } from '../../../../server/graphql/common/expenses';
 import { createTransactionsFromPaidExpense } from '../../../../server/lib/transactions';
+import models from '../../../../server/models';
 import { PayoutMethodTypes } from '../../../../server/models/PayoutMethod';
-import { fakeCollective, fakeExpense, fakePayoutMethod, fakeUser } from '../../../test-helpers/fake-data';
+import {
+  fakeCollective,
+  fakeCurrencyExchangeRate,
+  fakeExpense,
+  fakeHost,
+  fakePayoutMethod,
+  fakeTransaction,
+  fakeUser,
+} from '../../../test-helpers/fake-data';
 import { getApolloErrorCode, makeRequest } from '../../../utils';
 
 describe('server/graphql/common/expenses', () => {
@@ -649,6 +660,75 @@ describe('server/graphql/common/expenses', () => {
           });
         });
       });
+    });
+  });
+
+  describe('checkHasBalanceToPayExpense', () => {
+    let host, collective, payoutMethod;
+    before(async () => {
+      host = await fakeHost({ currency: 'USD' });
+      collective = await fakeCollective({ currency: 'USD', HostCollectiveId: host.id });
+      payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
+      await fakeTransaction({
+        type: 'CREDIT',
+        CollectiveId: collective.id,
+        HostCollectiveId: host.id,
+        amount: 1000 * 100,
+      });
+      await models.CurrencyExchangeRate.destroy({ where: { to: ['BRL', 'EUR'] } });
+      await Promise.all([
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'BRL', rate: 5.0, createdAt: moment().subtract(3, 'days') }),
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'BRL', rate: 5.1, createdAt: moment().subtract(2, 'days') }),
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'BRL', rate: 5.2, createdAt: moment().subtract(1, 'days') }),
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'BRL', rate: 5.1, createdAt: moment() }),
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'EUR', rate: 1, createdAt: moment().subtract(3, 'days') }),
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'EUR', rate: 1.1, createdAt: moment().subtract(2, 'days') }),
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'EUR', rate: 1.15, createdAt: moment().subtract(1, 'days') }),
+        fakeCurrencyExchangeRate({ from: 'USD', to: 'EUR', rate: 1.05, createdAt: moment() }),
+      ]);
+    });
+
+    it('throws if the collective has not enough balance to cover for the expense', async () => {
+      const expense = await fakeExpense({
+        currency: 'USD',
+        CollectiveId: collective.id,
+        HostCollectiveId: host.id,
+        PayoutMethodId: payoutMethod.id,
+        FromCollectiveId: payoutMethod.CollectiveId,
+        amount: 100001,
+      });
+
+      await expect(checkHasBalanceToPayExpense(host, expense, payoutMethod)).to.be.rejectedWith(
+        'Collective does not have enough funds to pay this expense. Current balance: $1,000.00, Expense amount: $1,000.01',
+      );
+    });
+
+    it('throws if the collective has not enough balance to cover for the exchange rate variance', async () => {
+      let expense = await fakeExpense({
+        currency: 'BRL',
+        CollectiveId: collective.id,
+        HostCollectiveId: host.id,
+        PayoutMethodId: payoutMethod.id,
+        FromCollectiveId: payoutMethod.CollectiveId,
+        amount: 500000,
+      });
+
+      await expect(checkHasBalanceToPayExpense(host, expense, payoutMethod)).to.be.rejectedWith(
+        'Collective does not have enough funds to pay this expense. Current balance: $1,000.00, Expense amount: R$5,000.00. For expenses submitted in a different currency than the collective, an error margin of 2σ to the latest rate is applied. The maximum amount that can be paid is R$4,936.70',
+      );
+
+      expense = await fakeExpense({
+        currency: 'EUR',
+        CollectiveId: collective.id,
+        HostCollectiveId: host.id,
+        PayoutMethodId: payoutMethod.id,
+        FromCollectiveId: payoutMethod.CollectiveId,
+        amount: 500000,
+      });
+
+      await expect(checkHasBalanceToPayExpense(host, expense, payoutMethod)).to.be.rejectedWith(
+        'Collective does not have enough funds to pay this expense. Current balance: $1,000.00, Expense amount: €5,000.00. For expenses submitted in a different currency than the collective, an error margin of 2σ to the latest rate is applied. The maximum amount that can be paid is €920.90',
+      );
     });
   });
 });

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -714,7 +714,7 @@ describe('server/graphql/common/expenses', () => {
       });
 
       await expect(checkHasBalanceToPayExpense(host, expense, payoutMethod)).to.be.rejectedWith(
-        'Collective does not have enough funds to pay this expense. Current balance: $1,000.00, Expense amount: R$5,000.00. For expenses submitted in a different currency than the collective, an error margin of 2σ to the latest rate is applied. The maximum amount that can be paid is R$4,936.70',
+        'Collective does not have enough funds to pay this expense. Current balance: $1,000.00, Expense amount: R$5,000.00. For expenses submitted in a different currency than the collective, an error margin is applied to accommodate for fluctuations. The maximum amount that can be paid is R$4,936.70',
       );
 
       expense = await fakeExpense({
@@ -727,7 +727,7 @@ describe('server/graphql/common/expenses', () => {
       });
 
       await expect(checkHasBalanceToPayExpense(host, expense, payoutMethod)).to.be.rejectedWith(
-        'Collective does not have enough funds to pay this expense. Current balance: $1,000.00, Expense amount: €5,000.00. For expenses submitted in a different currency than the collective, an error margin of 2σ to the latest rate is applied. The maximum amount that can be paid is €920.90',
+        'Collective does not have enough funds to pay this expense. Current balance: $1,000.00, Expense amount: €5,000.00. For expenses submitted in a different currency than the collective, an error margin is applied to accommodate for fluctuations. The maximum amount that can be paid is €920.90',
       );
     });
   });

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -20,6 +20,7 @@ import { randEmail, randUrl } from '../../../../stores';
 import {
   fakeCollective,
   fakeConnectedAccount,
+  fakeCurrencyExchangeRate,
   fakeExpense,
   fakeExpenseItem,
   fakeHost,
@@ -1558,6 +1559,14 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
       });
 
       describe('Multi-currency expense', () => {
+        before(async () => {
+          await fakeCurrencyExchangeRate({
+            from: 'USD',
+            to: 'EUR',
+            rate: 1.1,
+          });
+        });
+
         it('Pays the expense manually', async () => {
           const paymentProcessorFee = 100; // Expressed in collective currency
           const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -1031,7 +1031,7 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
         expect(result.errors).to.exist;
         expect(result.errors[0].message).to.eq(
-          'Collective does not have enough funds to pay this expense. Current balance: $0.00, Expense amount: $10.00',
+          'Collective does not have enough funds to pay this expense. Current balance: $0.00, Expense amount: $10.00.',
         );
       });
 
@@ -1049,7 +1049,7 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
         expect(result.errors).to.exist;
         expect(result.errors[0].message).to.eq(
-          'Collective does not have enough funds to cover for the fees of this payment method. Current balance: $10.00, Expense amount: $10.00, Estimated PAYPAL fees: $0.69',
+          'Collective does not have enough funds to cover for the fees of this payment method. Current balance: $10.00, Expense amount: $10.00, Estimated PAYPAL fees: $0.69.',
         );
       });
 


### PR DESCRIPTION
I've been receiving some errors related to how we calculate how much balance a collective must have to cover an expense in a different currency.
We've been using a 20% rule across the board, which is not fair when paying to relatively stable currencies.

My new proposal considers the standard deviation (2*σ should cover 95% of rates) of the exchange rate between currencies to calculate a safe margin for the expense amount.