### PR TITLE
Deprecate 2fa form input for payouts

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -655,7 +655,7 @@ async function validateExpensePayout2FALimit(req, host, expense, expensePaidAmou
 export const scheduleExpenseForPayment = async (
   req: express.Request,
   expense: typeof models.Expense,
-  options: { feesPayer?: 'COLLECTIVE' | 'PAYEE'; twoFactorAuthenticatorCode?: string } = {},
+  options: { feesPayer?: 'COLLECTIVE' | 'PAYEE' } = {},
 ): Promise<typeof models.Expense> => {
   if (expense.status === expenseStatus.SCHEDULED_FOR_PAYMENT) {
     throw new BadRequest('Expense is already scheduled for payment');

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -12,6 +12,7 @@ import { payExpense } from '../../../../../server/graphql/common/expenses';
 import { idEncode, IDENTIFIER_TYPES } from '../../../../../server/graphql/v2/identifiers';
 import { getFxRate } from '../../../../../server/lib/currency';
 import emailLib from '../../../../../server/lib/email';
+import { TwoFactorAuthenticationHeader } from '../../../../../server/lib/two-factor-authentication/lib';
 import models from '../../../../../server/models';
 import { PayoutMethodTypes } from '../../../../../server/models/PayoutMethod';
 import paymentProviders from '../../../../../server/paymentProviders';
@@ -2077,9 +2078,10 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
       const expenseMutationParams1 = {
         expenseId: expense1.id,
         action: 'PAY',
-        paymentParams: { twoFactorAuthenticatorCode },
       };
-      const result1 = await graphqlQueryV2(processExpenseMutation, expenseMutationParams1, hostAdmin);
+      const result1 = await graphqlQueryV2(processExpenseMutation, expenseMutationParams1, hostAdmin, null, {
+        [TwoFactorAuthenticationHeader]: `totp ${twoFactorAuthenticatorCode}`,
+      });
 
       expect(result1.errors).to.not.exist;
       expect(result1.data.processExpense.status).to.eq('PROCESSING');
@@ -2160,9 +2162,12 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         {
           expenseId: expense1.id,
           action: 'PAY',
-          paymentParams: { twoFactorAuthenticatorCode },
         },
         hostAdmin,
+        null,
+        {
+          [TwoFactorAuthenticationHeader]: `totp ${twoFactorAuthenticatorCode}`,
+        },
       );
       expect(result2.errors).to.not.exist;
       expect(result2.data.processExpense.status).to.eq('PROCESSING');


### PR DESCRIPTION
Deprecate unused 2FA form fields in favor of new 2FA flow. 