### PR TITLE
Stop relying on pm.creditCardInfo, 

### DIFF
--- a/server/graphql/v2/input/CreditCardCreateInput.ts
+++ b/server/graphql/v2/input/CreditCardCreateInput.ts
@@ -4,12 +4,12 @@ export const CreditCardCreateInput = new GraphQLInputObjectType({
   name: 'CreditCardCreateInput',
   fields: () => ({
     token: { type: new GraphQLNonNull(GraphQLString) },
-    brand: { type: new GraphQLNonNull(GraphQLString) },
-    country: { type: new GraphQLNonNull(GraphQLString) },
-    expMonth: { type: new GraphQLNonNull(GraphQLInt) },
-    expYear: { type: new GraphQLNonNull(GraphQLInt) },
-    fullName: { type: GraphQLString },
-    funding: { type: GraphQLString },
+    brand: { type: GraphQLString, deprecationReason: '2022-11-22: the `token` parameter is sufficient' },
+    country: { type: GraphQLString, deprecationReason: '2022-11-22: the `token` parameter is sufficient' },
+    expMonth: { type: GraphQLInt, deprecationReason: '2022-11-22: the `token` parameter is sufficient' },
+    expYear: { type: GraphQLInt, deprecationReason: '2022-11-22: the `token` parameter is sufficient' },
+    fullName: { type: GraphQLString, deprecationReason: '2022-11-22: the field was not used since 2017' },
+    funding: { type: GraphQLString, deprecationReason: '2022-11-22: the `token` parameter is sufficient' },
     zip: { type: GraphQLString },
   }),
 });


### PR DESCRIPTION
Only token should be looked at. This is simpler for the implementer and more solid.

Make brand, country, expMonth, expYear optional. Should actually be deprecated?