### PR TITLE
Add multiple SQL indexes (ExpenseItems, PaymentMethods)

### DIFF
--- a/migrations/20221013133158-add-multiple-indexes.ts
+++ b/migrations/20221013133158-add-multiple-indexes.ts
@@ -1,0 +1,22 @@
+'use strict';
+
+import { QueryInterface } from 'sequelize';
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.addIndex('ExpenseItems', ['ExpenseId'], {
+      concurrently: true,
+      where: { deletedAt: null },
+    });
+
+    await queryInterface.addIndex('PaymentMethods', ['CollectiveId'], {
+      concurrently: true,
+      where: { deletedAt: null },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('ExpenseItems', ['ExpenseId']);
+    await queryInterface.removeIndex('ExpenseItems', ['CollectiveId']);
+  },
+};


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/6036

- Add index on `Items.ExpenseId`, which should address:
![image](https://user-images.githubusercontent.com/1556356/195612467-7a377290-e6c7-432c-8ef8-c4630ff88e28.png)

- Add index on `PaymentMethods.CollectiveId`, which should address:
![image](https://user-images.githubusercontent.com/1556356/195612586-60d0ae45-9e89-4747-bd10-5e31c93fe5d7.png)
