### PR TITLE
Fix missing paypal subscriptions

### DIFF
--- a/scripts/fetch-sentry-issue-events.ts
+++ b/scripts/fetch-sentry-issue-events.ts
@@ -1,0 +1,67 @@
+/**
+ * A script to fetch all the details from a Sentry issue.
+ * Useful for debugging at scale.
+ */
+
+import fs from 'fs';
+
+import { Command } from 'commander';
+import fetch from 'node-fetch';
+
+import { sleep } from '../server/lib/utils';
+
+const fetchIssueEvents = (issueId: string, cursor: number) => {
+  return fetch(`https://sentry.io/api/0/issues/${issueId}/events/?full=true&cursor=0:${cursor}:0`, {
+    headers: {
+      accept: 'application/json; charset=utf-8',
+      authorization: `Bearer ${process.env.SENTRY_USER_TOKEN}`,
+    },
+    body: null,
+    method: 'GET',
+  }).then(response => (response.status === 200 ? response.json() : 'ERROR'));
+};
+
+const main = async (issueId: string, options) => {
+  const allIssues = [];
+
+  // Load existing file
+  if (options['resume']) {
+    try {
+      const existing = JSON.parse(fs.readFileSync('sentry-result.json', 'utf8'));
+      allIssues.push(...existing);
+      console.log(`Loaded ${existing.length} events from sentry-result.json`);
+    } catch (e) {
+      console.error(`Error loading sentry-result.json:`, e);
+    }
+  }
+
+  try {
+    for (let i = allIssues.length; i < parseInt(options.limit); i += 100) {
+      console.log(`Fetching ${i} to ${i + 100} events...`);
+      const result = await fetchIssueEvents(issueId, i);
+      if (!result.length) {
+        console.log('No more events');
+        break;
+      }
+
+      allIssues.push(...result);
+      await sleep(1000);
+    }
+  } catch (e) {
+    console.error(`Stopped in the loop:`, e);
+  }
+
+  if (allIssues.length) {
+    console.log('Saving result to sentry-result.json');
+    fs.writeFileSync('sentry-result.json', JSON.stringify(allIssues, null, 2));
+  }
+};
+
+const program = new Command()
+  .description('Helper to fetch the events of a Sentry issue')
+  .option('--limit <number>', 'The number of events to fetch', parseInt, 10000)
+  .option('--resume', 'Resume from the last cursor (based on sentry-result.json)', false)
+  .argument('issueId')
+  .parse();
+
+main(program.args[0], program.opts());

--- a/server/graphql/v2/mutation/RootMutations.ts
+++ b/server/graphql/v2/mutation/RootMutations.ts
@@ -198,7 +198,7 @@ export default {
       }
 
       const banSummary = await getBanSummary(accounts);
-      const isAllowed = !banSummary.undeletableTransactionsCount;
+      const isAllowed = !(banSummary.undeletableTransactionsCount || banSummary.newOrdersCount);
       if (args.dryRun) {
         return { isAllowed, accounts, message: stringifyBanSummary(banSummary) };
       }

--- a/server/lib/moderation.ts
+++ b/server/lib/moderation.ts
@@ -59,6 +59,7 @@ type BanSummary = {
   transactionsCount: number;
   expensesCount: number;
   ordersCount: number;
+  newOrdersCount: number;
   usersCount: number;
 };
 
@@ -146,12 +147,17 @@ export const getBanSummary = async (accounts: typeof models.Collective[]): Promi
     ordersCount: await models.Order.count({
       where: { [Op.or]: [{ CollectiveId: collectiveIds }, { FromCollectiveId: collectiveIds }] },
     }),
+    newOrdersCount: await models.Order.count({
+      where: { [Op.or]: [{ CollectiveId: collectiveIds }, { FromCollectiveId: collectiveIds }], status: 'NEW' },
+    }),
   };
 };
 
 export const stringifyBanSummary = (banSummary: BanSummary) => {
   if (banSummary.undeletableTransactionsCount) {
     return `Can't proceed: there are ${banSummary.undeletableTransactionsCount} undeletable transactions in this batch`;
+  } else if (banSummary.newOrdersCount) {
+    return `Can't proceed: there are ${banSummary.newOrdersCount} orders with a pending payment not yet synchronized`;
   }
 
   const countFields = Object.keys(banSummary).filter(key => key.endsWith('Count'));

--- a/server/paymentProviders/paypal/subscription.ts
+++ b/server/paymentProviders/paypal/subscription.ts
@@ -17,6 +17,8 @@ import { PaymentProviderService } from '../types';
 import { paypalRequest } from './api';
 import { refundPaypalCapture } from './payment';
 
+export const CANCEL_PAYPAL_EDITED_SUBSCRIPTION_REASON = 'Updated subscription';
+
 export const cancelPaypalSubscription = async (
   order: typeof models.Order,
   reason = undefined,
@@ -218,7 +220,7 @@ export const setupPaypalSubscriptionForOrder = async (
     if (existingSubscription) {
       // Cancel existing PayPal subscription
       if (existingSubscription.paypalSubscriptionId) {
-        await cancelPaypalSubscription(order, 'Updated subscription');
+        await cancelPaypalSubscription(order, CANCEL_PAYPAL_EDITED_SUBSCRIPTION_REASON);
       }
 
       // Update the subscription with the new params

--- a/server/paymentProviders/paypal/webhook.ts
+++ b/server/paymentProviders/paypal/webhook.ts
@@ -59,8 +59,8 @@ const loadSubscriptionForWebhookEvent = async (req: Request, subscriptionId: str
 
   const order = await models.Order.findOne({
     include: [
-      { association: 'fromCollective' },
-      { association: 'createdByUser' },
+      { association: 'fromCollective', required: false },
+      { association: 'createdByUser', required: false },
       { association: 'collective', required: true },
       {
         association: 'Subscription',

--- a/server/paymentProviders/paypal/webhook.ts
+++ b/server/paymentProviders/paypal/webhook.ts
@@ -18,6 +18,7 @@ import { PayoutWebhookRequest } from '../../types/paypal';
 import { paypalRequestV2 } from './api';
 import { findTransactionByPaypalId, recordPaypalCapture, recordPaypalSale } from './payment';
 import { checkBatchItemStatus } from './payouts';
+import { CANCEL_PAYPAL_EDITED_SUBSCRIPTION_REASON } from './subscription';
 
 const debug = Debug('paypal:webhook');
 
@@ -254,6 +255,11 @@ async function handleCaptureRefunded(req: Request): Promise<void> {
  */
 async function handleSubscriptionCancelled(req: Request): Promise<void> {
   const subscription = req.body.resource;
+  if (subscription['status_change_note'] === CANCEL_PAYPAL_EDITED_SUBSCRIPTION_REASON) {
+    // Ignore, this is a subscription that was updated by the user through the edit subscription page
+    return;
+  }
+
   const { order } = await loadSubscriptionForWebhookEvent(req, subscription.id);
   if (order.status !== OrderStatus.CANCELLED) {
     await order.update({


### PR DESCRIPTION
Fixes for missing PayPal subscriptions.

This PR adds to things:
- It prevents banning users that just setup a PayPal subscription that is not confirmed yet
- It adds a new command on `scripts/paypal/payment-reconciliator.ts` to reconciliate a subscription between DB and PayPal. Usage:
```
npm run script scripts/paypal/payment-reconciliator.ts subscription I-XXXXXXXXXX
```