### PR TITLE
Check `approvedAt` for host (instead of `isActive`)

### DIFF
--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -91,7 +91,7 @@ export const loaders = req => {
   );
 
   context.loaders.Collective.host = buildLoaderForAssociation(models.Collective, 'host', {
-    filter: collective => collective.isActive,
+    filter: collective => Boolean(collective.approvedAt),
     loader: hostIds => context.loaders.Collective.byId.loadMany(hostIds),
   });
 


### PR DESCRIPTION
Should resolve https://opencollective.slack.com/archives/GFH4N961L/p1669052831511419, https://sentry.io/organizations/open-collective/issues/3643173997/, https://sentry.io/organizations/open-collective/issues/3643174148

