### PR TITLE
Increase timeout for MergeAccounts

### DIFF
--- a/test/server/lib/merge-accounts.test.ts
+++ b/test/server/lib/merge-accounts.test.ts
@@ -93,7 +93,7 @@ describe('server/lib/merge-accounts', () => {
 
   before(async function () {
     // This test can take some time to setup on local env
-    this.timeout(30000);
+    this.timeout(45000);
 
     await resetTestDB();
 


### PR DESCRIPTION
This test seems to be often failing with timeouts lately, which could be related to the recent changes with `resetTestDb`. Increasing the timeout limit for now, but we should aim to optimize this.