### PR TITLE
Host admins to see hosted accounts activity

### DIFF
--- a/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
@@ -72,7 +72,7 @@ const ActivitiesCollectionQuery = {
     const where = { [Op.or]: accountOrConditions };
     const include = [];
     for (const account of accounts) {
-      if (isRootUser || req.remoteUser.isAdminOfCollective(account)) {
+      if (isRootUser || req.remoteUser.isAdminOfCollectiveOrHost(account)) {
         // Include all activities related to the account itself
         if (!args.excludeParentAccount) {
           accountOrConditions.push({ CollectiveId: account.id }, { FromCollectiveId: account.id });


### PR DESCRIPTION
Without this check, the feature does not work when selecting specific hosted collectives from the Host Activity log.