### PR TITLE
Move `Contact` feature to GraphQL V2

### DIFF
--- a/server/graphql/common/collective.js
+++ b/server/graphql/common/collective.js
@@ -1,3 +1,13 @@
+import config from 'config';
+import sanitize from 'sanitize-html';
+
+import activities from '../../constants/activities';
+import FEATURE from '../../constants/feature';
+import RateLimit, { ONE_HOUR_IN_SECONDS } from '../../lib/rate-limit';
+import { canUseFeature } from '../../lib/user-permissions';
+import models from '../../models';
+import { FeatureNotAllowedForUser, NotFound, RateLimitExceeded, Unauthorized } from '../errors';
+
 /**
  * Resolver function for host field on Collective type.
  */
@@ -16,4 +26,65 @@ async function hostResolver(collective, _, { loaders }) {
   return hostCollective;
 }
 
-export { hostResolver };
+async function sendMessage({ req, collective, args, isGqlV2 }) {
+  const user = req.remoteUser;
+
+  if (!canUseFeature(user, FEATURE.CONTACT_COLLECTIVE)) {
+    throw new FeatureNotAllowedForUser(
+      'You are not authorized to contact Collectives. Please contact support@opencollective.com if you think this is an error.',
+    );
+  }
+
+  if (!collective) {
+    throw new NotFound(`${isGqlV2 ? 'Account' : 'Collective'} not found`);
+  }
+
+  if (!(await collective.canContact())) {
+    throw new Unauthorized(`You can't contact this ${isGqlV2 ? 'account' : 'collective'}`);
+  }
+
+  const message = args.message && sanitize(args.message, { allowedTags: [], allowedAttributes: {} }).trim();
+  if (!message || message.length < 10) {
+    throw new Error('Message is too short');
+  }
+
+  const subject =
+    args.subject && sanitize(args.subject, { allowedTags: [], allowedAttributes: {} }).trim().slice(0, 60);
+
+  // User sending the email must have an associated collective
+  const fromCollective = await models.Collective.findByPk(user.CollectiveId);
+  if (!fromCollective) {
+    throw new Error("Your user account doesn't have any profile associated. Please contact support");
+  }
+
+  // Limit email sent per user
+  if (!user.isAdminOfCollectiveOrHost(collective) && !user.isRoot()) {
+    const maxEmailMessagePerHour = config.limits.collectiveEmailMessagePerHour;
+    const cacheKey = `user_contact_send_message_${user.id}`;
+    const rateLimit = new RateLimit(cacheKey, maxEmailMessagePerHour, ONE_HOUR_IN_SECONDS);
+    if (!(await rateLimit.registerCall())) {
+      throw new RateLimitExceeded('Too many messages sent in a limited time frame. Please try again later.');
+    }
+  }
+
+  // Create the activity (which will send the message to the users)
+  await models.Activity.create({
+    type: activities.COLLECTIVE_CONTACT,
+    UserId: user.id,
+    UserTokenId: req.userToken?.id,
+    CollectiveId: collective.id,
+    FromCollectiveId: user.CollectiveId,
+    HostCollectiveId: collective.approvedAt ? collective.HostCollectiveId : null,
+    data: {
+      fromCollective,
+      collective,
+      user,
+      subject: subject || null,
+      message: message,
+    },
+  });
+
+  return { success: true };
+}
+
+export { hostResolver, sendMessage };

--- a/server/graphql/common/collective.js
+++ b/server/graphql/common/collective.js
@@ -8,6 +8,8 @@ import { canUseFeature } from '../../lib/user-permissions';
 import models from '../../models';
 import { FeatureNotAllowedForUser, NotFound, RateLimitExceeded, Unauthorized } from '../errors';
 
+import { checkRemoteUserCanUseAccount } from './scope-check';
+
 /**
  * Resolver function for host field on Collective type.
  */
@@ -27,6 +29,7 @@ async function hostResolver(collective, _, { loaders }) {
 }
 
 async function sendMessage({ req, collective, args, isGqlV2 }) {
+  checkRemoteUserCanUseAccount(req);
   const user = req.remoteUser;
 
   if (!canUseFeature(user, FEATURE.CONTACT_COLLECTIVE)) {

--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -3664,6 +3664,7 @@ type Mutation {
   archiveCollective(id: Int!): CollectiveInterface
   unarchiveCollective(id: Int!): CollectiveInterface
   sendMessageToCollective(collectiveId: Int!, message: String!, subject: String): SendMessageToCollectiveResult
+    @deprecated(reason: "2022-08-01: Please use the sendMessage mutation from GraphQL v2 instead.")
 
   """
   Create a user with an optional organization.

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -12019,7 +12019,7 @@ type Mutation {
   ): Account
 
   """
-  Send message to an account.
+  Send a message to an account. Scope: "account"
   """
   sendMessage(
     """
@@ -12030,7 +12030,7 @@ type Mutation {
     """
     Message to send to the account.
     """
-    message: String!
+    message: NonEmptyString!
     subject: String
   ): SendMessageResult
   createApplication(application: ApplicationCreateInput!): Application
@@ -13135,6 +13135,11 @@ input PoliciesCollectiveMinimumAdminsInput {
 type SendMessageResult {
   success: Boolean
 }
+
+"""
+A string that cannot be passed as an empty value
+"""
+scalar NonEmptyString
 
 """
 Input type for Application
@@ -14323,11 +14328,6 @@ input TierUpdateInput {
   minimumAmount: AmountInput
   useStandalonePage: Boolean
 }
-
-"""
-A string that cannot be passed as an empty value
-"""
-scalar NonEmptyString
 
 input TierCreateInput {
   amount: AmountInput!

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -12017,6 +12017,22 @@ type Mutation {
     """
     account: AccountReferenceInput!
   ): Account
+
+  """
+  Send message to an account.
+  """
+  sendMessage(
+    """
+    Reference to the Account to send message to.
+    """
+    account: AccountReferenceInput!
+
+    """
+    Message to send to the account.
+    """
+    message: String!
+    subject: String
+  ): SendMessageResult
   createApplication(application: ApplicationCreateInput!): Application
   updateApplication(application: ApplicationUpdateInput!): Application
   deleteApplication(application: ApplicationReferenceInput!): Application
@@ -13114,6 +13130,10 @@ input PoliciesCollectiveMinimumAdminsInput {
   numberOfAdmins: Int
   applies: PolicyApplication
   freeze: Boolean
+}
+
+type SendMessageResult {
+  success: Boolean
 }
 
 """

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -116,6 +116,7 @@ const mutations = {
       return unarchiveCollective(_, args, req);
     },
   },
+
   sendMessageToCollective: {
     type: new GraphQLObjectType({
       name: 'SendMessageToCollectiveResult',
@@ -123,6 +124,7 @@ const mutations = {
         success: { type: GraphQLBoolean },
       },
     }),
+    deprecationReason: '2022-08-01: Please use the sendMessage mutation from GraphQL v2 instead.',
     args: {
       collectiveId: { type: new GraphQLNonNull(GraphQLInt) },
       message: { type: new GraphQLNonNull(GraphQLString) },

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -2,6 +2,7 @@ import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectT
 
 import models from '../../models';
 import { bulkCreateGiftCards, createGiftCardsForEmails } from '../../paymentProviders/opencollective/giftcard';
+import { sendMessage } from '../common/collective';
 import { editPublicMessage } from '../common/members';
 import { createUser } from '../common/user';
 import { NotFound, Unauthorized } from '../errors';
@@ -18,7 +19,6 @@ import {
   deactivateCollectiveAsHost,
   deleteCollective,
   editCollective,
-  sendMessageToCollective,
   unarchiveCollective,
 } from './mutations/collectives';
 import { editConnectedAccount } from './mutations/connectedAccounts';
@@ -128,8 +128,10 @@ const mutations = {
       message: { type: new GraphQLNonNull(GraphQLString) },
       subject: { type: GraphQLString },
     },
-    resolve(_, args, req) {
-      return sendMessageToCollective(_, args, req);
+    async resolve(_, args, req) {
+      const collective = await models.Collective.findByPk(args.collectiveId);
+
+      return sendMessage({ req, args, collective, isGqlV2: false });
     },
   },
   createUser: {

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -9,6 +9,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
+import { GraphQLNonEmptyString } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
 import { cloneDeep, isNull, omitBy, set } from 'lodash';
 
@@ -493,14 +494,14 @@ const accountMutations = {
         success: { type: GraphQLBoolean },
       },
     }),
-    description: 'Send message to an account.',
+    description: 'Send a message to an account. Scope: "account"',
     args: {
       account: {
         type: new GraphQLNonNull(AccountReferenceInput),
         description: 'Reference to the Account to send message to.',
       },
       message: {
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNull(GraphQLNonEmptyString),
         description: 'Message to send to the account.',
       },
       subject: { type: GraphQLString },


### PR DESCRIPTION
Related FE PR - https://github.com/opencollective/opencollective-frontend/pull/8243

- [x] Introduce a new sendMessage mutation on GraphQL V2 (use an AccountReferenceInput for the account)
- [x] Mark sendMessageToCollective (GraphQL V1) as deprecated
