### PR TITLE
Improve Confirm credit card" email content

### DIFF
--- a/server/lib/handlebars.js
+++ b/server/lib/handlebars.js
@@ -56,6 +56,13 @@ handlebars.registerHelper('toLowerCase', str => {
   return str.toLowerCase();
 });
 
+handlebars.registerHelper('toUpperCase', str => {
+  if (!str) {
+    return '';
+  }
+  return str.toUpperCase();
+});
+
 handlebars.registerHelper('increment', str => {
   if (isNaN(str)) {
     return '';

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -61,6 +61,7 @@ export const notify = {
       if (!activity.data.recipientName) {
         user.collective = user.collective || (await user.getCollective());
         if (user.collective) {
+          activity.data.recipientCollective = user.collective.info;
           activity.data.recipientName = user.collective.name || user.collective.legalName;
         }
       }

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -441,13 +441,27 @@ export async function createPaymentCreditCardConfirmationActivity(order) {
     type: activities.PAYMENT_CREDITCARD_CONFIRMATION,
     CollectiveId: order.CollectiveId,
     FromCollectiveId: order.FromCollectiveId,
-    HostCollectiveId: order.collective?.approvedAt ? order.collective.HostCollectiveId : null,
+    HostCollectiveId: order.collective.approvedAt ? order.collective.HostCollectiveId : null,
     OrderId: order.id,
     data: {
       order: order.info,
       collective: order.collective.info,
       fromCollective: order.fromCollective.minimal,
-      confirmOrderLink: `${config.host.website}/orders/${order.id}/confirm`,
+      confirmOrderLink: `${config.host.website}/${order.fromCollective.slug}/orders/${order.id}/confirm`,
+      paymentMethod: order.paymentMethod?.info,
     },
   });
 }
+
+// TODO: Remove me
+setTimeout(async () => {
+  const order = await models.Order.findByPk(6435, {
+    include: [
+      { model: models.Collective, as: 'collective' },
+      { model: models.Collective, as: 'fromCollective' },
+      { model: models.PaymentMethod, as: 'paymentMethod' },
+      { model: models.Subscription, as: 'Subscription' },
+    ],
+  });
+  await createPaymentCreditCardConfirmationActivity(order);
+}, 2000);

--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -685,6 +685,7 @@ const Collective = sequelize.define(
           name: this.name,
           image: this.image,
           slug: this.slug,
+          isIncognito: this.isIncognito,
           twitterHandle: this.twitterHandle,
           githubHandle: this.githubHandle,
           repositoryUrl: this.repositoryUrl,

--- a/templates/emails/payment.creditcard.confirmation.hbs
+++ b/templates/emails/payment.creditcard.confirmation.hbs
@@ -1,20 +1,62 @@
-Subject: Confirm your credit card to continue supporting {{{collective.name}}}
+Subject: Action required: Verify your credit card to continue supporting {{{collective.name}}} on Open Collective
 
 {{> header}}
 
 {{> toplogo}}
 
-{{#if fromCollective.name}}
-<p>Dear {{fromCollective.name}},</p>
-{{else}}
-<p>Hi!</p>
-{{/if}}
+<p>{{> greeting}}</p>
 
-<p>To comply with banking regulations, we are required to confirm your credit card in order to process your payment of {{currency order.totalAmount currency=order.currency}} to {{collective.name}}.</p>
+<p>
+  To comply with banking regulations, we are required to verify your credit card
+  {{#if paymentMethod}}(<small>{{toUpperCase paymentMethod.data.brand}} <i>**** {{paymentMethod.name}}</i></small>) {{/if}}
+  in order to process your {{order.interval}}ly payment of {{currency order.totalAmount currency=order.currency}}
+  {{#ifCond fromCollective.id '!==' recipientCollective.id}}
+    {{#unless fromCollective.isIncognito}}
+      from {{> linkCollective collective=fromCollective}}
+    {{/unless}}
+  {{/ifCond}}
+  to {{> linkCollective collective=collective}}.
+</p>
 
-<p>Please <a href="{{confirmOrderLink}}">confirm your credit card now</a> to continue supporting {{collective.name}}.</p>
+<center style="margin: 32px 0;">
+  <a class="btn" style="margin-right: 8px;" href="https://docs.opencollective.com/help/financial-contributors/payments#credit-cards-verification">
+    <div style="font-size: 15px;">Learn more</div>
+  </a>
+  <a class="btn blue" href="{{confirmOrderLink}}">
+    <div style="font-size: 15px;">Verify your credit card</div>
+  </a>
+</center>
 
-<p>If you have questions, <a href="mailto:support@opencollective.com?Subject=Confirm%20credit%20card">contact support</a>.</p>
+<div style="border: 1px solid #efefef;padding: 12px 16px;margin: 32px 16px;border-radius: 8px;">
+  <p style="font-size: 14px; font-weight: bold;">FAQ</p>
+  <ul>
+    <li>
+      Why should I trust this email?
+      <p style="font-size: 14px; margin-top: 4px;">
+        This email was sent by Open Collective, the platform that processes the financial contributions for {{> linkCollective collective=collective}}.
+        You can verify that the email is from us by checking the email address in your inbox and all links point toward our official domain, <a href="https://opencollective.com">https://opencollective.com</a>. This process, along with other payment-related topics, is explained
+        in details on our <a href="https://docs.opencollective.com/help/financial-contributors/payments#credit-cards-verification">public documentation</a>.<br/> 
+      </p>
+    </li>
+    <li>
+      Why does this happen?
+      <p style="font-size: 14px; margin-top: 4px;">
+        To secure online payments, it is sometimes required to confirm payments with a second factor authentication. This happens today mostly in Europe but this is being deployed in more countries over time.
+        In Europe, the policy is named <a href="https://en.wikipedia.org/wiki/Strong_customer_authentication">Strong Customer Authentication (SCA)</a> and the most common way of authenticating
+        an online card payment relies on 3D Secure, which asks you to confirm the payment through your phone, banking app, or dedicated device.<br/> 
+      </p>
+    </li>
+    <li>
+      What will happen if I don't verify my credit card?
+      <p style="font-size: 14px; margin-top: 4px;">
+        If you don't verify your credit card, we will not be able to process your {{order.interval}}ly payment to {{> linkCollective collective=collective}}.
+        We will retry in the coming days, then after 6 attempts your recurring contribution will be cancelled.<br/> 
+      </p>
+    </li>
+  </ul>
+</div>
+
+<p>If you have questions, you can reach out to <a href="mailto:support@opencollective.com?Subject=Confirm%20credit%20card">our support</a>.</p>
 
 <p>Warmly,</p>
 

--- a/templates/emails/payment.creditcard.confirmation.hbs
+++ b/templates/emails/payment.creditcard.confirmation.hbs
@@ -19,7 +19,7 @@ Subject: Action required: Verify your credit card to continue supporting {{{coll
 </p>
 
 <center style="margin: 32px 0;">
-  <a class="btn" style="margin-right: 8px;" href="https://docs.opencollective.com/help/financial-contributors/payments#credit-cards-verification">
+  <a class="btn" style="margin-right: 8px;" href="https://docs.opencollective.com/help/financial-contributors/payments#credit-card-verification">
     <div style="font-size: 15px;">Learn more</div>
   </a>
   <a class="btn blue" href="{{confirmOrderLink}}">
@@ -35,7 +35,7 @@ Subject: Action required: Verify your credit card to continue supporting {{{coll
       <p style="font-size: 14px; margin-top: 4px;">
         This email was sent by Open Collective, the platform that processes the financial contributions for {{> linkCollective collective=collective}}.
         You can verify that the email is from us by checking the email address in your inbox and all links point toward our official domain, <a href="https://opencollective.com">https://opencollective.com</a>. This process, along with other payment-related topics, is explained
-        in details on our <a href="https://docs.opencollective.com/help/financial-contributors/payments#credit-cards-verification">public documentation</a>.<br/> 
+        in detail on our <a href="https://docs.opencollective.com/help/financial-contributors/payments#credit-card-verification">public documentation</a>.<br/>
       </p>
     </li>
     <li>

--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -80,7 +80,7 @@
     }
     .btn {
       padding: 10px;
-      border: 2px solid #3399FF;
+      border: 1px solid #3399FF;
       border-radius: 16px;
       display: inline-block;
       color: #3399FF;

--- a/test/server/lib/email.test.js.snap
+++ b/test/server/lib/email.test.js.snap
@@ -178,7 +178,7 @@ exports[`server/lib/email render Automatically generates text version 1`] = `
 
 <center>
   <h3 style=\\"color: #303233; font-family: 'Helvetica Neue'; font-size: 20px; font-weight: bold; line-height: 25px;\\">You are one click away from logging into Open Collective.</h3>
-  <a href=\\"https://opencollective/USER_LOGIN_LINK\\" class=\\"btn blue\\" style=\\"text-decoration: none; padding: 10px; border: 2px solid #3399FF; border-radius: 16px; display: inline-block; font-weight: 600; font-size: 14px; line-height: 17px; padding-bottom: 14px; padding-left: 24px; padding-right: 24px; padding-top: 14px; border-radius: 100px; min-height: 18px; background-color: #3399FF; background: linear-gradient(180deg,#1869F5 0%,#1258e2 100%); background-color: #1869F5; border-color: #1869F5; color: #FFFFFF;\\"><div style=\\"font-family: 'Inter', sans-serif; font-weight: 600; font-size: 14px; line-height: 17px; font-size: 12px; text-align: center; color: white;\\">One-click login</div></a>
+  <a href=\\"https://opencollective/USER_LOGIN_LINK\\" class=\\"btn blue\\" style=\\"text-decoration: none; padding: 10px; border: 1px solid #3399FF; border-radius: 16px; display: inline-block; font-weight: 600; font-size: 14px; line-height: 17px; padding-bottom: 14px; padding-left: 24px; padding-right: 24px; padding-top: 14px; border-radius: 100px; min-height: 18px; background-color: #3399FF; background: linear-gradient(180deg,#1869F5 0%,#1258e2 100%); background-color: #1869F5; border-color: #1869F5; color: #FFFFFF;\\"><div style=\\"font-family: 'Inter', sans-serif; font-weight: 600; font-size: 14px; line-height: 17px; font-size: 12px; text-align: center; color: white;\\">One-click login</div></a>
   <br>
   <br>
   <br>


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/5812
Require https://github.com/opencollective/opencollective-frontend/pull/8433

Before merging, open a frontend PR:
- Add the `:slug` at the beginning of URL
- Fail if slug doesn't match contributor's slug

First draft that needs to be iterated on in a sync call with other engineers + feedback from the wording channel.

- [x] Link to a @opencollective/documentation page to explain this process with screenshots of the email/page
- [x] Improve the content of the email
  - [x] The subject is not catchy enough, prefix with "Action Required:"
  - [x] See if we can improve the wording
  - [x] Explain what will happen if they don't update
  - [x] Explain why you should trust this email
  - [x] Surface data to show it's not a random phishing email
    - Missing card last numbers
    - Card details (VISA, mastercard?)
    - Having the amount is good
    - More info on the contribution (monthly? yearly?)
- [ ] Improve the design of the email
  - [x] Remove collective logo
  - [x] Always show Open Collective logo
  - [x] Add something to show that the email is verified?
  - [ ] Maybe we can have a quick improvement of the global email design?
  - [ ] See if we can improve the fonts
  - [ ] Check if we can find a header


![image](https://user-images.githubusercontent.com/1556356/204501177-e767f001-d5a6-47fc-b346-ccf4a13c2e83.png)