### PR TITLE
test: add unit tests for OAuth scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "test:update": "TZ=UTC CHAI_JEST_SNAPSHOT_UPDATE_ALL=true nyc mocha",
     "test:clean": "rm -rf .nyc_output coverage",
     "test:coverage": "codecov",
-    "test:graphql": "npm run test test/server/graphql/common/scope-check.test.ts",
+    "test:graphql": "npm run test test/server/graphql/v2/mutation/AddFundsMutations.test.js",
     "test:lib": "npm run test test/server/lib",
     "test:models": "npm run test test/server/models",
     "test:payment-providers": "npm run test test/server/paymentProviders",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "test:update": "TZ=UTC CHAI_JEST_SNAPSHOT_UPDATE_ALL=true nyc mocha",
     "test:clean": "rm -rf .nyc_output coverage",
     "test:coverage": "codecov",
-    "test:graphql": "npm run test test/server/graphql",
+    "test:graphql": "npm run test test/server/graphql/common/scope-check.test.ts",
     "test:lib": "npm run test test/server/lib",
     "test:models": "npm run test test/server/models",
     "test:payment-providers": "npm run test test/server/paymentProviders",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "test:update": "TZ=UTC CHAI_JEST_SNAPSHOT_UPDATE_ALL=true nyc mocha",
     "test:clean": "rm -rf .nyc_output coverage",
     "test:coverage": "codecov",
-    "test:graphql": "npm run test test/server/graphql/v2/mutation/AddFundsMutations.test.js",
+    "test:graphql": "npm run test test/server/graphql",
     "test:lib": "npm run test test/server/lib",
     "test:models": "npm run test test/server/models",
     "test:payment-providers": "npm run test test/server/paymentProviders",

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -4,6 +4,7 @@ import {
   checkRemoteUserCanRoot,
   checkRemoteUserCanUseAccount,
   checkRemoteUserCanUseApplications,
+  checkRemoteUserCanUseConversations,
   checkRemoteUserCanUseHost,
   checkRemoteUserCanUseOrders,
   checkRemoteUserCanUseTransactions,
@@ -131,8 +132,8 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseOrders(req)).to.not.throw();
     });
     it(`Execute without errors if the scope is allowed by the user token`, async () => {
-      const userTokenWithScopeTransactions = await fakeUserToken({ scope: ['orders'] });
-      req.userToken = userTokenWithScopeTransactions;
+      const userTokenWithScopeOrders = await fakeUserToken({ scope: ['orders'] });
+      req.userToken = userTokenWithScopeOrders;
       expect(() => checkRemoteUserCanUseOrders(req)).to.not.throw();
     });
     it(`Throws when not authenticated`, async () => {
@@ -149,8 +150,8 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseApplications(req)).to.not.throw();
     });
     it(`Execute without errors if the scope is allowed by the user token`, async () => {
-      const userTokenWithScopeTransactions = await fakeUserToken({ scope: ['applications'] });
-      req.userToken = userTokenWithScopeTransactions;
+      const userTokenWithScopeApplications = await fakeUserToken({ scope: ['applications'] });
+      req.userToken = userTokenWithScopeApplications;
       expect(() => checkRemoteUserCanUseApplications(req)).to.not.throw();
     });
     it(`Throws when not authenticated`, async () => {
@@ -159,6 +160,24 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseApplications(req)).to.throw(`The User Token is not allowed for operations in scope "applications".`);
+    });
+  });
+  describe('checkRemoteUserCanUseConversations', () => {
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseConversations(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeConversations = await fakeUserToken({ scope: ['conversations'] });
+      req.userToken = userTokenWithScopeConversations;
+      expect(() => checkRemoteUserCanUseConversations(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseConversations(req)).to.throw(`You need to be logged in to manage conversations`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseConversations(req)).to.throw(`The User Token is not allowed for operations in scope "conversations".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -4,6 +4,7 @@ import {
   checkRemoteUserCanRoot,
   checkRemoteUserCanUseAccount,
   checkRemoteUserCanUseHost,
+  checkRemoteUserCanUseOrders,
   checkRemoteUserCanUseTransactions,
   checkRemoteUserCanUseVirtualCards,
   checkScope,
@@ -140,6 +141,28 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseTransactions(req)).to.throw(`The User Token is not allowed for operations in scope "transactions".`);
+    });
+  });
+  describe('checkRemoteUserCanUseOrders', () => {
+    beforeEach(async () => {
+      req = makeRequest(userOwningTheToken);
+      req.userToken = userToken;
+    });
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseOrders(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeTransactions = await fakeUserToken({ scope: ['orders'] });
+      req.userToken = userTokenWithScopeTransactions;
+      expect(() => checkRemoteUserCanUseOrders(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseOrders(req)).to.throw(`You need to be logged in to manage orders`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseOrders(req)).to.throw(`The User Token is not allowed for operations in scope "orders".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { checkScope, enforceScope } from '../../../../server/graphql/common/scope-check';
+import { checkRemoteUserCanRoot, checkScope, enforceScope } from '../../../../server/graphql/common/scope-check';
 import { fakeApplication, fakeUser, fakeUserToken } from '../../../test-helpers/fake-data';
 import { makeRequest, resetTestDB } from '../../../utils';
 
@@ -42,6 +42,24 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throw error if doesn't have the scope`, async () => {
       expect(() => enforceScope(req, 'root')).to.throw(`The User Token is not allowed for operations in scope "root".`);
+    });
+  });
+  describe('checkRemoteUserCanRoot', () => {
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanRoot(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeRoot = await fakeUserToken({ scope: ['root'] });
+      req.userToken = userTokenWithScopeRoot;
+      expect(() => checkRemoteUserCanRoot(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanRoot(req)).to.throw(`You need to be logged in.`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanRoot(req)).to.throw(`The User Token is not allowed for operations in scope "root".`);
     });
   });
 });

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -4,6 +4,7 @@ import {
   checkRemoteUserCanRoot,
   checkRemoteUserCanUseAccount,
   checkRemoteUserCanUseApplications,
+  checkRemoteUserCanUseComment,
   checkRemoteUserCanUseConnectedAccounts,
   checkRemoteUserCanUseConversations,
   checkRemoteUserCanUseExpenses,
@@ -14,19 +15,34 @@ import {
   checkRemoteUserCanUseVirtualCards,
   checkRemoteUserCanUseWebhooks,
   checkScope,
-  enforceScope
+  enforceScope,
 } from '../../../../server/graphql/common/scope-check';
-import { fakeApplication, fakeOrganization, fakeUser, fakeUserToken } from '../../../test-helpers/fake-data';
+import {
+  fakeApplication,
+  fakeComment,
+  fakeConversation,
+  fakeExpense,
+  fakeOrganization,
+  fakeUpdate,
+  fakeUser,
+  fakeUserToken,
+} from '../../../test-helpers/fake-data';
 import { makeRequest, resetTestDB } from '../../../utils';
 
 describe('server/graphql/v2/mutation/AccountMutations', () => {
-  let req, userToken, application, userOwningTheToken;
+  let req, userToken, application, userOwningTheToken, randomUser;
 
   before(async () => {
     await resetTestDB();
     application = await fakeApplication({ type: 'oAuth' });
     userOwningTheToken = await fakeUser();
-    userToken = await fakeUserToken({ type: 'OAUTH', ApplicationId: application.id, UserId: userOwningTheToken.id, scope: ['account'] });
+    randomUser = await fakeUser();
+    userToken = await fakeUserToken({
+      type: 'OAUTH',
+      ApplicationId: application.id,
+      UserId: userOwningTheToken.id,
+      scope: ['account'],
+    });
   });
 
   beforeEach(async () => {
@@ -73,7 +89,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     it(`Throws if the scope is not available on the token`, async () => {
       const userTokenWithScopeRoot = await fakeUserToken({ scope: ['root'] });
       req.userToken = userTokenWithScopeRoot;
-      expect(() => checkRemoteUserCanUseAccount(req)).to.throw(`The User Token is not allowed for operations in scope "account".`);
+      expect(() => checkRemoteUserCanUseAccount(req)).to.throw(
+        `The User Token is not allowed for operations in scope "account".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseVirtualCards', () => {
@@ -88,10 +106,14 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws when not authenticated`, async () => {
       req.remoteUser = null;
-      expect(() => checkRemoteUserCanUseVirtualCards(req)).to.throw(`You need to be logged in to manage virtual cards.`);
+      expect(() => checkRemoteUserCanUseVirtualCards(req)).to.throw(
+        `You need to be logged in to manage virtual cards.`,
+      );
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseVirtualCards(req)).to.throw(`The User Token is not allowed for operations in scope "virtualCards".`);
+      expect(() => checkRemoteUserCanUseVirtualCards(req)).to.throw(
+        `The User Token is not allowed for operations in scope "virtualCards".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseHost', () => {
@@ -109,7 +131,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseHost(req)).to.throw(`You need to be logged in to manage hosted accounts.`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseHost(req)).to.throw(`The User Token is not allowed for operations in scope "host".`);
+      expect(() => checkRemoteUserCanUseHost(req)).to.throw(
+        `The User Token is not allowed for operations in scope "host".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseTransactions', () => {
@@ -127,7 +151,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseTransactions(req)).to.throw(`You need to be logged in to manage transactions.`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseTransactions(req)).to.throw(`The User Token is not allowed for operations in scope "transactions".`);
+      expect(() => checkRemoteUserCanUseTransactions(req)).to.throw(
+        `The User Token is not allowed for operations in scope "transactions".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseOrders', () => {
@@ -145,7 +171,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseOrders(req)).to.throw(`You need to be logged in to manage orders`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseOrders(req)).to.throw(`The User Token is not allowed for operations in scope "orders".`);
+      expect(() => checkRemoteUserCanUseOrders(req)).to.throw(
+        `The User Token is not allowed for operations in scope "orders".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseApplications', () => {
@@ -163,7 +191,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseApplications(req)).to.throw(`You need to be logged in to manage applications.`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseApplications(req)).to.throw(`The User Token is not allowed for operations in scope "applications".`);
+      expect(() => checkRemoteUserCanUseApplications(req)).to.throw(
+        `The User Token is not allowed for operations in scope "applications".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseConversations', () => {
@@ -178,10 +208,14 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws when not authenticated`, async () => {
       req.remoteUser = null;
-      expect(() => checkRemoteUserCanUseConversations(req)).to.throw(`You need to be logged in to manage conversations`);
+      expect(() => checkRemoteUserCanUseConversations(req)).to.throw(
+        `You need to be logged in to manage conversations`,
+      );
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseConversations(req)).to.throw(`The User Token is not allowed for operations in scope "conversations".`);
+      expect(() => checkRemoteUserCanUseConversations(req)).to.throw(
+        `The User Token is not allowed for operations in scope "conversations".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseExpenses', () => {
@@ -199,7 +233,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseExpenses(req)).to.throw(`You need to be logged in to manage expenses`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseExpenses(req)).to.throw(`The User Token is not allowed for operations in scope "expenses".`);
+      expect(() => checkRemoteUserCanUseExpenses(req)).to.throw(
+        `The User Token is not allowed for operations in scope "expenses".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseUpdates', () => {
@@ -217,7 +253,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseUpdates(req)).to.throw(`You need to be logged in to manage updates.`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseUpdates(req)).to.throw(`The User Token is not allowed for operations in scope "updates".`);
+      expect(() => checkRemoteUserCanUseUpdates(req)).to.throw(
+        `The User Token is not allowed for operations in scope "updates".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseConnectedAccounts', () => {
@@ -232,10 +270,14 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws when not authenticated`, async () => {
       req.remoteUser = null;
-      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.throw(`You need to be logged in to manage connected accounts.`);
+      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.throw(
+        `You need to be logged in to manage connected accounts.`,
+      );
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.throw(`The User Token is not allowed for operations in scope "connectedAccounts".`);
+      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.throw(
+        `The User Token is not allowed for operations in scope "connectedAccounts".`,
+      );
     });
   });
   describe('checkRemoteUserCanUseWebhooks', () => {
@@ -253,7 +295,79 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanUseWebhooks(req)).to.throw(`You need to be logged in to manage webhooks`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanUseWebhooks(req)).to.throw(`The User Token is not allowed for operations in scope "webhooks".`);
+      expect(() => checkRemoteUserCanUseWebhooks(req)).to.throw(
+        `The User Token is not allowed for operations in scope "webhooks".`,
+      );
+    });
+  });
+  describe('checkRemoteUserCanUseComment', () => {
+    let commentOnExpense, commentOnConversation, commentOnUpdate, expense, conversation, update;
+    before(async () => {
+      expense = await fakeExpense({
+        status: 'APPROVED',
+        FromCollectiveId: userOwningTheToken.collective.id,
+        amount: 8000,
+        currency: 'USD',
+        CollectiveId: randomUser.collective.id,
+      });
+      update = await fakeUpdate({
+        CollectiveId: randomUser.collective.id,
+        publishedAt: new Date(),
+      });
+      conversation = await fakeConversation({
+        CollectiveId: randomUser.collective.id,
+      });
+      commentOnExpense = await fakeComment({
+        ExpenseId: expense.id,
+        FromCollectiveId: userOwningTheToken.collective.id,
+        CollectiveId: expense.CollectiveId,
+      });
+      commentOnConversation = await fakeComment({
+        ConversationId: conversation.id,
+        FromCollectiveId: userOwningTheToken.collective.id,
+        CollectiveId: conversation.CollectiveId,
+      });
+      commentOnUpdate = await fakeComment({
+        UpdateId: update.id,
+        FromCollectiveId: userOwningTheToken.collective.id,
+        CollectiveId: update.CollectiveId,
+      });
+    });
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.not.throw();
+    });
+    it(`Execute without errors for comment on Expense if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeExpense = await fakeUserToken({ scope: ['expenses'] });
+      req.userToken = userTokenWithScopeExpense;
+      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.not.throw();
+    });
+    it(`Execute without errors for comment on Update if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeUpdates = await fakeUserToken({ scope: ['updates'] });
+      req.userToken = userTokenWithScopeUpdates;
+      expect(() => checkRemoteUserCanUseComment(commentOnUpdate, req)).to.not.throw();
+    });
+    it(`Execute without errors for comment on Conversation if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeConversations = await fakeUserToken({ scope: ['conversations'] });
+      req.userToken = userTokenWithScopeConversations;
+      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.throw(`You need to be logged in to manage expenses`);
+      expect(() => checkRemoteUserCanUseComment(commentOnUpdate, req)).to.throw(`You need to be logged in to manage updates.`);
+      expect(() => checkRemoteUserCanUseComment(commentOnConversation, req)).to.throw(`You need to be logged in to manage conversations`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.throw(
+        `The User Token is not allowed for operations in scope "expenses".`,
+      );
+      expect(() => checkRemoteUserCanUseComment(commentOnUpdate, req)).to.throw(
+        `The User Token is not allowed for operations in scope "updates".`,
+      );
+      expect(() => checkRemoteUserCanUseComment(commentOnConversation, req)).to.throw(
+        `The User Token is not allowed for operations in scope "conversations".`,
+      );
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {
@@ -263,11 +377,11 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       rootOrg = await fakeOrganization({ id: 8686, slug: 'opencollective' });
       rootUser = await fakeUser({}, { name: 'Root user' });
       await rootOrg.addUserWithRole(rootUser, 'ADMIN');
-      console.log("isRoot", rootUser.isRoot());
-    })
+      console.log('isRoot', rootUser.isRoot());
+    });
     beforeEach(async () => {
       req = makeRequest(rootUser);
-      console.log("🚀 ~ file: scope-check.test.ts ~ line 59 ~ beforeEach ~ req", req.remoteUser.isRoot())
+      console.log('🚀 ~ file: scope-check.test.ts ~ line 59 ~ beforeEach ~ req', req.remoteUser.isRoot());
       req.userToken = userToken;
     });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
@@ -288,7 +402,9 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(() => checkRemoteUserCanRoot(req)).to.throw(`You need to be logged in as root.`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
-      expect(() => checkRemoteUserCanRoot(req)).to.throw(`The User Token is not allowed for operations in scope "root".`);
+      expect(() => checkRemoteUserCanRoot(req)).to.throw(
+        `The User Token is not allowed for operations in scope "root".`,
+      );
     });
   });
 });

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -10,8 +10,8 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
   before(async () => {
     await resetTestDB();
     application = await fakeApplication({ type: 'oAuth' });
-    userOwningTheToken = await fakeUser({ scope: ['account'] });
-    userToken = await fakeUserToken({ type: 'OAUTH', ApplicationId: application.id, UserId: userOwningTheToken.id });
+    userOwningTheToken = await fakeUser();
+    userToken = await fakeUserToken({ type: 'OAUTH', ApplicationId: application.id, UserId: userOwningTheToken.id, scope: ['account'] });
     console.log("🚀 ~ file: scope-check.test.ts ~ line 15 ~ before ~ userToken", userToken)
   });
 

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -23,11 +23,12 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     userToken = await fakeUserToken({ type: 'OAUTH', ApplicationId: application.id, UserId: userOwningTheToken.id, scope: ['account'] });
   });
 
+  beforeEach(async () => {
+    req = makeRequest(userOwningTheToken);
+    req.userToken = userToken;
+  });
+
   describe('checkScope', () => {
-    beforeEach(async () => {
-      req = makeRequest();
-      req.userToken = userToken;
-    });
     it(`Returns true if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(checkScope(req, 'account')).to.be.true;
@@ -40,10 +41,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('enforceScope', () => {
-    beforeEach(async () => {
-      req = makeRequest();
-      req.userToken = userToken;
-    });
     it(`Doesn't throw error if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => enforceScope(req, 'account')).to.not.throw();
@@ -56,10 +53,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('checkRemoteUserCanUseAccount', () => {
-    beforeEach(async () => {
-      req = makeRequest(userOwningTheToken);
-      req.userToken = userToken;
-    });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => checkRemoteUserCanUseAccount(req)).to.not.throw();
@@ -78,10 +71,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('checkRemoteUserCanUseVirtualCards', () => {
-    beforeEach(async () => {
-      req = makeRequest(userOwningTheToken);
-      req.userToken = userToken;
-    });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => checkRemoteUserCanUseVirtualCards(req)).to.not.throw();
@@ -100,10 +89,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('checkRemoteUserCanUseHost', () => {
-    beforeEach(async () => {
-      req = makeRequest(userOwningTheToken);
-      req.userToken = userToken;
-    });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => checkRemoteUserCanUseHost(req)).to.not.throw();
@@ -122,10 +107,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('checkRemoteUserCanUseTransactions', () => {
-    beforeEach(async () => {
-      req = makeRequest(userOwningTheToken);
-      req.userToken = userToken;
-    });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => checkRemoteUserCanUseTransactions(req)).to.not.throw();
@@ -144,10 +125,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('checkRemoteUserCanUseOrders', () => {
-    beforeEach(async () => {
-      req = makeRequest(userOwningTheToken);
-      req.userToken = userToken;
-    });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => checkRemoteUserCanUseOrders(req)).to.not.throw();

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -22,7 +22,7 @@ import {
   fakeComment,
   fakeConversation,
   fakeExpense,
-  fakeOrganization,
+  fakeMember,
   fakeUpdate,
   fakeUser,
   fakeUserToken,
@@ -376,14 +376,13 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       );
     });
   });
-  describe.skip('checkRemoteUserCanRoot', () => {
-    let rootUser, rootOrg;
+  describe('checkRemoteUserCanRoot', () => {
+    let rootUser;
 
+    before(resetTestDB);
     before(async () => {
-      rootOrg = await fakeOrganization({ id: 8686, slug: 'opencollective' });
-      rootUser = await fakeUser({}, { name: 'Root user' });
-      await rootOrg.addUserWithRole(rootUser, 'ADMIN');
-      console.log('isRoot', rootUser.isRoot());
+      rootUser = await fakeUser();
+      await fakeMember({ CollectiveId: rootUser.id, MemberCollectiveId: 1, role: 'ADMIN' });
     });
     beforeEach(async () => {
       req = makeRequest(rootUser);

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -52,9 +52,11 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     before(async () => {
       rootUser = await fakeUser();
       await fakeMember({ CollectiveId: rootUser.id, MemberCollectiveId: 1, role: 'ADMIN' });
+      
     })
     beforeEach(async () => {
       req = makeRequest(rootUser);
+      console.log("🚀 ~ file: scope-check.test.ts ~ line 59 ~ beforeEach ~ req", req.remoteUser.isRoot())
       req.userToken = userToken;
     });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -380,6 +380,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     let rootUser;
 
     before(async () => {
+      await resetTestDB();
       rootUser = await fakeUser();
       await fakeMember({ CollectiveId: rootUser.id, MemberCollectiveId: 1, role: 'ADMIN' });
     });

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -10,7 +10,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
   before(async () => {
     await resetTestDB();
     application = await fakeApplication({ type: 'oAuth' });
-    userOwningTheToken = await fakeUser();
+    userOwningTheToken = await fakeUser({ scope: ['account'] });
     userToken = await fakeUserToken({ type: 'OAUTH', ApplicationId: application.id, UserId: userOwningTheToken.id });
     console.log("🚀 ~ file: scope-check.test.ts ~ line 15 ~ before ~ userToken", userToken)
   });

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -12,6 +12,7 @@ import {
   checkRemoteUserCanUseTransactions,
   checkRemoteUserCanUseUpdates,
   checkRemoteUserCanUseVirtualCards,
+  checkRemoteUserCanUseWebhooks,
   checkScope,
   enforceScope
 } from '../../../../server/graphql/common/scope-check';
@@ -235,6 +236,24 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.throw(`The User Token is not allowed for operations in scope "connectedAccounts".`);
+    });
+  });
+  describe('checkRemoteUserCanUseWebhooks', () => {
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseWebhooks(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeWebhooks = await fakeUserToken({ scope: ['webhooks'] });
+      req.userToken = userTokenWithScopeWebhooks;
+      expect(() => checkRemoteUserCanUseWebhooks(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseWebhooks(req)).to.throw(`You need to be logged in to manage webhooks`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseWebhooks(req)).to.throw(`The User Token is not allowed for operations in scope "webhooks".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -54,6 +54,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
+      console.log("🚀 ~ file: scope-check.test.ts ~ line 57 ~ it ~ req", req)
       expect(() => checkRemoteUserCanRoot(req)).to.not.throw();
     });
     it(`Execute without errors if the scope is allowed by the user token`, async () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -12,7 +12,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     application = await fakeApplication({ type: 'oAuth' });
     userOwningTheToken = await fakeUser();
     userToken = await fakeUserToken({ type: 'OAUTH', ApplicationId: application.id, UserId: userOwningTheToken.id, scope: ['account'] });
-    console.log("🚀 ~ file: scope-check.test.ts ~ line 15 ~ before ~ userToken", userToken)
   });
 
   describe('checkScope', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -54,7 +54,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       const rootOrg = await fakeOrganization({ id: 8686, slug: 'opencollective' });
       rootUser = await fakeUser({}, { name: 'Root user' });
       await rootOrg.addUserWithRole(rootUser, 'ADMIN');
-      
+      console.log("isRoot", rootUser.isRoot());
     })
     beforeEach(async () => {
       req = makeRequest(rootUser);

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -354,9 +354,15 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws when not authenticated`, async () => {
       req.remoteUser = null;
-      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.throw(`You need to be logged in to manage expenses`);
-      expect(() => checkRemoteUserCanUseComment(commentOnUpdate, req)).to.throw(`You need to be logged in to manage updates.`);
-      expect(() => checkRemoteUserCanUseComment(commentOnConversation, req)).to.throw(`You need to be logged in to manage conversations`);
+      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.throw(
+        `You need to be logged in to manage expenses`,
+      );
+      expect(() => checkRemoteUserCanUseComment(commentOnUpdate, req)).to.throw(
+        `You need to be logged in to manage updates.`,
+      );
+      expect(() => checkRemoteUserCanUseComment(commentOnConversation, req)).to.throw(
+        `You need to be logged in to manage conversations`,
+      );
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.throw(

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+
+import { checkScope, enforceScope } from '../../../../server/graphql/common/scope-check';
+import { fakeApplication, fakeUser, fakeUserToken } from '../../../test-helpers/fake-data';
+import { makeRequest, resetTestDB } from '../../../utils';
+
+describe('server/graphql/v2/mutation/AccountMutations', () => {
+  let req, userToken , application, userOwningTheToken;
+
+  before(async () => {
+    await resetTestDB();
+    application = await fakeApplication({ type: 'oAuth' });
+    userOwningTheToken = await fakeUser();
+    userToken = await fakeUserToken({ type: 'OAUTH', ApplicationId: application.id, UserId: userOwningTheToken.id });
+    console.log("🚀 ~ file: scope-check.test.ts ~ line 15 ~ before ~ userToken", userToken)
+  });
+
+  beforeEach(async () => {
+    req = makeRequest();
+    req.userToken = userToken;
+  });
+
+  describe('checkScope', () => {
+    it(`Returns true if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(checkScope(req, 'account')).to.be.true;
+    });
+    it(`Returns true if user token has scope`, async () => {
+      expect(checkScope(req, 'account')).to.be.true;
+    });
+    it(`Returns false if doesn't have the scope`, async () => {
+      expect(checkScope(req, 'root')).to.be.false;
+    });
+  });
+  describe('enforceScope', () => {
+    it(`Doesn't throw error if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(enforceScope(req, 'account')).to.not.throw();
+    });
+    it(`Doesn't throw error if true if user token has scope`, async () => {
+      expect(enforceScope(req, 'account')).to.not.throw();
+    });
+    it(`Throw errorif doesn't have the scope`, async () => {
+      expect(enforceScope(req, 'root')).to.throw(`The User Token is not allowed for operations in scope "root".`);
+    });
+  });
+});

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -350,7 +350,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     it(`Execute without errors for comment on Conversation if the scope is allowed by the user token`, async () => {
       const userTokenWithScopeConversations = await fakeUserToken({ scope: ['conversations'] });
       req.userToken = userTokenWithScopeConversations;
-      expect(() => checkRemoteUserCanUseComment(commentOnExpense, req)).to.not.throw();
+      expect(() => checkRemoteUserCanUseComment(commentOnConversation, req)).to.not.throw();
     });
     it(`Throws when not authenticated`, async () => {
       req.remoteUser = null;

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -73,7 +73,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     it(`Throws when not authenticated as a root user`, async () => {
       req.remoteUser = userOwningTheToken;
       req.remoteUser = null;
-      expect(() => checkRemoteUserCanRoot(req)).to.throw(`You need to be logged in.`);
+      expect(() => checkRemoteUserCanRoot(req)).to.throw(`You need to be logged in as root.`);
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanRoot(req)).to.throw(`The User Token is not allowed for operations in scope "root".`);

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -5,6 +5,7 @@ import {
   checkRemoteUserCanUseAccount,
   checkRemoteUserCanUseApplications,
   checkRemoteUserCanUseConversations,
+  checkRemoteUserCanUseExpenses,
   checkRemoteUserCanUseHost,
   checkRemoteUserCanUseOrders,
   checkRemoteUserCanUseTransactions,
@@ -178,6 +179,24 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseConversations(req)).to.throw(`The User Token is not allowed for operations in scope "conversations".`);
+    });
+  });
+  describe('checkRemoteUserCanUseExpenses', () => {
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseExpenses(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeExpenses = await fakeUserToken({ scope: ['expenses'] });
+      req.userToken = userTokenWithScopeExpenses;
+      expect(() => checkRemoteUserCanUseExpenses(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseExpenses(req)).to.throw(`You need to be logged in to manage expenses`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseExpenses(req)).to.throw(`The User Token is not allowed for operations in scope "expenses".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -15,12 +15,11 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     console.log("🚀 ~ file: scope-check.test.ts ~ line 15 ~ before ~ userToken", userToken)
   });
 
-  beforeEach(async () => {
-    req = makeRequest();
-    req.userToken = userToken;
-  });
-
   describe('checkScope', () => {
+    beforeEach(async () => {
+      req = makeRequest();
+      req.userToken = userToken;
+    });
     it(`Returns true if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(checkScope(req, 'account')).to.be.true;
@@ -33,6 +32,10 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('enforceScope', () => {
+    beforeEach(async () => {
+      req = makeRequest();
+      req.userToken = userToken;
+    });
     it(`Doesn't throw error if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => enforceScope(req, 'account')).to.not.throw();
@@ -45,6 +48,10 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('checkRemoteUserCanRoot', () => {
+    beforeEach(async () => {
+      req = makeRequest();
+      req.userToken = userToken;
+    });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
       expect(() => checkRemoteUserCanRoot(req)).to.not.throw();

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -35,13 +35,13 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
   describe('enforceScope', () => {
     it(`Doesn't throw error if not using OAuth (aka. if there's no req.userToken)`, async () => {
       req.userToken = null;
-      expect(enforceScope(req, 'account')).to.not.throw();
+      expect(() => enforceScope(req, 'account')).to.not.throw();
     });
     it(`Doesn't throw error if true if user token has scope`, async () => {
-      expect(enforceScope(req, 'account')).to.not.throw();
+      expect(() => enforceScope(req, 'account')).to.not.throw();
     });
-    it(`Throw errorif doesn't have the scope`, async () => {
-      expect(enforceScope(req, 'root')).to.throw(`The User Token is not allowed for operations in scope "root".`);
+    it(`Throw error if doesn't have the scope`, async () => {
+      expect(() => enforceScope(req, 'root')).to.throw(`The User Token is not allowed for operations in scope "root".`);
     });
   });
 });

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -9,6 +9,7 @@ import {
   checkRemoteUserCanUseHost,
   checkRemoteUserCanUseOrders,
   checkRemoteUserCanUseTransactions,
+  checkRemoteUserCanUseUpdates,
   checkRemoteUserCanUseVirtualCards,
   checkScope,
   enforceScope
@@ -197,6 +198,24 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseExpenses(req)).to.throw(`The User Token is not allowed for operations in scope "expenses".`);
+    });
+  });
+  describe('checkRemoteUserCanUseUpdates', () => {
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseUpdates(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeUpdates = await fakeUserToken({ scope: ['updates'] });
+      req.userToken = userTokenWithScopeUpdates;
+      expect(() => checkRemoteUserCanUseUpdates(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseUpdates(req)).to.throw(`You need to be logged in to manage updates.`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseUpdates(req)).to.throw(`The User Token is not allowed for operations in scope "updates".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -47,11 +47,10 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
   });
   describe('checkRemoteUserCanRoot', () => {
-    let rootUser;
+    let rootUser, rootOrg;
 
     before(async () => {
-      await resetTestDB();
-      const rootOrg = await fakeOrganization({ id: 8686, slug: 'opencollective' });
+      rootOrg = await fakeOrganization({ id: 8686, slug: 'opencollective' });
       rootUser = await fakeUser({}, { name: 'Root user' });
       await rootOrg.addUserWithRole(rootUser, 'ADMIN');
       console.log("isRoot", rootUser.isRoot());

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -48,7 +48,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
   });
   describe('checkRemoteUserCanRoot', () => {
     beforeEach(async () => {
-      req = makeRequest();
+      req = makeRequest(userOwningTheToken);
       req.userToken = userToken;
     });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -379,14 +379,12 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
   describe('checkRemoteUserCanRoot', () => {
     let rootUser;
 
-    before(resetTestDB);
     before(async () => {
       rootUser = await fakeUser();
       await fakeMember({ CollectiveId: rootUser.id, MemberCollectiveId: 1, role: 'ADMIN' });
     });
     beforeEach(async () => {
       req = makeRequest(rootUser);
-      console.log('🚀 ~ file: scope-check.test.ts ~ line 59 ~ beforeEach ~ req', req.remoteUser.isRoot());
       req.userToken = userToken;
     });
     it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -67,7 +67,7 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       req.userToken = null;
       expect(() => enforceScope(req, 'account')).to.not.throw();
     });
-    it(`Doesn't throw error if true if user token has scope`, async () => {
+    it(`Doesn't throw error if user token has scope`, async () => {
       expect(() => enforceScope(req, 'account')).to.not.throw();
     });
     it(`Throw error if doesn't have the scope`, async () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -4,6 +4,7 @@ import {
   checkRemoteUserCanRoot,
   checkRemoteUserCanUseAccount,
   checkRemoteUserCanUseApplications,
+  checkRemoteUserCanUseConnectedAccounts,
   checkRemoteUserCanUseConversations,
   checkRemoteUserCanUseExpenses,
   checkRemoteUserCanUseHost,
@@ -216,6 +217,24 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseUpdates(req)).to.throw(`The User Token is not allowed for operations in scope "updates".`);
+    });
+  });
+  describe('checkRemoteUserCanUseConnectedAccounts', () => {
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeConnectedAccounts = await fakeUserToken({ scope: ['connectedAccounts'] });
+      req.userToken = userTokenWithScopeConnectedAccounts;
+      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.throw(`You need to be logged in to manage connected accounts.`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseConnectedAccounts(req)).to.throw(`The User Token is not allowed for operations in scope "connectedAccounts".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import { checkRemoteUserCanRoot, checkScope, enforceScope } from '../../../../server/graphql/common/scope-check';
-import { fakeApplication, fakeMember, fakeUser, fakeUserToken } from '../../../test-helpers/fake-data';
+import { fakeApplication, fakeOrganization, fakeUser, fakeUserToken } from '../../../test-helpers/fake-data';
 import { makeRequest, resetTestDB } from '../../../utils';
 
 describe('server/graphql/v2/mutation/AccountMutations', () => {
@@ -50,8 +50,10 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     let rootUser;
 
     before(async () => {
-      rootUser = await fakeUser();
-      await fakeMember({ CollectiveId: rootUser.id, MemberCollectiveId: 1, role: 'ADMIN' });
+      await resetTestDB();
+      const rootOrg = await fakeOrganization({ id: 8686, slug: 'opencollective' });
+      rootUser = await fakeUser({}, { name: 'Root user' });
+      await rootOrg.addUserWithRole(rootUser, 'ADMIN');
       
     })
     beforeEach(async () => {
@@ -74,7 +76,6 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws when not authenticated as a root user`, async () => {
       req.remoteUser = userOwningTheToken;
-      req.remoteUser = null;
       expect(() => checkRemoteUserCanRoot(req)).to.throw(`You need to be logged in as root.`);
     });
     it(`Throws if the scope is not available on the token`, async () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   checkRemoteUserCanRoot,
   checkRemoteUserCanUseAccount,
+  checkRemoteUserCanUseApplications,
   checkRemoteUserCanUseHost,
   checkRemoteUserCanUseOrders,
   checkRemoteUserCanUseTransactions,
@@ -140,6 +141,24 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseOrders(req)).to.throw(`The User Token is not allowed for operations in scope "orders".`);
+    });
+  });
+  describe('checkRemoteUserCanUseApplications', () => {
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseApplications(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeTransactions = await fakeUserToken({ scope: ['applications'] });
+      req.userToken = userTokenWithScopeTransactions;
+      expect(() => checkRemoteUserCanUseApplications(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseApplications(req)).to.throw(`You need to be logged in to manage applications.`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseApplications(req)).to.throw(`The User Token is not allowed for operations in scope "applications".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/common/scope-check.test.ts
+++ b/test/server/graphql/common/scope-check.test.ts
@@ -1,6 +1,14 @@
 import { expect } from 'chai';
 
-import { checkRemoteUserCanRoot, checkRemoteUserCanUseAccount, checkRemoteUserCanUseHost, checkRemoteUserCanUseVirtualCards, checkScope, enforceScope } from '../../../../server/graphql/common/scope-check';
+import {
+  checkRemoteUserCanRoot,
+  checkRemoteUserCanUseAccount,
+  checkRemoteUserCanUseHost,
+  checkRemoteUserCanUseTransactions,
+  checkRemoteUserCanUseVirtualCards,
+  checkScope,
+  enforceScope
+} from '../../../../server/graphql/common/scope-check';
 import { fakeApplication, fakeOrganization, fakeUser, fakeUserToken } from '../../../test-helpers/fake-data';
 import { makeRequest, resetTestDB } from '../../../utils';
 
@@ -110,6 +118,28 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
     });
     it(`Throws if the scope is not available on the token`, async () => {
       expect(() => checkRemoteUserCanUseHost(req)).to.throw(`The User Token is not allowed for operations in scope "host".`);
+    });
+  });
+  describe('checkRemoteUserCanUseTransactions', () => {
+    beforeEach(async () => {
+      req = makeRequest(userOwningTheToken);
+      req.userToken = userToken;
+    });
+    it(`Execute without errors if not using OAuth (aka. if there's no req.userToken)`, async () => {
+      req.userToken = null;
+      expect(() => checkRemoteUserCanUseTransactions(req)).to.not.throw();
+    });
+    it(`Execute without errors if the scope is allowed by the user token`, async () => {
+      const userTokenWithScopeTransactions = await fakeUserToken({ scope: ['transactions'] });
+      req.userToken = userTokenWithScopeTransactions;
+      expect(() => checkRemoteUserCanUseTransactions(req)).to.not.throw();
+    });
+    it(`Throws when not authenticated`, async () => {
+      req.remoteUser = null;
+      expect(() => checkRemoteUserCanUseTransactions(req)).to.throw(`You need to be logged in to manage transactions.`);
+    });
+    it(`Throws if the scope is not available on the token`, async () => {
+      expect(() => checkRemoteUserCanUseTransactions(req)).to.throw(`The User Token is not allowed for operations in scope "transactions".`);
     });
   });
   describe.skip('checkRemoteUserCanRoot', () => {

--- a/test/server/graphql/v2/mutation/AddFundsMutations.test.js
+++ b/test/server/graphql/v2/mutation/AddFundsMutations.test.js
@@ -87,12 +87,7 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
         randomUser,
       );
 
-      expect(result.errors[0]).to.include('The User Token is not allowed for operations in scope "host".');
-      console.log(
-        '🚀 ~ file: AddFundsMutations.test.js ~ line 83 ~ it ~ result',
-        typeof result.errors[0],
-        result.errors[0].message,
-      );
+      expect(result.errors[0].message).to.match(/The User Token is not allowed for operations in scope "host"./);
     });
 
     it('cannot add funds as non-admin', async () => {

--- a/test/server/graphql/v2/mutation/AddFundsMutations.test.js
+++ b/test/server/graphql/v2/mutation/AddFundsMutations.test.js
@@ -73,7 +73,7 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
 
   describe('addFunds', () => {
     it('verifies the scope', async () => {
-      const userToken = await fakeUserToken({ scope: ['account'] });
+      const userToken = await fakeUserToken({ scope: ['account'], UserId: randomUser.id });
       const result = await oAuthGraphqlQueryV2(
         addFundsMutation,
         {
@@ -84,7 +84,6 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
           hostFeePercent: 6,
         },
         userToken,
-        randomUser,
       );
 
       expect(result.errors[0].message).to.match(/The User Token is not allowed for operations in scope "host"./);
@@ -137,7 +136,7 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
     });
 
     it('can add funds as host admin with authorization', async () => {
-      const userToken = await fakeUserToken({ scope: ['host'] });
+      const userToken = await fakeUserToken({ scope: ['host'], UserId: hostAdmin.id });
       const result = await oAuthGraphqlQueryV2(
         addFundsMutation,
         {
@@ -148,7 +147,6 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
           hostFeePercent: 6,
         },
         userToken,
-        hostAdmin,
       );
       result.errors && console.error(result.errors);
       expect(result.errors).to.not.exist;

--- a/test/server/graphql/v2/mutation/AddFundsMutations.test.js
+++ b/test/server/graphql/v2/mutation/AddFundsMutations.test.js
@@ -86,8 +86,13 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
         userToken,
         randomUser,
       );
-      console.log('🚀 ~ file: AddFundsMutations.test.js ~ line 83 ~ it ~ result', result);
-      expect(result.errors[0]).to.eq('The User Token is not allowed for operations in scope "host".');
+
+      expect(result.errors[0]).to.include('The User Token is not allowed for operations in scope "host".');
+      console.log(
+        '🚀 ~ file: AddFundsMutations.test.js ~ line 83 ~ it ~ result',
+        typeof result.errors[0],
+        result.errors[0].message,
+      );
     });
 
     it('cannot add funds as non-admin', async () => {

--- a/test/server/graphql/v2/mutation/AddFundsMutations.test.js
+++ b/test/server/graphql/v2/mutation/AddFundsMutations.test.js
@@ -86,6 +86,7 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
         userToken,
         randomUser,
       );
+      console.log('🚀 ~ file: AddFundsMutations.test.js ~ line 83 ~ it ~ result', result);
       expect(result.errors[0]).to.eq('The User Token is not allowed for operations in scope "host".');
     });
 
@@ -137,7 +138,7 @@ describe('server/graphql/v2/mutation/AddFundsMutations', () => {
 
     it('can add funds as host admin with authorization', async () => {
       const userToken = await fakeUserToken({ scope: ['host'] });
-      const result = await graphqlQueryV2(
+      const result = await oAuthGraphqlQueryV2(
         addFundsMutation,
         {
           account: { legacyId: collective.id },

--- a/test/utils.js
+++ b/test/utils.js
@@ -231,18 +231,10 @@ export async function graphqlQueryV2(query, variables, remoteUser = null, jwtPay
  * This function allows to test queries and mutations against schema v2.
  * @param {string} query - Queries and Mutations to serve against the type schema. Example: `query Expense($id: Int!) { Expense(id: $id) { description } }`
  * @param {object} variables - Variables to use in the queries and mutations. Example: { id: 1 }
- * @param {object} authorization - The user token to add to the context.
- * @param {object} remoteUser - The user to add to the context. It is not required.
+ * @param {object} userToken - The user token to add to the context.
  */
-export async function oAuthGraphqlQueryV2(
-  query,
-  variables,
-  authorization,
-  remoteUser = null,
-  jwtPayload = null,
-  headers = {},
-) {
-  return graphqlQuery(query, variables, remoteUser, schemaV2, jwtPayload, headers, authorization);
+export async function oAuthGraphqlQueryV2(query, variables, userToken = {}, jwtPayload = null, headers = {}) {
+  return graphqlQuery(query, variables, userToken.user, schemaV2, jwtPayload, headers, userToken);
 }
 
 /** Helper for interpreting fee description in BDD tests


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5737

 
* [x]  For the lib: `test/server/graphql/common/scope-check.test.ts`. You can manually set the `userToken` on a `req` object created with `makeRequest` to test things in this file.
     * [x]  `checkScope`
         * [x]  Returns true if not using OAuth (aka. if there's no req.userToken)
         * [x]  Returns true if user token has scope
         * [x]  Returns false if doesn't have the scope
     * [x]  `enforceScope`
         * Same as the previous one, but throw if not allowed. Error message must be checked.
     * [x]  Check all `checkRemoteUserCanUse*` for 3 things:
         * Execute without errors if the scope is allowed by the user token
         * Execute without errors if not using OAuth (aka. if there's no req.userToken)
         * Throws when not authenticated
         * Throws if the scope is not available on the token
     * [x]  For GraphQL:
       * 1. Add a `oAuthGraphqlQueryV2` helper in `test/utils.js` like: `oAuthGraphqlQueryV2(query, variables, authorization)`
       * 2. In the future, this helper should be used for all queries/mutations enforcing OAuth. As a proof of concept, the helper should be added for the (["Add funds" mutation test](https://github.com/opencollective/opencollective-api/blob/9bfe08e3abc33575cba57fc737334c68d722700e/test/server/graphql/v2/mutation/AddFundsMutations.test.js#L58)), with something like:
        ```js
         it('verifies the scope', async () => {
           const result = await oAuthGraphqlQueryV2(query, variables, await fakeUserToken({ scope: [] });
           expect(result.errors[0]).to.eq(...);
         }
        ```