### PR TITLE
Introduce simplified activity indexes

### DIFF
--- a/migrations/20220928111043-add-simplified-activity-indexes.js
+++ b/migrations/20220928111043-add-simplified-activity-indexes.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    // FromCollectiveId
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "activities__from_collective_id_simple"
+      ON "Activities"("FromCollectiveId")
+      WHERE "FromCollectiveId" IS NOT NULL
+      AND "type" NOT IN ('collective.transaction.created')
+    `);
+
+    // CollectiveId
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "activities__collective_id_simple"
+      ON "Activities"("CollectiveId")
+      WHERE "CollectiveId" IS NOT NULL
+      AND "type" NOT IN ('collective.transaction.created')
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "activities__from_collective_id_simple";
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "activities__collective_id_simple";
+    `);
+  },
+};


### PR DESCRIPTION
Should resolve https://github.com/opencollective/opencollective/issues/5959 (results with a local prod copy are promising)

The `collective.transaction.created` activity makes up to 80% of all activities created; yet we're not surfacing it in the activity log because it creates too much noise. Indexes that ignore this activity are drastically smaller and allow for quickly pre-filtered queries in the activity log.