### PR TITLE
Don't return non-approved collectives when searching by host

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -200,6 +200,7 @@ export const searchCollectivesInDB = async (
 
   if (hostCollectiveIds && hostCollectiveIds.length > 0) {
     dynamicConditions += 'AND c."HostCollectiveId" IN (:hostCollectiveIds) ';
+    dynamicConditions += 'AND c."approvedAt" IS NOT NULL ';
   }
 
   if (parentCollectiveIds && parentCollectiveIds.length > 0) {


### PR DESCRIPTION
Spotted on https://discover.opencollective.com/foundation. Should return 450, not 507 collectives.