### PR TITLE
Change permissions for MEMBER role on `createOder`

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -368,21 +368,13 @@ export async function createOrder(order, req) {
         throw new FeatureNotSupportedForCollective();
       }
 
-      const possibleRoles = [];
-      if (fromCollective.type === types.ORGANIZATION) {
-        possibleRoles.push(roles.MEMBER);
-      }
-
-      if (!remoteUser?.isAdminOfCollective(fromCollective) && !remoteUser?.hasRole(possibleRoles, fromCollective.id)) {
+      if (!remoteUser?.isAdminOfCollective(fromCollective) && !remoteUser?.isAdminOfCollective(host)) {
         // We only allow to add funds on behalf of a collective if the user is an admin of that collective or an admin of the host of the collective that receives the money
-        const HostId = await collective.getHostCollectiveId();
-        if (!remoteUser?.isAdmin(HostId)) {
-          throw new Error(
-            `You don't have sufficient permissions to create an order on behalf of the ${
-              fromCollective.name
-            } ${fromCollective.type.toLowerCase()}`,
-          );
-        }
+        throw new Error(
+          `You don't have sufficient permissions to create an order on behalf of the ${
+            fromCollective.name
+          } ${fromCollective.type.toLowerCase()}`,
+        );
       }
     }
 

--- a/server/models/PaymentMethod.js
+++ b/server/models/PaymentMethod.js
@@ -408,7 +408,7 @@ PaymentMethod.prototype.getBalanceForUser = async function (user) {
 
   // Independently of the balance of the external source, the owner of the payment method
   // may have set up a monthlyLimitPerMember or an initialBalance
-  if (!this.initialBalance && (!this.monthlyLimitPerMember || (user && user.isAdmin(this.CollectiveId)))) {
+  if (!this.initialBalance && !this.monthlyLimitPerMember) {
     return { amount: balanceAmount, currency: this.currency };
   }
 

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -729,7 +729,7 @@ describe('server/graphql/v1/createOrder', () => {
     await models.Member.create({
       CollectiveId: newco.id,
       MemberCollectiveId: duc.CollectiveId,
-      role: 'MEMBER',
+      role: 'ADMIN',
       CreatedByUserId: duc.id,
     });
 


### PR DESCRIPTION
Removes the historical ability for `MEMBER` role to create orders using the payment method of the shared account. This was not documented and, according to the query below, never used.

```sql
select * from "Orders" o
INNER JOIN "Users" u ON o."CreatedByUserId" = u.id
INNER JOIN "Members" m ON m."MemberCollectiveId" = u."CollectiveId" AND m."CollectiveId" = o."FromCollectiveId" AND m.role = 'MEMBER'
LEFT JOIN "Members" admin ON m."MemberCollectiveId" = u."CollectiveId" AND m."CollectiveId" = o."FromCollectiveId" AND admin.role = 'ADMIN'
WHERE admin.id IS NULL
ORDER BY o."createdAt" DESC
```