### PR TITLE
Handle privacy virtual card limit interval

### DIFF
--- a/cron/hourly/reconcile-transactions.js
+++ b/cron/hourly/reconcile-transactions.js
@@ -13,6 +13,7 @@ import { reportErrorToSentry } from '../../server/lib/sentry';
 import models, { Op } from '../../server/models';
 import privacy from '../../server/paymentProviders/privacy';
 import { processTransaction } from '../../server/paymentProviders/stripe/virtual-cards';
+import { PrivacyVirtualCardLimitIntervalToOCInterval } from '../../server/types/privacy';
 
 const DRY = process.env.DRY;
 
@@ -65,7 +66,7 @@ async function reconcileConnectedAccount(connectedAccount) {
           } else {
             await card.update({
               spendingLimitAmount: privacyCard['spend_limit'] === 0 ? null : privacyCard['spend_limit'],
-              spendingLimitInterval: privacyCard['spend_limit_duration'],
+              spendingLimitInterval: PrivacyVirtualCardLimitIntervalToOCInterval[privacyCard['spend_limit_duration']],
               data: omit(privacyCard, ['pan', 'cvv', 'exp_year', 'exp_month']),
             });
           }

--- a/migrations/20221021125027-update-privacy-virtual-card-limit-interval.js
+++ b/migrations/20221021125027-update-privacy-virtual-card-limit-interval.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE "VirtualCards" vc
+      SET
+        "spendingLimitInterval" = CASE 
+            WHEN "spendingLimitInterval" = 'TRANSACTION' THEN 'PER_AUTHORIZATION'
+            WHEN "spendingLimitInterval" = 'MONTHLY' THEN 'MONTHLY'
+            WHEN "spendingLimitInterval" = 'ANNUALLY' THEN 'YEARLY'
+            WHEN "spendingLimitInterval" = 'FOREVER' THEN 'ALL_TIME'
+            ELSE "spendingLimitInterval" END
+      WHERE 
+        provider = 'PRIVACY';
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE "VirtualCards" vc
+      SET
+        "spendingLimitInterval" = CASE 
+            WHEN "spendingLimitInterval" = 'PER_AUTHORIZATION' THEN 'TRANSACTION'
+            WHEN "spendingLimitInterval" = 'MONTHLY' THEN 'MONTHLY'
+            WHEN "spendingLimitInterval" = 'YEARLY' THEN 'ANNUALLY'
+            WHEN "spendingLimitInterval" = 'ALL_TIME' THEN 'FOREVER'
+            ELSE "spendingLimitInterval" END
+      WHERE 
+        provider = 'PRIVACY';
+    `);
+  },
+};

--- a/server/paymentProviders/privacy/index.ts
+++ b/server/paymentProviders/privacy/index.ts
@@ -7,7 +7,7 @@ import * as privacy from '../../lib/privacy';
 import { reportMessageToSentry } from '../../lib/sentry';
 import models from '../../models';
 import VirtualCardModel from '../../models/VirtualCard';
-import { Transaction } from '../../types/privacy';
+import { PrivacyVirtualCardLimitIntervalToOCInterval, Transaction } from '../../types/privacy';
 import { CardProviderService } from '../types';
 import { getVirtualCardForTransaction, persistTransaction } from '../utils';
 
@@ -74,7 +74,7 @@ const assignCardToCollective = async (
     UserId: userId,
     provider: VirtualCardProviders.PRIVACY,
     spendingLimitAmount: card['spend_limit'] === 0 ? null : card['spend_limit'],
-    spendingLimitInterval: card['spend_limit_duration'],
+    spendingLimitInterval: PrivacyVirtualCardLimitIntervalToOCInterval[card['spend_limit_duration']],
   });
 };
 

--- a/server/types/privacy.ts
+++ b/server/types/privacy.ts
@@ -1,5 +1,7 @@
 /* eslint-disable camelcase */
 
+import { VirtualCardLimitIntervals } from '../constants/virtual-cards';
+
 export type PagingParams = {
   page?: number;
   page_size?: number;
@@ -34,13 +36,29 @@ export type Card = {
   memo: string;
   spend_limit: number;
   token: string;
-  spend_limit_duration: 'TRANSACTION' | 'MONTHLY' | 'ANNUALLY' | 'FOREVER';
+  spend_limit_duration: PrivacyVirtualCardLimitInterval;
   state: 'OPEN' | 'PAUSED' | 'CLOSED' | 'PENDING_FULFILLMENT' | 'PENDING_ACTIVATION';
   type: 'SINGLE_USE' | 'MERCHANT_LOCKED' | 'UNLOCKED' | 'PHYSICAL';
   cvv?: string;
   pan?: string;
   exp_year?: string;
   exp_month?: string;
+};
+
+export enum PrivacyVirtualCardLimitInterval {
+  TRANSACTION = 'TRANSACTION',
+  MONTHLY = 'MONTHLY',
+  ANNUALLY = 'ANNUALLY',
+  FOREVER = 'FOREVER',
+}
+
+export const PrivacyVirtualCardLimitIntervalToOCInterval: {
+  [privacyInterval in PrivacyVirtualCardLimitInterval]: VirtualCardLimitIntervals;
+} = {
+  [PrivacyVirtualCardLimitInterval.TRANSACTION]: VirtualCardLimitIntervals.PER_AUTHORIZATION,
+  [PrivacyVirtualCardLimitInterval.MONTHLY]: VirtualCardLimitIntervals.MONTHLY,
+  [PrivacyVirtualCardLimitInterval.ANNUALLY]: VirtualCardLimitIntervals.YEARLY,
+  [PrivacyVirtualCardLimitInterval.FOREVER]: VirtualCardLimitIntervals.ALL_TIME,
 };
 
 export type Merchant = {


### PR DESCRIPTION
Privacy virtual card interval names differ from what we defined in the platform, causing a graphql error on the enum in staging:

https://sentry.io/organizations/open-collective/issues/3688214894/?project=5199682&referrer=slack

This PR normalizes the interval values using the enum previously defined.
