### PR TITLE
Enable recurring contributions for ACH/SEPA

### DIFF
--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -105,7 +105,6 @@ async function processRecurringOrder(order: typeof models.Order) {
       return;
     } else if (paymentIntent.status !== 'succeeded') {
       logger.error('Unknown error with Stripe Payment Intent.');
-      logger.error(paymentIntent);
       reportMessageToSentry('Unknown error with Stripe Payment Intent', { extra: { paymentIntent } });
       throw new Error('Something went wrong with the payment, please contact support@opencollective.com.');
     }

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -5,12 +5,21 @@ import type Stripe from 'stripe';
 import OrderStatuses from '../../constants/order_status';
 import logger from '../../lib/logger';
 import { getApplicationFee } from '../../lib/payments';
+import { reportMessageToSentry } from '../../lib/sentry';
 import stripe, { convertToStripeAmount } from '../../lib/stripe';
 import models from '../../models';
 
 import { APPLICATION_FEE_INCOMPATIBLE_CURRENCIES, refundTransaction, refundTransactionOnlyInDatabase } from './common';
 
 const processOrder = async (order: typeof models.Order): Promise<void> => {
+  if (order.SubscriptionId) {
+    return processRecurringOrder(order);
+  }
+
+  return processNewOrder(order);
+};
+
+async function processNewOrder(order: typeof models.Order) {
   const hostStripeAccount = await order.collective.getHostStripeAccount();
   const host = await order.collective.getHostCollective();
   const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
@@ -46,11 +55,75 @@ const processOrder = async (order: typeof models.Order): Promise<void> => {
     await order.destroy({ force: true });
     throw new Error(errorMessage);
   }
-};
+}
+
+async function processRecurringOrder(order: typeof models.Order) {
+  const hostStripeAccount = await order.collective.getHostStripeAccount();
+  const host = await order.collective.getHostCollective();
+  const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
+    ? false
+    : host?.settings?.isPlatformRevenueDirectlyCollected ?? true;
+  const applicationFee = await getApplicationFee(order, host);
+  const paymentIntentParams: Stripe.PaymentIntentCreateParams = {
+    currency: order.currency,
+    amount: convertToStripeAmount(order.currency, order.totalAmount),
+    description: order.description,
+  };
+
+  if (applicationFee && isPlatformRevenueDirectlyCollected && hostStripeAccount.username !== config.stripe.accountId) {
+    // eslint-disable-next-line camelcase
+    paymentIntentParams.application_fee_amount = convertToStripeAmount(order.currency, applicationFee);
+  }
+
+  // eslint-disable-next-line camelcase
+  paymentIntentParams.payment_method_types = [order.paymentMethod?.type];
+  // eslint-disable-next-line camelcase
+  paymentIntentParams.payment_method = order.paymentMethod?.data?.stripePaymentMethodId;
+  paymentIntentParams.customer = order?.paymentMethod?.customerId;
+  paymentIntentParams.metadata = {
+    from: order.fromCollective ? `${config.host.website}/${order.fromCollective.slug}` : undefined,
+    to: `${config.host.website}/${order.collective.slug}`,
+    orderId: order.id,
+    chargeNumber: order.Subscription.chargeNumber,
+    chargeRetryCount: order.Subscription.chargeRetryCount,
+  };
+
+  try {
+    let paymentIntent = await stripe.paymentIntents.create(paymentIntentParams, {
+      stripeAccount: hostStripeAccount.username,
+    });
+
+    order.update({ data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } } });
+    await order.save();
+
+    paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
+      stripeAccount: hostStripeAccount.username,
+    });
+
+    order.data = { ...order.data, paymentIntent };
+    order.update({ data: { ...order.data, paymentIntent } });
+    await order.save();
+
+    if (paymentIntent.status === 'processing') {
+      return;
+    } else if (paymentIntent.status !== 'succeeded') {
+      logger.error('Unknown error with Stripe Payment Intent.');
+      logger.error(paymentIntent);
+      reportMessageToSentry('Unknown error with Stripe Payment Intent', { extra: { paymentIntent } });
+      throw new Error('Something went wrong with the payment, please contact support@opencollective.com.');
+    }
+  } catch (e) {
+    const sanitizedError = pick(e, ['code', 'message', 'requestId', 'statusCode']);
+    const errorMessage = `Error processing Stripe Payment Intent: ${e.message}`;
+    logger.error(errorMessage, sanitizedError);
+    // Hard-delete the order so we can re-use the existing Payment Intent in the next attempt.
+    throw new Error(errorMessage);
+  }
+}
 
 export default {
   features: {
-    recurring: false,
+    recurring: true,
     waitToCharge: false,
   },
   processOrder,

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -99,9 +99,7 @@ async function processRecurringOrder(order: typeof models.Order) {
       stripeAccount: hostStripeAccount.username,
     });
 
-    order.data = { ...order.data, paymentIntent };
-    order.update({ data: { ...order.data, paymentIntent } });
-    await order.save();
+    await order.update({ data: { ...order.data, paymentIntent } });
 
     if (paymentIntent.status === 'processing') {
       return;

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -93,8 +93,7 @@ async function processRecurringOrder(order: typeof models.Order) {
       stripeAccount: hostStripeAccount.username,
     });
 
-    order.update({ data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } } });
-    await order.save();
+    await order.update({ data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } } });
 
     paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
       stripeAccount: hostStripeAccount.username,

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -93,7 +93,9 @@ async function processRecurringOrder(order: typeof models.Order) {
       stripeAccount: hostStripeAccount.username,
     });
 
-    await order.update({ data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } } });
+    await order.update({
+      data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } },
+    });
 
     paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
       stripeAccount: hostStripeAccount.username,

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -154,7 +154,7 @@ export const paymentIntentFailed = async (event: Stripe.Response<Stripe.Event>) 
   sendOrderFailedEmail(order, reason);
 };
 
-export const chargeDisputeCreated = async (event: Stripe.Response<Stripe.Event>) => {
+export const chargeDisputeCreated = async (event: Stripe.Event) => {
   const dispute = event.data.object as Stripe.Dispute;
   const chargeTransaction = await models.Transaction.findOne({
     where: { data: { charge: { id: dispute.charge } } },
@@ -203,7 +203,7 @@ export const chargeDisputeCreated = async (event: Stripe.Response<Stripe.Event>)
 };
 
 // Charge dispute has been closed on Stripe (with status of: won/lost/closed)
-export const chargeDisputeClosed = async (event: Stripe.Response<Stripe.Event>) => {
+export const chargeDisputeClosed = async (event: Stripe.Event) => {
   const dispute = event.data.object as Stripe.Dispute;
   const chargeTransaction = await models.Transaction.findOne({
     where: { data: { charge: { id: dispute.charge } }, isDisputed: true },
@@ -330,7 +330,7 @@ export const chargeDisputeClosed = async (event: Stripe.Response<Stripe.Event>) 
 };
 
 // Charge on Stripe had a fraud review opened
-export const reviewOpened = async (event: Stripe.Response<Stripe.Event>) => {
+export const reviewOpened = async (event: Stripe.Event) => {
   const review = event.data.object as Stripe.Review;
   const paymentIntentTransaction = await models.Transaction.findOne({
     // eslint-disable-next-line camelcase
@@ -375,7 +375,7 @@ export const reviewOpened = async (event: Stripe.Response<Stripe.Event>) => {
 };
 
 // Charge on Stripe had a fraud review closed (either approved/refunded)
-export const reviewClosed = async (event: Stripe.Response<Stripe.Event>) => {
+export const reviewClosed = async (event: Stripe.Event) => {
   const review = event.data.object as Stripe.Review;
   const stripePaymentIntentId = review.payment_intent;
   const closedReason = review.closed_reason;

--- a/test/mocks/stripe.ts
+++ b/test/mocks/stripe.ts
@@ -1,3 +1,5 @@
+import Stripe from 'stripe';
+
 export default {
   accounts: {
     create: {
@@ -425,15 +427,15 @@ export default {
         charge: 'ch_3LpDOFJKGTeo5jKp0PfknYNd',
         created: 1664898640,
         currency: 'usd',
-        evidence: [],
-        evidence_details: [],
+        evidence: null,
+        evidence_details: null,
         is_charge_refundable: true,
         livemode: false,
         metadata: {},
         payment_intent: null,
         reason: 'fraudulent',
         status: 'warning_needs_response',
-      },
+      } as Stripe.Dispute,
     },
     livemode: false,
     pending_webhooks: 0,
@@ -442,7 +444,7 @@ export default {
       idempotency_key: 'b1b89be2-8b91-4af0-92f4-611130deea26',
     },
     type: 'charge.dispute.created',
-  },
+  } as Stripe.Event,
 
   webhook_dispute_lost: {
     id: 'evt_3LpcvEJKGTeo5jKp1P6hkDxm',
@@ -491,7 +493,7 @@ export default {
       idempotency_key: 'edac8120-a02b-4136-9e4d-295c2f506b95',
     },
     type: 'charge.dispute.closed',
-  },
+  } as Stripe.Event,
 
   webhook_dispute_won: {
     id: 'evt_3LpcvEJKGTeo5jKp1P6hkDxm',
@@ -526,7 +528,7 @@ export default {
       idempotency_key: 'edac8120-a02b-4136-9e4d-295c2f506b95',
     },
     type: 'charge.dispute.closed',
-  },
+  } as Stripe.Event,
 
   webhook_review_opened: {
     id: 'evt_1LxBZNJKGTeo5jKpolE0e9UC',
@@ -549,7 +551,7 @@ export default {
         payment_intent: 'pi_3LxBZLJKGTeo5jKp1gkxl8fZ',
         reason: 'rule',
         session: null,
-      },
+      } as Stripe.Review,
     },
     livemode: false,
     pending_webhooks: 0,
@@ -558,7 +560,7 @@ export default {
       idempotency_key: 'stripe-node-retry-2422a1ef-6f8a-4c0d-aa84-a321ac2ffe86',
     },
     type: 'review.opened',
-  },
+  } as Stripe.Event,
 
   webhook_review_closed_approved: {
     id: 'evt_1LxEqyJKGTeo5jKpxdR6BOHy',
@@ -590,7 +592,7 @@ export default {
       idempotency_key: 'f84e30db-86d8-4690-80ad-309f9a17e5d7',
     },
     type: 'review.closed',
-  },
+  } as Stripe.Event,
 
   webhook_review_closed_refunded_as_fraud: {
     id: 'evt_1LxGJgJKGTeo5jKpnnjocxf9',
@@ -633,7 +635,7 @@ export default {
       idempotency_key: '17564838-36c1-4042-8f68-11573a6da999',
     },
     type: 'review.closed',
-  },
+  } as Stripe.Event,
 
   webhook_review_closed_refunded: {
     id: 'evt_1LxGWeJKGTeo5jKplp4QrJGt',
@@ -676,5 +678,5 @@ export default {
       idempotency_key: '744656f9-94ad-491e-a5ad-3f604444f268',
     },
     type: 'review.closed',
-  },
+  } as Stripe.Event,
 };

--- a/test/server/paymentProviders/stripe/payment-intent.test.ts
+++ b/test/server/paymentProviders/stripe/payment-intent.test.ts
@@ -10,8 +10,11 @@ import stripe from '../../../../server/lib/stripe';
 import models from '../../../../server/models';
 import paymentIntent from '../../../../server/paymentProviders/stripe/payment-intent';
 import { fakeConnectedAccount, fakeOrder, fakePaymentMethod, randStr } from '../../../test-helpers/fake-data';
+import * as utils from '../../../utils';
 
 describe('stripe/payment-intent', () => {
+  before(utils.resetTestDB);
+
   describe('processOrder', () => {
     describe('new order', () => {
       let order;

--- a/test/server/paymentProviders/stripe/payment-intent.test.ts
+++ b/test/server/paymentProviders/stripe/payment-intent.test.ts
@@ -3,88 +3,232 @@
 import { expect } from 'chai';
 import { assert, createSandbox } from 'sinon';
 
+import { Service } from '../../../../server/constants/connected_account';
 import OrderStatuses from '../../../../server/constants/order_status';
+import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../../server/constants/paymentMethods';
 import stripe from '../../../../server/lib/stripe';
 import models from '../../../../server/models';
 import paymentIntent from '../../../../server/paymentProviders/stripe/payment-intent';
 import { fakeConnectedAccount, fakeOrder, fakePaymentMethod, randStr } from '../../../test-helpers/fake-data';
 
 describe('stripe/payment-intent', () => {
-  const sandbox = createSandbox();
-  beforeEach(() => {
-    sandbox.stub(stripe.paymentIntents, 'update').callsFake((id, intent) => Promise.resolve({ id, ...intent }));
-  });
-  afterEach(sandbox.restore);
-
   describe('processOrder', () => {
-    let order;
+    describe('new order', () => {
+      let order;
 
-    beforeEach(async () => {
-      const paymentMethod = await fakePaymentMethod({ type: 'paymentintent', service: 'stripe' });
-      order = await fakeOrder({
-        PaymentMethodId: paymentMethod.id,
-        FromCollectiveId: paymentMethod.CollectiveId,
-        status: 'NEW',
-        totalAmount: 100e2,
-        description: 'Do you even donate, brah?!',
-
-        data: { paymentIntent: { id: randStr('pi_fake') } },
+      const sandbox = createSandbox();
+      beforeEach(() => {
+        sandbox.stub(stripe.paymentIntents, 'update').callsFake((id, intent) => Promise.resolve({ id, ...intent }));
       });
-      const hostId = order.collective.HostCollectiveId;
-      await fakeConnectedAccount({
-        CollectiveId: hostId,
-        service: 'stripe',
-        username: 'testUserName',
-        token: 'faketoken',
+      afterEach(sandbox.restore);
+
+      beforeEach(async () => {
+        const paymentMethod = await fakePaymentMethod({ type: 'paymentintent', service: 'stripe' });
+        order = await fakeOrder({
+          PaymentMethodId: paymentMethod.id,
+          FromCollectiveId: paymentMethod.CollectiveId,
+          status: 'NEW',
+          totalAmount: 100e2,
+          description: 'Do you even donate, brah?!',
+
+          data: { paymentIntent: { id: randStr('pi_fake') } },
+        });
+        const hostId = order.collective.HostCollectiveId;
+        await fakeConnectedAccount({
+          CollectiveId: hostId,
+          service: 'stripe',
+          username: 'testUserName',
+          token: 'faketoken',
+        });
+      });
+
+      it('updates paymentIntent with correct amount and currency', async () => {
+        await paymentIntent.processOrder(order);
+
+        assert.calledWithMatch(
+          stripe.paymentIntents.update,
+          order.data.paymentIntent.id,
+          { currency: order.currency, amount: order.totalAmount, description: order.description },
+          { stripeAccount: 'testUserName' },
+        );
+      });
+
+      it('updates paymentIntent applicationFee if there is platform tips', async () => {
+        await order.update({ platformTipAmount: 100 });
+        await paymentIntent.processOrder(order);
+
+        assert.calledWithMatch(
+          stripe.paymentIntents.update,
+          order.data.paymentIntent.id,
+          {
+            currency: order.currency,
+            amount: order.totalAmount,
+            description: order.description,
+            application_fee_amount: 100,
+          },
+          { stripeAccount: 'testUserName' },
+        );
+      });
+
+      it('set order status to PROCESSING and update data.paymentIntent', async () => {
+        await paymentIntent.processOrder(order);
+
+        await order.reload();
+        const orderJSON = order.toJSON();
+        expect(orderJSON).to.have.nested.property('data.paymentIntent');
+        expect(orderJSON).to.have.nested.property('data.paymentIntent.amount');
+        expect(orderJSON).to.have.nested.property('data.paymentIntent.description');
+        expect(orderJSON).to.have.property('status', OrderStatuses.PROCESSING);
+      });
+
+      it('destroys the order if something goes wrong', async () => {
+        (stripe.paymentIntents.update as any).throws();
+        const processOrder = paymentIntent.processOrder(order);
+        await expect(processOrder).to.be.eventually.rejectedWith(Error);
+
+        order = await models.Order.findByPk(order.id);
+        expect(order).to.be.null;
       });
     });
 
-    it('updates paymentIntent with correct amount and currency', async () => {
-      await paymentIntent.processOrder(order);
+    describe('recurring orders', () => {
+      let order;
 
-      assert.calledWithMatch(
-        stripe.paymentIntents.update,
-        order.data.paymentIntent.id,
-        { currency: order.currency, amount: order.totalAmount, description: order.description },
-        { stripeAccount: 'testUserName' },
-      );
-    });
+      const sandbox = createSandbox();
+      afterEach(sandbox.restore);
 
-    it('updates paymentIntent applicationFee if there is platform tips', async () => {
-      await order.update({ platformTipAmount: 100 });
-      await paymentIntent.processOrder(order);
+      beforeEach(async () => {
+        const paymentMethod = await fakePaymentMethod({
+          type: PAYMENT_METHOD_TYPE.US_BANK_ACCOUNT,
+          service: PAYMENT_METHOD_SERVICE.STRIPE,
+          customerId: 'cus_test',
+          data: {
+            stripePaymentMethodId: 'pm_test',
+          },
+        });
+        order = await fakeOrder(
+          {
+            PaymentMethodId: paymentMethod.id,
+            FromCollectiveId: paymentMethod.CollectiveId,
+            status: OrderStatuses.ACTIVE,
+            totalAmount: 100e2,
+            description: 'Recurring contribution',
+          },
+          { withSubscription: true },
+        );
+        const hostId = order.collective.HostCollectiveId;
+        await fakeConnectedAccount({
+          CollectiveId: hostId,
+          service: Service.STRIPE,
+          username: 'testUserName',
+          token: 'faketoken',
+        });
+      });
 
-      assert.calledWithMatch(
-        stripe.paymentIntents.update,
-        order.data.paymentIntent.id,
-        {
-          currency: order.currency,
-          amount: order.totalAmount,
-          description: order.description,
-          application_fee_amount: 100,
-        },
-        { stripeAccount: 'testUserName' },
-      );
-    });
+      it('creates and confirms a payment intent', async () => {
+        const paymentIntentId = 'pi_test';
+        sandbox.stub(stripe.paymentIntents, 'create').resolves({ id: paymentIntentId });
+        sandbox.stub(stripe.paymentIntents, 'confirm').resolves({ id: paymentIntentId, status: 'processing' });
 
-    it('set order status to PROCESSING and update data.paymentIntent', async () => {
-      await paymentIntent.processOrder(order);
+        await paymentIntent.processOrder(order);
 
-      await order.reload();
-      const orderJSON = order.toJSON();
-      expect(orderJSON).to.have.nested.property('data.paymentIntent');
-      expect(orderJSON).to.have.nested.property('data.paymentIntent.amount');
-      expect(orderJSON).to.have.nested.property('data.paymentIntent.description');
-      expect(orderJSON).to.have.property('status', OrderStatuses.PROCESSING);
-    });
+        expect(order.data.paymentIntent).to.eql({ id: paymentIntentId, status: 'processing' });
 
-    it('destroys the order if something goes wrong', async () => {
-      (stripe.paymentIntents.update as any).throws();
-      const processOrder = paymentIntent.processOrder(order);
-      await expect(processOrder).to.be.eventually.rejectedWith(Error);
+        assert.calledWithMatch(
+          stripe.paymentIntents.create,
+          {
+            currency: 'USD',
+            amount: 10000,
+            description: 'Recurring contribution',
+            payment_method_types: ['us_bank_account'],
+            payment_method: 'pm_test',
+            customer: 'cus_test',
+          },
+          { stripeAccount: 'testUserName' },
+        );
 
-      order = await models.Order.findByPk(order.id);
-      expect(order).to.be.null;
+        assert.calledWithMatch(stripe.paymentIntents.confirm, paymentIntentId, { stripeAccount: 'testUserName' });
+      });
+
+      it('throws error if create payment intent fails', async () => {
+        const paymentIntentId = 'pi_test';
+        sandbox.stub(stripe.paymentIntents, 'create').rejects(new Error('failed to create payment intent'));
+        sandbox.stub(stripe.paymentIntents, 'confirm').resolves({ id: paymentIntentId, status: 'processing' });
+
+        await expect(paymentIntent.processOrder(order)).to.eventually.rejectedWith(
+          Error,
+          'failed to create payment intent',
+        );
+
+        assert.calledWithMatch(
+          stripe.paymentIntents.create,
+          {
+            currency: 'USD',
+            amount: 10000,
+            description: 'Recurring contribution',
+            payment_method_types: ['us_bank_account'],
+            payment_method: 'pm_test',
+            customer: 'cus_test',
+          },
+          { stripeAccount: 'testUserName' },
+        );
+
+        assert.notCalled(stripe.paymentIntents.confirm);
+      });
+
+      it('throws error if confirm payment intent fails', async () => {
+        const paymentIntentId = 'pi_test';
+        sandbox.stub(stripe.paymentIntents, 'create').resolves({ id: paymentIntentId });
+        sandbox.stub(stripe.paymentIntents, 'confirm').rejects(new Error('failed to confirm payment intent'));
+
+        await expect(paymentIntent.processOrder(order)).to.eventually.rejectedWith(
+          Error,
+          'failed to confirm payment intent',
+        );
+
+        assert.calledWithMatch(
+          stripe.paymentIntents.create,
+          {
+            currency: 'USD',
+            amount: 10000,
+            description: 'Recurring contribution',
+            payment_method_types: ['us_bank_account'],
+            payment_method: 'pm_test',
+            customer: 'cus_test',
+          },
+          { stripeAccount: 'testUserName' },
+        );
+
+        assert.calledWithMatch(stripe.paymentIntents.confirm, paymentIntentId);
+      });
+
+      it('throws error if payment intent requires action after confirm', async () => {
+        const paymentIntentId = 'pi_test';
+        sandbox.stub(stripe.paymentIntents, 'create').resolves({ id: paymentIntentId });
+        sandbox.stub(stripe.paymentIntents, 'confirm').resolves({ id: paymentIntentId, status: 'requires_action' });
+
+        await expect(paymentIntent.processOrder(order)).to.eventually.rejectedWith(
+          Error,
+          'Error processing Stripe Payment Intent: Something went wrong with the payment, please contact support@opencollective.com.',
+        );
+
+        expect(order.data.paymentIntent).to.eql({ id: paymentIntentId, status: 'requires_action' });
+
+        assert.calledWithMatch(
+          stripe.paymentIntents.create,
+          {
+            currency: 'USD',
+            amount: 10000,
+            description: 'Recurring contribution',
+            payment_method_types: ['us_bank_account'],
+            payment_method: 'pm_test',
+            customer: 'cus_test',
+          },
+          { stripeAccount: 'testUserName' },
+        );
+
+        assert.calledWithMatch(stripe.paymentIntents.confirm, paymentIntentId);
+      });
     });
   });
 });


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/6196

Enables recurring contributions for payment intent based payment methods (currently only enabled for ACH and SEPA bank debits).