### PR TITLE
Remove log in buttons from new member emails

### DIFF
--- a/server/models/Collective.js
+++ b/server/models/Collective.js
@@ -1957,7 +1957,6 @@ Collective.prototype.sendNewMemberEmail = async function (user, role, member, se
       recipient: {
         collective: memberUser.collective.activity,
       },
-      loginLink: `${config.host.website}/signin?next=/${memberUser.collective.slug}/admin`,
     },
     { bcc: remoteUser.email },
   );

--- a/templates/emails/collective.newmember.hbs
+++ b/templates/emails/collective.newmember.hbs
@@ -34,8 +34,4 @@ Subject: {{{remoteUser.collective.name}}} added you as {{{collective.name}}} {{r
   {{/if}}
 </table>
 
-<a href="{{{loginLink}}}" class="btn blue">
-  <div>Log in</div>
-</a>
-
 {{> footer}}

--- a/templates/emails/organization.newmember.hbs
+++ b/templates/emails/organization.newmember.hbs
@@ -28,10 +28,6 @@ Subject: {{{remoteUser.collective.name}}} added you as {{role}} to {{{collective
   <tr><th>Twitter:</th><td>{{recipient.collective.twitterHandle}}</td></tr>
 </table>
 
-<a href="{{{loginLink}}}" class="btn blue">
-  <div>Log in</div>
-</a>
-
 <p>If you have questions, feel free to reply to this email.</p>
 
 {{> footer}}


### PR DESCRIPTION
While looking at some email templates I was surprised to see some `Log in` buttons, since we stopped including them in random emails. Turns out they're redirect links (i.e. `/signin?next=/...`) so nothing to worry about, but they still didn't make much sense when looking at the emails, especially since we now have an invitation process where you need to be signed in already. 

![image](https://user-images.githubusercontent.com/1556356/206006968-6614f87b-75f6-4e64-8b8c-7a68adabac85.png)
