### PR TITLE
Handle payment attach event for stripe cards

### DIFF
--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -507,6 +507,10 @@ function formatPaymentMethodName(paymentMethod: Stripe.PaymentMethod) {
 async function paymentMethodAttached(event: Stripe.Response<Stripe.Event>) {
   const stripePaymentMethod = event.data.object as Stripe.PaymentMethod;
 
+  if (!['us_bank_account', 'sepa_debit'].includes(stripePaymentMethod.type)) {
+    return;
+  }
+
   const stripeAccount = event.account ?? config.stripe.accountId;
 
   const stripeCustomerId = stripePaymentMethod.customer;


### PR DESCRIPTION
Stripe cards are attached directly when the user chooses to save a card during the contribution flow, or when the user setups a card in the settings.