### PR TITLE
Improve Socket Puppet detection

### DIFF
--- a/server/lib/security/expense.ts
+++ b/server/lib/security/expense.ts
@@ -219,11 +219,14 @@ export const checkExpense = async (expense: typeof models.Expense): Promise<Secu
     );
 
     // Check if this Payout Method is being used by someone other user or collective
-    const similarPayoutMethods = await expense.PayoutMethod.findSimilar({ include: [models.Collective] });
+    const similarPayoutMethods = await expense.PayoutMethod.findSimilar({
+      include: [models.Collective],
+      where: { CollectiveId: { [Op.ne]: expense.User.collective.id } },
+    });
     if (similarPayoutMethods) {
       addBooleanCheck(checks, similarPayoutMethods.length > 0, {
         scope: Scope.PAYOUT_METHOD,
-        level: Level.LOW,
+        level: Level.MEDIUM,
         message: `Payout Method is also being used by other accounts`,
         details: `${compact(similarPayoutMethods.map(pm => pm.Collective?.slug)).join(
           ', ',

--- a/test/server/lib/security/expense.test.ts.snap
+++ b/test/server/lib/security/expense.test.ts.snap
@@ -8,5 +8,5 @@ exports[`lib/security/expense checkExpense() returns potential threats related t
 | USER          | MEDIUM | User is not using 2FA                              |
 | USER          | HIGH   | User was never been paid on the platform           |
 | PAYOUT_METHOD | HIGH   | Payout Method was never been paid on the platform  |
-| PAYOUT_METHOD | LOW    | Payout Method is also being used by other accounts |"
+| PAYOUT_METHOD | MEDIUM | Payout Method is also being used by other accounts |"
 `;


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/5200

Improves the tools used to detect socket puppets:
- Compares IP of users who logged in around the time the expense was created and updated.
- Compares IP of users who logged in around the time the author of the expense was created and last logged in to the platform.
- Compares ConnectedAccount of different services that share the same username to this user.