### PR TITLE
Misc performance improvements

### DIFF
--- a/migrations/20221104083518-add-index-on-expense-user-id.ts
+++ b/migrations/20221104083518-add-index-on-expense-user-id.ts
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addIndex('Expenses', ['UserId'], {
+      concurrently: true,
+      where: { deletedAt: null },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('Expenses', ['UserId']);
+  },
+};

--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -229,9 +229,10 @@ export const loaders = req => {
         `
           SELECT t.id, (t."maxQuantity" - COALESCE(SUM(o.quantity), 0)) AS "availableQuantity"
           FROM "Tiers" t
-          LEFT JOIN "Orders" o ON o."TierId" = t.id AND o."processedAt" IS NOT NULL AND o."status" NOT IN (?)
+          LEFT JOIN "Orders" o ON o."TierId" = t.id AND o."deletedAt" IS NULL AND o."processedAt" IS NOT NULL AND o."status" NOT IN (?)
           WHERE t.id IN (?)
           AND t."maxQuantity" IS NOT NULL
+          AND t."deletedAt" IS NULL
           GROUP BY t.id
         `,
         {

--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -329,15 +329,9 @@ export async function isCollectiveDeletable(collective) {
         AND "deletedAt" IS NULL
       )
       -- Expenses
-      OR EXISTS (
-        SELECT 1 FROM "Expenses"
-        WHERE (
-          "CollectiveId" = :CollectiveId
-          OR "FromCollectiveId" = :CollectiveId
-          ${user ? `OR "UserId" = :UserId` : ''}
-        )
-        AND "deletedAt" IS NULL
-      )
+      OR EXISTS (SELECT 1 FROM "Expenses" WHERE "CollectiveId" = :CollectiveId AND "deletedAt" IS NULL)
+      OR EXISTS (SELECT 1 FROM "Expenses" WHERE "FromCollectiveId" = :CollectiveId AND "deletedAt" IS NULL)
+      ${user ? `OR EXISTS (SELECT 1 FROM "Expenses" WHERE "UserId" = :UserId AND "deletedAt" IS NULL) ` : ''}
       -- Orders
       OR EXISTS (
         SELECT 1 FROM "Orders"


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/6036

- Improvement on Tiers available quantity loader that was [not taking advantage of indexes](https://sentry.io/organizations/open-collective/performance/oc-api:7ea96bfea2524626882e960bcad2665d/?project=5199682&query=http.method%3APOST+&statsPeriod=24h&transaction=GraphQL%3A+CollectivePage#span-8755c0e210075cdb) (and was also counting deleted entries, which is buggy)
- Add an index on `Expense.UserId`, including the [fraud project queries](https://github.com/opencollective/opencollective-api/blob/44cd0976d3e58bd6c8df890a4c325c7a9fcb176c/server/lib/security/expense.ts#L196)