### PR TITLE
Add tagSearchOperator to Accounts collection query

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -3783,29 +3783,29 @@ type AccountStats {
     kind: [TransactionKind]
 
     """
-    Calculate total amount received before this date
+    Calculate total amount spent before this date
     """
     dateTo: DateTime
 
     """
-    Calculate total amount received after this date
+    Calculate total amount spent after this date
     """
     dateFrom: DateTime
 
     """
-    Computes contributions from the last x months. Cannot be used with startDate/endDate
+    Calculate total amount spent in the last x months. Cannot be used with startDate/endDate
     """
     periodInMonths: Int
+
+    """
+    Include money spent in children (Projects and Events)
+    """
+    includeChildren: Boolean = false
 
     """
     Set this to true to use cached data
     """
     useCache: Boolean! = false
-
-    """
-    Include money received in children (Projects and Events)
-    """
-    includeChildren: Boolean = false
   ): Amount!
 
   """
@@ -3838,7 +3838,32 @@ type AccountStats {
   """
   Total net amount received
   """
-  totalNetAmountReceived: Amount!
+  totalNetAmountReceived(
+    """
+    Filter by kind
+    """
+    kind: [TransactionKind]
+
+    """
+    Calculate total amount spent before this date
+    """
+    dateTo: DateTime
+
+    """
+    Calculate total amount spent after this date
+    """
+    dateFrom: DateTime
+
+    """
+    Calculate total amount spent in the last x months. Cannot be used with startDate/endDate
+    """
+    periodInMonths: Int
+
+    """
+    Include money spent in children (Projects and Events)
+    """
+    includeChildren: Boolean = false
+  ): Amount!
   activeRecurringContributions: JSON
     @deprecated(reason: "2022-10-21: Use activeRecurringContributionsV2 while we migrate to better semantics.")
   activeRecurringContributionsV2(
@@ -8706,6 +8731,11 @@ type Query {
     tag: [String]
 
     """
+    Operator to use when searching with tags. Defaults to 'AND'
+    """
+    tagSearchOperator: TagSearchOperator = AND
+
+    """
     Host hosting the account
     """
     host: [AccountReferenceInput]
@@ -9374,6 +9404,14 @@ type Query {
   ): PaypalPlan!
   loggedInAccount: Individual
   me: Individual
+}
+
+"""
+The operator to use when searching with tags
+"""
+enum TagSearchOperator {
+  AND
+  OR
 }
 
 """

--- a/server/graphql/v2/enum/TagSearchOperator.ts
+++ b/server/graphql/v2/enum/TagSearchOperator.ts
@@ -1,0 +1,10 @@
+import { GraphQLEnumType } from 'graphql';
+
+export const TagSearchOperator = new GraphQLEnumType({
+  name: 'TagSearchOperator',
+  description: 'The operator to use when searching with tags',
+  values: {
+    AND: {},
+    OR: {},
+  },
+});

--- a/server/graphql/v2/query/collection/AccountsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/AccountsCollectionQuery.ts
@@ -82,7 +82,7 @@ const AccountsCollectionQuery = {
       // Bind arguments
       if (args.tag?.length) {
         if (args.tagSearchOperator === 'OR') {
-          where['tags'] = { [Op.in]: args.tag };
+          where['tags'] = { [Op.overlap]: args.tag };
         } else {
           where['tags'] = { [Op.contains]: args.tag };
         }

--- a/server/graphql/v2/query/collection/AccountsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/AccountsCollectionQuery.ts
@@ -5,6 +5,7 @@ import models, { Op, sequelize } from '../../../../models';
 import { AccountCollection } from '../../collection/AccountCollection';
 import { AccountType, AccountTypeToModelMapping, CountryISO } from '../../enum';
 import { PaymentMethodService } from '../../enum/PaymentMethodService';
+import { TagSearchOperator } from '../../enum/TagSearchOperator';
 import { AccountReferenceInput, fetchAccountsIdsWithReference } from '../../input/AccountReferenceInput';
 import { OrderByInput } from '../../input/OrderByInput';
 import { CollectionArgs, CollectionReturnType } from '../../interface/Collection';
@@ -20,6 +21,11 @@ const AccountsCollectionQuery = {
     tag: {
       type: new GraphQLList(GraphQLString),
       description: 'Only accounts that match these tags',
+    },
+    tagSearchOperator: {
+      type: TagSearchOperator,
+      defaultValue: 'AND',
+      description: "Operator to use when searching with tags. Defaults to 'AND'",
     },
     host: {
       type: new GraphQLList(AccountReferenceInput),
@@ -75,7 +81,11 @@ const AccountsCollectionQuery = {
 
       // Bind arguments
       if (args.tag?.length) {
-        where['tags'] = { [Op.contains]: args.tag };
+        if (args.tagSearchOperator === 'OR') {
+          where['tags'] = { [Op.in]: args.tag };
+        } else {
+          where['tags'] = { [Op.contains]: args.tag };
+        }
       }
 
       if (args.type?.length) {
@@ -141,6 +151,7 @@ const AccountsCollectionQuery = {
         hasCustomContributionsEnabled: args.hasCustomContributionsEnabled,
         countries: args.country,
         tags: args.tag,
+        tagSearchOperator: args.tagSearchOperator,
         includeArchived: args.includeArchived,
       };
 

--- a/server/graphql/v2/query/collection/AccountsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/AccountsCollectionQuery.ts
@@ -23,7 +23,7 @@ const AccountsCollectionQuery = {
       description: 'Only accounts that match these tags',
     },
     tagSearchOperator: {
-      type: TagSearchOperator,
+      type: new GraphQLNonNull(TagSearchOperator),
       defaultValue: 'AND',
       description: "Operator to use when searching with tags. Defaults to 'AND'",
     },

--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -187,6 +187,7 @@ export const searchCollectivesInDB = async (
     hasCustomContributionsEnabled,
     countries,
     tags,
+    tagSearchOperator,
   } = {},
 ) => {
   // Build dynamic conditions based on arguments
@@ -243,7 +244,11 @@ export const searchCollectivesInDB = async (
 
   if (tags?.length) {
     searchedTags = tags.map(tag => tag.toLowerCase());
-    dynamicConditions += `AND c."tags" @> Array[:searchedTags]::varchar[] `;
+    if (tagSearchOperator === 'OR') {
+      dynamicConditions += `AND c."tags" && Array[:searchedTags]::varchar[] `;
+    } else {
+      dynamicConditions += `AND c."tags" @> Array[:searchedTags]::varchar[] `;
+    }
   }
 
   const searchTermConditions = getSearchTermSQLConditions(term, 'c');


### PR DESCRIPTION
Fix for https://github.com/opencollective/opencollective/issues/6170

Adding a `tagSearchOperator` field to the accounts collection query, that defaults to `AND` which is the current behavior.

```graphql
accounts(tags: ["climate justice", "climate change"], tagSearchOperator: OR)
```