### PR TITLE
Improve Sock Puppet IP detection

### DIFF
--- a/scripts/generate-jwt.js
+++ b/scripts/generate-jwt.js
@@ -26,7 +26,7 @@ async function main(args) {
   const user = await models.User.findByPk(args.user_id);
   const lastLoginAt = user.lastLoginAt ? user.lastLoginAt.getTime() : null;
 
-  const jwt = user.jwt({ scope: 'login', lastLoginAt }, JWT_TOKEN_EXPIRATION);
+  const jwt = user.jwt({ scope: 'login', lastLoginAt, traceless: true }, JWT_TOKEN_EXPIRATION);
   console.log(jwt);
 }
 

--- a/server/lib/security/expense.ts
+++ b/server/lib/security/expense.ts
@@ -147,23 +147,23 @@ export const checkExpense = async (expense: typeof models.Expense): Promise<Secu
     details.push(
       `${compact(
         [expense.User, ...relatedUsersByIp].map(user =>
-          user.Collective ? `${user.Collective?.slug} <${user.email}>` : user.email,
+          user.collective ? `${user.collective?.slug} <${user.email}>` : user.email,
         ),
-      ).join(', ')} where all accessed from the same IP.`,
+      ).join(', ')} were all accessed from the same IP.`,
     );
   }
   if (relatedUsersByConnectedAccounts.length > 0) {
     details.push(
       `${compact(
         [expense.User, ...relatedUsersByConnectedAccounts].map(user =>
-          user.Collective ? `${user.Collective?.slug} <${user.email}>` : user.email,
+          user.collective ? `${user.collective?.slug} <${user.email}>` : user.email,
         ),
-      ).join(', ')} share similar connected account usernames.`,
+      ).join(', ')} share connected account usernames.`,
     );
   }
   addBooleanCheck(checks, relatedUsersByIp.length > 0 || relatedUsersByConnectedAccounts.length > 0, {
     scope: Scope.USER,
-    level: Level.HIGH,
+    level: relatedUsersByConnectedAccounts.length ? Level.HIGH : Level.MEDIUM,
     message: `This user may be impersonating multiple profiles`,
     details: compact(details).join(' '),
   });

--- a/server/middleware/authentication.js
+++ b/server/middleware/authentication.js
@@ -157,7 +157,7 @@ export const _authenticateUserByJwt = async (req, res, next) => {
       await confirmGuestAccount(user);
     }
 
-    if (!parseToBoolean(config.database.readOnly)) {
+    if (!parseToBoolean(config.database.readOnly) && req.jwtPayload?.traceless !== true) {
       await user.update({
         // The login was accepted, we can update lastLoginAt. This will invalidate all older tokens.
         lastLoginAt: new Date(),

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -233,6 +233,7 @@ function defineModel() {
    * Generate a JWT for user.
    *
    * @param {object} `payload` - data to attach to the token
+   * @param {Boolean} `payload.traceless` - if token should update lastLoginAt information
    * @param {Number} `expiration` - expiration period in seconds
    */
   User.prototype.jwt = function (payload, expiration) {

--- a/test/server/middleware/authentication.test.ts
+++ b/test/server/middleware/authentication.test.ts
@@ -1,0 +1,34 @@
+/* eslint-disable camelcase */
+
+import { expect } from 'chai';
+
+import { authenticateUser } from '../../../server/middleware/authentication';
+import { fakeUser } from '../../test-helpers/fake-data';
+
+describe('authenticateUser()', () => {
+  it('updates user lastLoginAt if scope = login', async () => {
+    const user = await fakeUser();
+    const jwt = user.jwt({ scope: 'login' });
+    const req = { path: '/users/update-token', params: { access_token: jwt }, header: () => 'Test' };
+
+    await new Promise(resolve => {
+      authenticateUser(req, {}, resolve);
+    });
+
+    expect(req).to.have.property('remoteUser');
+    expect(req).to.have.nested.property('remoteUser.lastLoginAt').to.be.a('date');
+  });
+
+  it('does not updates user lastLoginAt if scope = login and traceless = true', async () => {
+    const user = await fakeUser();
+    const jwt = user.jwt({ scope: 'login', traceless: true });
+    const req = { path: '/users/update-token', params: { access_token: jwt }, header: () => 'Test' };
+
+    await new Promise(resolve => {
+      authenticateUser(req, {}, resolve);
+    });
+
+    expect(req).to.have.property('remoteUser');
+    expect(req).to.have.nested.property('remoteUser.lastLoginAt').to.be.a('null');
+  });
+});

--- a/test/server/routes/users.test.js
+++ b/test/server/routes/users.test.js
@@ -91,6 +91,7 @@ describe('server/routes/users', () => {
       const response = await request(expressApp).post(updateTokenUrl);
       expect(response.statusCode).to.equal(401);
     });
+
     it('should fail if expired token is provided', async () => {
       // Given a user and an authentication token
       const user = await fakeUser({ email: 'test@mctesterson.com' });
@@ -102,6 +103,7 @@ describe('server/routes/users', () => {
       // Then the API rejects the request
       expect(response.statusCode).to.equal(401);
     });
+
     it("should fail if user's collective is marked as deleted", async () => {
       const user = await fakeUser({ email: 'test@mctesterson.com' });
       await user.collective.destroy(); // mark collective as deleted
@@ -109,6 +111,7 @@ describe('server/routes/users', () => {
       const response = await request(expressApp).post(updateTokenUrl).set('Authorization', `Bearer ${currentToken}`);
       expect(response.statusCode).to.equal(401);
     });
+
     it('should validate received token', async () => {
       // Given a user and an authentication token
       const user = await fakeUser({ email: 'test@mctesterson.com' });
@@ -127,6 +130,7 @@ describe('server/routes/users', () => {
       // And then the token should have a long expiration
       expect(moment(parsedToken.exp).diff(parsedToken.iat)).to.equal(auth.TOKEN_EXPIRATION_SESSION);
     });
+
     it('should respond with 2FA token if the user has 2FA enabled on account', async () => {
       const secret = speakeasy.generateSecret({ length: 64 });
       const encryptedToken = crypto[CIPHER].encrypt(secret.base32, SECRET_KEY).toString();
@@ -166,6 +170,7 @@ describe('server/routes/users', () => {
       const response = await request(expressApp).post(twoFactorAuthUrl);
       expect(response.statusCode).to.equal(400);
     });
+
     it('should fail if token with wrong scope is provided', async () => {
       // Given a user and an authentication token
       const user = await fakeUser({ email: 'test@mctesterson.com' });
@@ -177,6 +182,7 @@ describe('server/routes/users', () => {
       // Then the API rejects the request
       expect(response.statusCode).to.equal(401);
     });
+
     it('should reject 2FA if invalid TOTP code is received', async () => {
       // Given a user and an authentication token and a TOTP
       const secret = speakeasy.generateSecret({ length: 64 });
@@ -196,6 +202,7 @@ describe('server/routes/users', () => {
       expect(response.body.error).to.exist;
       expect(response.body.error.message).to.match(/Two-factor authentication code failed. Please try again/);
     });
+
     it('should validate 2FA if correct TOTP code is received', async () => {
       // Given a user and an authentication token and a TOTP
       const secret = speakeasy.generateSecret({ length: 64 });


### PR DESCRIPTION
Improvements:
- [x] Make sure that root-generated tokens do not affect lastLoginAt
- [x] Fix sock-puppet security check message
- [x] Set different sock-puppet security check levels based on the type of user correlation