### PR TITLE
Make budget version default to v2 

### DIFF
--- a/migrations/20221109120112-balance-v2.js
+++ b/migrations/20221109120112-balance-v2.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      START TRANSACTION;
+
+      CREATE TEMP TABLE "CollectiveWithCurrencyIssues" AS (
+        SELECT c.*
+        FROM "Transactions" t
+        INNER JOIN "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL AND c."deactivatedAt" IS NULL
+        AND c."isActive" IS TRUE AND c."HostCollectiveId" IS NOT NULL AND c."approvedAt" IS NOT NULL
+        WHERE t."currency" != t."hostCurrency"
+        AND t."deletedAt" IS NULL
+        GROUP BY c."id"
+        HAVING c."settings"->'budget'->'version' IS NULL
+        OR (c."settings"->'budget'->'version')::text = 'null'
+      );
+
+      UPDATE "Collectives"
+        SET "settings" = '{}'::jsonb
+        FROM "CollectiveWithCurrencyIssues"
+        WHERE "Collectives"."settings" IS NULL
+        AND "CollectiveWithCurrencyIssues"."id" = "Collectives"."id" ;
+
+      UPDATE "Collectives"
+        SET "settings" = jsonb_set("Collectives"."settings"::jsonb, '{budget}', '{"version": "v1"}'::jsonb)
+        FROM "CollectiveWithCurrencyIssues"
+        WHERE (
+          "Collectives"."settings"->'budget'->'version' IS NULL
+          OR
+          ("Collectives"."settings"->'budget'->'version')::text = 'null'
+        )
+        AND "CollectiveWithCurrencyIssues"."id" = "Collectives"."id" ;
+
+      DROP TABLE "CollectiveWithCurrencyIssues";
+
+      COMMIT;
+   `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      START TRANSACTION;
+
+      CREATE TEMP TABLE "CollectiveWithBalanceV1" AS (
+        SELECT c.*
+        FROM "Transactions" t
+        INNER JOIN "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL AND c."deactivatedAt" IS NULL
+        AND c."isActive" IS TRUE AND c."HostCollectiveId" IS NOT NULL AND c."approvedAt" IS NOT NULL
+        WHERE t."currency" != t."hostCurrency"
+        AND t."deletedAt" IS NULL
+        GROUP BY c."id"
+        HAVING COALESCE(TRIM('"' FROM (c."settings"->'budget'->'version')::text), null) = 'v1'
+      );
+
+      UPDATE "Collectives"
+        SET "settings" = jsonb_set("Collectives"."settings"::jsonb, '{budget}', '{"version": null}'::jsonb)
+        FROM "CollectiveWithBalanceV1"
+        WHERE COALESCE(TRIM('"' FROM ("Collectives"."settings"->'budget'->'version')::text), null) = 'v1'
+        AND "CollectiveWithBalanceV1"."id" = "Collectives"."id" ;;
+
+      DROP TABLE "CollectiveWithBalanceV1";
+
+      COMMIT;
+   `);
+  },
+};

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -64,7 +64,8 @@ const updateFilterConditionsForReadyToPay = async (where, include, host): Promis
     // Check the balances for these collectives. The following will emit an SQL like:
     // AND ((CollectiveId = 1 AND amount < 5000) OR (CollectiveId = 2 AND amount < 3000))
     const collectiveIds = uniq(expensesWithoutPendingTaxForm.map(e => e.CollectiveId));
-    const balances = await getBalancesWithBlockedFunds(collectiveIds); // TODO: move to new balance calculation v2 when possible
+    // TODO: this can conflict for collectives stuck on balance v1 as this is now using balance v2 by default
+    const balances = await getBalancesWithBlockedFunds(collectiveIds);
     const fxRates = await loadFxRatesMap(
       uniq(
         expensesWithoutPendingTaxForm.map(expense => {

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -8,6 +8,8 @@ import { getFxRate } from './currency';
 const { CREDIT, DEBIT } = TransactionTypes;
 const { PROCESSING, SCHEDULED_FOR_PAYMENT } = expenseStatus;
 
+const DEFAULT_BUDGET_VERSION = 'v2';
+
 async function sumTransactionsInCurrency(results, currency) {
   let total = 0;
 
@@ -42,11 +44,11 @@ export async function getBalanceAmount(
   collective,
   { startDate, endDate, currency, version, loaders, includeChildren } = {},
 ) {
-  version = version || collective.settings?.budget?.version || 'v1';
+  version = version || collective.settings?.budget?.version || DEFAULT_BUDGET_VERSION;
   currency = currency || collective.currency;
 
   // Optimized version using loaders
-  if (loaders && version === 'v1' && !startDate && !endDate && !includeChildren) {
+  if (loaders && version === DEFAULT_BUDGET_VERSION && !startDate && !endDate && !includeChildren) {
     const result = await loaders.Collective.balance.load(collective.id);
     const fxRate = await getFxRate(result.currency, currency);
     return {
@@ -76,11 +78,11 @@ export async function getBalanceWithBlockedFundsAmount(
   collective,
   { startDate, endDate, currency, version, loaders } = {},
 ) {
-  version = version || collective.settings?.budget?.version || 'v1';
+  version = version || collective.settings?.budget?.version || DEFAULT_BUDGET_VERSION;
   currency = currency || collective.currency;
 
   // Optimized version using loaders
-  if (loaders && version === 'v1') {
+  if (loaders && version === DEFAULT_BUDGET_VERSION) {
     const result = await loaders.Collective.balanceWithBlockedFunds.load(collective.id);
     const fxRate = await getFxRate(result.currency, currency);
     return {
@@ -100,7 +102,7 @@ export async function getBalanceWithBlockedFundsAmount(
   });
 }
 
-export function getBalances(collectiveIds, { startDate, endDate, currency, version = 'v1' } = {}) {
+export function getBalances(collectiveIds, { startDate, endDate, currency, version = DEFAULT_BUDGET_VERSION } = {}) {
   return sumCollectivesTransactions(collectiveIds, {
     startDate,
     endDate,
@@ -112,7 +114,10 @@ export function getBalances(collectiveIds, { startDate, endDate, currency, versi
   });
 }
 
-export function getBalancesWithBlockedFunds(collectiveIds, { startDate, endDate, currency, version = 'v1' } = {}) {
+export function getBalancesWithBlockedFunds(
+  collectiveIds,
+  { startDate, endDate, currency, version = DEFAULT_BUDGET_VERSION } = {},
+) {
   return sumCollectivesTransactions(collectiveIds, {
     startDate,
     endDate,
@@ -128,7 +133,7 @@ export async function getTotalAmountReceivedAmount(
   collective,
   { startDate, endDate, currency, version, kind, includeChildren } = {},
 ) {
-  version = version || collective.settings?.budget?.version || 'v1';
+  version = version || collective.settings?.budget?.version || DEFAULT_BUDGET_VERSION;
   currency = currency || collective.currency;
 
   const collectiveIds = await getCollectiveIds(collective, includeChildren);
@@ -154,7 +159,7 @@ export async function getTotalAmountSpentAmount(
   collective,
   { startDate, endDate, currency, version, kind, includeChildren, net } = {},
 ) {
-  version = version || collective.settings?.budget?.version || 'v1';
+  version = version || collective.settings?.budget?.version || DEFAULT_BUDGET_VERSION;
   currency = currency || collective.currency;
 
   const collectiveIds = await getCollectiveIds(collective, includeChildren);
@@ -218,7 +223,7 @@ export async function getTotalNetAmountReceivedAmount(
   collective,
   { startDate, endDate, currency, version, includeChildren } = {},
 ) {
-  version = version || collective.settings?.budget?.version || 'v1';
+  version = version || collective.settings?.budget?.version || DEFAULT_BUDGET_VERSION;
   currency = currency || collective.currency;
 
   const collectiveIds = await getCollectiveIds(collective, includeChildren);
@@ -250,7 +255,7 @@ export async function getTotalNetAmountReceivedAmount(
 }
 
 export async function getTotalMoneyManagedAmount(host, { startDate, endDate, collectiveIds, currency, version } = {}) {
-  version = version || host.settings?.budget?.version || 'v1';
+  version = version || host.settings?.budget?.version || DEFAULT_BUDGET_VERSION;
   currency = currency || host.currency;
 
   if (!collectiveIds) {

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -811,9 +811,12 @@ describe('server/graphql/v1/createOrder', () => {
         CreatedByUserId: hostAdmin.id,
         HostCollectiveId: fromCollective.HostCollectiveId,
         CollectiveId: fromCollective.id,
+        amount: 746149,
+        amountInHostCurrency: 746149,
         netAmountInCollectiveCurrency: 746149,
         type: 'CREDIT',
         currency: 'USD',
+        hostCurrency: 'USD',
       });
     });
 
@@ -859,9 +862,12 @@ describe('server/graphql/v1/createOrder', () => {
       CreatedByUserId: xdamman.id,
       HostCollectiveId: fromCollective.HostCollectiveId,
       CollectiveId: fromCollective.id,
+      amount: 746149,
+      amountInHostCurrency: 746149,
       netAmountInCollectiveCurrency: 746149,
       type: 'CREDIT',
       currency: 'USD',
+      hostCurrency: 'USD',
     });
 
     order.fromCollective = { id: fromCollective.id };

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -487,7 +487,9 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
         ...transactionProps,
         kind: TransactionKind.CONTRIBUTION,
         amount: 3000,
+        amountInHostCurrency: 3000,
         hostFeeInHostCurrency: -600,
+        netAmountInCollectiveCurrency: 2400,
       });
 
       const result = await graphqlQueryV2(
@@ -502,7 +504,7 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       );
 
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal('Unable to change host: you still have a balance of $30.00');
+      expect(result.errors[0].message).to.equal('Unable to change host: you still have a balance of $24.00');
     });
 
     it('validates if user is admin of target host collective', async () => {

--- a/test/server/graphql/v2/query/AccountQuery.test.js
+++ b/test/server/graphql/v2/query/AccountQuery.test.js
@@ -442,7 +442,7 @@ describe('server/graphql/v2/query/AccountQuery', () => {
         expect(result1.data.account.stats.balance.valueInCents).to.eq(0);
         expect(result1.data.account.stats.balance.currency).to.eq('USD');
 
-        await fakeTransaction({ type: 'CREDIT', CollectiveId: collective.id, netAmountInCollectiveCurrency: 1000 });
+        await fakeTransaction({ type: 'CREDIT', CollectiveId: collective.id, amount: 1000 });
         const result2 = await graphqlQueryV2(accountQuery, { slug: collective.slug });
         expect(result2.data.account.stats.balance.value).to.eq(10);
         expect(result2.data.account.stats.balance.valueInCents).to.eq(1000);
@@ -456,7 +456,7 @@ describe('server/graphql/v2/query/AccountQuery', () => {
             fakeTransaction({
               type: 'CREDIT',
               CollectiveId: collective.id,
-              netAmountInCollectiveCurrency: GRAPHQL_MAX_INT,
+              amount: GRAPHQL_MAX_INT,
             }),
           ),
         );

--- a/test/server/paymentProviders/opencollective/collective.test.js
+++ b/test/server/paymentProviders/opencollective/collective.test.js
@@ -149,9 +149,9 @@ describe('server/paymentProviders/opencollective/collective', () => {
 
     beforeEach('create transactions for 3 donations from organization to collective1', async () => {
       transactions = [
-        { amount: 500, netAmountInCollectiveCurrency: 500 },
-        { amount: 200, netAmountInCollectiveCurrency: 200 },
-        { amount: 1000, netAmountInCollectiveCurrency: 1000 },
+        { amount: 500, netAmountInCollectiveCurrency: 500, amountInHostCurrency: 500 },
+        { amount: 200, netAmountInCollectiveCurrency: 200, amountInHostCurrency: 200 },
+        { amount: 1000, netAmountInCollectiveCurrency: 1000, amountInHostCurrency: 1000 },
       ];
       const transactionsDefaultValue = {
         CreatedByUserId: user1.id,
@@ -159,6 +159,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         CollectiveId: collective1.id,
         PaymentMethodId: stripePaymentMethod.id,
         currency: collective1.currency,
+        hostCurrency: collective1.currency,
         HostCollectiveId: collective1.HostCollectiveId,
         type: 'DEBIT',
       };
@@ -167,9 +168,9 @@ describe('server/paymentProviders/opencollective/collective', () => {
 
     beforeEach('create transactions for 3 donations from organization to collective5', async () => {
       transactions = [
-        { amount: 500, netAmountInCollectiveCurrency: 500 },
-        { amount: 200, netAmountInCollectiveCurrency: 200 },
-        { amount: 1000, netAmountInCollectiveCurrency: 1000 },
+        { amount: 500, netAmountInCollectiveCurrency: 500, amountInHostCurrency: 500 },
+        { amount: 200, netAmountInCollectiveCurrency: 200, amountInHostCurrency: 200 },
+        { amount: 1000, netAmountInCollectiveCurrency: 1000, amountInHostCurrency: 1000 },
       ];
       const transactionsDefaultValue = {
         CreatedByUserId: user1.id,
@@ -177,6 +178,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         CollectiveId: collective5.id,
         PaymentMethodId: stripePaymentMethod.id,
         currency: collective5.currency,
+        hostCurrency: collective5.currency,
         HostCollectiveId: collective5.HostCollectiveId,
         type: 'DEBIT',
       };

--- a/test/stories/ledger.test.ts
+++ b/test/stories/ledger.test.ts
@@ -428,11 +428,18 @@ describe('test/stories/ledger', () => {
         Math.round(expectedPlatformProfitInHostCurrency * hostToPlatformFxRate),
       );
 
-      expect(await collective.getBalance()).to.eq(
+      expect(await collective.getBalance({ version: 'v1' })).to.eq(
         orderAmountInCollectiveCurrency -
           platformTipInCollectiveCurrency -
           expectedHostFeeInCollectiveCurrency -
           processorFeeInCollectiveCurrency,
+      );
+
+      expect(await collective.getBalance()).to.eq(
+        Math.round(
+          (orderNetAmountInHostCurrency - processorFeeInHostCurrency - expectedHostFeeInHostCurrency) *
+            RATES[host.currency][collective.currency],
+        ),
       );
 
       // Check host metrics pre-refund


### PR DESCRIPTION
- freeze collective with issues on v1 (migration)
- count in `hostCurrency` vs `currency` (v2)

Fix: https://github.com/opencollective/opencollective/issues/5858