### PR TITLE
Add combined time series on account

### DIFF
--- a/server/graphql/v2/object/AccountStats.js
+++ b/server/graphql/v2/object/AccountStats.js
@@ -1,7 +1,7 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
-import { get, has, initial, isNil } from 'lodash';
+import { get, has, isNil } from 'lodash';
 import moment from 'moment';
 
 import { getCollectiveIds } from '../../../lib/budget';

--- a/server/graphql/v2/object/AccountStats.js
+++ b/server/graphql/v2/object/AccountStats.js
@@ -473,8 +473,6 @@ export const AccountStats = new GraphQLObjectType({
           for (const val of results) {
             const key = val.date.toISOString();
             const isContribution = val.type === 'CREDIT' && (val.kind === 'CONTRIBUTION' || val.kind === 'ADDED_FUNDS');
-            const isHostFee = val.type === 'DEBIT' && val.kind === 'HOST_FEE';
-            const isSpent = val.type === 'DEBIT' && val.kind !== 'HOST_FEE';
 
             if (!merged[key]) {
               merged[key] = {
@@ -487,7 +485,6 @@ export const AccountStats = new GraphQLObjectType({
             }
 
             let amount;
-
             if (val.currency !== currency) {
               const fxRate = await getFxRate(val.currency, currency, val.date);
               amount = val.amount * fxRate;
@@ -495,9 +492,9 @@ export const AccountStats = new GraphQLObjectType({
               amount = val.amount;
             }
 
-            if (isSpent) {
+            if (val.type === 'DEBIT' && val.kind !== 'HOST_FEE') {
               merged[key].totalSpent.value += Math.abs(amount);
-            } else if (isContribution || isHostFee) {
+            } else if (val.type === 'CREDIT' || (val.type === 'DEBIT' && val.kind === 'HOST_FEE')) {
               merged[key].totalNetRaised.value += amount;
             }
 

--- a/server/graphql/v2/object/TimeSeriesCombined.ts
+++ b/server/graphql/v2/object/TimeSeriesCombined.ts
@@ -1,0 +1,30 @@
+import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+
+import { getTimeSeriesFields, TimeSeries } from '../interface/TimeSeries';
+
+import { Amount } from './Amount';
+
+const TimeSeriesCombinedNode = new GraphQLObjectType({
+  name: 'TimeSeriesCombinedNode',
+  fields: () => ({
+    date: { type: new GraphQLNonNull(GraphQLDateTime) },
+    totalNetRaised: { type: new GraphQLNonNull(Amount) },
+    totalSpent: { type: new GraphQLNonNull(Amount) },
+    contributions: { type: GraphQLInt },
+    contributors: { type: GraphQLInt },
+  }),
+});
+
+export const TimeSeriesCombined = new GraphQLObjectType({
+  name: 'TimeSeriesCombined',
+  description: 'Combined time series of net raised, spent, contributors and contributions',
+  interfaces: [TimeSeries],
+  fields: () => ({
+    ...getTimeSeriesFields(),
+    nodes: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TimeSeriesCombinedNode))),
+      description: 'Time series data points',
+    },
+  }),
+});


### PR DESCRIPTION
This PR is adding a combined time series on `account.stats`, so that we can get all data that is interesting for the Horizons dashboard in one database query per collective. 

Beyond allowing for big improvements in performance, it's also adding the currently not existing ability of getting number of contributors in a timespan or timeseries, required for the dashboard.

```graphql
query {
  accounts {
    nodes {
      id
      stats {
        combinedTimeSeries(dateFrom: DateTime, dateTo: DateTime, timeUnit: TimeUnit) {
          nodes {
            date
            contributions
            contributors
            totalNetRaised {
              value
              currency
            }
            totalSpent {
              value
              currency
            }
          }
        }
      }
    }
  }
}
```

### TODO
- [ ] discuss/improve API design
- [ ] review what transactions should be included to calculate totalNetRaised and totalSpent
- [x] fix currency conversion if there can be two host currencies on one collective