### PR TITLE
Improvements on `isCollectiveDeletable`

### DIFF
--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -8,13 +8,13 @@ import activities from '../constants/activities';
 import { types as CollectiveTypes } from '../constants/collectives';
 import { MODERATION_CATEGORIES } from '../constants/moderation-categories';
 import { VAT_OPTIONS } from '../constants/vat';
-import models, { Op } from '../models';
+import models, { Op, sequelize } from '../models';
 
 import logger from './logger';
 import { stripHTML } from './sanitize-html';
 import { md5 } from './utils';
 
-const { EVENT, PROJECT, USER } = CollectiveTypes;
+const { USER } = CollectiveTypes;
 
 type AvatarUrlOpts = {
   height?: boolean;
@@ -290,63 +290,76 @@ export async function isCollectiveDeletable(collective) {
 
   let user;
   if (collective.type === USER) {
-    user = await models.User.findOne({ where: { CollectiveId: collective.id } });
+    const { isLastAdminOfAnyCollective } = await sequelize.query(
+      `
+      SELECT EXISTS (
+        SELECT 1
+        FROM "Members" m
+        INNER JOIN "Collectives" c ON m."CollectiveId" = c.id
+        -- Try to find another admins for the same collective
+        LEFT OUTER JOIN "Members" other_members
+          ON m."CollectiveId" = other_members."CollectiveId"
+          AND other_members.role = 'ADMIN'
+          AND other_members."MemberCollectiveId" != m."MemberCollectiveId"
+          AND other_members."deletedAt" IS NULL
+        WHERE m.role = 'ADMIN'
+        AND m."MemberCollectiveId" = :CollectiveId
+        AND m."deletedAt" IS NULL
+        AND c."deletedAt" IS NULL
+        AND other_members.id IS NULL
+      ) AS "isLastAdminOfAnyCollective"
+    `,
+      { plain: true, replacements: { CollectiveId: collective.id } },
+    );
 
-    const adminMemberships = await models.Member.findAll({
-      where: { MemberCollectiveId: collective.id, role: 'ADMIN' },
-      include: [{ model: models.Collective, as: 'collective', required: true }],
-    });
-    if (adminMemberships.length >= 1) {
-      for (const adminMembership of adminMemberships) {
-        if (adminMembership.collective) {
-          const admins = await adminMembership.collective.getAdmins();
-          if (admins.length === 1) {
-            return false;
-          }
-        }
-      }
+    if (isLastAdminOfAnyCollective) {
+      return false;
     }
+
+    user = await models.User.findOne({ where: { CollectiveId: collective.id } });
   }
 
-  const transactionCount = await models.Transaction.count({
-    where: {
-      [Op.or]: [{ CollectiveId: collective.id }, { FromCollectiveId: collective.id }],
+  const { hasUndeletableData } = await sequelize.query(
+    `
+    SELECT (
+      -- Children
+      EXISTS (
+        SELECT 1 FROM "Collectives"
+        WHERE "ParentCollectiveId" = :CollectiveId
+        AND "deletedAt" IS NULL
+      )
+      -- Expenses
+      OR EXISTS (
+        SELECT 1 FROM "Expenses"
+        WHERE (
+          "CollectiveId" = :CollectiveId
+          OR "FromCollectiveId" = :CollectiveId
+          ${user ? `OR "UserId" = :UserId` : ''}
+        )
+        AND "deletedAt" IS NULL
+      )
+      -- Orders
+      OR EXISTS (
+        SELECT 1 FROM "Orders"
+        WHERE ("CollectiveId" = :CollectiveId OR "FromCollectiveId" = :CollectiveId)
+        AND "deletedAt" IS NULL
+        AND status IN ('PAID', 'ACTIVE', 'CANCELLED')
+      )
+      -- Transactions
+      OR EXISTS (
+        SELECT 1 FROM "Transactions"
+        WHERE ("CollectiveId" = :CollectiveId OR "FromCollectiveId" = :CollectiveId)
+        AND "deletedAt" IS NULL
+      )
+    ) AS "hasUndeletableData"
+  `,
+    {
+      plain: true,
+      replacements: { CollectiveId: collective.id, UserId: user?.id },
     },
-  });
+  );
 
-  const orderCount = await models.Order.count({
-    where: {
-      [Op.or]: [{ CollectiveId: collective.id }, { FromCollectiveId: collective.id }],
-      status: ['PAID', 'ACTIVE', 'CANCELLED'],
-    },
-  });
-
-  let expenseCount;
-  if (user) {
-    expenseCount = await models.Expense.count({
-      where: {
-        [Op.or]: [{ CollectiveId: collective.id }, { FromCollectiveId: collective.id }, { UserId: user.id }],
-        status: ['PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT'],
-      },
-    });
-  } else {
-    expenseCount = await models.Expense.count({
-      where: {
-        [Op.or]: [{ CollectiveId: collective.id }, { FromCollectiveId: collective.id }],
-        status: ['PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT'],
-      },
-    });
-  }
-
-  const childrenCount = await models.Collective.count({
-    where: { ParentCollectiveId: collective.id, type: { [Op.in]: [EVENT, PROJECT] } },
-  });
-
-  if (transactionCount > 0 || orderCount > 0 || expenseCount > 0 || childrenCount > 0) {
-    return false;
-  }
-
-  return true;
+  return !hasUndeletableData;
 }
 
 export async function deleteCollective(collective) {

--- a/test/server/lib/collectivelib.test.ts
+++ b/test/server/lib/collectivelib.test.ts
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+
+import { isCollectiveDeletable } from '../../../server/lib/collectivelib';
+import {
+  fakeCollective,
+  fakeEvent,
+  fakeExpense,
+  fakeHost,
+  fakeOrder,
+  fakeTransaction,
+  fakeUser,
+} from '../../test-helpers/fake-data';
+
+describe('server/lib/collectivelib', () => {
+  describe('isCollectiveDeletable', () => {
+    it('returns true for a collective that can be deleted', async () => {
+      const collective = await fakeCollective();
+      expect(await isCollectiveDeletable(collective)).to.be.true;
+    });
+
+    it('returns true for a user that can be deleted', async () => {
+      const user = await fakeUser();
+      expect(await isCollectiveDeletable(user.collective)).to.be.true;
+    });
+
+    it('returns false for fiscal hosts', async () => {
+      const host = await fakeHost();
+      expect(await isCollectiveDeletable(host)).to.be.false;
+    });
+
+    it('returns false if the user is the last admin on an account', async () => {
+      const user = await fakeUser();
+      const collective = await fakeCollective({ admin: user });
+      expect(await isCollectiveDeletable(user.collective)).to.be.false;
+
+      // If we delete the collective, then the user should be deletable
+      await collective.destroy();
+      expect(await isCollectiveDeletable(user.collective)).to.be.true;
+    });
+
+    it('returns true if the user is not the last admin on an account', async () => {
+      const user = await fakeUser();
+      const otherUser = await fakeUser();
+      const collective = await fakeCollective({ admin: user });
+      await collective.addUserWithRole(otherUser, 'ADMIN');
+      expect(await isCollectiveDeletable(user.collective)).to.be.true;
+    });
+
+    it('returns false if the collective has transactions', async () => {
+      const collective = await fakeCollective();
+      await fakeTransaction({ CollectiveId: collective.id });
+      expect(await isCollectiveDeletable(collective)).to.be.false;
+    });
+
+    it('returns false if the collective has orders associated with a payment', async () => {
+      for (const status of ['ACTIVE', 'PAID', 'CANCELLED']) {
+        const collective = await fakeCollective();
+        await fakeOrder({ CollectiveId: collective.id, status });
+        expect(await isCollectiveDeletable(collective)).to.be.false;
+      }
+    });
+
+    it('returns false if the collective has expenses associated with a payment', async () => {
+      for (const status of ['SCHEDULED_FOR_PAYMENT', 'PROCESSING', 'PAID']) {
+        // Testing FromCollective
+        const fromCollective = await fakeCollective();
+        await fakeExpense({ FromCollectiveId: fromCollective.id, status });
+        expect(await isCollectiveDeletable(fromCollective)).to.be.false;
+
+        // Testing Collective
+        const collective = await fakeCollective();
+        await fakeExpense({ CollectiveId: collective.id, status });
+        expect(await isCollectiveDeletable(collective)).to.be.false;
+      }
+    });
+
+    it('returns false if the collective has children', async () => {
+      const parent = await fakeCollective();
+      await fakeEvent({ ParentCollectiveId: parent.id });
+      expect(await isCollectiveDeletable(parent)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
The field was pretty expensive to compute, almost 2s in some cases:
![image](https://user-images.githubusercontent.com/1556356/195694884-1a09baa3-e3d4-42e4-ab60-045548e274b7.png)

Since it was fetched on the `LoggedInUser` query (which is going to change with https://github.com/opencollective/opencollective-frontend/pull/8287) the field was intensively used.

I approached this change in two steps:
1. Started by implementing unit tests to make sure this PR wouldn't introduce regressions
2. Optimized the code that was marked as expensive in Sentry performance (see details below)