### PR TITLE
Improve associations deletion in Ban Accounts

### DIFF
--- a/migrations/20221118092410-remove-deleted-associations.js
+++ b/migrations/20221118092410-remove-deleted-associations.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    const [result] = await queryInterface.sequelize.query(
+      `
+      WITH deleted_expenses AS (
+        UPDATE "Expenses" e
+        SET "deletedAt" = NOW()
+        FROM "Collectives" c
+        WHERE e."deletedAt" IS NULL
+        AND c."deletedAt" IS NOT NULL
+        AND (e."CollectiveId" = c.id OR e."FromCollectiveId" = c.id)
+        RETURNING e.id
+      ), deleted_comments AS (
+        UPDATE "Comments" comment
+        SET "deletedAt" = NOW()
+        FROM "Collectives" c
+        WHERE comment."deletedAt" IS NULL
+        AND c."deletedAt" IS NOT NULL
+        AND (comment."CollectiveId" = c.id OR comment."FromCollectiveId" = c.id)
+        RETURNING comment.id
+      ), deleted_applications AS (
+        UPDATE "Applications" app
+        SET "deletedAt" = NOW()
+        FROM "Collectives" c
+        WHERE app."deletedAt" IS NULL
+        AND c."deletedAt" IS NOT NULL
+        AND app."CollectiveId" = c.id
+        RETURNING app.id
+      ) SELECT
+        (SELECT ARRAY_AGG(DISTINCT id) FROM deleted_expenses) AS "deletedExpenses",
+        (SELECT ARRAY_AGG(DISTINCT id) FROM deleted_comments) AS "deletedComments",
+        (SELECT ARRAY_AGG(DISTINCT id) FROM deleted_applications) AS "deletedApplications"
+    `,
+      {
+        type: queryInterface.sequelize.QueryTypes.SELECT,
+      },
+    );
+
+    await queryInterface.sequelize.query(
+      `
+      INSERT INTO "MigrationLogs"
+      ("createdAt", "type", "description", "CreatedByUserId", "data")
+      VALUES (NOW(), 'MIGRATION', 'Remove deleted associations', NULL, :data)
+    `,
+      {
+        replacements: { data: JSON.stringify(result) },
+        type: queryInterface.sequelize.QueryTypes.INSERT,
+      },
+    );
+  },
+
+  async down() {
+    console.log('Rollback must be done manually by looking at the MigrationLogs entry');
+  },
+};

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -369,7 +369,7 @@ export const fakeComment = async (commentData: Record<string, unknown> = {}, seq
     ExpenseId = (await fakeExpense()).id;
   }
 
-  return models.Comment.create(
+  const comment = await models.Comment.create(
     {
       html: '<div><strong>Hello</strong> Test comment!</div>',
       ...commentData,
@@ -381,6 +381,10 @@ export const fakeComment = async (commentData: Record<string, unknown> = {}, seq
     },
     sequelizeParams,
   );
+
+  comment.fromCollective = await models.Collective.findByPk(FromCollectiveId);
+  comment.collective = await models.Collective.findByPk(CollectiveId);
+  return comment;
 };
 
 /**


### PR DESCRIPTION
Resolve cases like https://sentry.io/organizations/open-collective/issues/3728229596/

In some cases, we were missing the deletion of associations when banning collectives. The problem was with queries like:

```sql
UPDATE "Comments"
SET "deletedAt" = NULL
FROM deleted_profiles, deleted_conversations
```

If `deleted_conversations` was null (aka no conversation deleted) then the entire update for comments was canceled. To prevent that, these queries have been updated to something like:

```sql
UPDATE "Comments"
SET "deletedAt" = NULL
WHERE id IN (
    SELECT id FROM "Comments" WHERE "CollectiveId" IN (SELECT id FROM deleted_profiles)
    UNION DISTINCT SELECT id FROM "Comments" WHERE "ConversationId" IN (SELECT id FROM deleted_conversations)
)
```

Also:
- Added unit tests for some of these cases
- Added a migration to delete zombies