### PR TITLE
Fix expense author cannot approve policy resolver

### DIFF
--- a/server/graphql/v2/object/Policies.ts
+++ b/server/graphql/v2/object/Policies.ts
@@ -14,7 +14,7 @@ export const Policies = new GraphQLObjectType({
   fields: () => ({
     [POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE]: {
       type: GraphQLBoolean,
-      resolve(account, req) {
+      resolve(account, _, req) {
         if (req.remoteUser?.isAdminOfCollective(account) && checkScope(req, 'account')) {
           return getPolicy(account, POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE);
         }


### PR DESCRIPTION
Resolver was always resolving to `null` due to wrong resolver argument.