### PR TITLE
Pass `expense.info` instead of whole `expense` object to activity

### DIFF
--- a/server/paymentProviders/stripe/virtual-cards.js
+++ b/server/paymentProviders/stripe/virtual-cards.js
@@ -216,7 +216,7 @@ export const processAuthorization = async (stripeAuthorization, stripeEvent) => 
         VirtualCardId: virtualCard.id,
         responsibleAdmin: responsibleAdmin.activity,
         collective: collective.activity,
-        expense,
+        expense: expense.info,
         amount,
         currency,
       },


### PR DESCRIPTION
Related to comment, https://github.com/opencollective/opencollective-api/pull/8135#discussion_r1012634971