### PR TITLE
Add time series stats to account collection

### DIFF
--- a/server/graphql/v2/collection/AccountCollection.js
+++ b/server/graphql/v2/collection/AccountCollection.js
@@ -21,14 +21,10 @@ const AccountCollection = new GraphQLObjectType({
       stats: {
         type: new GraphQLNonNull(AccountCollectionStats),
         args: {
-          ...TimeSeriesArgs,
           includeChildren: { type: GraphQLBoolean, defaultValue: false },
         },
+        description: 'Stats for the returned results (i.e. accounts within the limit)',
         async resolve(collection, args) {
-          const dateFrom = args.dateFrom ? moment(args.dateFrom) : null;
-          const dateTo = args.dateTo ? moment(args.dateTo) : null;
-          const timeUnit = args.timeUnit || getTimeUnit(getNumberOfDays(dateFrom, dateTo, {}) || 1);
-
           const collectiveIds = collection.nodes.map(c => c.id);
 
           if (args.includeChildren) {
@@ -38,7 +34,7 @@ const AccountCollection = new GraphQLObjectType({
             });
             collectiveIds.push(...childCollectives.map(c => c.id));
           }
-          return { timeUnit, dateFrom, dateTo, collectiveIds };
+          return { collectiveIds };
         },
       },
     };

--- a/server/graphql/v2/collection/AccountCollection.js
+++ b/server/graphql/v2/collection/AccountCollection.js
@@ -1,7 +1,5 @@
-import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
-import { Op } from 'sequelize';
+import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
 
-import models from '../../../models';
 import { Account } from '../interface/Account';
 import { Collection, CollectionFields } from '../interface/Collection';
 import { AccountCollectionStats } from '../object/AccountCollectionStats';
@@ -18,21 +16,9 @@ const AccountCollection = new GraphQLObjectType({
       },
       stats: {
         type: new GraphQLNonNull(AccountCollectionStats),
-        args: {
-          includeChildren: { type: GraphQLBoolean, defaultValue: false },
-        },
         description: 'Stats for the returned results (i.e. accounts within the limit)',
-        async resolve(collection, args) {
-          const collectiveIds = collection.nodes.map(c => c.id);
-
-          if (args.includeChildren) {
-            const childCollectives = await models.Collective.findAll({
-              attributes: ['id'],
-              where: { ParentCollectiveId: { [Op.in]: collectiveIds } },
-            });
-            collectiveIds.push(...childCollectives.map(c => c.id));
-          }
-          return { collectiveIds };
+        resolve(collection) {
+          return collection;
         },
       },
     };

--- a/server/graphql/v2/collection/AccountCollection.js
+++ b/server/graphql/v2/collection/AccountCollection.js
@@ -1,7 +1,10 @@
-import { GraphQLList, GraphQLObjectType } from 'graphql';
+import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import moment from 'moment';
 
 import { Account } from '../interface/Account';
 import { Collection, CollectionFields } from '../interface/Collection';
+import { AccountCollectionStats } from '../object/AccountCollectionStats';
+import { getNumberOfDays, getTimeUnit, TimeSeriesArgs } from '../object/TimeSeriesAmount';
 
 const AccountCollection = new GraphQLObjectType({
   name: 'AccountCollection',
@@ -12,6 +15,29 @@ const AccountCollection = new GraphQLObjectType({
       ...CollectionFields,
       nodes: {
         type: new GraphQLList(Account),
+      },
+      stats: {
+        type: new GraphQLNonNull(AccountCollectionStats),
+        args: {
+          ...TimeSeriesArgs,
+          includeChildren: { type: GraphQLBoolean, defaultValue: false },
+        },
+        async resolve(collection, args) {
+          const dateFrom = args.dateFrom ? moment(args.dateFrom) : null;
+          const dateTo = args.dateTo ? moment(args.dateTo) : null;
+          const timeUnit = args.timeUnit || getTimeUnit(getNumberOfDays(dateFrom, dateTo, {}) || 1);
+
+          const collectiveIds = collection.nodes.map(c => c.id);
+
+          if (args.includeChildren) {
+            const childCollectiveIds = await Promise.all(
+              collection.nodes.map(async c => await c.getChildren({ attributes: ['id'] })),
+            );
+            collectiveIds.push(...childCollectiveIds.flat().map(c => c.id));
+          }
+
+          return { timeUnit, dateFrom, dateTo, collectiveIds };
+        },
       },
     };
   },

--- a/server/graphql/v2/collection/AccountCollection.js
+++ b/server/graphql/v2/collection/AccountCollection.js
@@ -1,12 +1,10 @@
 import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
-import moment from 'moment';
 import { Op } from 'sequelize';
 
 import models from '../../../models';
 import { Account } from '../interface/Account';
 import { Collection, CollectionFields } from '../interface/Collection';
 import { AccountCollectionStats } from '../object/AccountCollectionStats';
-import { getNumberOfDays, getTimeUnit, TimeSeriesArgs } from '../object/TimeSeriesAmount';
 
 const AccountCollection = new GraphQLObjectType({
   name: 'AccountCollection',

--- a/server/graphql/v2/object/AccountCollectionStats.ts
+++ b/server/graphql/v2/object/AccountCollectionStats.ts
@@ -8,13 +8,6 @@ import { resultsToAmountNode } from '../object/HostMetricsTimeSeries';
 import { TimeSeriesAmount } from '../object/TimeSeriesAmount';
 import { TimeSeriesCount } from '../object/TimeSeriesCount';
 
-const resultsToCountNode = results => {
-  return results.map(result => ({
-    date: result.date,
-    count: result.count,
-  }));
-};
-
 export const AccountCollectionStats = new GraphQLObjectType({
   name: 'AccountCollectionStats',
   description: 'Account collection stats',
@@ -26,8 +19,10 @@ export const AccountCollectionStats = new GraphQLObjectType({
       resolve: async ({ collectiveIds, dateFrom, dateTo, timeUnit }) => {
         const kind = [TransactionKind.CONTRIBUTION];
         const transactionParams = { type: TransactionTypes.CREDIT, kind, dateFrom, dateTo, collectiveIds };
-        const amountDataPoints = await queries.getTransactionsCountTimeSeries(timeUnit, transactionParams);
-        return { dateFrom, dateTo, timeUnit, nodes: resultsToCountNode(amountDataPoints) };
+        const countNodes = collectiveIds.length
+          ? await queries.getTransactionsCountTimeSeries(timeUnit, transactionParams)
+          : [];
+        return { dateFrom, dateTo, timeUnit, nodes: countNodes };
       },
     },
     totalReceivedTimeSeries: {
@@ -36,7 +31,9 @@ export const AccountCollectionStats = new GraphQLObjectType({
       resolve: async ({ collectiveIds, dateFrom, dateTo, timeUnit }) => {
         const kind = [TransactionKind.CONTRIBUTION, TransactionKind.ADDED_FUNDS];
         const transactionParams = { type: TransactionTypes.CREDIT, kind, dateFrom, dateTo, collectiveIds };
-        const amountDataPoints = await queries.getTransactionsTimeSeries(timeUnit, transactionParams);
+        const amountDataPoints = collectiveIds.length
+          ? await queries.getTransactionsTimeSeries(timeUnit, transactionParams)
+          : [];
         return { dateFrom, dateTo, timeUnit, nodes: resultsToAmountNode(amountDataPoints) };
       },
     },

--- a/server/graphql/v2/object/AccountCollectionStats.ts
+++ b/server/graphql/v2/object/AccountCollectionStats.ts
@@ -25,7 +25,7 @@ export const AccountCollectionStats = new GraphQLObjectType({
           description: 'The transaction type (DEBIT or CREDIT)',
         },
       },
-      description: 'Time series of the number of contributions to these accounts',
+      description: 'Time series of the number of transactions to these accounts',
       resolve: async ({ collectiveIds }, args) => {
         const dateFrom = args.dateFrom ? moment(args.dateFrom) : null;
         const dateTo = args.dateTo ? moment(args.dateTo) : null;
@@ -38,7 +38,7 @@ export const AccountCollectionStats = new GraphQLObjectType({
         return { dateFrom, dateTo, timeUnit, nodes: countNodes };
       },
     },
-    transactionsTimeSeries: {
+    transactionsAmountTimeSeries: {
       type: new GraphQLNonNull(TimeSeriesAmount),
       args: {
         ...TimeSeriesArgs,
@@ -51,7 +51,7 @@ export const AccountCollectionStats = new GraphQLObjectType({
           description: 'The transaction type (DEBIT or CREDIT)',
         },
       },
-      description: 'Time series of the total money received by these accounts',
+      description: 'Time series of the sum of transactions to these accounts',
       resolve: async ({ collectiveIds }, args) => {
         const dateFrom = args.dateFrom ? moment(args.dateFrom) : null;
         const dateTo = args.dateTo ? moment(args.dateTo) : null;

--- a/server/graphql/v2/object/AccountCollectionStats.ts
+++ b/server/graphql/v2/object/AccountCollectionStats.ts
@@ -2,8 +2,7 @@ import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
 
 import { TransactionKind } from '../../../constants/transaction-kind';
 import { TransactionTypes } from '../../../constants/transactions';
-import sequelize from '../../../lib/sequelize';
-import { computeDatesAsISOStrings } from '../../../lib/utils';
+import queries from '../../../lib/queries';
 import { getTimeSeriesFields } from '../interface/TimeSeries';
 import { resultsToAmountNode } from '../object/HostMetricsTimeSeries';
 import { TimeSeriesAmount } from '../object/TimeSeriesAmount';
@@ -27,7 +26,7 @@ export const AccountCollectionStats = new GraphQLObjectType({
       resolve: async ({ collectiveIds, dateFrom, dateTo, timeUnit }) => {
         const kind = [TransactionKind.CONTRIBUTION];
         const transactionParams = { type: TransactionTypes.CREDIT, kind, dateFrom, dateTo, collectiveIds };
-        const amountDataPoints = await getTransactionsCountTimeSeries(timeUnit, transactionParams);
+        const amountDataPoints = await queries.getTransactionsCountTimeSeries(timeUnit, transactionParams);
         return { dateFrom, dateTo, timeUnit, nodes: resultsToCountNode(amountDataPoints) };
       },
     },
@@ -37,67 +36,9 @@ export const AccountCollectionStats = new GraphQLObjectType({
       resolve: async ({ collectiveIds, dateFrom, dateTo, timeUnit }) => {
         const kind = [TransactionKind.CONTRIBUTION, TransactionKind.ADDED_FUNDS];
         const transactionParams = { type: TransactionTypes.CREDIT, kind, dateFrom, dateTo, collectiveIds };
-        const amountDataPoints = await getTransactionsTimeSeries(timeUnit, transactionParams);
+        const amountDataPoints = await queries.getTransactionsTimeSeries(timeUnit, transactionParams);
         return { dateFrom, dateTo, timeUnit, nodes: resultsToAmountNode(amountDataPoints) };
       },
     },
   }),
 });
-
-const getTransactionsTimeSeries = async (
-  timeUnit,
-  { type = null, kind = null, collectiveIds = [], dateFrom = null, dateTo = null } = {},
-) => {
-  return sequelize.query(
-    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", sum("amountInHostCurrency") as "amount", "hostCurrency" as "currency"
-         FROM "Transactions"
-         WHERE "deletedAt" IS NULL
-           AND "CollectiveId" IN (:collectiveIds)
-           ${type ? `AND "type" = :type` : ``}
-           ${kind?.length ? `AND "kind" IN (:kind)` : ``}
-           ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
-           ${dateTo ? `AND "createdAt" <= :endDate` : ``}
-         GROUP BY DATE_TRUNC(:timeUnit, "createdAt"), "hostCurrency"
-         ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
-        `,
-    {
-      type: sequelize.QueryTypes.SELECT,
-      replacements: {
-        kind: Array.isArray(kind) ? kind : [kind],
-        type,
-        timeUnit,
-        collectiveIds,
-        ...computeDatesAsISOStrings(dateFrom, dateTo),
-      },
-    },
-  );
-};
-
-const getTransactionsCountTimeSeries = async (
-  timeUnit,
-  { type = null, kind = null, collectiveIds = [], dateFrom = null, dateTo = null } = {},
-) => {
-  return sequelize.query(
-    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", count("id") as "count"
-         FROM "Transactions"
-         WHERE "deletedAt" IS NULL
-           AND "CollectiveId" IN (:collectiveIds)
-           ${type ? `AND "type" = :type` : ``}
-           ${kind?.length ? `AND "kind" IN (:kind)` : ``}
-           ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
-           ${dateTo ? `AND "createdAt" <= :endDate` : ``}
-         GROUP BY DATE_TRUNC(:timeUnit, "createdAt")
-         ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
-        `,
-    {
-      type: sequelize.QueryTypes.SELECT,
-      replacements: {
-        kind: Array.isArray(kind) ? kind : [kind],
-        type,
-        timeUnit,
-        collectiveIds,
-        ...computeDatesAsISOStrings(dateFrom, dateTo),
-      },
-    },
-  );
-};

--- a/server/graphql/v2/object/AccountCollectionStats.ts
+++ b/server/graphql/v2/object/AccountCollectionStats.ts
@@ -1,0 +1,103 @@
+import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
+
+import { TransactionKind } from '../../../constants/transaction-kind';
+import { TransactionTypes } from '../../../constants/transactions';
+import sequelize from '../../../lib/sequelize';
+import { computeDatesAsISOStrings } from '../../../lib/utils';
+import { getTimeSeriesFields } from '../interface/TimeSeries';
+import { resultsToAmountNode } from '../object/HostMetricsTimeSeries';
+import { TimeSeriesAmount } from '../object/TimeSeriesAmount';
+import { TimeSeriesCount } from '../object/TimeSeriesCount';
+
+const resultsToCountNode = results => {
+  return results.map(result => ({
+    date: result.date,
+    count: result.count,
+  }));
+};
+
+export const AccountCollectionStats = new GraphQLObjectType({
+  name: 'AccountCollectionStats',
+  description: 'Account collection stats',
+  fields: () => ({
+    ...getTimeSeriesFields(),
+    contributionsCountTimeSeries: {
+      type: new GraphQLNonNull(TimeSeriesCount),
+      description: 'Time series of the number of contributions to these accounts',
+      resolve: async ({ collectiveIds, dateFrom, dateTo, timeUnit }) => {
+        const kind = [TransactionKind.CONTRIBUTION];
+        const transactionParams = { type: TransactionTypes.CREDIT, kind, dateFrom, dateTo, collectiveIds };
+        const amountDataPoints = await getTransactionsCountTimeSeries(timeUnit, transactionParams);
+        return { dateFrom, dateTo, timeUnit, nodes: resultsToCountNode(amountDataPoints) };
+      },
+    },
+    totalReceivedTimeSeries: {
+      type: new GraphQLNonNull(TimeSeriesAmount),
+      description: 'Time series of the total money received by these accounts',
+      resolve: async ({ collectiveIds, dateFrom, dateTo, timeUnit }) => {
+        const kind = [TransactionKind.CONTRIBUTION, TransactionKind.ADDED_FUNDS];
+        const transactionParams = { type: TransactionTypes.CREDIT, kind, dateFrom, dateTo, collectiveIds };
+        const amountDataPoints = await getTransactionsTimeSeries(timeUnit, transactionParams);
+        return { dateFrom, dateTo, timeUnit, nodes: resultsToAmountNode(amountDataPoints) };
+      },
+    },
+  }),
+});
+
+const getTransactionsTimeSeries = async (
+  timeUnit,
+  { type = null, kind = null, collectiveIds = [], dateFrom = null, dateTo = null } = {},
+) => {
+  return sequelize.query(
+    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", sum("amountInHostCurrency") as "amount", "hostCurrency" as "currency"
+         FROM "Transactions"
+         WHERE "deletedAt" IS NULL
+           AND "CollectiveId" IN (:collectiveIds)
+           ${type ? `AND "type" = :type` : ``}
+           ${kind?.length ? `AND "kind" IN (:kind)` : ``}
+           ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
+           ${dateTo ? `AND "createdAt" <= :endDate` : ``}
+         GROUP BY DATE_TRUNC(:timeUnit, "createdAt"), "hostCurrency"
+         ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
+        `,
+    {
+      type: sequelize.QueryTypes.SELECT,
+      replacements: {
+        kind: Array.isArray(kind) ? kind : [kind],
+        type,
+        timeUnit,
+        collectiveIds,
+        ...computeDatesAsISOStrings(dateFrom, dateTo),
+      },
+    },
+  );
+};
+
+const getTransactionsCountTimeSeries = async (
+  timeUnit,
+  { type = null, kind = null, collectiveIds = [], dateFrom = null, dateTo = null } = {},
+) => {
+  return sequelize.query(
+    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", count("id") as "count"
+         FROM "Transactions"
+         WHERE "deletedAt" IS NULL
+           AND "CollectiveId" IN (:collectiveIds)
+           ${type ? `AND "type" = :type` : ``}
+           ${kind?.length ? `AND "kind" IN (:kind)` : ``}
+           ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
+           ${dateTo ? `AND "createdAt" <= :endDate` : ``}
+         GROUP BY DATE_TRUNC(:timeUnit, "createdAt")
+         ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
+        `,
+    {
+      type: sequelize.QueryTypes.SELECT,
+      replacements: {
+        kind: Array.isArray(kind) ? kind : [kind],
+        type,
+        timeUnit,
+        collectiveIds,
+        ...computeDatesAsISOStrings(dateFrom, dateTo),
+      },
+    },
+  );
+};

--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -18,7 +18,7 @@ import OrderStatuses from '../../../constants/order_status';
 import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../constants/paymentMethods';
 import { TransactionKind } from '../../../constants/transaction-kind';
 import { TransactionTypes } from '../../../constants/transactions';
-import queries from '../../../lib/queries';
+import * as HostMetricsLib from '../../../lib/host-metrics';
 import { buildSearchConditions } from '../../../lib/search';
 import models, { Op } from '../../../models';
 import { PayoutMethodTypes } from '../../../models/PayoutMethod';
@@ -626,15 +626,13 @@ export const Host = new GraphQLObjectType({
             const dateTo = args.dateTo ? moment(args.dateTo) : null;
             const timeUnit = args.timeUnit || getTimeUnit(numberOfDays);
 
-            const amountDataPoints = await queries.getTransactionsTimeSeries(
-              TransactionKind.EXPENSE,
-              TransactionTypes.DEBIT,
-              host.id,
-              timeUnit,
+            const amountDataPoints = await HostMetricsLib.getTransactionsTimeSeries(host.id, timeUnit, {
+              type: TransactionTypes.DEBIT,
+              kind: TransactionKind.EXPENSE,
               collectiveIds,
               dateFrom,
               dateTo,
-            );
+            });
 
             return {
               dateFrom: args.dateFrom || host.createdAt,

--- a/server/graphql/v2/object/HostMetricsTimeSeries.ts
+++ b/server/graphql/v2/object/HostMetricsTimeSeries.ts
@@ -79,7 +79,11 @@ export const HostMetricsTimeSeries = new GraphQLObjectType({
       resolve: async ({ host, collectiveIds, dateFrom, dateTo, timeUnit }) => {
         const kind = [TransactionKind.CONTRIBUTION, TransactionKind.ADDED_FUNDS];
         const transactionParams = { type: TransactionTypes.CREDIT, kind, dateFrom, dateTo, collectiveIds };
-        const amountDataPoints = await HostMetricsLib.getTransactionsTimeSeries(host.id, timeUnit, transactionParams);
+        const amountDataPoints = await HostMetricsLib.getTransactionsTimeSeriesByKind(
+          host.id,
+          timeUnit,
+          transactionParams,
+        );
         return { dateFrom, dateTo, timeUnit, nodes: resultsToAmountWithKindNode(amountDataPoints) };
       },
     },
@@ -89,7 +93,11 @@ export const HostMetricsTimeSeries = new GraphQLObjectType({
       resolve: async ({ host, collectiveIds, dateFrom, dateTo, timeUnit }) => {
         const kind = TransactionKind.EXPENSE;
         const transactionParams = { type: TransactionTypes.DEBIT, kind, dateFrom, dateTo, collectiveIds };
-        const amountDataPoints = await HostMetricsLib.getTransactionsTimeSeries(host.id, timeUnit, transactionParams);
+        const amountDataPoints = await HostMetricsLib.getTransactionsTimeSeriesByKind(
+          host.id,
+          timeUnit,
+          transactionParams,
+        );
         return { dateFrom, dateTo, timeUnit, nodes: resultsToAmountWithKindNode(amountDataPoints) };
       },
     },

--- a/server/graphql/v2/object/TimeSeriesAmountWithCount.ts
+++ b/server/graphql/v2/object/TimeSeriesAmountWithCount.ts
@@ -3,22 +3,25 @@ import { GraphQLDateTime } from 'graphql-scalars';
 
 import { getTimeSeriesFields, TimeSeries } from '../interface/TimeSeries';
 
-const TimeSeriesCountNode = new GraphQLObjectType({
-  name: 'TimeSeriesCountNode',
+import { Amount } from './Amount';
+
+const TimeSeriesAmountCountNodes = new GraphQLObjectType({
+  name: 'TimeSeriesAmountWithCountNode',
   fields: () => ({
     date: { type: new GraphQLNonNull(GraphQLDateTime) },
+    amount: { type: new GraphQLNonNull(Amount) },
     count: { type: new GraphQLNonNull(GraphQLInt) },
   }),
 });
 
-export const TimeSeriesCount = new GraphQLObjectType({
-  name: 'TimeSeriesCount',
-  description: 'Count time series',
+export const TimeSeriesAmountWithCount = new GraphQLObjectType({
+  name: 'TimeSeriesAmountWithCount',
+  description: 'Amounts with count time series',
   interfaces: [TimeSeries],
   fields: () => ({
     ...getTimeSeriesFields(),
     nodes: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TimeSeriesCountNode))),
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TimeSeriesAmountCountNodes))),
       description: 'Time series data points',
     },
   }),

--- a/server/graphql/v2/object/TimeSeriesAmountWithCount.ts
+++ b/server/graphql/v2/object/TimeSeriesAmountWithCount.ts
@@ -5,7 +5,7 @@ import { getTimeSeriesFields, TimeSeries } from '../interface/TimeSeries';
 
 import { Amount } from './Amount';
 
-const TimeSeriesAmountCountNodes = new GraphQLObjectType({
+const TimeSeriesAmountWithCountNodes = new GraphQLObjectType({
   name: 'TimeSeriesAmountWithCountNode',
   fields: () => ({
     date: { type: new GraphQLNonNull(GraphQLDateTime) },
@@ -21,7 +21,7 @@ export const TimeSeriesAmountWithCount = new GraphQLObjectType({
   fields: () => ({
     ...getTimeSeriesFields(),
     nodes: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TimeSeriesAmountCountNodes))),
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TimeSeriesAmountWithCountNodes))),
       description: 'Time series data points',
     },
   }),

--- a/server/graphql/v2/object/TimeSeriesCount.ts
+++ b/server/graphql/v2/object/TimeSeriesCount.ts
@@ -1,0 +1,25 @@
+import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+
+import { getTimeSeriesFields, TimeSeries } from '../interface/TimeSeries';
+
+const TimeSeriesCountNode = new GraphQLObjectType({
+  name: 'TimeSeriesCountNode',
+  fields: () => ({
+    date: { type: new GraphQLNonNull(GraphQLDateTime) },
+    count: { type: new GraphQLNonNull(GraphQLInt) },
+  }),
+});
+
+export const TimeSeriesCount = new GraphQLObjectType({
+  name: 'TimeSeriesCount',
+  description: 'Count time series',
+  interfaces: [TimeSeries],
+  fields: () => ({
+    ...getTimeSeriesFields(),
+    nodes: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TimeSeriesCountNode))),
+      description: 'Time series data points',
+    },
+  }),
+});

--- a/server/lib/host-metrics.js
+++ b/server/lib/host-metrics.js
@@ -480,10 +480,46 @@ GROUP BY t1."hostCurrency"`,
 }
 
 /**
+ * Returns transaction amounts over time
+ * Ex: [ { date: '2020-01-01', amount: 2000 }, { date: '2021-01-01', amount: 1000 }, ... ]
+ */
+export const getTransactionsTimeSeries = async (
+  hostCollectiveId,
+  timeUnit,
+  { type = null, kind = null, collectiveIds = null, dateFrom = null, dateTo = null } = {},
+) => {
+  return sequelize.query(
+    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", sum("amountInHostCurrency") as "amount", "hostCurrency" as "currency"
+       FROM "Transactions"
+       WHERE "HostCollectiveId" = :hostCollectiveId
+         AND "deletedAt" IS NULL
+         ${type ? `AND "type" = :type` : ``}
+         ${kind?.length ? `AND "kind" IN (:kind)` : ``}
+         ${collectiveIds?.length ? `AND "CollectiveId" IN (:collectiveIds)` : ``}
+         ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
+         ${dateTo ? `AND "createdAt" <= :endDate` : ``}
+       GROUP BY DATE_TRUNC(:timeUnit, "createdAt"), "hostCurrency"
+       ORDER BY DATE_TRUNC(:timeUnit, "createdAt"),
+      `,
+    {
+      type: sequelize.QueryTypes.SELECT,
+      replacements: {
+        kind: Array.isArray(kind) ? kind : [kind],
+        type,
+        hostCollectiveId,
+        timeUnit,
+        collectiveIds,
+        ...computeDatesAsISOStrings(dateFrom, dateTo),
+      },
+    },
+  );
+};
+
+/**
  * Returns transaction amounts over time, grouped by kind.
  * Ex: [ { date: '2020-01-01', amount: 1000, kind: 'CONTRIBUTION' }, { date: '2020-01-01', amount: 1000, kind: 'ADDED_FUNDS' }, ... ]
  */
-export const getTransactionsTimeSeries = async (
+export const getTransactionsTimeSeriesByKind = async (
   hostCollectiveId,
   timeUnit,
   { type = null, kind = null, collectiveIds = null, dateFrom = null, dateTo = null } = {},

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -1134,7 +1134,7 @@ const getTransactionsTimeSeries = async (
   { collectiveIds = [], type = null, kind = null, dateFrom = null, dateTo = null } = {},
 ) => {
   return sequelize.query(
-    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", sum("amountInHostCurrency") as "amount", "hostCurrency" as "currency"
+    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", sum("amountInHostCurrency") as "amount", "hostCurrency" as "currency", count("id") as "count"
          FROM "Transactions"
          WHERE "deletedAt" IS NULL
            AND "CollectiveId" IN (:collectiveIds)
@@ -1143,38 +1143,6 @@ const getTransactionsTimeSeries = async (
            ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
            ${dateTo ? `AND "createdAt" <= :endDate` : ``}
          GROUP BY DATE_TRUNC(:timeUnit, "createdAt"), "hostCurrency"
-         ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
-        `,
-    {
-      type: sequelize.QueryTypes.SELECT,
-      replacements: {
-        kind: Array.isArray(kind) ? kind : [kind],
-        type,
-        timeUnit,
-        collectiveIds,
-        ...computeDatesAsISOStrings(dateFrom, dateTo),
-      },
-    },
-  );
-};
-
-/**
- * Returns the count of transactions over time.
- */
-const getTransactionsCountTimeSeries = async (
-  timeUnit,
-  { collectiveIds = [], type = null, kind = null, dateFrom = null, dateTo = null } = {},
-) => {
-  return sequelize.query(
-    `SELECT DATE_TRUNC(:timeUnit, "createdAt") AS "date", count("id") as "count"
-         FROM "Transactions"
-         WHERE "deletedAt" IS NULL
-           AND "CollectiveId" IN (:collectiveIds)
-           ${type ? `AND "type" = :type` : ``}
-           ${kind?.length ? `AND "kind" IN (:kind)` : ``}
-           ${dateFrom ? `AND "createdAt" >= :startDate` : ``}
-           ${dateTo ? `AND "createdAt" <= :endDate` : ``}
-         GROUP BY DATE_TRUNC(:timeUnit, "createdAt")
          ORDER BY DATE_TRUNC(:timeUnit, "createdAt")
         `,
     {
@@ -1234,7 +1202,6 @@ const queries = {
   getUniqueCollectiveTags,
   getGiftCardBatchesForCollective,
   getTransactionsTimeSeries,
-  getTransactionsCountTimeSeries,
 };
 
 export default queries;


### PR DESCRIPTION
This is adding a `AccountCollectionStats` field to `AccountCollection` under `stats`, so that you can query for time series information for the particular set of accounts that you have filtered out:

```graphql
query SearchAccounts($dateFrom: DateTime, $dateTo: DateTime) {
  accounts(type: [COLLECTIVE], tag: ["civic tech"], limit: 100) {
    totalCount
    nodes {
      id
      slug
    }
    stats(
      dateFrom: $dateFrom
      dateTo: $dateTo
      timeUnit: YEAR
      includeChildren: true
    ) {
      timeUnit
      contributionsCountTimeSeries {
        nodes {
          date
          count
        }
      }
      totalReceivedTimeSeries {
        nodes {
          date
          amount {
            value
            currency
          }
        }
      }
    }
  }
}
```

Current implementation is that it will only query stats for the collectives that are within the limit.

Since account collection is not limited to a single host I added a new query to get transaction time series for any set of CollectiveIds. Also adding a query for getting transactions **count** time series data.

Did some reorganization to be able to put the new queries in `lib/queries.js`, commented below.