### PR TITLE
Make TagStats amount nullable

### DIFF
--- a/server/graphql/v2/object/TagStats.js
+++ b/server/graphql/v2/object/TagStats.js
@@ -19,7 +19,7 @@ export const TagStats = new GraphQLObjectType({
       description: 'Number of entries for this tag',
     },
     amount: {
-      type: new GraphQLNonNull(Amount),
+      type: Amount,
       description: 'Total amount for this tag',
       resolve(entry) {
         if (entry.amount) {


### PR DESCRIPTION
Resolve https://sentry.io/organizations/open-collective/issues/3730198773

The field was introduced in https://github.com/opencollective/opencollective-api/pull/7853 as non-nullable, but we don't set any `amount` in many places where we return a `TagStats`.