### PR TITLE
Use up-to-date version of burner-email-providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "bayes": "1.0.0",
         "bcrypt": "5.0.1",
         "bluebird": "3.7.2",
-        "burner-email-providers": "1.0.67",
+        "burner-email-providers": "github:opencollective/burner-email-providers",
         "cloudflare": "2.9.1",
         "cloudflare-ip": "0.0.7",
         "commander": "^9.0.0",
@@ -6017,8 +6017,8 @@
     },
     "node_modules/burner-email-providers": {
       "version": "1.0.67",
-      "resolved": "https://registry.npmjs.org/burner-email-providers/-/burner-email-providers-1.0.67.tgz",
-      "integrity": "sha512-w3aWPwragdi/fyGvPFl3Ll4jlbsVecdiC/vsApzyTMReylKBl8w+nN0Oh4fGJanu7Mcn13Xgnrl1OyQk7XEiug=="
+      "resolved": "git+ssh://git@github.com/opencollective/burner-email-providers.git#1784d2a4ec9b56f5296e9aa777952358987636ad",
+      "license": "MIT"
     },
     "node_modules/busboy": {
       "version": "0.2.14",
@@ -24002,9 +24002,8 @@
       "integrity": "sha1-8JVoKolqvUs9ngjeQJzCIuIT+d0=sha512-IxLEnfsCYLjlpf6mG7SWpWgA4A8IAT5dAX3FxXHFn+6FTLf3ums771elQ74sj1BCOVanBf6esu0rEC6zgwfmIg==sha512-IxLEnfsCYLjlpf6mG7SWpWgA4A8IAT5dAX3FxXHFn+6FTLf3ums771elQ74sj1BCOVanBf6esu0rEC6zgwfmIg== sha512-IxLEnfsCYLjlpf6mG7SWpWgA4A8IAT5dAX3FxXHFn+6FTLf3ums771elQ74sj1BCOVanBf6esu0rEC6zgwfmIg=="
     },
     "burner-email-providers": {
-      "version": "1.0.67",
-      "resolved": "https://registry.npmjs.org/burner-email-providers/-/burner-email-providers-1.0.67.tgz",
-      "integrity": "sha512-w3aWPwragdi/fyGvPFl3Ll4jlbsVecdiC/vsApzyTMReylKBl8w+nN0Oh4fGJanu7Mcn13Xgnrl1OyQk7XEiug=="
+      "version": "git+ssh://git@github.com/opencollective/burner-email-providers.git#1784d2a4ec9b56f5296e9aa777952358987636ad",
+      "from": "burner-email-providers@opencollective/burner-email-providers"
     },
     "busboy": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "bayes": "1.0.0",
     "bcrypt": "5.0.1",
     "bluebird": "3.7.2",
-    "burner-email-providers": "1.0.67",
+    "burner-email-providers": "github:opencollective/burner-email-providers",
     "cloudflare": "2.9.1",
     "cloudflare-ip": "0.0.7",
     "commander": "^9.0.0",


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5984

It turns out our user sign-up email verification library is super outdated. It hasn't been updated since more than a year ago.
I'm updating our fork and installing it from our repo to make sure this is up to date with [@wesbos/burner-email-providers.](https://github.com/wesbos/burner-email-providers) original list.