### PR TITLE
Move Transactions "internal" to its own column

### DIFF
--- a/migrations/20221123082049-move-transactions-internal-to-own-column.js
+++ b/migrations/20221123082049-move-transactions-internal-to-own-column.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Transactions', 'isInternal', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+
+    await queryInterface.sequelize.query(`
+      UPDATE "Transactions"
+      SET "isInternal" = TRUE
+      WHERE "data" ->> 'internal' IS NOT NULL
+      AND ("data" ->> 'internal')::boolean = TRUE
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Transactions', 'isInternal');
+  },
+};

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -356,7 +356,7 @@ export async function sumCollectivesTransactions(
   }
   if (excludeInternals) {
     // Exclude internal transactions (we can tag some Transactions like "Switching Host" as internal)
-    where.data = { internal: { [Op.not]: true } };
+    where.isInternal = { [Op.not]: true };
   }
   if (kind) {
     where.kind = kind;

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -218,6 +218,12 @@ const Transaction = sequelize.define(
       defaultValue: false,
     },
 
+    isInternal: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
+
     createdAt: {
       type: DataTypes.DATE,
       defaultValue: DataTypes.NOW,


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6176

Tested on a local prod DB copy.

Before:
```
GroupAggregate  (cost=24361.39..24550.49 rows=3424 width=40) (actual time=103.484..103.485 rows=1 loops=1)
"  Group Key: ""CollectiveId"", ""hostCurrency"""
  ->  Sort  (cost=24361.39..24370.01 rows=3448 width=44) (actual time=101.646..101.935 rows=11262 loops=1)
"        Sort Key: ""hostCurrency"""
        Sort Method: quicksort  Memory: 1264kB
"        ->  Bitmap Heap Scan on ""Transactions"" ""Transaction""  (cost=106.42..24158.79 rows=3448 width=44) (actual time=2.055..98.924 rows=11262 loops=1)"
"              Recheck Cond: ((""CollectiveId"" = 580) AND ((type)::text = 'CREDIT'::text))"
"              Filter: ((""deletedAt"" IS NULL) AND (""RefundTransactionId"" IS NULL) AND (""isRefund"" IS NOT TRUE) AND (((data #>> '{internal}'::text[]))::boolean IS NOT TRUE))"
              Rows Removed by Filter: 29
              Heap Blocks: exact=10158
"              ->  Bitmap Index Scan on ""CollectiveId-type""  (cost=0.00..105.56 rows=7313 width=0) (actual time=0.886..0.886 rows=11291 loops=1)"
"                    Index Cond: ((""CollectiveId"" = 580) AND ((type)::text = 'CREDIT'::text))"
Planning Time: 0.173 ms
Execution Time: 103.597 ms
```

After:
```
GroupAggregate  (cost=24306.54..24495.64 rows=3424 width=40) (actual time=14.468..14.469 rows=1 loops=1)
"  Group Key: ""CollectiveId"", ""hostCurrency"""
  ->  Sort  (cost=24306.54..24315.16 rows=3448 width=44) (actual time=12.599..12.907 rows=11262 loops=1)
"        Sort Key: ""hostCurrency"""
        Sort Method: quicksort  Memory: 1264kB
"        ->  Bitmap Heap Scan on ""Transactions"" ""Transaction""  (cost=106.42..24103.95 rows=3448 width=44) (actual time=2.011..10.779 rows=11262 loops=1)"
"              Recheck Cond: ((""CollectiveId"" = 580) AND ((type)::text = 'CREDIT'::text))"
"              Filter: ((""deletedAt"" IS NULL) AND (""RefundTransactionId"" IS NULL) AND (""isRefund"" IS NOT TRUE) AND (NOT ""isInternal""))"
              Rows Removed by Filter: 29
              Heap Blocks: exact=10158
"              ->  Bitmap Index Scan on ""CollectiveId-type""  (cost=0.00..105.56 rows=7313 width=0) (actual time=0.845..0.845 rows=11291 loops=1)"
"                    Index Cond: ((""CollectiveId"" = 580) AND ((type)::text = 'CREDIT'::text))"
Planning Time: 0.163 ms
Execution Time: 14.573 ms
```

Estimated gain: -86% execution time.