### PR TITLE
Ability to fetch submitted expenses for user

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -287,6 +287,7 @@ type UserDetails {
   """
   isLimited: Boolean
   hasSeenLatestChangelogEntry: Boolean!
+  hasTwoFactorAuth: Boolean
 }
 
 """
@@ -1168,6 +1169,7 @@ type PlanType {
 
 type Policies {
   EXPENSE_AUTHOR_CANNOT_APPROVE: Boolean
+  REQUIRE_2FA_FOR_ADMINS: Boolean
   COLLECTIVE_MINIMUM_ADMINS: COLLECTIVE_MINIMUM_ADMINS
   MAXIMUM_VIRTUAL_CARD_LIMIT_AMOUNT_FOR_INTERVAL: MAXIMUM_VIRTUAL_CARD_LIMIT_AMOUNT_FOR_INTERVAL
 }

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -1210,6 +1210,11 @@ enum ExpenseCurrencySource {
   The expense currency expressed as the expense currency
   """
   EXPENSE
+
+  """
+  The expense currency expressed as the expense currency
+  """
+  CREATED_BY_ACCOUNT
 }
 
 """
@@ -8829,7 +8834,7 @@ type Query {
     """
     Return expenses only created by this INDIVIDUAL account
     """
-    createdBy: AccountReferenceInput
+    createdByAccount: AccountReferenceInput
 
     """
     Use this field to filter expenses on their statuses

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -8822,14 +8822,14 @@ type Query {
     account: AccountReferenceInput
 
     """
-    If `account` is an individual and this param is true, the query will return submitted expenses
-    """
-    returnSubmittedIfIndividual: Boolean
-
-    """
     Return expenses only for this host
     """
     host: AccountReferenceInput
+
+    """
+    Return expenses only created by this INDIVIDUAL account
+    """
+    createdBy: AccountReferenceInput
 
     """
     Use this field to filter expenses on their statuses

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -8622,6 +8622,11 @@ type Query {
     tag: [String]
 
     """
+    Host hosting the account
+    """
+    host: [AccountReferenceInput]
+
+    """
     Only return accounts that match these account types (COLLECTIVE, FUND, EVENT, PROJECT, ORGANIZATION or INDIVIDUAL)
     """
     type: [AccountType]
@@ -8815,6 +8820,11 @@ type Query {
     Reference of an account that is the payer of an expense
     """
     account: AccountReferenceInput
+
+    """
+    If `account` is an individual and this param is true, the query will return submitted expenses
+    """
+    returnSubmittedIfIndividual: Boolean
 
     """
     Return expenses only for this host

--- a/server/graphql/v2/enum/ExpenseCurrencySource.ts
+++ b/server/graphql/v2/enum/ExpenseCurrencySource.ts
@@ -13,5 +13,8 @@ export const ExpenseCurrencySource = new GraphQLEnumType({
     EXPENSE: {
       description: 'The expense currency expressed as the expense currency',
     },
+    CREATED_BY_ACCOUNT: {
+      description: 'The expense currency expressed as the expense currency',
+    },
   },
 });

--- a/server/graphql/v2/object/Expense.js
+++ b/server/graphql/v2/object/Expense.js
@@ -98,6 +98,13 @@ const Expense = new GraphQLObjectType({
           } else if (args.currencySource === 'HOST') {
             const host = await loadHostForExpense(expense, req);
             currency = host?.currency;
+          } else if (args.currencySource === 'CREATED_BY_ACCOUNT') {
+            expense.User = expense.User || (await req.loaders.User.byId.load(expense.UserId));
+            if (expense.User) {
+              expense.User.collective =
+                expense.User.collective || (await req.loaders.Collective.byId.load(expense.User.CollectiveId));
+              currency = expense.User?.collective?.currency || 'USD';
+            }
           }
 
           // Return null if the currency can't be looked up (e.g. asking for the host currency when the collective has no fiscal host)

--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -205,6 +205,7 @@ export const collectiveSlugReservedList = [
   'events',
   'expense',
   'expenses',
+  'submitted-expenses',
   'faq',
   'fund',
   'gift-card',

--- a/test/server/graphql/v2/collection/ExpenseCollectionQuery.test.ts
+++ b/test/server/graphql/v2/collection/ExpenseCollectionQuery.test.ts
@@ -88,12 +88,12 @@ describe('server/graphql/v2/collection/ExpenseCollection', () => {
 
     const expenseQuery = gqlV2/* GraphQL */ `
       query Expenses(
-        $createdBy: AccountReferenceInput
+        $createdByAccount: AccountReferenceInput
         $account: AccountReferenceInput
         $host: AccountReferenceInput
         $fromAccount: AccountReferenceInput
       ) {
-        expenses(createdByAccount: $createdBy, account: $account, host: $host, fromAccount: $fromAccount) {
+        expenses(createdByAccount: $createdByAccount, account: $account, host: $host, fromAccount: $fromAccount) {
           nodes {
             id
             legacyId

--- a/test/server/graphql/v2/collection/ExpenseCollectionQuery.test.ts
+++ b/test/server/graphql/v2/collection/ExpenseCollectionQuery.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import gqlV2 from 'fake-tag';
-import { differenceBy } from 'lodash';
+import { differenceBy, times } from 'lodash';
 import { createSandbox } from 'sinon';
 
 import { US_TAX_FORM_THRESHOLD } from '../../../../../server/constants/tax-form';
@@ -80,6 +80,48 @@ describe('server/graphql/v2/collection/ExpenseCollection', () => {
 
       result = await graphqlQueryV2(expensesQuery, { ...queryParams, status: 'REJECTED' });
       expect(result.data.expenses.totalCount).to.eq(1);
+    });
+  });
+
+  describe('Filter by accounts', async () => {
+    let expenses;
+
+    const expenseQuery = gqlV2/* GraphQL */ `
+      query Expenses(
+        $createdBy: AccountReferenceInput
+        $account: AccountReferenceInput
+        $host: AccountReferenceInput
+        $fromAccount: AccountReferenceInput
+      ) {
+        expenses(createdByAccount: $createdBy, account: $account, host: $host, fromAccount: $fromAccount) {
+          nodes {
+            id
+            legacyId
+            account {
+              legacyId
+            }
+            payee {
+              legacyId
+            }
+            createdByAccount {
+              legacyId
+            }
+          }
+        }
+      }
+    `;
+
+    before(async () => {
+      expenses = await Promise.all(times(3, () => fakeExpense()));
+    });
+
+    it('with createdByAccount', async () => {
+      const result = await graphqlQueryV2(expenseQuery, {
+        createdByAccount: { legacyId: expenses[0].fromCollective.id },
+      });
+      expect(result.errors).to.not.exist;
+      expect(result.data.expenses.nodes.length).to.eq(1);
+      expect(result.data.expenses.nodes[0].legacyId).to.eq(expenses[0].id);
     });
   });
 
@@ -203,9 +245,13 @@ describe('server/graphql/v2/collection/ExpenseCollection', () => {
       expect(result.errors).to.not.exist;
       expect(result.data.expenses.totalCount).to.eq(expensesReadyToPay.length);
 
-      const missingExpenses = differenceBy(expensesReadyToPay, result.data.expenses.nodes, e => e.legacyId || e.id);
+      const missingExpenses = differenceBy(
+        expensesReadyToPay,
+        result.data.expenses.nodes,
+        e => e['legacyId'] || e['id'],
+      );
       if (missingExpenses.length) {
-        throw new Error(`Missing expenses: ${missingExpenses.map(e => JSON.stringify(e.info))}`);
+        throw new Error(`Missing expenses: ${missingExpenses.map(e => JSON.stringify(e['info']))}`);
       }
     });
   });

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -341,6 +341,7 @@ export const fakeExpense = async (expenseData: Record<string, unknown> = {}) => 
   }
 
   expense.User = await models.User.findByPk(expense.UserId);
+  expense.fromCollective = await models.Collective.findByPk(expense.FromCollectiveId);
   expense.collective = await models.Collective.findByPk(expense.CollectiveId, {
     include: [{ association: 'host' }],
   });


### PR DESCRIPTION
- Introduce a `createdByUserAccount` argument on `expenses`. As proposed by @kewitz, we could further refactor this to have a direct `individual.submittedExpenses` field in the future. Not doing this now as it can be done later as a non-breaking change.
- Add a new `CREATED_BY_ACCOUNT` option for  `currencySource`. This allows us to fetch all amounts to display in the user's currency.