### PR TITLE
Add associations loaders

### DIFF
--- a/server/graphql/loaders/helpers.ts
+++ b/server/graphql/loaders/helpers.ts
@@ -1,4 +1,6 @@
+import DataLoader from 'dataloader';
 import { get } from 'lodash';
+import { Model } from 'sequelize';
 
 /** A default getter that returns item's id */
 const defaultKeyGetter = (item): number | string => item.id;
@@ -107,3 +109,82 @@ export const sortResults = (
   });
   return keys.map(id => resultsById[id] || defaultValue);
 };
+
+/**
+ * A helper to create a dataloader for a sequelize association. This helper brings a few advantages compared to the default ones:
+ * - It looks inside the model to retrieve the association is already loaded (e.g. collective.host)
+ * - It sets the association on the model instances, optimizing future calls
+ * - If any other model called for this loader already has
+ */
+export function buildLoaderForAssociation<AssociatedModel extends Model>(
+  model: Model,
+  association: string,
+  options: {
+    /** Will not load the association if this filter returns false */
+    filter?: (item) => boolean;
+    /** A custom function to load target entities by their referenced column. Useful to further optimize with loaders */
+    loader?: (ids: readonly (string | number)[]) => Promise<AssociatedModel[]>;
+  } = {},
+) {
+  return new DataLoader<typeof model, AssociatedModel>(
+    async (entities: typeof model[]): Promise<AssociatedModel[]> => {
+      const associationInfo = model['associations'][association];
+      const associationsByForeignKey: Record<ForeignKeyType, AssociatedModel> = {};
+      type ForeignKeyType = typeof associationInfo.foreignKey;
+
+      // Cache all associations that are already loaded and list all foreign keys that need to be loaded
+      for (const entity of entities) {
+        const alreadyLoaded: AssociatedModel | null = entity[associationInfo.as];
+        const associationId: ForeignKeyType = entity[associationInfo.foreignKey];
+        if (associationsByForeignKey[associationId]) {
+          continue; // We already have this association
+        } else if (alreadyLoaded) {
+          associationsByForeignKey[associationId] = alreadyLoaded;
+        } else if (associationId && (!options.filter || options.filter(entity))) {
+          associationsByForeignKey[associationId] = null;
+        }
+      }
+
+      // Load missing associations
+      const associationNotLoadedYet = (id: ForeignKeyType): boolean => !associationsByForeignKey[id];
+      const associationsIdsToLoad = Object.keys(associationsByForeignKey).filter(associationNotLoadedYet);
+      if (associationsIdsToLoad.length > 0) {
+        let loadedAssociations: AssociatedModel[];
+        if (options.loader) {
+          // If a loader is provided, use it to load the associations using the IDs we've collective
+          loadedAssociations = await options.loader(associationsIdsToLoad);
+        } else {
+          // Otherwise fallback on making a query using the model + foreign key
+          loadedAssociations = await associationInfo.target.findAll({
+            where: { [associationInfo.targetKey]: associationsIdsToLoad },
+          });
+        }
+
+        // Add loaded associations to our `associationsByForeignKey` map
+        for (const association of loadedAssociations) {
+          if (association) {
+            const foreignKey = association.getDataValue(associationInfo.targetKey);
+            associationsByForeignKey[foreignKey] = association;
+          }
+        }
+      }
+
+      // Link entities to their associations
+      return entities.map(entity => {
+        const alreadyLoaded = entity[associationInfo.as];
+        const associationId = entity[associationInfo.foreignKey];
+        if (alreadyLoaded) {
+          return alreadyLoaded;
+        } else if (associationId && (!options.filter || options.filter(entity))) {
+          entity[associationInfo.as] = associationsByForeignKey[associationId]; // Attach association to model instance
+          return entity[associationInfo.as];
+        } else {
+          return null;
+        }
+      });
+    },
+    {
+      cacheKeyFn: (entity: typeof model) => entity[model['primaryKeyAttribute']],
+    },
+  );
+}

--- a/server/graphql/v2/interface/AccountWithContributions.ts
+++ b/server/graphql/v2/interface/AccountWithContributions.ts
@@ -87,7 +87,7 @@ export const AccountWithContributionsFields = {
       if (!isNil(account.data?.platformTips)) {
         return account.data.platformTips;
       }
-      const host = await req.loaders.Collective.host.load(account.id);
+      const host = await req.loaders.Collective.host.load(account);
       if (host) {
         const plan = await host.getPlan();
         return plan.platformTips;

--- a/server/graphql/v2/interface/AccountWithHost.ts
+++ b/server/graphql/v2/interface/AccountWithHost.ts
@@ -36,10 +36,9 @@ export const AccountWithHostFields = {
       paymentMethodService: { type: PaymentMethodService },
       paymentMethodType: { type: PaymentMethodType },
     },
-    async resolve(account: typeof models.Collective, args): Promise<number> {
-      const parent = await account.getParentCollective();
-      const host = await account.getHostCollective();
-
+    async resolve(account: typeof models.Collective, args, req): Promise<number> {
+      const parent = await req.loaders.Collective.parent.load(account);
+      const host = await req.loaders.Collective.host.load(account);
       const possibleValues = [];
 
       if (args.paymentMethodType === 'host') {

--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -234,7 +234,7 @@ const HostApplicationMutations = {
         throw new ValidationFailed(`Cannot unhost projects/events with a parent. Please unhost the parent instead.`);
       }
 
-      const host = await req.loaders.Collective.host.load(account.id);
+      const host = await req.loaders.Collective.host.load(account);
       if (!host) {
         return account;
       }

--- a/server/graphql/v2/object/AccountStats.js
+++ b/server/graphql/v2/object/AccountStats.js
@@ -179,7 +179,7 @@ export const AccountStats = new GraphQLObjectType({
           if (args.useCache && !dateFrom && !dateTo && !args.includeChildren) {
             const cachedAmount = collective.dataValues['__stats_totalAmountReceivedInHostCurrency__'];
             if (!isNil(cachedAmount)) {
-              const host = collective.HostCollectiveId && (await req.loaders.Collective.host.load(collective.id));
+              const host = collective.HostCollectiveId && (await req.loaders.Collective.host.load(collective));
               if (!host?.currency || host.currency === collective.currency) {
                 return { value: cachedAmount, currency: collective.currency };
               }

--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -46,7 +46,7 @@ const EXPENSE_DRAFT_PUBLIC_FIELDS = [
 const loadHostForExpense = async (expense, req) => {
   return expense.HostCollectiveId
     ? req.loaders.Collective.byId.load(expense.HostCollectiveId)
-    : req.loaders.Collective.host.load(expense.CollectiveId);
+    : req.loaders.Collective.hostByCollectiveId.load(expense.CollectiveId);
 };
 
 const Expense = new GraphQLObjectType({
@@ -234,7 +234,7 @@ const Expense = new GraphQLObjectType({
           if (expense.HostCollectiveId) {
             return req.loaders.Collective.byId.load(expense.HostCollectiveId);
           } else {
-            return req.loaders.Collective.host.load(expense.CollectiveId);
+            return req.loaders.Collective.hostByCollectiveId.load(expense.CollectiveId);
           }
         },
       },

--- a/test/server/graphql/loaders/helpers.test.ts
+++ b/test/server/graphql/loaders/helpers.test.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import { createSandbox, stub } from 'sinon';
+
+import { buildLoaderForAssociation } from '../../../../server/graphql/loaders/helpers';
+import models from '../../../../server/models';
+import { fakeCollective, fakeHost } from '../../../test-helpers/fake-data';
+import { resetTestDB } from '../../../utils';
+
+describe('server/graphql/loaders/helpers', () => {
+  let sandbox;
+
+  before(async () => {
+    await resetTestDB();
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('buildLoaderForAssociation', () => {
+    it("loads the requested model's association from the model", async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ isActive: true, HostCollectiveId: host.id });
+      const dbSpy = sandbox.spy(models.Collective, 'findAll');
+      const loader = buildLoaderForAssociation<typeof models.Collective>(models.Collective, 'host');
+
+      collective.host = host;
+      const result = await loader.load(collective);
+      expect(result.id).to.equal(host.id);
+      expect(dbSpy.called).to.be.false;
+    });
+
+    it("loads the requested model's association from the database", async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ isActive: true, HostCollectiveId: host.id });
+      const dbSpy = sandbox.spy(models.Collective, 'findAll');
+      const loader = buildLoaderForAssociation<typeof models.Collective>(models.Collective, 'host');
+
+      collective.host = undefined;
+      const result = await loader.load(collective);
+      expect(result.id).to.equal(host.id);
+      expect(dbSpy.calledOnce).to.be.true;
+    });
+
+    it('previous results are cached', async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ isActive: true, HostCollectiveId: host.id });
+      const dbSpy = sandbox.spy(models.Collective, 'findAll');
+      const loader = buildLoaderForAssociation<typeof models.Collective>(models.Collective, 'host');
+
+      // First call
+      collective.host = undefined;
+      const result = await loader.load(collective);
+      expect(result.id).to.equal(host.id);
+      expect(dbSpy.calledOnce).to.be.true;
+
+      // Second call
+      dbSpy.resetHistory();
+      collective.host = undefined;
+      const result2 = await loader.load(collective);
+      expect(result2.id).to.equal(host.id);
+      expect(dbSpy.called).to.be.false;
+    });
+
+    it("loads the requested model's association from a custom loader", async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ isActive: true, HostCollectiveId: host.id });
+      const customLoader = stub().resolves([host]);
+      const dbSpy = sandbox.spy(models.Collective, 'findAll');
+      const loader = buildLoaderForAssociation<typeof models.Collective>(models.Collective, 'host', {
+        loader: customLoader,
+      });
+
+      collective.host = undefined;
+      const result = await loader.load(collective);
+      expect(result.id).to.equal(host.id);
+      expect(dbSpy.called).to.be.false;
+      expect(customLoader.calledOnce).to.be.true;
+    });
+
+    it("loads the requested model's association from another entity passed alongside the first one", async () => {
+      const host = await fakeHost();
+      const collective1 = await fakeCollective({ isActive: true, HostCollectiveId: host.id });
+      const collective2 = await fakeCollective({ isActive: true, HostCollectiveId: host.id });
+      const dbSpy = sandbox.spy(models.Collective, 'findAll');
+      const loader = buildLoaderForAssociation<typeof models.Collective>(models.Collective, 'host');
+
+      collective1.host = undefined;
+      collective2.host = host;
+      const results = await loader.loadMany([collective1, collective2]);
+      results.forEach(result => expect(result.id).to.equal(host.id));
+      expect(dbSpy.called).to.be.false;
+    });
+
+    it('can use a filter to conditionally load', async () => {
+      const host = await fakeHost();
+      const collective = await fakeCollective({ isActive: true, HostCollectiveId: host.id });
+      const dbSpy = sandbox.spy(models.Collective, 'findAll');
+      const loader = buildLoaderForAssociation<typeof models.Collective>(models.Collective, 'host', {
+        filter: () => false,
+      });
+
+      collective.host = undefined;
+      const result = await loader.load(collective);
+      expect(result).to.be.null;
+      expect(dbSpy.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Multiple performance issues appear to be linked to the cumulative loading of associations in GraphQL resolvers.

This PR intends to improve that by offering a simpler way to create association loaders with the following philosophy:
- Declarative approach
- As much as possible, rely on the models definitions to understand the associations
- Take advantage of model getters/setters to prevent reloading an already-loaded value (e.g. `collective.host`)
- Provide an easy way to load associations with another loader, in case the association has already been loaded somewhere else