### PR TITLE
Strip images that can't be uploaded to s3

### DIFF
--- a/server/lib/sanitize-html.ts
+++ b/server/lib/sanitize-html.ts
@@ -26,6 +26,20 @@ interface AllowedContentType {
   tables?: boolean;
 }
 
+/**
+ * A config to allow everything supported on RichTextEditor
+ */
+export const SANITIZE_OPTIONS_ALL: AllowedContentType = Object.freeze({
+  titles: true,
+  mainTitles: true,
+  basicTextFormatting: true,
+  multilineTextFormatting: true,
+  links: true,
+  images: true,
+  videoIframes: true,
+  tables: true,
+});
+
 interface SanitizeOptions {
   allowedTags: string[];
   allowedAttributes: Record<string, unknown>;


### PR DESCRIPTION
Last bit of https://github.com/opencollective/opencollective-api/pull/7952 that will allow to resolve https://github.com/opencollective/opencollective/issues/5728 by stripping images that we can't upload (usually, because the link is dead). Also added a timeout on fetch.