### PR TITLE
Use a single stripe customer per host stripe account

### DIFF
--- a/server/paymentProviders/stripe/common.ts
+++ b/server/paymentProviders/stripe/common.ts
@@ -1,6 +1,8 @@
 import config from 'config';
 import { get, result, toUpper } from 'lodash';
 
+import { Service } from '../../constants/connected_account';
+import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../constants/paymentMethods';
 import * as constants from '../../constants/transactions';
 import {
   createRefundTransaction,
@@ -182,3 +184,181 @@ export const createChargeTransactions = async (charge, { order }) => {
     isPlatformRevenueDirectlyCollected,
   });
 };
+
+/**
+ * Returns the stripe card payment method to be used for this order.
+ */
+export async function resolvePaymentMethodForOrder(
+  hostStripeAccount: string,
+  order: typeof models.Order,
+): Promise<typeof models.PaymentMethod> {
+  const isPlatformHost = hostStripeAccount === config.stripe.accountId;
+
+  const user = await order.getUser();
+
+  let paymentMethod = order.paymentMethod;
+  // a new card token to attach on the platform account
+  if (!paymentMethod.customerId) {
+    paymentMethod = await attachCardToPlatformCustomer(paymentMethod, order.fromCollective, user);
+  }
+
+  const isPlatformPaymentMethod =
+    !paymentMethod?.data?.stripeAccount || paymentMethod?.data?.stripeAccount === config.stripe.accountId;
+
+  if (isPlatformHost && !isPlatformPaymentMethod) {
+    throw new Error('Cannot clone payment method from connected account to platform account');
+  }
+
+  if (!isPlatformPaymentMethod && order.paymentMethod?.data?.stripeAccount !== hostStripeAccount) {
+    throw new Error('Cannot clone payment method that are not attached to the platform account');
+  }
+
+  if (isPlatformPaymentMethod && !isPlatformHost) {
+    const hostCustomer = await getOrCreateStripeCustomer(hostStripeAccount, order.fromCollective, user);
+    paymentMethod = await getOrCloneCardPaymentMethod(
+      paymentMethod,
+      order.fromCollective,
+      hostStripeAccount,
+      hostCustomer,
+    );
+  }
+
+  return paymentMethod;
+}
+
+export async function getOrCreateStripeCustomer(
+  stripeAccount: string,
+  collective: typeof models.Collective,
+  user: User,
+): Promise<string> {
+  let stripeCustomerConnectedAccount = await collective.getCustomerStripeAccount(stripeAccount);
+  // customer was not yet created for this host, so create it
+  if (!stripeCustomerConnectedAccount) {
+    const customer = await stripe.customers.create(
+      {
+        email: user?.email,
+        description: `${config.host.website}/${collective.slug}`,
+      },
+      {
+        stripeAccount,
+      },
+    );
+
+    stripeCustomerConnectedAccount = await models.ConnectedAccount.create({
+      clientId: stripeAccount,
+      username: customer.id,
+      CollectiveId: collective.id,
+      service: Service.STRIPE_CUSTOMER,
+    });
+  }
+
+  return stripeCustomerConnectedAccount.username;
+}
+
+export async function attachCardToPlatformCustomer(
+  paymentMethod: typeof models.PaymentMethod,
+  collective: typeof models.Collective,
+  user: User,
+): Promise<typeof models.PaymentMethod> {
+  const platformCustomer = await getOrCreateStripeCustomer(config.stripe.accountId, collective, user);
+
+  let stripePaymentMethod = await stripe.paymentMethods.create({
+    type: 'card',
+    card: {
+      token: paymentMethod.token,
+    },
+  });
+
+  stripePaymentMethod = await stripe.paymentMethods.attach(stripePaymentMethod.id, {
+    customer: platformCustomer,
+  });
+
+  return await paymentMethod.update({
+    customerId: platformCustomer,
+    data: {
+      ...paymentMethod.data,
+      stripePaymentMethodId: stripePaymentMethod.id,
+      fingerprint: stripePaymentMethod.card.fingerprint,
+    },
+  });
+}
+
+export async function getOrCloneCardPaymentMethod(
+  platformPaymentMethod: typeof models.PaymentMethod,
+  collective: typeof models.Collective,
+  hostStripeAccount: string,
+  hostCustomer: string,
+) {
+  let platformCardTokenCardId = platformPaymentMethod.data?.stripePaymentMethodId;
+  let platformCardFingerprint = platformPaymentMethod.data?.fingerprint;
+
+  // store platform card payment method id and fingerprint for reuse.
+  if (!platformCardTokenCardId || !platformCardFingerprint) {
+    const platformCardToken = await stripe.tokens.retrieve(platformPaymentMethod.token);
+    platformCardFingerprint = platformCardToken.card.fingerprint;
+    platformCardTokenCardId = platformCardToken.card.id;
+
+    await platformPaymentMethod.update({
+      data: {
+        ...platformPaymentMethod?.data,
+        fingerprint: platformCardFingerprint,
+        stripePaymentMethodId: platformCardTokenCardId,
+      },
+    });
+  }
+
+  const cardPaymentMethodOnHostAccount = await models.PaymentMethod.findOne({
+    where: {
+      service: PAYMENT_METHOD_SERVICE.STRIPE,
+      type: PAYMENT_METHOD_TYPE.CREDITCARD,
+      CollectiveId: collective.id,
+      data: {
+        stripeAccount: hostStripeAccount,
+        fingerprint: platformCardFingerprint,
+      },
+    },
+  });
+
+  // card was already cloned to fiscal host customer account
+  if (cardPaymentMethodOnHostAccount) {
+    return cardPaymentMethodOnHostAccount;
+  }
+
+  // clone payment method to host stripe account
+  let clonedPaymentMethod = await stripe.paymentMethods.create(
+    {
+      // this is the customer on the platform account which holds the original card
+      customer: platformPaymentMethod.customerId,
+      // eslint-disable-next-line camelcase
+      payment_method: platformCardTokenCardId,
+    },
+    {
+      stripeAccount: hostStripeAccount,
+    },
+  );
+
+  // we attach the newly cloned payment method to the customer in the fiscal host account
+  clonedPaymentMethod = await stripe.paymentMethods.attach(
+    clonedPaymentMethod.id,
+    {
+      customer: hostCustomer,
+    },
+    {
+      stripeAccount: hostStripeAccount,
+    },
+  );
+
+  return await models.PaymentMethod.create({
+    customerId: hostCustomer,
+    CollectiveId: collective.id,
+    service: PAYMENT_METHOD_SERVICE.STRIPE,
+    type: PAYMENT_METHOD_TYPE.CREDITCARD,
+    confirmedAt: new Date(),
+    token: clonedPaymentMethod.id,
+    data: {
+      stripePaymentMethodId: clonedPaymentMethod.id,
+      stripeAccount: hostStripeAccount,
+      ...clonedPaymentMethod[clonedPaymentMethod.type],
+    },
+  });
+}

--- a/server/paymentProviders/stripe/creditcard.ts
+++ b/server/paymentProviders/stripe/creditcard.ts
@@ -1,5 +1,5 @@
 import config from 'config';
-import { get, toUpper } from 'lodash';
+import { toUpper } from 'lodash';
 import type Stripe from 'stripe';
 
 import logger from '../../lib/logger';
@@ -11,122 +11,20 @@ import User from '../../models/User';
 
 import {
   APPLICATION_FEE_INCOMPATIBLE_CURRENCIES,
+  attachCardToPlatformCustomer,
   createChargeTransactions,
   refundTransaction,
   refundTransactionOnlyInDatabase,
+  resolvePaymentMethodForOrder,
 } from './common';
 
 const UNKNOWN_ERROR_MSG = 'Something went wrong with the payment, please contact support@opencollective.com.';
 
 /**
- * Get or create a customer under the platform stripe account
- */
-const getOrCreateCustomerOnPlatformAccount = async ({
-  paymentMethod,
-  user,
-  collective,
-}: {
-  paymentMethod: typeof models.PaymentMethod;
-  user?: User;
-  collective?: typeof models.Collective;
-}) => {
-  if (paymentMethod.customerId) {
-    return stripe.customers.retrieve(paymentMethod.customerId);
-  }
-
-  const payload: Stripe.CustomerCreateParams = { source: paymentMethod.token };
-  if (user) {
-    payload.email = user.email;
-  }
-  if (collective) {
-    payload.description = `https://opencollective.com/${collective.slug}`;
-  }
-
-  const customer = await stripe.customers.create(payload);
-
-  paymentMethod.customerId = customer.id;
-  await paymentMethod.update({ customerId: customer.id });
-
-  return customer;
-};
-
-/**
- * Get the customerId for the Stripe Account of the Host
- * Or create one using the Stripe token associated with the platform (paymentMethod.token)
- * and saves it under PaymentMethod.data[hostStripeAccount.username]
- * @param {*} hostStripeAccount
- */
-const getOrCreateCustomerOnHostAccount = async (hostStripeAccount, { paymentMethod, user }) => {
-  // Customers pre-migration will have their stripe user connected
-  // to the platform stripe account, not to the host's stripe
-  // account. Since payment methods had no name before that
-  // migration, we're using it to test for pre-migration users;
-
-  // Well, DISCARD what is written above, these customers are coming from the Host
-  if (!paymentMethod.name) {
-    const customer = await stripe.customers.retrieve(paymentMethod.customerId, {
-      stripeAccount: hostStripeAccount.username,
-    });
-
-    if (customer) {
-      logger.info(`Pre-migration customer found: ${paymentMethod.customerId}`);
-      logger.info(JSON.stringify(customer));
-      return customer;
-    }
-
-    logger.info(`Pre-migration customer not found: ${paymentMethod.customerId}`);
-    return { id: paymentMethod.customerId };
-  }
-
-  const data = paymentMethod.data || {};
-  data.customerIdForHost = data.customerIdForHost || {};
-  if (data.customerIdForHost[hostStripeAccount.username]) {
-    return stripe.customers.retrieve(data.customerIdForHost[hostStripeAccount.username], {
-      stripeAccount: hostStripeAccount.username,
-    });
-  } else {
-    const platformStripeCustomer = await getOrCreateCustomerOnPlatformAccount({
-      paymentMethod,
-      user,
-    });
-
-    let customer;
-
-    // This is a special case where the account is the root account
-    if (hostStripeAccount.username === config.stripe.accountId) {
-      customer = platformStripeCustomer;
-    }
-
-    // This is the normal case where we create a customer on the host connected account
-    if (!customer) {
-      // More info about that
-      // - Documentation: https://stripe.com/docs/connect/shared-customers
-      // - API: https://stripe.com/docs/api/tokens/create_card
-      const token = await stripe.tokens.create(
-        { customer: platformStripeCustomer.id },
-        { stripeAccount: hostStripeAccount.username },
-      );
-
-      customer = await stripe.customers.create(
-        { source: token.id, email: user.email },
-        { stripeAccount: hostStripeAccount.username },
-      );
-    }
-
-    data.customerIdForHost[hostStripeAccount.username] = customer.id;
-    paymentMethod.data = data;
-    await paymentMethod.update({ data });
-
-    return customer;
-  }
-};
-
-/**
  * Returns a Promise with the transaction created
- * Note: we need to create a token for hostStripeAccount because paymentMethod.customerId is a customer of the platform
- * See: Shared Customers: https://stripe.com/docs/connect/shared-customers
+ * Creates and confirms a payment intent, on success creates associated transactions
  */
-const createChargeAndTransactions = async (hostStripeAccount, { order, hostStripeCustomer }) => {
+const createChargeAndTransactions = async (hostStripeAccount, { order, paymentMethod }) => {
   const host = await order.collective.getHostCollective();
   const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
     ? false
@@ -145,7 +43,7 @@ const createChargeAndTransactions = async (hostStripeAccount, { order, hostStrip
     const createPayload: Stripe.PaymentIntentCreateParams = {
       amount: convertToStripeAmount(order.currency, order.totalAmount),
       currency: order.currency,
-      customer: hostStripeCustomer.id,
+      customer: paymentMethod.customerId,
       description: order.description,
       confirm: false,
       confirmation_method: 'manual',
@@ -167,13 +65,13 @@ const createChargeAndTransactions = async (hostStripeAccount, { order, hostStrip
     } else if (!order.processedAt && order.data.savePaymentMethod) {
       createPayload.setup_future_usage = 'on_session';
     }
-    // Add Payment Method ID if it's available
-    const paymentMethodId = get(hostStripeCustomer, 'default_source', get(hostStripeCustomer, 'sources.data[0].id'));
-    if (paymentMethodId) {
-      createPayload.payment_method = paymentMethodId;
+
+    const stripePaymentMethodId = paymentMethod.data?.stripePaymentMethodId;
+    if (stripePaymentMethodId) {
+      createPayload.payment_method = stripePaymentMethodId;
     } else {
-      logger.info('paymentMethod is missing in hostStripeCustomer to pass to Payment Intent.');
-      logger.info(JSON.stringify(hostStripeCustomer));
+      logger.info('paymentMethod is missing in paymentMethod to pass to Payment Intent.');
+      logger.info(JSON.stringify(paymentMethod));
     }
     paymentIntent = await stripe.paymentIntents.create(createPayload, {
       stripeAccount: hostStripeAccount.username,
@@ -212,13 +110,7 @@ export const setupCreditCard = async (
   paymentMethod: typeof models.PaymentMethod,
   { user, collective }: { user?: User; collective?: typeof models.Collective } = {},
 ) => {
-  const platformStripeCustomer = (await getOrCreateCustomerOnPlatformAccount({
-    paymentMethod,
-    user,
-    collective,
-  })) as Stripe.Response<Stripe.Customer>;
-
-  const paymentMethodId = platformStripeCustomer.sources.data[0].id;
+  paymentMethod = await attachCardToPlatformCustomer(paymentMethod, collective, user);
 
   let setupIntent;
   if (paymentMethod.data.setupIntent) {
@@ -227,8 +119,8 @@ export const setupCreditCard = async (
   }
   if (!setupIntent) {
     setupIntent = await stripe.setupIntents.create({
-      customer: platformStripeCustomer.id,
-      payment_method: paymentMethodId, // eslint-disable-line camelcase
+      customer: paymentMethod.customerId,
+      payment_method: paymentMethod.data?.stripePaymentMethodId, // eslint-disable-line camelcase
       confirm: true,
     });
   }
@@ -262,14 +154,10 @@ export default {
 
     let transactions;
     try {
-      const hostStripeCustomer = await getOrCreateCustomerOnHostAccount(hostStripeAccount, {
-        paymentMethod: order.paymentMethod,
-        user: order.createdByUser,
-      });
-
+      const paymentMethod = await resolvePaymentMethodForOrder(hostStripeAccount.username, order);
       transactions = await createChargeAndTransactions(hostStripeAccount, {
         order,
-        hostStripeCustomer,
+        paymentMethod,
       });
     } catch (error) {
       // Here, we check strictly the error message

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -8,6 +8,7 @@ import { v4 as uuid } from 'uuid';
 
 import { maxInteger } from '../../../../server/constants/math';
 import emailLib from '../../../../server/lib/email';
+import stripe from '../../../../server/lib/stripe';
 import twitter from '../../../../server/lib/twitter';
 import models from '../../../../server/models';
 import * as store from '../../../stores';
@@ -467,6 +468,7 @@ describe('server/graphql/v1/createOrder', () => {
     const remoteUser = await models.User.createUserWithCollective({
       email: store.randEmail('rejectedcard@protonmail.ch'),
     });
+    stripe.paymentIntents.confirm.rejects(new Error('Your card was declined.'));
     const res = await utils.graphqlQuery(createOrderMutation, { order: newOrder }, remoteUser);
     expect(res.errors[0].message).to.equal('Your card was declined.');
     const pm = await models.PaymentMethod.findOne({ where: { name: uniqueName } });

--- a/test/server/graphql/v1/tiers.test.js
+++ b/test/server/graphql/v1/tiers.test.js
@@ -90,9 +90,17 @@ describe('server/graphql/v1/tiers', () => {
 
   before(() => {
     sandbox.stub(stripe.tokens, 'create').callsFake(() => Promise.resolve({ id: 'tok_B5s4wkqxtUtNyM' }));
+    sandbox.stub(stripe.tokens, 'retrieve').callsFake(() => Promise.resolve({ id: 'tok_B5s4wkqxtUtNyM', card: {} }));
 
     sandbox.stub(stripe.customers, 'create').callsFake(() => Promise.resolve({ id: 'cus_B5s4wkqxtUtNyM' }));
     sandbox.stub(stripe.customers, 'retrieve').callsFake(() => Promise.resolve({ id: 'cus_B5s4wkqxtUtNyM' }));
+
+    sandbox
+      .stub(stripe.paymentMethods, 'create')
+      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+    sandbox
+      .stub(stripe.paymentMethods, 'attach')
+      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
 
     /* eslint-disable camelcase */
 

--- a/test/server/graphql/v1/transaction.test.js.snap
+++ b/test/server/graphql/v1/transaction.test.js.snap
@@ -18,7 +18,7 @@ Object {
           },
           "id": 40,
           "paymentMethod": Object {
-            "id": 18,
+            "id": 13,
             "name": null,
           },
           "subscription": null,
@@ -44,7 +44,7 @@ Object {
           },
           "id": 36,
           "paymentMethod": Object {
-            "id": 16,
+            "id": 12,
             "name": null,
           },
           "subscription": null,
@@ -70,7 +70,7 @@ Object {
           },
           "id": 32,
           "paymentMethod": Object {
-            "id": 15,
+            "id": 11,
             "name": null,
           },
           "subscription": null,
@@ -96,7 +96,7 @@ Object {
           },
           "id": 28,
           "paymentMethod": Object {
-            "id": 13,
+            "id": 10,
             "name": null,
           },
           "subscription": null,
@@ -122,7 +122,7 @@ Object {
           },
           "id": 24,
           "paymentMethod": Object {
-            "id": 12,
+            "id": 9,
             "name": null,
           },
           "subscription": null,
@@ -148,7 +148,7 @@ Object {
           },
           "id": 20,
           "paymentMethod": Object {
-            "id": 10,
+            "id": 8,
             "name": null,
           },
           "subscription": null,
@@ -174,7 +174,7 @@ Object {
           },
           "id": 16,
           "paymentMethod": Object {
-            "id": 9,
+            "id": 7,
             "name": null,
           },
           "subscription": null,
@@ -200,7 +200,7 @@ Object {
           },
           "id": 12,
           "paymentMethod": Object {
-            "id": 7,
+            "id": 6,
             "name": null,
           },
           "subscription": null,
@@ -226,7 +226,7 @@ Object {
           },
           "id": 8,
           "paymentMethod": Object {
-            "id": 6,
+            "id": 5,
             "name": null,
           },
           "subscription": null,
@@ -478,7 +478,7 @@ Object {
         "id": 36,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 16,
+          "id": 12,
           "name": null,
         },
         "subscription": null,
@@ -522,7 +522,7 @@ Object {
         "id": 28,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 13,
+          "id": 10,
           "name": null,
         },
         "subscription": null,
@@ -566,7 +566,7 @@ Object {
         "id": 20,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 10,
+          "id": 8,
           "name": null,
         },
         "subscription": null,
@@ -610,7 +610,7 @@ Object {
         "id": 12,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 7,
+          "id": 6,
           "name": null,
         },
         "subscription": null,
@@ -698,7 +698,7 @@ Object {
         "id": 40,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 18,
+          "id": 13,
           "name": null,
         },
         "subscription": null,
@@ -742,7 +742,7 @@ Object {
         "id": 32,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 15,
+          "id": 11,
           "name": null,
         },
         "subscription": null,
@@ -786,7 +786,7 @@ Object {
         "id": 24,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 12,
+          "id": 9,
           "name": null,
         },
         "subscription": null,
@@ -830,7 +830,7 @@ Object {
         "id": 16,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 9,
+          "id": 7,
           "name": null,
         },
         "subscription": null,
@@ -874,7 +874,7 @@ Object {
         "id": 8,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 6,
+          "id": 5,
           "name": null,
         },
         "subscription": null,

--- a/test/server/graphql/v1/transaction.test.js.snap
+++ b/test/server/graphql/v1/transaction.test.js.snap
@@ -18,7 +18,7 @@ Object {
           },
           "id": 40,
           "paymentMethod": Object {
-            "id": 13,
+            "id": 18,
             "name": null,
           },
           "subscription": null,
@@ -44,7 +44,7 @@ Object {
           },
           "id": 36,
           "paymentMethod": Object {
-            "id": 12,
+            "id": 16,
             "name": null,
           },
           "subscription": null,
@@ -70,7 +70,7 @@ Object {
           },
           "id": 32,
           "paymentMethod": Object {
-            "id": 11,
+            "id": 15,
             "name": null,
           },
           "subscription": null,
@@ -96,7 +96,7 @@ Object {
           },
           "id": 28,
           "paymentMethod": Object {
-            "id": 10,
+            "id": 13,
             "name": null,
           },
           "subscription": null,
@@ -122,7 +122,7 @@ Object {
           },
           "id": 24,
           "paymentMethod": Object {
-            "id": 9,
+            "id": 12,
             "name": null,
           },
           "subscription": null,
@@ -148,7 +148,7 @@ Object {
           },
           "id": 20,
           "paymentMethod": Object {
-            "id": 8,
+            "id": 10,
             "name": null,
           },
           "subscription": null,
@@ -174,7 +174,7 @@ Object {
           },
           "id": 16,
           "paymentMethod": Object {
-            "id": 7,
+            "id": 9,
             "name": null,
           },
           "subscription": null,
@@ -200,7 +200,7 @@ Object {
           },
           "id": 12,
           "paymentMethod": Object {
-            "id": 6,
+            "id": 7,
             "name": null,
           },
           "subscription": null,
@@ -226,7 +226,7 @@ Object {
           },
           "id": 8,
           "paymentMethod": Object {
-            "id": 5,
+            "id": 6,
             "name": null,
           },
           "subscription": null,
@@ -478,7 +478,7 @@ Object {
         "id": 36,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 12,
+          "id": 16,
           "name": null,
         },
         "subscription": null,
@@ -522,7 +522,7 @@ Object {
         "id": 28,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 10,
+          "id": 13,
           "name": null,
         },
         "subscription": null,
@@ -566,7 +566,7 @@ Object {
         "id": 20,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 8,
+          "id": 10,
           "name": null,
         },
         "subscription": null,
@@ -610,7 +610,7 @@ Object {
         "id": 12,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 6,
+          "id": 7,
           "name": null,
         },
         "subscription": null,
@@ -698,7 +698,7 @@ Object {
         "id": 40,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 13,
+          "id": 18,
           "name": null,
         },
         "subscription": null,
@@ -742,7 +742,7 @@ Object {
         "id": 32,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 11,
+          "id": 15,
           "name": null,
         },
         "subscription": null,
@@ -786,7 +786,7 @@ Object {
         "id": 24,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 9,
+          "id": 12,
           "name": null,
         },
         "subscription": null,
@@ -830,7 +830,7 @@ Object {
         "id": 16,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 7,
+          "id": 9,
           "name": null,
         },
         "subscription": null,
@@ -874,7 +874,7 @@ Object {
         "id": 8,
         "kind": "CONTRIBUTION",
         "paymentMethod": Object {
-          "id": 5,
+          "id": 6,
           "name": null,
         },
         "subscription": null,

--- a/test/server/graphql/v2/mutation/TransactionMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TransactionMutations.test.ts
@@ -51,6 +51,14 @@ describe('server/graphql/v2/mutation/TransactionMutations', () => {
     sandbox.stub(stripe.balanceTransactions, 'retrieve').callsFake(() => Promise.resolve(stripeMocks.balance));
     sandbox.stub(stripe.refunds, 'create').callsFake(() => Promise.resolve('foo'));
     sandbox.stub(stripe.charges, 'retrieve').callsFake(() => Promise.resolve('foo'));
+
+    sandbox
+      .stub(stripe.paymentMethods, 'create')
+      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+    sandbox
+      .stub(stripe.paymentMethods, 'attach')
+      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+
     sendEmailSpy = sandbox.spy(emailLib, 'send');
     refundTransactionSpy = sandbox.spy(orders, 'refundTransaction');
   });

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -67,7 +67,16 @@ describe('server/lib/payments', () => {
     sandbox = createSandbox();
     sandbox.stub(stripe.customers, 'create').callsFake(() => Promise.resolve({ id: 'cus_BM7mGwp1Ea8RtL' }));
     sandbox.stub(stripe.customers, 'retrieve').callsFake(() => Promise.resolve({ id: 'cus_BM7mGwp1Ea8RtL' }));
+    sandbox.stub(stripe.tokens, 'retrieve').callsFake(async id => {
+      id;
+    });
     sandbox.stub(stripe.tokens, 'create').callsFake(() => Promise.resolve({ id: 'tok_1AzPXGD8MNtzsDcgwaltZuvp' }));
+    sandbox
+      .stub(stripe.paymentMethods, 'create')
+      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+    sandbox
+      .stub(stripe.paymentMethods, 'attach')
+      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
     sandbox.stub(stripe.paymentIntents, 'create').callsFake(() =>
       Promise.resolve({
         id: 'pi_1F82vtBYycQg1OMfS2Rctiau',

--- a/test/server/paymentProviders/stripe/common.test.js
+++ b/test/server/paymentProviders/stripe/common.test.js
@@ -1,0 +1,400 @@
+/* eslint-disable camelcase */
+
+import { expect } from 'chai';
+import config from 'config';
+import { assert, createSandbox } from 'sinon';
+
+import { Service } from '../../../../server/constants/connected_account';
+import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../../server/constants/paymentMethods';
+import stripe from '../../../../server/lib/stripe';
+import * as common from '../../../../server/paymentProviders/stripe/common';
+import {
+  fakeCollective,
+  fakeConnectedAccount,
+  fakeOrder,
+  fakePaymentMethod,
+  fakeUser,
+} from '../../../test-helpers/fake-data';
+import * as utils from '../../../utils';
+
+describe('server/paymentProviders/stripe/common', () => {
+  describe('#getOrCreateStripeCustomer()', async () => {
+    beforeEach(() => utils.resetTestDB());
+
+    const sandbox = createSandbox();
+    afterEach(sandbox.restore);
+
+    let collective, user;
+    beforeEach(async () => {
+      user = await fakeUser();
+      collective = await fakeCollective();
+      sandbox.stub(stripe.customers, 'create');
+    });
+
+    it('creates a new customer on stripe if one does not exist', async () => {
+      stripe.customers.create.resolves({ id: 'cus_test' });
+
+      const stripeCustomer = await common.getOrCreateStripeCustomer('acc_test', collective, user);
+
+      expect(stripeCustomer).to.equal('cus_test');
+      assert.calledWithMatch(stripe.customers.create, { email: user.email }, { stripeAccount: 'acc_test' });
+    });
+
+    it('returns existing customer', async () => {
+      await fakeConnectedAccount({
+        CollectiveId: collective.id,
+        service: Service.STRIPE_CUSTOMER,
+        username: 'cus_test',
+        clientId: 'acc_test',
+      });
+
+      const stripeCustomer = await common.getOrCreateStripeCustomer('acc_test', collective, user);
+
+      expect(stripeCustomer).to.equal('cus_test');
+      assert.notCalled(stripe.customers.create);
+    });
+  });
+
+  describe('#getOrClonePaymentMethod()', async () => {
+    beforeEach(() => utils.resetTestDB());
+
+    const sandbox = createSandbox();
+    afterEach(sandbox.restore);
+
+    let collective, platformPaymentMethod;
+    beforeEach(async () => {
+      collective = await fakeCollective();
+
+      platformPaymentMethod = await fakePaymentMethod({
+        customerId: 'cus_platformcardcustomer',
+        token: 'tok_platformcardtoken1234567',
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        CollectiveId: collective.id,
+      });
+
+      sandbox.stub(stripe.tokens, 'retrieve');
+      sandbox.stub(stripe.paymentMethods, 'create');
+      sandbox.stub(stripe.paymentMethods, 'attach');
+    });
+
+    it('clones the card payment method if not cloned already', async () => {
+      stripe.tokens.retrieve.resolves({
+        id: 'tok_platformcardtoken1234567',
+        card: {
+          id: 'card_platform',
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      stripe.paymentMethods.create.resolves({
+        id: 'pm_aclonedcardinhostaccount',
+      });
+
+      stripe.paymentMethods.attach.resolves({
+        id: 'pm_aclonedcardinhostaccount',
+        type: 'card',
+        card: {
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      const paymentMethod = await common.getOrCloneCardPaymentMethod(
+        platformPaymentMethod,
+        collective,
+        'acc_host_test',
+        'cus_host_test',
+      );
+
+      expect(paymentMethod).to.exist;
+      expect(paymentMethod.customerId).to.equal('cus_host_test');
+      expect(paymentMethod.data?.fingerprint).to.equal('fingerprint');
+      expect(paymentMethod.data?.stripePaymentMethodId).to.equal('pm_aclonedcardinhostaccount');
+
+      assert.calledWithMatch(stripe.tokens.retrieve, platformPaymentMethod.token);
+      assert.calledWithMatch(
+        stripe.paymentMethods.create,
+        { customer: platformPaymentMethod.customerId, payment_method: 'card_platform' },
+        { stripeAccount: 'acc_host_test' },
+      );
+
+      assert.calledWithMatch(
+        stripe.paymentMethods.attach,
+        'pm_aclonedcardinhostaccount',
+        { customer: 'cus_host_test' },
+        { stripeAccount: 'acc_host_test' },
+      );
+    });
+
+    it('return card payment method already cloned', async () => {
+      await platformPaymentMethod.update({
+        data: {
+          ...platformPaymentMethod.data,
+          fingerprint: 'fingerprint',
+          stripePaymentMethodId: 'card_platform',
+        },
+      });
+
+      await fakePaymentMethod({
+        CollectiveId: collective.id,
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        customerId: 'cus_host_test',
+        data: {
+          stripeAccount: 'acc_host_test',
+          fingerprint: 'fingerprint',
+          stripePaymentMethodId: 'pm_aclonedcardinhostaccount',
+        },
+      });
+
+      const paymentMethod = await common.getOrCloneCardPaymentMethod(
+        platformPaymentMethod,
+        collective,
+        'acc_host_test',
+        'cus_host_test',
+      );
+
+      expect(paymentMethod).to.exist;
+      expect(paymentMethod.customerId).to.equal('cus_host_test');
+      expect(paymentMethod.data?.fingerprint).to.equal('fingerprint');
+      expect(paymentMethod.data?.stripePaymentMethodId).to.equal('pm_aclonedcardinhostaccount');
+
+      assert.notCalled(stripe.tokens.retrieve);
+      assert.notCalled(stripe.paymentMethods.create);
+      assert.notCalled(stripe.paymentMethods.attach);
+    });
+  });
+
+  describe('#attachCardToPlatformCustomer()', async () => {
+    beforeEach(() => utils.resetTestDB());
+
+    const sandbox = createSandbox();
+    afterEach(sandbox.restore);
+
+    let collective, paymentMethod, user;
+    beforeEach(async () => {
+      collective = await fakeCollective();
+      user = await fakeUser();
+
+      paymentMethod = await fakePaymentMethod({
+        customerId: undefined,
+        token: 'tok_platformcardtoken1234567',
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        CollectiveId: collective.id,
+      });
+
+      sandbox.stub(stripe.paymentMethods, 'create');
+      sandbox.stub(stripe.paymentMethods, 'attach');
+    });
+
+    it('attaches card to platform customer account', async () => {
+      stripe.paymentMethods.create.resolves({
+        id: 'pm_platformcard123456789012',
+      });
+
+      stripe.paymentMethods.attach.resolves({
+        id: 'pm_platformcard123456789012',
+        type: 'card',
+        card: {
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      await fakeConnectedAccount({
+        clientId: config.stripe.accountId,
+        username: 'cus_platform',
+        CollectiveId: collective.id,
+        service: Service.STRIPE_CUSTOMER,
+      });
+
+      paymentMethod = await common.attachCardToPlatformCustomer(paymentMethod, collective, user);
+
+      expect(paymentMethod).to.exist;
+      expect(paymentMethod.customerId).to.equal('cus_platform');
+      expect(paymentMethod.data?.fingerprint).to.equal('fingerprint');
+      expect(paymentMethod.data?.stripePaymentMethodId).to.equal('pm_platformcard123456789012');
+
+      assert.calledWithMatch(stripe.paymentMethods.create, {
+        type: 'card',
+        card: { token: 'tok_platformcardtoken1234567' },
+      });
+
+      assert.calledWithMatch(stripe.paymentMethods.attach, 'pm_platformcard123456789012', { customer: 'cus_platform' });
+    });
+  });
+
+  describe('#resolvePaymentMethodForOrder()', async () => {
+    beforeEach(() => utils.resetTestDB());
+
+    const sandbox = createSandbox();
+    afterEach(sandbox.restore);
+
+    let collective, paymentMethod, order;
+    beforeEach(async () => {
+      collective = await fakeCollective();
+
+      await fakeConnectedAccount({
+        clientId: config.stripe.accountId,
+        username: 'cus_platformcustomer',
+        CollectiveId: collective.id,
+        service: Service.STRIPE_CUSTOMER,
+      });
+
+      paymentMethod = await fakePaymentMethod({
+        customerId: 'cus_platformcustomer',
+        token: 'tok_platformcardtoken1234567',
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        CollectiveId: collective.id,
+        data: {
+          stripePaymentMethodId: 'pm_platformcard123456789012',
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      order = await fakeOrder({
+        PaymentMethodId: paymentMethod.id,
+        FromCollectiveId: collective.id,
+      });
+
+      await fakeConnectedAccount({
+        clientId: 'acc_host',
+        username: 'cus_hostcustomer',
+        CollectiveId: collective.id,
+        service: Service.STRIPE_CUSTOMER,
+      });
+
+      sandbox.stub(stripe.paymentMethods, 'create');
+      sandbox.stub(stripe.paymentMethods, 'attach');
+    });
+
+    it('clones card to host account', async () => {
+      stripe.paymentMethods.create.resolves({
+        id: 'pm_clonedcard12345678901234',
+      });
+
+      stripe.paymentMethods.attach.resolves({
+        id: 'pm_clonedcard12345678901234',
+        type: 'card',
+        card: {
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      paymentMethod = await common.resolvePaymentMethodForOrder('acc_host', order);
+
+      expect(paymentMethod).to.exist;
+      expect(paymentMethod.customerId).to.equal('cus_hostcustomer');
+      expect(paymentMethod.data?.fingerprint).to.equal('fingerprint');
+      expect(paymentMethod.data?.stripePaymentMethodId).to.equal('pm_clonedcard12345678901234');
+
+      assert.calledWithMatch(stripe.paymentMethods.create, {
+        customer: 'cus_platformcustomer',
+        payment_method: 'pm_platformcard123456789012',
+      });
+
+      assert.calledWithMatch(stripe.paymentMethods.attach, 'pm_clonedcard12345678901234', {
+        customer: 'cus_hostcustomer',
+      });
+    });
+
+    it('return existing cloned card', async () => {
+      await fakePaymentMethod({
+        customerId: 'cus_hostcustomer',
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        CollectiveId: collective.id,
+        data: {
+          stripeAccount: 'acc_host',
+          stripePaymentMethodId: 'pm_clonedcard12345678901234',
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      paymentMethod = await common.resolvePaymentMethodForOrder('acc_host', order);
+
+      expect(paymentMethod).to.exist;
+      expect(paymentMethod.customerId).to.equal('cus_hostcustomer');
+      expect(paymentMethod.data?.fingerprint).to.equal('fingerprint');
+      expect(paymentMethod.data?.stripePaymentMethodId).to.equal('pm_clonedcard12345678901234');
+
+      assert.notCalled(stripe.paymentMethods.create);
+      assert.notCalled(stripe.paymentMethods.attach);
+    });
+
+    it('return platform card for platform host', async () => {
+      const resolvedPM = await common.resolvePaymentMethodForOrder(config.stripe.accountId, order);
+
+      expect(resolvedPM.id).to.equal(paymentMethod.id);
+
+      assert.notCalled(stripe.paymentMethods.create);
+      assert.notCalled(stripe.paymentMethods.attach);
+    });
+
+    it('return same card if it exists on host account', async () => {
+      order.paymentMethod = await fakePaymentMethod({
+        customerId: 'cus_hostcustomer',
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        CollectiveId: collective.id,
+        data: {
+          stripeAccount: 'acc_host',
+          stripePaymentMethodId: 'pm_clonedcard12345678901234',
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      const resolvedPM = await common.resolvePaymentMethodForOrder('acc_host', order);
+
+      expect(resolvedPM.id).to.equal(order.paymentMethod.id);
+
+      assert.notCalled(stripe.paymentMethods.create);
+      assert.notCalled(stripe.paymentMethods.attach);
+    });
+
+    it('throws error if card is from another connected account', async () => {
+      order.paymentMethod = await fakePaymentMethod({
+        customerId: 'cus_anotherhostcustomer',
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        CollectiveId: collective.id,
+        data: {
+          stripeAccount: 'acc_anotherhost',
+          stripePaymentMethodId: 'pm_clonedcard12345678901234',
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      await expect(common.resolvePaymentMethodForOrder('acc_host', order)).to.eventually.be.rejectedWith(
+        Error,
+        'Cannot clone payment method that are not attached to the platform account',
+      );
+
+      assert.notCalled(stripe.paymentMethods.create);
+      assert.notCalled(stripe.paymentMethods.attach);
+    });
+
+    it('throws error if card is from connected account and host is platform', async () => {
+      order.paymentMethod = await fakePaymentMethod({
+        customerId: 'cus_hostcustomer',
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        CollectiveId: collective.id,
+        data: {
+          stripeAccount: 'acc_host',
+          stripePaymentMethodId: 'pm_clonedcard12345678901234',
+          fingerprint: 'fingerprint',
+        },
+      });
+
+      await expect(common.resolvePaymentMethodForOrder(config.stripe.accountId, order)).to.eventually.be.rejectedWith(
+        Error,
+        'Cannot clone payment method from connected account to platform account',
+      );
+
+      assert.notCalled(stripe.paymentMethods.create);
+      assert.notCalled(stripe.paymentMethods.attach);
+    });
+  });
+});

--- a/test/server/paymentProviders/stripe/creditcard.test.js
+++ b/test/server/paymentProviders/stripe/creditcard.test.js
@@ -55,7 +55,10 @@ describe('server/paymentProviders/stripe/creditcard', () => {
         currency: 'USD',
       });
 
-      sandbox.stub(common, 'resolvePaymentMethodForOrder').resolves(paymentMethod);
+      sandbox.stub(common, 'resolvePaymentMethodForOrder').resolves({
+        id: 'pm_test',
+        customer: 'cus_test',
+      });
       sandbox.stub(stripe.paymentIntents, 'create').resolves({ id: 'pm_test', status: 'requires_confirmation' });
       sandbox.stub(stripe.paymentIntents, 'confirm').resolves({
         id: 'pm_test',

--- a/test/server/paymentProviders/stripe/creditcard.test.js
+++ b/test/server/paymentProviders/stripe/creditcard.test.js
@@ -1,259 +1,237 @@
 /* eslint-disable camelcase */
-import querystring from 'querystring';
 
 import { expect } from 'chai';
-import nock from 'nock';
+import { assert, createSandbox } from 'sinon';
 
+import { Service } from '../../../../server/constants/connected_account';
+import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../../server/constants/paymentMethods';
 import cache from '../../../../server/lib/cache';
-import models, { sequelize } from '../../../../server/models';
+import stripe from '../../../../server/lib/stripe';
+import * as common from '../../../../server/paymentProviders/stripe/common';
 import creditcard from '../../../../server/paymentProviders/stripe/creditcard';
-import { fakeHost, fakeUser } from '../../../test-helpers/fake-data';
+import { fakeCollective, fakeConnectedAccount, fakeOrder, fakePaymentMethod } from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
-
-async function createOrderWithPaymentMethod(paymentMethodName, orderParams = {}) {
-  const user = await models.User.createUserWithCollective({
-    name: 'TestMcTesterson',
-    email: 'tmct@mct.com',
-  });
-  const host = await models.Collective.create({ name: 'Host Collective' });
-  const tier = await models.Tier.create({ name: 'backer', amount: 0 });
-  const collective = await models.Collective.create({ name: 'Parcel' });
-  await collective.addHost(host, user, { shouldAutomaticallyApprove: true });
-  const connectedAccount = await models.ConnectedAccount.create({
-    service: 'stripe',
-    token: 'tok_1Be9noDjPFcHOcTmT574CrEv',
-    CollectiveId: host.id,
-  });
-  const paymentMethod = await models.PaymentMethod.create({
-    name: paymentMethodName,
-    token: 'tok_123456781234567812345678',
-    service: 'stripe',
-    type: 'creditcard',
-    data: { expMonth: 11, expYear: 2025 },
-    monthlyLimitPerMember: 10000,
-    CollectiveId: collective.id,
-  });
-  const order = await models.Order.create(
-    Object.assign(
-      {
-        CreatedByUserId: user.id,
-        FromCollectiveId: user.CollectiveId,
-        CollectiveId: collective.id,
-        PaymentMethodId: paymentMethod.id,
-        TierId: tier.id,
-        totalAmount: 1000,
-        currency: 'USD',
-      },
-      orderParams,
-    ),
-  );
-  order.fromCollective = user.collective;
-  order.collective = collective;
-  order.createdByUser = user;
-  order.paymentMethod = paymentMethod;
-  return { order, user, collective, paymentMethod, connectedAccount, host };
-}
 
 describe('server/paymentProviders/stripe/creditcard', () => {
   describe('#processOrder()', async () => {
-    let secondCallToCreateCustomer, createIntentRequest;
-
-    const setupNock = ({ balanceTransactions = { amount: 1000, currency: 'usd', fee: 0, fee_details: [] } } = {}) => {
-      // Call performed by getOrCreateCustomerOnPlatformAccount
-      nock('https://api.stripe.com:443').post('/v1/customers').reply(200, {});
-
-      // Calls performed by getOrCreateCustomerIdForHost
-      nock('https://api.stripe.com:443').post('/v1/tokens').reply(200, {});
-      secondCallToCreateCustomer = nock('https://api.stripe.com:443').post('/v1/customers').reply(200, {});
-
-      // Calls performed by createChargeAndTransactions
-      nock('https://api.stripe.com:443')
-        .post('/v1/payment_intents')
-        .reply(200, (_, body) => {
-          createIntentRequest = querystring.parse(body);
-          return {
-            id: 'pi_1F82vtBYycQg1OMfS2Rctiau',
-            status: 'requires_confirmation',
-          };
-        });
-      nock('https://api.stripe.com:443')
-        .post('/v1/payment_intents/pi_1F82vtBYycQg1OMfS2Rctiau/confirm')
-        .reply(200, {
-          charges: {
-            data: [{ id: 'ch_1B5j91D8MNtzsDcgNMsUgI8L', balance_transaction: 'txn_1B5j92D8MNtzsDcgQzIcmfrn' }],
-          },
-          status: 'succeeded',
-        });
-      nock('https://api.stripe.com:443')
-        .get('/v1/balance_transactions/txn_1B5j92D8MNtzsDcgQzIcmfrn')
-        .reply(200, balanceTransactions);
-    };
-
     beforeEach(() => utils.resetTestDB());
 
-    beforeEach(setupNock);
+    const sandbox = createSandbox();
+    afterEach(sandbox.restore);
 
+    let collective, host, paymentMethod, order;
     beforeEach(async () => {
-      const user = await fakeUser({ id: 30 }, { id: 20, slug: 'pia' });
-      await fakeHost({ id: 8686, slug: 'opencollectiveinc', CreatedByUserId: user.id });
-      // Move Collectives ID auto increment pointer up, so we don't collide with the manually created id:1
-      await sequelize.query(`ALTER SEQUENCE "Groups_id_seq" RESTART WITH 1453`);
+      // platform tip transaction expects platform collective by id 8686
+      await fakeCollective({ id: 8686 });
+
+      const fromCollective = await fakeCollective();
+      collective = await fakeCollective();
+      host = collective.host;
+
+      await fakeConnectedAccount({
+        CollectiveId: collective.host.id,
+        service: Service.STRIPE,
+        username: 'acc_test',
+        token: 'sk_test',
+      });
+
+      paymentMethod = await fakePaymentMethod({
+        CollectiveId: fromCollective.id,
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        customerId: 'cus_test',
+        token: 'tok_testtoken123456789012345',
+        data: {
+          stripePaymentMethodId: 'pm_test',
+        },
+      });
+
+      order = await fakeOrder({
+        CreatedByUserId: fromCollective.CreatedByUserId,
+        CollectiveId: collective.id,
+        FromCollectiveId: fromCollective.id,
+        PaymentMethodId: paymentMethod.id,
+        totalAmount: 1000,
+        currency: 'USD',
+      });
+
+      sandbox.stub(common, 'resolvePaymentMethodForOrder').resolves(paymentMethod);
+      sandbox.stub(stripe.paymentIntents, 'create').resolves({ id: 'pm_test', status: 'requires_confirmation' });
+      sandbox.stub(stripe.paymentIntents, 'confirm').resolves({
+        id: 'pm_test',
+        status: 'succeeded',
+        charges: {
+          data: [{ id: 'ch_id', balance_transaction: 'txn_id' }],
+        },
+      });
+
+      sandbox.stub(stripe.balanceTransactions, 'retrieve').resolves({
+        amount: 1100,
+        currency: 'usd',
+        fee: 0,
+        fee_details: [],
+      });
     });
 
-    afterEach(() => nock.cleanAll());
-
-    it('should create a new customer id for a host', async () => {
-      const { order } = await createOrderWithPaymentMethod('name');
+    it('should process order correctly', async () => {
       await creditcard.processOrder(order);
-      expect(secondCallToCreateCustomer.isDone()).to.be.true;
+
+      assert.calledWithMatch(
+        stripe.paymentIntents.create,
+        {
+          customer: 'cus_test',
+          payment_method: 'pm_test',
+        },
+        {
+          stripeAccount: 'acc_test',
+        },
+      );
+
+      assert.calledWithMatch(stripe.paymentIntents.confirm, 'pm_test', {
+        stripeAccount: 'acc_test',
+      });
     });
 
     it('has tax information stored in transaction', async () => {
-      const taxAmount = 100;
-      const { order } = await createOrderWithPaymentMethod('name', { taxAmount });
+      await order.update({ taxAmount: 100 });
+
       const transaction = await creditcard.processOrder(order);
-      expect(transaction.taxAmount).to.be.equal(-taxAmount);
+      expect(transaction.taxAmount).to.be.equal(-100);
     });
 
     describe('platform tips and host revenue share', () => {
       it('should collect the platform fee as application fee', async () => {
-        nock.cleanAll();
-        setupNock({
-          balanceTransactions: {
-            amount: 1100,
-            currency: 'usd',
-            fee: 0,
-            fee_details: [
-              {
-                type: 'application_fee',
-                amount: 100,
-                currency: 'usd',
-                application: 'ca_',
-                description: 'OpenCollective application fee',
-              },
-            ],
-          },
+        stripe.balanceTransactions.retrieve.resolves({
+          amount: 1100,
+          currency: 'usd',
+          fee: 0,
+          fee_details: [
+            {
+              type: 'application_fee',
+              amount: 100,
+              currency: 'usd',
+              application: 'ca_',
+              description: 'OpenCollective application fee',
+            },
+          ],
         });
-        const { order } = await createOrderWithPaymentMethod('name', {
-          totalAmount: 1100,
-          platformTipAmount: 100,
-        });
+
+        await order.update({ totalAmount: 1100, platformTipAmount: 100 });
 
         await creditcard.processOrder(order);
 
-        expect(createIntentRequest).to.have.property('amount', '1100');
-        expect(createIntentRequest).to.have.property('application_fee_amount', '100');
+        assert.calledWithMatch(stripe.paymentIntents.create, {
+          amount: 1100,
+          application_fee_amount: 100,
+        });
       });
 
       it('should collect the host revenue share', async () => {
-        const { order, host, collective } = await createOrderWithPaymentMethod('name', {
-          totalAmount: 1000,
-        });
+        await order.update({ totalAmount: 1000 });
         await collective.update({ hostFeePercent: 10 });
         await host.update({ plan: 'grow-plan-2021' });
         await cache.clear();
 
         await creditcard.processOrder(order);
 
-        expect(createIntentRequest).to.have.property('amount', '1000');
-        expect(createIntentRequest).to.have.property('application_fee_amount', `${1000 * 0.1 * 0.15}`);
+        assert.calledWithMatch(stripe.paymentIntents.create, {
+          amount: 1000,
+          application_fee_amount: 1000 * 0.1 * 0.15,
+        });
       });
 
       it('should process orders correctly with zero decimal currencies', async () => {
-        const { order } = await createOrderWithPaymentMethod('name', {
+        await order.update({
           totalAmount: 25000,
-          currency: 'jpy',
+          currency: 'JPY',
           platformTipAmount: 5000,
         });
 
         await creditcard.processOrder(order);
 
-        expect(createIntentRequest).to.have.property('amount', '250');
-        expect(createIntentRequest).to.have.property('application_fee_amount', `50`);
+        assert.calledWithMatch(stripe.paymentIntents.create, {
+          currency: 'JPY',
+          amount: 250,
+          application_fee_amount: 50,
+        });
       });
 
       it('should work with custom creditCardHostFeeSharePercent', async () => {
-        const { order, host, collective } = await createOrderWithPaymentMethod('name', {
-          totalAmount: 1000,
-        });
+        await order.update({ totalAmount: 1000 });
         await collective.update({ hostFeePercent: 10 });
         await host.update({ plan: 'grow-plan-2021', data: { plan: { creditCardHostFeeSharePercent: 20 } } });
         await cache.clear();
 
         await creditcard.processOrder(order);
 
-        expect(createIntentRequest).to.have.property('amount', '1000');
-        expect(createIntentRequest).to.have.property('application_fee_amount', `${1000 * 0.1 * 0.2}`);
+        assert.calledWithMatch(stripe.paymentIntents.create, {
+          amount: 1000,
+          application_fee_amount: 1000 * 0.1 * 0.2,
+        });
       });
 
       it('should work with creditCardHostFeeSharePercent = 0', async () => {
-        const { order, host, collective } = await createOrderWithPaymentMethod('name', {
-          totalAmount: 1000,
-        });
+        await order.update({ totalAmount: 1000 });
         await collective.update({ hostFeePercent: 10, platformFeePercent: 0 });
         await host.update({ plan: 'grow-plan-2021', data: { plan: { creditCardHostFeeSharePercent: 0 } } });
         await cache.clear();
 
         await creditcard.processOrder(order);
 
-        expect(createIntentRequest).to.have.property('amount', '1000');
-        expect(createIntentRequest).to.not.have.property('application_fee_amount');
+        assert.calledWithMatch(stripe.paymentIntents.create, {
+          amount: 1000,
+          application_fee_amount: undefined,
+        });
       });
 
       it('should collect both', async () => {
-        nock.cleanAll();
-        setupNock({
-          balanceTransactions: {
-            amount: 1100,
-            currency: 'usd',
-            fee: 0,
-            fee_details: [
-              {
-                type: 'application_fee',
-                amount: 115,
-                currency: 'usd',
-                application: 'ca_',
-                description: 'OpenCollective application fee',
-              },
-            ],
-          },
-        });
-        const { order, host, collective } = await createOrderWithPaymentMethod('name', {
-          totalAmount: 1100,
-          platformTipAmount: 100,
-        });
         await collective.update({ hostFeePercent: 10 });
         await host.update({ plan: 'grow-plan-2021' });
         await cache.clear();
 
+        await order.update({ totalAmount: 1100, platformTipAmount: 100 });
+
+        stripe.balanceTransactions.retrieve.resolves({
+          amount: 1100,
+          currency: 'usd',
+          fee: 0,
+          fee_details: [
+            {
+              type: 'application_fee',
+              amount: 115,
+              currency: 'usd',
+              application: 'ca_',
+              description: 'OpenCollective application fee',
+            },
+          ],
+        });
+
         await creditcard.processOrder(order);
 
-        expect(createIntentRequest).to.have.property('amount', '1100');
-        expect(createIntentRequest).to.have.property('application_fee_amount', `${1000 * 0.1 * 0.15 + 100}`);
+        assert.calledWithMatch(stripe.paymentIntents.create, {
+          amount: 1100,
+          application_fee_amount: 1000 * 0.1 * 0.15 + 100,
+        });
       });
 
       it('should create a debt for platform tip and share if currency does not support application_fee', async () => {
-        nock.cleanAll();
-        setupNock({
-          balanceTransactions: {
-            amount: 1100,
-            currency: 'BRL',
-            fee_details: [],
-          },
-        });
-        const { order, host, collective } = await createOrderWithPaymentMethod('name', {
-          totalAmount: 1100,
-          platformTipAmount: 100,
-          currency: 'BRL',
-        });
+        await order.update({ currency: 'BRL', totalAmount: 1100, platformTipAmount: 100 });
         await collective.update({ hostFeePercent: 10 });
         await host.update({ currency: 'BRL', plan: 'grow-plan-2021' });
         await cache.clear();
 
+        stripe.balanceTransactions.retrieve.resolves({
+          amount: 1100,
+          currency: 'BRL',
+          fee_details: [],
+        });
+
         await creditcard.processOrder(order);
 
-        expect(createIntentRequest).to.have.property('amount', '1100');
-        expect(createIntentRequest).to.not.have.property('application_fee_amount');
+        assert.calledWithMatch(stripe.paymentIntents.create, {
+          amount: 1100,
+          application_fee_amount: undefined,
+        });
 
         const transactions = await order.getTransactions();
         expect(transactions.filter(t => t.kind === 'HOST_FEE_SHARE_DEBT')).to.have.lengthOf(2);

--- a/test/utils.js
+++ b/test/utils.js
@@ -255,6 +255,7 @@ export function stubStripeCreate(sandbox, overloadDefaults) {
     charge: { id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' },
     paymentIntent: { id: 'pi_1F82vtBYycQg1OMfS2Rctiau', status: 'requires_confirmation' },
     paymentIntentConfirmed: { charges: { data: [{ id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' }] }, status: 'succeeded' },
+    paymentMethod: { id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } },
     ...overloadDefaults,
   };
   /* Little helper function that returns the stub with a given
@@ -262,17 +263,12 @@ export function stubStripeCreate(sandbox, overloadDefaults) {
   const factory = name => async () => values[name];
   sandbox.stub(stripe.tokens, 'create').callsFake(factory('token'));
 
-  sandbox.stub(stripe.customers, 'create').callsFake(async ({ source }) => {
-    if (source.startsWith('tok_chargeDeclined')) {
-      throw new Error('Your card was declined.');
-    }
-
-    return values.customer;
-  });
-
+  sandbox.stub(stripe.customers, 'create').callsFake(factory('customer'));
   sandbox.stub(stripe.customers, 'retrieve').callsFake(factory('customer'));
   sandbox.stub(stripe.paymentIntents, 'create').callsFake(factory('paymentIntent'));
   sandbox.stub(stripe.paymentIntents, 'confirm').callsFake(factory('paymentIntentConfirmed'));
+  sandbox.stub(stripe.paymentMethods, 'create').callsFake(factory('paymentMethod'));
+  sandbox.stub(stripe.paymentMethods, 'attach').callsFake(factory('paymentMethod'));
 }
 
 export function stubStripeBalance(sandbox, amount, currency, applicationFee = 0, stripeFee = 0) {


### PR DESCRIPTION
Revolves https://github.com/opencollective/opencollective/issues/6198

This results in a single stripe customer record per host account, with multiple payment methods attached.
Reusing platform attached cards across host stripe accounts is still possible, but now the card is only cloned once and it is attached to a single customer.

![image](https://user-images.githubusercontent.com/5448927/205165867-44ddd58f-45fb-4a37-86f1-1efb703b3116.png)

