### PR TITLE
Misc performance optimizations

### DIFF
--- a/migrations/20221014071116-add-index-collectives-host.ts
+++ b/migrations/20221014071116-add-index-collectives-host.ts
@@ -1,0 +1,16 @@
+'use strict';
+
+import { QueryInterface } from 'sequelize';
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.addIndex('Collectives', ['HostCollectiveId'], {
+      concurrently: true,
+      where: { deletedAt: null },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('Collectives', ['HostCollectiveId']);
+  },
+};

--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -1596,7 +1596,9 @@ export const OrderType = new GraphQLObjectType({
             return {};
           }
 
-          return order.getCreatedByUser();
+          if (order.CreatedByUserId) {
+            return req.loaders.User.byId.load(order.CreatedByUserId);
+          }
         },
       },
       description: {
@@ -1651,10 +1653,11 @@ export const OrderType = new GraphQLObjectType({
           'Payment method used to pay for the order. The paymentMethod is also attached to individual transactions since a credit card can change over the lifetime of a subscription.',
         type: PaymentMethodType,
         resolve(order, args, req) {
-          if (!req.remoteUser) {
+          if (!order.PaymentMethodId || !order.FromCollectiveId || !req.remoteUser?.isAdmin(order.FromCollectiveId)) {
             return null;
+          } else {
+            return req.loaders.PaymentMethod.byId.load(order.PaymentMethodId);
           }
-          return order.getPaymentMethodForUser(req.remoteUser);
         },
       },
       transactions: {

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -422,17 +422,6 @@ function defineModel() {
     }).then(() => this);
   };
 
-  Order.prototype.getPaymentMethodForUser = function (user) {
-    return user.populateRoles().then(() => {
-      // this check is necessary to cover organizations as well as user collective
-      if (user.isAdmin(this.FromCollectiveId)) {
-        return models.PaymentMethod.findByPk(this.PaymentMethodId);
-      } else {
-        return null;
-      }
-    });
-  };
-
   Order.prototype.getSubscriptionForUser = function (user) {
     if (!this.SubscriptionId) {
       return null;


### PR DESCRIPTION
- Add an index on `Collectives.HostCollectiveId`. Should optimize many queries across the site where we rely on this, including the `totalHostedCollectives` field that was taking almost 2s to complete in some cases:
![image](https://user-images.githubusercontent.com/1556356/195788530-456b08cc-d16f-4e7c-b683-0d9851df04db.png)
- Small optimizations on GQLV1 orders. Not so used anymore, but we had some warnings from the `allTransactions` query (used by the legacy CSV export) and the change was cheap.