### PR TITLE
Add stripe customer payment method

### DIFF
--- a/server/constants/connected_account.ts
+++ b/server/constants/connected_account.ts
@@ -1,6 +1,7 @@
 export enum Service {
   PAYPAL = 'paypal',
   STRIPE = 'stripe',
+  STRIPE_CUSTOMER = 'stripe_customer',
   GITHUB = 'github',
   TWITTER = 'twitter',
   TRANSFERWISE = 'transferwise',

--- a/server/constants/paymentMethods.ts
+++ b/server/constants/paymentMethods.ts
@@ -21,6 +21,8 @@ export enum PAYMENT_METHOD_TYPE {
   MANUAL = 'manual',
   CRYPTO = 'crypto',
   PAYMENT_INTENT = 'paymentintent',
+  US_BANK_ACCOUNT = 'us_bank_account',
+  SEPA_DEBIT = 'sepa_debit',
 }
 
 export const PAYMENT_METHOD_TYPES = Object.values(PAYMENT_METHOD_TYPE);

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -226,7 +226,7 @@ const hasPaymentMethod = order => {
         paymentMethod.token ||
         paymentMethod.type === 'manual' ||
         paymentMethod.type === 'crypto' ||
-        paymentMethod.type === 'paymentintent' ||
+        paymentMethod.type === PAYMENT_METHOD_TYPE.PAYMENT_INTENT ||
         paymentMethod.type === PAYMENT_METHOD_TYPE.US_BANK_ACCOUNT ||
         paymentMethod.type === PAYMENT_METHOD_TYPE.SEPA_DEBIT,
     );

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -226,7 +226,9 @@ const hasPaymentMethod = order => {
         paymentMethod.token ||
         paymentMethod.type === 'manual' ||
         paymentMethod.type === 'crypto' ||
-        paymentMethod.type === 'paymentintent',
+        paymentMethod.type === 'paymentintent' ||
+        paymentMethod.type === PAYMENT_METHOD_TYPE.US_BANK_ACCOUNT ||
+        paymentMethod.type === PAYMENT_METHOD_TYPE.SEPA_DEBIT,
     );
   }
 };

--- a/server/graphql/v2/enum/PaymentMethodLegacyType.ts
+++ b/server/graphql/v2/enum/PaymentMethodLegacyType.ts
@@ -15,6 +15,8 @@ export enum PaymentMethodLegacyTypeEnum {
   ADDED_FUNDS = 'ADDED_FUNDS',
   CRYPTO = 'CRYPTO',
   PAYMENT_INTENT = 'PAYMENT_INTENT',
+  US_BANK_ACCOUNT = 'US_BANK_ACCOUNT',
+  SEPA_DEBIT = 'SEPA_DEBIT',
 }
 
 export const PaymentMethodLegacyType = new GraphQLEnumType({
@@ -31,6 +33,10 @@ export const getLegacyPaymentMethodType = ({ service, type }: PaymentMethod): Pa
   if (service === PAYMENT_METHOD_SERVICE.STRIPE) {
     if (type === PAYMENT_METHOD_TYPE.CREDITCARD) {
       return PaymentMethodLegacyTypeEnum.CREDIT_CARD;
+    } else if (type === PAYMENT_METHOD_TYPE.US_BANK_ACCOUNT) {
+      return PaymentMethodLegacyTypeEnum.US_BANK_ACCOUNT;
+    } else if (type === PAYMENT_METHOD_TYPE.SEPA_DEBIT) {
+      return PaymentMethodLegacyTypeEnum.SEPA_DEBIT;
     }
   } else if (service === PAYMENT_METHOD_SERVICE.OPENCOLLECTIVE) {
     if (type === PAYMENT_METHOD_TYPE.GIFTCARD) {

--- a/server/graphql/v2/input/PaymentMethodInput.ts
+++ b/server/graphql/v2/input/PaymentMethodInput.ts
@@ -124,7 +124,7 @@ export const getLegacyPaymentMethodFromPaymentMethodInput = async (
       };
     }
   } else if (pm.paymentIntentId) {
-    return { service: pm.service, type: pm.newType, paymentIntentId: pm.paymentIntentId };
+    return { service: pm.service, type: pm.newType, paymentIntentId: pm.paymentIntentId, save: pm.isSavedForLater };
   } else if (pm.legacyType) {
     return getServiceTypeFromLegacyPaymentMethodType(pm.legacyType);
   } else if (pm.service && pm.newType) {

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -684,19 +684,19 @@ const orderMutations = {
           },
         });
 
-        const customer = await stripe.customers.create(
-          {
-            email: req.remoteUser.email,
-            description: `${config.host.website}/${fromAccount.slug}`,
-          },
-          !isPlatformHost
-            ? {
-                stripeAccount: hostStripeAccount.username,
-              }
-            : undefined,
-        );
-
         if (!pm) {
+          const customer = await stripe.customers.create(
+            {
+              email: req.remoteUser.email,
+              description: `${config.host.website}/${fromAccount.slug}`,
+            },
+            !isPlatformHost
+              ? {
+                  stripeAccount: hostStripeAccount.username,
+                }
+              : undefined,
+          );
+
           pm = await models.PaymentMethod.create({
             customerId: customer.id,
             CreatedByUserId: req.remoteUser.id,

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -716,8 +716,6 @@ const orderMutations = {
         const paymentIntent = await stripe.paymentIntents.create(
           {
             customer: stripeCustomerId,
-            // eslint-disable-next-line camelcase
-            setup_future_usage: 'off_session',
             description: `Contribution to ${toAccount.name}`,
             amount: convertToStripeAmount(currency, totalOrderAmount),
             currency: paymentIntentInput.amount.currency.toLowerCase(),

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -120,7 +120,7 @@ export const PaymentMethod = new GraphQLObjectType({
           }
 
           if (paymentMethod.service === PAYMENT_METHOD_SERVICE.STRIPE) {
-            allowedFields.push('stripeAccount', 'paymentMethodId');
+            allowedFields.push('stripeAccount', 'stripePaymentMethodId');
           }
 
           return pick(paymentMethod.data, allowedFields);

--- a/server/graphql/v2/object/PaymentMethod.js
+++ b/server/graphql/v2/object/PaymentMethod.js
@@ -119,6 +119,10 @@ export const PaymentMethod = new GraphQLObjectType({
             allowedFields = ['depositAddress'];
           }
 
+          if (paymentMethod.service === PAYMENT_METHOD_SERVICE.STRIPE) {
+            allowedFields.push('stripeAccount', 'paymentMethodId');
+          }
+
           return pick(paymentMethod.data, allowedFields);
         },
       },

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -141,7 +141,7 @@ export async function processOrderWithSubscription(order, options) {
         }
         order.status = status.ACTIVE;
         // TODO: we should consolidate on error and remove latestError
-        order.data = omit(order.data, ['error', 'latestError', 'paymentIntent']);
+        order.data = omit(order.data, ['error', 'latestError']);
       }
     }
   } else if (options.simulate) {

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -34,6 +34,7 @@ import { isISO31661Alpha2 } from 'validator';
 
 import activities from '../constants/activities';
 import { CollectiveTypesList, types } from '../constants/collectives';
+import { Service } from '../constants/connected_account';
 import expenseStatus from '../constants/expense_status';
 import expenseTypes from '../constants/expense_type';
 import FEATURE from '../constants/feature';
@@ -3034,6 +3035,17 @@ Collective.prototype.getHostCollectiveId = function () {
   return models.Collective.getHostCollectiveId(this.ParentCollectiveId || this.id).then(HostCollectiveId => {
     this.HostCollectiveId = HostCollectiveId;
     return HostCollectiveId;
+  });
+};
+
+Collective.prototype.getCustomerStripeAccount = function (hostStripeAccount, sequelizeOptions = {}) {
+  return models.ConnectedAccount.findOne({
+    where: {
+      clientId: hostStripeAccount,
+      CollectiveId: this.id,
+      service: Service.STRIPE_CUSTOMER,
+    },
+    ...sequelizeOptions,
   });
 };
 

--- a/server/paymentProviders/stripe/index.js
+++ b/server/paymentProviders/stripe/index.js
@@ -53,6 +53,10 @@ export default {
     default: creditcard,
     creditcard,
     paymentintent,
+    // eslint-disable-next-line camelcase
+    us_bank_account: paymentintent,
+    // eslint-disable-next-line camelcase
+    sepa_debit: paymentintent,
   },
 
   oauth: {

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -5,21 +5,12 @@ import type Stripe from 'stripe';
 import OrderStatuses from '../../constants/order_status';
 import logger from '../../lib/logger';
 import { getApplicationFee } from '../../lib/payments';
-import { reportMessageToSentry } from '../../lib/sentry';
 import stripe, { convertToStripeAmount } from '../../lib/stripe';
 import models from '../../models';
 
 import { APPLICATION_FEE_INCOMPATIBLE_CURRENCIES, refundTransaction, refundTransactionOnlyInDatabase } from './common';
 
 const processOrder = async (order: typeof models.Order): Promise<void> => {
-  if (order.SubscriptionId) {
-    return processRecurringOrder(order);
-  }
-
-  return processNewOrder(order);
-};
-
-async function processNewOrder(order: typeof models.Order) {
   const hostStripeAccount = await order.collective.getHostStripeAccount();
   const host = await order.collective.getHostCollective();
   const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
@@ -52,73 +43,9 @@ async function processNewOrder(order: typeof models.Order) {
   }
 }
 
-async function processRecurringOrder(order: typeof models.Order) {
-  const hostStripeAccount = await order.collective.getHostStripeAccount();
-  const host = await order.collective.getHostCollective();
-  const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
-    ? false
-    : host?.settings?.isPlatformRevenueDirectlyCollected ?? true;
-  const applicationFee = await getApplicationFee(order, host);
-  const paymentIntentParams: Stripe.PaymentIntentCreateParams = {
-    currency: order.currency,
-    amount: convertToStripeAmount(order.currency, order.totalAmount),
-    description: order.description,
-  };
-
-  if (applicationFee && isPlatformRevenueDirectlyCollected && hostStripeAccount.username !== config.stripe.accountId) {
-    // eslint-disable-next-line camelcase
-    paymentIntentParams.application_fee_amount = convertToStripeAmount(order.currency, applicationFee);
-  }
-
-  // eslint-disable-next-line camelcase
-  paymentIntentParams.payment_method_types = [order.paymentMethod?.type];
-  // eslint-disable-next-line camelcase
-  paymentIntentParams.payment_method = order.paymentMethod?.data?.stripePaymentMethodId;
-  paymentIntentParams.customer = order?.paymentMethod?.customerId;
-  paymentIntentParams.metadata = {
-    from: order.fromCollective ? `${config.host.website}/${order.fromCollective.slug}` : undefined,
-    to: `${config.host.website}/${order.collective.slug}`,
-    orderId: order.id,
-    chargeNumber: order.Subscription.chargeNumber,
-    chargeRetryCount: order.Subscription.chargeRetryCount,
-  };
-
-  try {
-    let paymentIntent = await stripe.paymentIntents.create(paymentIntentParams, {
-      stripeAccount: hostStripeAccount.username,
-    });
-
-    order.update({ data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } } });
-    await order.save();
-
-    paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
-      stripeAccount: hostStripeAccount.username,
-    });
-
-    order.data = { ...order.data, paymentIntent };
-    order.update({ data: { ...order.data, paymentIntent } });
-    await order.save();
-
-    if (paymentIntent.status === 'processing') {
-      return;
-    } else if (paymentIntent.status !== 'succeeded') {
-      logger.error('Unknown error with Stripe Payment Intent.');
-      logger.error(paymentIntent);
-      reportMessageToSentry('Unknown error with Stripe Payment Intent', { extra: { paymentIntent } });
-      throw new Error('Something went wrong with the payment, please contact support@opencollective.com.');
-    }
-  } catch (e) {
-    const sanitizedError = pick(e, ['code', 'message', 'requestId', 'statusCode']);
-    const errorMessage = `Error processing Stripe Payment Intent: ${e.message}`;
-    logger.error(errorMessage, sanitizedError);
-    // Hard-delete the order so we can re-use the existing Payment Intent in the next attempt.
-    throw new Error(errorMessage);
-  }
-}
-
 export default {
   features: {
-    recurring: true,
+    recurring: false,
     waitToCharge: false,
   },
   processOrder,

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -28,6 +28,11 @@ const processOrder = async (order: typeof models.Order): Promise<void> => {
     paymentIntentParams.application_fee_amount = convertToStripeAmount(order.currency, applicationFee);
   }
 
+  if (order.data?.savePaymentMethod) {
+    // eslint-disable-next-line camelcase
+    paymentIntentParams.setup_future_usage = 'off_session';
+  }
+
   try {
     const paymentIntent = await stripe.paymentIntents.update(order.data.paymentIntent.id, paymentIntentParams, {
       stripeAccount: hostStripeAccount.username,
@@ -41,7 +46,7 @@ const processOrder = async (order: typeof models.Order): Promise<void> => {
     await order.destroy({ force: true });
     throw new Error(errorMessage);
   }
-}
+};
 
 export default {
   features: {

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -5,12 +5,18 @@ import type Stripe from 'stripe';
 import OrderStatuses from '../../constants/order_status';
 import logger from '../../lib/logger';
 import { getApplicationFee } from '../../lib/payments';
+import { reportMessageToSentry } from '../../lib/sentry';
 import stripe, { convertToStripeAmount } from '../../lib/stripe';
 import models from '../../models';
 
-import { APPLICATION_FEE_INCOMPATIBLE_CURRENCIES, refundTransaction, refundTransactionOnlyInDatabase } from './common';
+import {
+  APPLICATION_FEE_INCOMPATIBLE_CURRENCIES,
+  createChargeTransactions,
+  refundTransaction,
+  refundTransactionOnlyInDatabase,
+} from './common';
 
-const processOrder = async (order: typeof models.Order): Promise<void> => {
+async function processNewOrder(order: typeof models.Order) {
   const hostStripeAccount = await order.collective.getHostStripeAccount();
   const host = await order.collective.getHostCollective();
   const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
@@ -41,11 +47,94 @@ const processOrder = async (order: typeof models.Order): Promise<void> => {
     await order.destroy({ force: true });
     throw new Error(errorMessage);
   }
+}
+
+async function processRecurringOrder(order: typeof models.Order) {
+  const hostStripeAccount = await order.collective.getHostStripeAccount();
+  const host = await order.collective.getHostCollective();
+  const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
+    ? false
+    : host?.settings?.isPlatformRevenueDirectlyCollected ?? true;
+  const applicationFee = await getApplicationFee(order, host);
+  const paymentIntentParams: Stripe.PaymentIntentCreateParams = {
+    currency: order.currency,
+    amount: convertToStripeAmount(order.currency, order.totalAmount),
+    description: order.description,
+  };
+
+  if (applicationFee && isPlatformRevenueDirectlyCollected && hostStripeAccount.username !== config.stripe.accountId) {
+    // eslint-disable-next-line camelcase
+    paymentIntentParams.application_fee_amount = convertToStripeAmount(order.currency, applicationFee);
+  }
+
+  // eslint-disable-next-line camelcase
+  paymentIntentParams.payment_method_types = [order.paymentMethod?.type];
+  // eslint-disable-next-line camelcase
+  paymentIntentParams.payment_method = order.paymentMethod?.data?.stripePaymentMethodId;
+  paymentIntentParams.customer = order?.paymentMethod?.customerId;
+  paymentIntentParams.metadata = {
+    from: order.fromCollective ? `${config.host.website}/${order.fromCollective.slug}` : undefined,
+    to: `${config.host.website}/${order.collective.slug}`,
+    orderId: order.id,
+    chargeNumber: order.Subscription.chargeNumber,
+    chargeRetryCount: order.Subscription.chargeRetryCount,
+  };
+
+  try {
+    let paymentIntent = await stripe.paymentIntents.create(paymentIntentParams, {
+      stripeAccount: hostStripeAccount.username,
+    });
+
+    order.update({ data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } } });
+    await order.save();
+
+    paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
+      stripeAccount: hostStripeAccount.username,
+    });
+
+    if (paymentIntent.next_action) {
+      const paymentIntentError = new Error('Payment Intent require action');
+      paymentIntentError['stripeAccount'] = hostStripeAccount.username;
+      paymentIntentError['stripeResponse'] = { paymentIntent };
+      throw paymentIntentError;
+    }
+
+    if (paymentIntent.status === 'processing') {
+      order.data = { ...order.data, paymentIntent };
+      order.update({ data: { ...order.data, paymentIntent } });
+      await order.save();
+      return;
+    } else if (paymentIntent.status !== 'succeeded') {
+      logger.error('Unknown error with Stripe Payment Intent.');
+      logger.error(paymentIntent);
+      reportMessageToSentry('Unknown error with Stripe Payment Intent', { extra: { paymentIntent } });
+      throw new Error('Something went wrong with the payment, please contact support@opencollective.com.');
+    }
+
+    // Recently, Stripe updated their library and removed the 'charges' property in favor of 'latest_charge',
+    // but this is something that only makes sense in the LatestApiVersion, and that's not the one we're using.
+    const charge = (paymentIntent as any).charges.data[0] as Stripe.Charge;
+    return createChargeTransactions(charge, { order });
+  } catch (e) {
+    const sanitizedError = pick(e, ['code', 'message', 'requestId', 'statusCode']);
+    const errorMessage = `Error processing Stripe Payment Intent: ${e.message}`;
+    logger.error(errorMessage, sanitizedError);
+    // Hard-delete the order so we can re-use the existing Payment Intent in the next attempt.
+    throw new Error(errorMessage);
+  }
+}
+
+const processOrder = async (order: typeof models.Order): Promise<void> => {
+  if (order.SubscriptionId) {
+    return processRecurringOrder(order);
+  }
+
+  return processNewOrder(order);
 };
 
 export default {
   features: {
-    recurring: false,
+    recurring: true,
     waitToCharge: false,
   },
   processOrder,

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -9,11 +9,7 @@ import { reportMessageToSentry } from '../../lib/sentry';
 import stripe, { convertToStripeAmount } from '../../lib/stripe';
 import models from '../../models';
 
-import {
-  APPLICATION_FEE_INCOMPATIBLE_CURRENCIES,
-  refundTransaction,
-  refundTransactionOnlyInDatabase,
-} from './common';
+import { APPLICATION_FEE_INCOMPATIBLE_CURRENCIES, refundTransaction, refundTransactionOnlyInDatabase } from './common';
 
 const processOrder = async (order: typeof models.Order): Promise<void> => {
   if (order.SubscriptionId) {

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -66,7 +66,7 @@ const paymentIntentProcessing = async (event: Stripe.Response<Stripe.Event>) => 
   const stripeAccount = event.account ?? config.stripe.accountId;
 
   await sequelize.transaction(async transaction => {
-    await models.PaymentMethod.findOne({
+    const stripePaymentMethodCustomer = await models.PaymentMethod.findOne({
       where: {
         customerId: paymentIntent.customer,
         type: PAYMENT_METHOD_TYPE.PAYMENT_INTENT,
@@ -75,6 +75,10 @@ const paymentIntentProcessing = async (event: Stripe.Response<Stripe.Event>) => 
       transaction,
       lock: transaction.LOCK.UPDATE,
     });
+
+    if (!stripePaymentMethodCustomer) {
+      return;
+    }
 
     const order = await models.Order.findOne({
       where: {

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -52,15 +52,15 @@ const paymentIntentSucceeded = async (event: Stripe.Response<Stripe.Event>) => {
   const charge = (paymentIntent as any).charges.data[0] as Stripe.Charge;
   const transaction = await createChargeTransactions(charge, { order });
 
-  await order.update({
-    status: !order.SubscriptionId ? OrderStatuses.PAID : undefined,
-    processedAt: new Date(),
-    data: { ...order.data, paymentIntent },
-  });
-
   if (order.interval && !order.SubscriptionId) {
     await createSubscription(order);
   }
+
+  await order.update({
+    status: !order.SubscriptionId ? OrderStatuses.PAID : OrderStatuses.ACTIVE,
+    processedAt: new Date(),
+    data: { ...order.data, paymentIntent },
+  });
 
   if (order.fromCollective?.ParentCollectiveId !== order.collective.id) {
     await order.getOrCreateMembers();

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -15,12 +15,7 @@ import { getFxRate } from '../../lib/currency';
 import errors from '../../lib/errors';
 import logger from '../../lib/logger';
 import { toNegative } from '../../lib/math';
-import {
-  createRefundTransaction,
-  createSubscription,
-  sendEmailNotifications,
-  sendOrderFailedEmail,
-} from '../../lib/payments';
+import { createRefundTransaction, sendEmailNotifications, sendOrderFailedEmail } from '../../lib/payments';
 import stripe from '../../lib/stripe';
 import models, { sequelize } from '../../models';
 
@@ -122,10 +117,11 @@ const paymentIntentProcessing = async (event: Stripe.Response<Stripe.Event>) => 
           service: PAYMENT_METHOD_SERVICE.STRIPE,
           type: stripePaymentMethod.type,
           confirmedAt: new Date(),
-          saved: true,
+          saved: paymentIntent.setup_future_usage === 'off_session',
           data: {
             stripePaymentMethodId: paymentIntent.payment_method,
             stripeAccount,
+            ...stripePaymentMethod[stripePaymentMethod.type],
           },
         },
         { transaction },
@@ -550,6 +546,7 @@ async function paymentMethodAttached(event: Stripe.Response<Stripe.Event>) {
         data: {
           stripePaymentMethodId: stripePaymentMethod.id,
           stripeAccount,
+          ...stripePaymentMethod[stripePaymentMethod.type],
         },
       },
       { transaction },

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -52,12 +52,8 @@ const paymentIntentSucceeded = async (event: Stripe.Response<Stripe.Event>) => {
   const charge = (paymentIntent as any).charges.data[0] as Stripe.Charge;
   const transaction = await createChargeTransactions(charge, { order });
 
-  if (order.interval && !order.SubscriptionId) {
-    await createSubscription(order);
-  }
-
   await order.update({
-    status: !order.SubscriptionId ? OrderStatuses.PAID : OrderStatuses.ACTIVE,
+    status: OrderStatuses.PAID,
     processedAt: new Date(),
     data: { ...order.data, paymentIntent },
   });


### PR DESCRIPTION
Creates payment intents using a single customerId per stripe account and stores attached payment methods for reuse by same customerId