### PR TITLE
Completely archive children when archiving parent

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -468,6 +468,7 @@ export async function archiveCollective(_, args, req) {
   }
 
   const collective = await models.Collective.findByPk(args.id);
+
   if (!collective) {
     throw new NotFound(`Collective with id ${args.id} not found`);
   }

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -14,7 +14,7 @@ import * as github from '../../../lib/github';
 import RateLimit, { ONE_HOUR_IN_SECONDS } from '../../../lib/rate-limit';
 import { canUseFeature } from '../../../lib/user-permissions';
 import { defaultHostCollective } from '../../../lib/utils';
-import models, { Op, sequelize } from '../../../models';
+import models, { sequelize } from '../../../models';
 import { FeatureNotAllowedForUser, NotFound, RateLimitExceeded, Unauthorized, ValidationFailed } from '../../errors';
 import { CollectiveInputType } from '../inputTypes';
 

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -220,6 +220,7 @@ const getTopBackers = (since, until, tags, limit) => {
     LEFT JOIN "Collectives" collective ON collective.id = t."CollectiveId"
     WHERE
       t.type='CREDIT'
+      AND t."deletedAt" IS NULL
       ${sinceClause}
       ${untilClause}
       ${tagsClause}

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -2392,7 +2392,15 @@ function defineModel() {
 
     const balance = await this.getBalance();
     if (balance > 0) {
-      throw new Error(`Unable to change host: you still have a balance of ${formatCurrency(balance, this.currency)}`);
+      if (options?.isChildren) {
+        throw new Error(
+          `Unable to change host: your ${this.type.toLowerCase()} "${
+            this.name
+          }" still has a balance of ${formatCurrency(balance, this.currency)}`,
+        );
+      } else {
+        throw new Error(`Unable to change host: you still have a balance of ${formatCurrency(balance, this.currency)}`);
+      }
     }
 
     await models.Member.destroy({
@@ -2421,11 +2429,11 @@ function defineModel() {
     // Prepare events and projects to receive a new host
     const events = await this.getEvents();
     if (events?.length > 0) {
-      await Promise.all(events.map(e => e.changeHost(null)));
+      await Promise.all(events.map(e => e.changeHost(null, remoteUser, { isChildren: true })));
     }
     const projects = await this.getProjects();
     if (projects?.length > 0) {
-      await Promise.all(projects.map(e => e.changeHost(null)));
+      await Promise.all(projects.map(e => e.changeHost(null, remoteUser, { isChildren: true })));
     }
 
     // Reset current host

--- a/test/server/graphql/v1/mutation.test.js
+++ b/test/server/graphql/v1/mutation.test.js
@@ -95,12 +95,19 @@ describe('server/graphql/v1/mutation', () => {
         CreatedByUserId: user1.id,
         ParentCollectiveId: collective1.id,
         HostCollectiveId: collective1.HostCollectiveId,
+        isActive: true,
+        approvedAt: new Date(),
       }),
     );
   });
 
   beforeEach('create a project  under collective1', async () => {
-    await fakeProject({ ParentCollectiveId: collective1.id });
+    await fakeProject({
+      ParentCollectiveId: collective1.id,
+      HostCollectiveId: collective1.HostCollectiveId,
+      isActive: true,
+      approvedAt: new Date(),
+    });
   });
 
   describe('createCollective tests', () => {

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -345,6 +345,16 @@ describe('server/models/Collective', () => {
       }
     });
 
+    it('fails to change host if one of the children has a pending balance', async () => {
+      const collective = await fakeCollective();
+      const event = await fakeEvent({ name: 'Crazy Party', ParentCollectiveId: collective.id });
+      const transaction = await fakeTransaction({ CollectiveId: event.id, type: 'CREDIT', amount: 1000 });
+      await expect(collective.changeHost(null)).to.be.eventually.rejectedWith(
+        'Unable to change host: your event "Crazy Party" still has a balance of $10.00',
+      );
+      await transaction.destroy(); // We unfortunately have to do that because `getTopBackers` is based on previous tests' data
+    });
+
     it('fails to deactivate as host if it is hosting any collective', async () => {
       try {
         await hostUser.collective.deactivateAsHost();


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-api/pull/8002#discussion_r985920152
Cherry-pick the tests from, and closes https://github.com/opencollective/opencollective-api/pull/7693

@hdiniz implemented a new solution for archiving in https://github.com/opencollective/opencollective-api/pull/8002/files#diff-f35d6394d656027361220f1c2baea5ee1fa2ff0e027ac8e6d9b3fb6d2541b86dR516-R517: by re-using `changeHost`, the recursive of marking all children as inactive is handled automatically. All we have to do it to update the `deactivatedAt` flag.

I've also set a special `children.data.archivedFromParent` flag in case we want to use it for un-archiving in the future.
