### PR TITLE
Ignore deleted orders in queries

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -698,7 +698,10 @@ export const Host = new GraphQLObjectType({
             `
             SELECT o.id FROM "Orders" o
             JOIN "Transactions" t ON t."OrderId" = o.id
-            WHERE t."HostCollectiveId" = :hostCollectiveId AND o.status = 'DISPUTED'
+            WHERE t."HostCollectiveId" = :hostCollectiveId
+            AND o.status = 'DISPUTED'
+            AND o."deletedAt" IS NULL
+            AND t."deletedAt" IS NULL
             LIMIT 1;
             `,
             {

--- a/server/lib/security/order.ts
+++ b/server/lib/security/order.ts
@@ -29,6 +29,7 @@ export const getUserStats = async (user: typeof models.User, interval?: string):
     `
     ${BASE_STATS_QUERY} 
     WHERE o."CreatedByUserId" = :userId
+    AND o."deletedAt" IS NULL
     AND pm."type" = 'creditcard'
     ${ifStr(interval, 'AND o."createdAt" >= NOW() - INTERVAL :interval')}
     `,
@@ -42,6 +43,7 @@ export const getEmailStats = async (email: string, interval?: string): Promise<F
     ${BASE_STATS_QUERY} 
     LEFT JOIN "Users" u ON u."id" = o."CreatedByUserId"
     WHERE LOWER(u."email") LIKE LOWER(:email)
+    AND o."deletedAt" IS NULL
     AND pm."type" = 'creditcard'
     ${ifStr(interval, 'AND o."createdAt" >= NOW() - INTERVAL :interval')}
     `,
@@ -54,6 +56,7 @@ export const getIpStats = async (ip: string, interval?: string): Promise<FraudSt
     `
     ${BASE_STATS_QUERY} 
     WHERE o."data"->>'reqIp' LIKE :ip
+    AND o."deletedAt" IS NULL
     AND pm."type" = 'creditcard'
     ${ifStr(interval, 'AND o."createdAt" >= NOW() - INTERVAL :interval')}
     `,
@@ -69,6 +72,7 @@ export const getCreditCardStats = async (
     `
     ${BASE_STATS_QUERY} 
     WHERE pm."type" = 'creditcard'
+    AND o."deletedAt" IS NULL
     AND pm."name" = :name
     AND pm."data"->>'expYear' = :expYear
     AND pm."data"->>'expMonth' = :expMonth


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/6036
Resolve https://github.com/opencollective/opencollective/issues/6072

This PR addresses some performance issues related to queries where we don't filter deleted orders. Because indexes are built with `where deletedAt IS NULL`, we need this filter to happen to take advantage of them.