### PR TITLE
Properly record tax refunds

### DIFF
--- a/migrations/20230106150127-fix-transactions-tax-amount-refund.js
+++ b/migrations/20230106150127-fix-transactions-tax-amount-refund.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // See https://github.com/opencollective/opencollective/issues/5438 for the why
+    // A small shortcut has been taken in this query since `hostCurrencyFxRate` is always 1 for fixed entries
+    await queryInterface.sequelize.query(`
+      UPDATE "Transactions"
+      SET
+        "taxAmount" = -invalid_transactions."taxAmount", -- Make it positive
+        "data" = jsonb_set("data"::jsonb, '{migration}', '"20230106150127-fix-transactions-tax-amount-refund"'::jsonb),
+        "amount" = CASE WHEN "type" = 'DEBIT' THEN "amount" ELSE "amount" + invalid_transactions."taxAmount"  END,
+        "netAmountInCollectiveCurrency" = CASE WHEN "type" = 'CREDIT' THEN "netAmountInCollectiveCurrency" ELSE "netAmountInCollectiveCurrency" - invalid_transactions."taxAmount" END
+      FROM (
+        SELECT t.id AS transaction_id, refund.id AS refund_id, t."taxAmount" as "taxAmount"
+        FROM "Transactions" t
+        INNER JOIN "Transactions" refund ON t."RefundTransactionId" = refund.id AND refund."isRefund" IS TRUE
+        WHERE t."taxAmount" IS NOT NULL
+        AND t."isRefund" IS NOT TRUE
+        AND t."taxAmount" < 0
+      ) invalid_transactions
+      WHERE "Transactions".id = invalid_transactions.refund_id
+    `);
+  },
+
+  async down() {
+    console.log(
+      'Rollback can be done manually by looking at data.migration = "20230106150127-fix-transactions-tax-amount-refund"',
+    );
+  },
+};

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -170,6 +170,7 @@ export const buildRefundForTransaction = (t, user, data, refundedPaymentProcesso
     'hostFeeInHostCurrency',
     'platformFeeInHostCurrency',
     'paymentProcessorFeeInHostCurrency',
+    'taxAmount',
     'data.hasPlatformTip',
     'data.isFeesOnTop', // deprecated form, replaced by hasPlatformTip
     'data.tax',
@@ -189,6 +190,7 @@ export const buildRefundForTransaction = (t, user, data, refundedPaymentProcesso
   refund.hostFeeInHostCurrency = -refund.hostFeeInHostCurrency;
   refund.platformFeeInHostCurrency = -refund.platformFeeInHostCurrency;
   refund.paymentProcessorFeeInHostCurrency = -refund.paymentProcessorFeeInHostCurrency;
+  refund.taxAmount = -refund.taxAmount;
 
   /* Amount fields. Must be calculated after tweaking all the fees */
   refund.amount = -t.amount;

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -26,7 +26,6 @@ import { createPrepaidPaymentMethod, isPrepaidBudgetOrder } from './prepaid-budg
 import { getNextChargeAndPeriodStartDates } from './recurring-contributions';
 import { stripHTML } from './sanitize-html';
 import { reportMessageToSentry } from './sentry';
-import { netAmount } from './transactions';
 import { formatAccountDetails } from './transferwise';
 import { getEditRecurringContributionsUrl } from './url-utils';
 import { formatCurrency, toIsoDateStr } from './utils';
@@ -195,7 +194,7 @@ export const buildRefundForTransaction = (t, user, data, refundedPaymentProcesso
   /* Amount fields. Must be calculated after tweaking all the fees */
   refund.amount = -t.amount;
   refund.amountInHostCurrency = -t.amountInHostCurrency;
-  refund.netAmountInCollectiveCurrency = -netAmount(t);
+  refund.netAmountInCollectiveCurrency = -models.Transaction.calculateNetAmountInCollectiveCurrency(t);
   refund.isRefund = true;
 
   // We're handling host fees in separate transactions
@@ -227,7 +226,7 @@ export const buildRefundForTransaction = (t, user, data, refundedPaymentProcesso
   }
 
   // Re-compute the net amount
-  refund.netAmountInCollectiveCurrency = netAmount(refund);
+  refund.netAmountInCollectiveCurrency = models.Transaction.calculateNetAmountInCollectiveCurrency(refund);
 
   return refund;
 };

--- a/server/lib/transactions.ts
+++ b/server/lib/transactions.ts
@@ -8,7 +8,7 @@ import { TransactionKind } from '../constants/transaction-kind';
 import { TransactionTypes } from '../constants/transactions';
 import { toNegative } from '../lib/math';
 import { exportToCSV } from '../lib/utils';
-import models, { Op, sequelize } from '../models';
+import models, { Op } from '../models';
 import Tier from '../models/Tier';
 
 import { getFxRate } from './currency';
@@ -303,6 +303,7 @@ const computeExpenseTaxes = (expense): number | null => {
 };
 
 /**
+ * @deprecated Use Transaction.calculateNetAmountInHostCurrency
  * Calculate net amount of a transaction in the currency of the collective
  * Notes:
  * - fees are negative numbers
@@ -315,6 +316,7 @@ export function netAmount(tr) {
 }
 
 /**
+ * @deprecated user Transaction.verify
  * Verify net amount of a transaction
  */
 export function verify(tr) {
@@ -344,24 +346,6 @@ export function verify(tr) {
  * & netAmountInCollectiveCurrency */
 export function difference(tr) {
   return netAmount(tr) - tr.netAmountInCollectiveCurrency;
-}
-
-/** Returnt he sum of transaction rows that match search.
- *
- * @param {Object} where is an object that contains all the fields
- *  that you want to use to narrow down the search against the
- *  transactions table. For example, if you want to sum up the
- *  donations of a user to a specific collective, use the following:
- * @example
- *  > const babel = await models.Collectives.findOne({ slug: 'babel' });
- *  > libransactions.sum({ FromCollectiveId: userCollective.id, CollectiveId: babel.id })
- * @return the sum of the column `amount`.
- */
-export async function sum(where) {
-  const totalAttr = sequelize.fn('COALESCE', sequelize.fn('SUM', sequelize.col('netAmountInCollectiveCurrency')), 0);
-  const attributes = [[totalAttr, 'total']];
-  const result = await models.Transaction.findOne({ attributes, where });
-  return result.dataValues.total;
 }
 
 const kindStrings = {

--- a/test/server/graphql/v1/refundTransaction.test.js.snap
+++ b/test/server/graphql/v1/refundTransaction.test.js.snap
@@ -2,48 +2,48 @@
 
 exports[`server/graphql/v1/refundTransaction Stripe Transaction - for hosts created after September 17th 2017 should be able to refund a stripe transaction with zero decimal currencies 1`] = `
 "
-| type   | kind                    | isRefund | To             | From           | amount | paymentFee | platformFee | netAmountInCollectiveCurrency |
-| ------ | ----------------------- | -------- | -------------- | -------------- | ------ | ---------- | ----------- | ----------------------------- |
-| DEBIT  | HOST_FEE                | false    | Scouts d'Arlon | WWCode         | -500   | 0          | 0           | -500                          |
-| CREDIT | HOST_FEE                | false    | WWCode         | Scouts d'Arlon | 500    | 0          | 0           | 500                           |
-| DEBIT  | CONTRIBUTION            | false    | Phil Mod       | Scouts d'Arlon | -4575  | -175       | -250        | -5000                         |
-| CREDIT | CONTRIBUTION            | false    | Scouts d'Arlon | Phil Mod       | 5000   | -175       | -250        | 4575                          |
-| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | WWCode         | Scouts d'Arlon | -175   | 0          | 0           | -175                          |
-| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Scouts d'Arlon | WWCode         | 175    | 0          | 0           | 175                           |
-| DEBIT  | HOST_FEE                | true     | WWCode         | Scouts d'Arlon | -500   | 0          | 0           | -500                          |
-| CREDIT | HOST_FEE                | true     | Scouts d'Arlon | WWCode         | 500    | 0          | 0           | 500                           |
-| DEBIT  | CONTRIBUTION            | true     | Scouts d'Arlon | Phil Mod       | -5000  | 0          | 250         | -4750                         |
-| CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 4750   | 0          | 250         | 5000                          |"
+| type   | kind                    | isRefund | To             | From           | amount | paymentFee | platformFee | tax | netAmountInCollectiveCurrency |
+| ------ | ----------------------- | -------- | -------------- | -------------- | ------ | ---------- | ----------- | --- | ----------------------------- |
+| DEBIT  | HOST_FEE                | false    | Scouts d'Arlon | WWCode         | -500   | 0          | 0           |     | -500                          |
+| CREDIT | HOST_FEE                | false    | WWCode         | Scouts d'Arlon | 500    | 0          | 0           |     | 500                           |
+| DEBIT  | CONTRIBUTION            | false    | Phil Mod       | Scouts d'Arlon | -4500  | -175       | -250        | -75 | -5000                         |
+| CREDIT | CONTRIBUTION            | false    | Scouts d'Arlon | Phil Mod       | 5000   | -175       | -250        | -75 | 4500                          |
+| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | WWCode         | Scouts d'Arlon | -175   | 0          | 0           |     | -175                          |
+| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Scouts d'Arlon | WWCode         | 175    | 0          | 0           |     | 175                           |
+| DEBIT  | HOST_FEE                | true     | WWCode         | Scouts d'Arlon | -500   | 0          | 0           | 0   | -500                          |
+| CREDIT | HOST_FEE                | true     | Scouts d'Arlon | WWCode         | 500    | 0          | 0           | 0   | 500                           |
+| DEBIT  | CONTRIBUTION            | true     | Scouts d'Arlon | Phil Mod       | -5000  | 0          | 250         | 75  | -4675                         |
+| CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 4675   | 0          | 250         | 75  | 5000                          |"
 `;
 
 exports[`server/graphql/v1/refundTransaction Stripe Transaction - for hosts created after September 17th 2017 should create negative transactions without the stripe fee being refunded 1`] = `
 "
-| type   | kind                    | isRefund | To             | From           | amount | paymentFee | platformFee | netAmountInCollectiveCurrency |
-| ------ | ----------------------- | -------- | -------------- | -------------- | ------ | ---------- | ----------- | ----------------------------- |
-| DEBIT  | HOST_FEE                | false    | Scouts d'Arlon | WWCode         | -500   | 0          | 0           | -500                          |
-| CREDIT | HOST_FEE                | false    | WWCode         | Scouts d'Arlon | 500    | 0          | 0           | 500                           |
-| DEBIT  | CONTRIBUTION            | false    | Phil Mod       | Scouts d'Arlon | -4575  | -175       | -250        | -5000                         |
-| CREDIT | CONTRIBUTION            | false    | Scouts d'Arlon | Phil Mod       | 5000   | -175       | -250        | 4575                          |
-| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | WWCode         | Scouts d'Arlon | -175   | 0          | 0           | -175                          |
-| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Scouts d'Arlon | WWCode         | 175    | 0          | 0           | 175                           |
-| DEBIT  | HOST_FEE                | true     | WWCode         | Scouts d'Arlon | -500   | 0          | 0           | -500                          |
-| CREDIT | HOST_FEE                | true     | Scouts d'Arlon | WWCode         | 500    | 0          | 0           | 500                           |
-| DEBIT  | CONTRIBUTION            | true     | Scouts d'Arlon | Phil Mod       | -5000  | 0          | 250         | -4750                         |
-| CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 4750   | 0          | 250         | 5000                          |"
+| type   | kind                    | isRefund | To             | From           | amount | paymentFee | platformFee | tax | netAmountInCollectiveCurrency |
+| ------ | ----------------------- | -------- | -------------- | -------------- | ------ | ---------- | ----------- | --- | ----------------------------- |
+| DEBIT  | HOST_FEE                | false    | Scouts d'Arlon | WWCode         | -500   | 0          | 0           |     | -500                          |
+| CREDIT | HOST_FEE                | false    | WWCode         | Scouts d'Arlon | 500    | 0          | 0           |     | 500                           |
+| DEBIT  | CONTRIBUTION            | false    | Phil Mod       | Scouts d'Arlon | -4500  | -175       | -250        | -75 | -5000                         |
+| CREDIT | CONTRIBUTION            | false    | Scouts d'Arlon | Phil Mod       | 5000   | -175       | -250        | -75 | 4500                          |
+| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | WWCode         | Scouts d'Arlon | -175   | 0          | 0           |     | -175                          |
+| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Scouts d'Arlon | WWCode         | 175    | 0          | 0           |     | 175                           |
+| DEBIT  | HOST_FEE                | true     | WWCode         | Scouts d'Arlon | -500   | 0          | 0           | 0   | -500                          |
+| CREDIT | HOST_FEE                | true     | Scouts d'Arlon | WWCode         | 500    | 0          | 0           | 0   | 500                           |
+| DEBIT  | CONTRIBUTION            | true     | Scouts d'Arlon | Phil Mod       | -5000  | 0          | 250         | 75  | -4675                         |
+| CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 4675   | 0          | 250         | 75  | 5000                          |"
 `;
 
 exports[`server/graphql/v1/refundTransaction Stripe Transaction - for hosts created before September 17th 2017 should create negative transactions with all the fees refunded 1`] = `
 "
-| type   | kind                    | isRefund | To             | From           | amount | paymentFee | platformFee | netAmountInCollectiveCurrency |
-| ------ | ----------------------- | -------- | -------------- | -------------- | ------ | ---------- | ----------- | ----------------------------- |
-| DEBIT  | HOST_FEE                | false    | Scouts d'Arlon | WWCode         | -500   | 0          | 0           | -500                          |
-| CREDIT | HOST_FEE                | false    | WWCode         | Scouts d'Arlon | 500    | 0          | 0           | 500                           |
-| DEBIT  | CONTRIBUTION            | false    | Phil Mod       | Scouts d'Arlon | -4575  | -175       | -250        | -5000                         |
-| CREDIT | CONTRIBUTION            | false    | Scouts d'Arlon | Phil Mod       | 5000   | -175       | -250        | 4575                          |
-| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | WWCode         | Scouts d'Arlon | -175   | 0          | 0           | -175                          |
-| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Scouts d'Arlon | WWCode         | 175    | 0          | 0           | 175                           |
-| DEBIT  | HOST_FEE                | true     | WWCode         | Scouts d'Arlon | -500   | 0          | 0           | -500                          |
-| CREDIT | HOST_FEE                | true     | Scouts d'Arlon | WWCode         | 500    | 0          | 0           | 500                           |
-| DEBIT  | CONTRIBUTION            | true     | Scouts d'Arlon | Phil Mod       | -5000  | 0          | 250         | -4750                         |
-| CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 4750   | 0          | 250         | 5000                          |"
+| type   | kind                    | isRefund | To             | From           | amount | paymentFee | platformFee | tax | netAmountInCollectiveCurrency |
+| ------ | ----------------------- | -------- | -------------- | -------------- | ------ | ---------- | ----------- | --- | ----------------------------- |
+| DEBIT  | HOST_FEE                | false    | Scouts d'Arlon | WWCode         | -500   | 0          | 0           |     | -500                          |
+| CREDIT | HOST_FEE                | false    | WWCode         | Scouts d'Arlon | 500    | 0          | 0           |     | 500                           |
+| DEBIT  | CONTRIBUTION            | false    | Phil Mod       | Scouts d'Arlon | -4500  | -175       | -250        | -75 | -5000                         |
+| CREDIT | CONTRIBUTION            | false    | Scouts d'Arlon | Phil Mod       | 5000   | -175       | -250        | -75 | 4500                          |
+| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | WWCode         | Scouts d'Arlon | -175   | 0          | 0           |     | -175                          |
+| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Scouts d'Arlon | WWCode         | 175    | 0          | 0           |     | 175                           |
+| DEBIT  | HOST_FEE                | true     | WWCode         | Scouts d'Arlon | -500   | 0          | 0           | 0   | -500                          |
+| CREDIT | HOST_FEE                | true     | Scouts d'Arlon | WWCode         | 500    | 0          | 0           | 0   | 500                           |
+| DEBIT  | CONTRIBUTION            | true     | Scouts d'Arlon | Phil Mod       | -5000  | 0          | 250         | 75  | -4675                         |
+| CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 4675   | 0          | 250         | 75  | 5000                          |"
 `;

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -389,7 +389,7 @@ describe('server/lib/payments', () => {
       expect(creditRefundTransaction.FromCollectiveId).to.equal(collective.id);
       expect(creditRefundTransaction.CollectiveId).to.equal(order.FromCollectiveId);
       expect(creditRefundTransaction.kind).to.equal('CONTRIBUTION');
-      expect(creditRefundTransaction.taxAmount).to.equal(-100);
+      expect(creditRefundTransaction.taxAmount).to.equal(100); // Taxes are always fully refunded, so it's a positive value
 
       // And then the values for the transaction from the donor to the
       // collective also look correct
@@ -397,7 +397,7 @@ describe('server/lib/payments', () => {
       expect(debitRefundTransaction.FromCollectiveId).to.equal(order.FromCollectiveId);
       expect(debitRefundTransaction.CollectiveId).to.equal(collective.id);
       expect(debitRefundTransaction.kind).to.equal('CONTRIBUTION');
-      expect(debitRefundTransaction.taxAmount).to.equal(-100);
+      expect(debitRefundTransaction.taxAmount).to.equal(100);
     });
 
     it('should refund platform fees on top when refunding original transaction', async () => {

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -355,6 +355,7 @@ describe('server/lib/payments', () => {
         hostCurrencyFxRate: 1,
         hostFeeInHostCurrency: 250,
         platformFeeInHostCurrency: 250,
+        taxAmount: 100,
         paymentProcessorFeeInHostCurrency: 175,
         description: 'Monthly subscription to Webpack',
         data: { charge: { id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' } },
@@ -388,6 +389,7 @@ describe('server/lib/payments', () => {
       expect(creditRefundTransaction.FromCollectiveId).to.equal(collective.id);
       expect(creditRefundTransaction.CollectiveId).to.equal(order.FromCollectiveId);
       expect(creditRefundTransaction.kind).to.equal('CONTRIBUTION');
+      expect(creditRefundTransaction.taxAmount).to.equal(-100);
 
       // And then the values for the transaction from the donor to the
       // collective also look correct
@@ -395,6 +397,7 @@ describe('server/lib/payments', () => {
       expect(debitRefundTransaction.FromCollectiveId).to.equal(order.FromCollectiveId);
       expect(debitRefundTransaction.CollectiveId).to.equal(collective.id);
       expect(debitRefundTransaction.kind).to.equal('CONTRIBUTION');
+      expect(debitRefundTransaction.taxAmount).to.equal(-100);
     });
 
     it('should refund platform fees on top when refunding original transaction', async () => {

--- a/test/server/models/Transaction.test.js.snap
+++ b/test/server/models/Transaction.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`server/models/Transaction createFromContributionPayload creates a double entry transaction for a Stripe payment in EUR with VAT 1`] = `
 "
-| kind         | type   | netAmountInCollectiveCurrency | currency | Host | platformFee | paymentFee | taxAmount | amount | description                              |
-| ------------ | ------ | ----------------------------- | -------- | ---- | ----------- | ---------- | --------- | ------ | ---------------------------------------- |
-| HOST_FEE     | DEBIT  | -500                          | EUR      | #2   | 0           | 0          |           | -500   | Host Fee                                 |
-| HOST_FEE     | CREDIT | 500                           | EUR      | #2   | 0           | 0          |           | 500    | Host Fee                                 |
-| CONTRIBUTION | DEBIT  | -12100                        | EUR      | NULL | -500        | -300       | -2100     | -9200  | €121 for Vegan Burgers including €21 VAT |
-| CONTRIBUTION | CREDIT | 9200                          | EUR      | #2   | -500        | -300       | -2100     | 12100  | €121 for Vegan Burgers including €21 VAT |"
+| kind         | type   | netAmountInCollectiveCurrency | currency | Host | platformFee | paymentFee | tax   | amount | description                              |
+| ------------ | ------ | ----------------------------- | -------- | ---- | ----------- | ---------- | ----- | ------ | ---------------------------------------- |
+| HOST_FEE     | DEBIT  | -500                          | EUR      | #2   | 0           | 0          |       | -500   | Host Fee                                 |
+| HOST_FEE     | CREDIT | 500                           | EUR      | #2   | 0           | 0          |       | 500    | Host Fee                                 |
+| CONTRIBUTION | DEBIT  | -12100                        | EUR      | NULL | -500        | -300       | -2100 | -9200  | €121 for Vegan Burgers including €21 VAT |
+| CONTRIBUTION | CREDIT | 9200                          | EUR      | #2   | -500        | -300       | -2100 | 12100  | €121 for Vegan Burgers including €21 VAT |"
 `;
 
 exports[`server/models/Transaction fees on top should create an additional pair of transactions between contributor and Open Collective Inc 1`] = `

--- a/test/utils.js
+++ b/test/utils.js
@@ -336,6 +336,7 @@ export const prettifyTransactionsData = (transactions, columns) => {
     TransactionGroup: 'Group',
     paymentProcessorFeeInHostCurrency: 'paymentFee',
     platformFeeInHostCurrency: 'platformFee',
+    taxAmount: 'tax',
   };
 
   // Prettify values


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5438

- [x] Fix refunds
- [x] Add tests
- [x] Migrate past data

Number of orders impacted: 9

Query:
```sql
SELECT t.id AS transaction_id, refund.id AS refund_id, t."taxAmount" as "taxAmount", t."hostCurrencyFxRate", t.type, t."amountInHostCurrency", refund."amountInHostCurrency"
FROM "Transactions" t
INNER JOIN "Transactions" refund ON t."RefundTransactionId" = refund.id AND refund."isRefund" IS TRUE
WHERE t."taxAmount" IS NOT NULL
AND t."isRefund" IS NOT TRUE
AND t."taxAmount" < 0
order by t.id
```