### PR TITLE
Faster amountReceived and amountSpent calculations

### DIFF
--- a/migrations/20221213000000-update-collective-transaction-stats-materialized-view.js
+++ b/migrations/20221213000000-update-collective-transaction-stats-materialized-view.js
@@ -3,7 +3,7 @@
 module.exports = {
   async up(queryInterface) {
     await queryInterface.sequelize.query(`
-      DROP MATERIALIZED VIEW "CollectiveTransactionStats";
+      DROP MATERIALIZED VIEW IF EXISTS  "CollectiveTransactionStats";
       CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
 
         WITH "ActiveCollectives" AS (
@@ -133,7 +133,7 @@ module.exports = {
   async down(queryInterface) {
     // Reinstate previous version
     await queryInterface.sequelize.query(`
-      DROP MATERIALIZED VIEW "CollectiveTransactionStats";
+      DROP MATERIALIZED VIEW IF EXISTS "CollectiveTransactionStats";
       CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
         SELECT
           c.id,

--- a/migrations/20221213000000-update-collective-transaction-stats-materialized-view.js
+++ b/migrations/20221213000000-update-collective-transaction-stats-materialized-view.js
@@ -1,0 +1,154 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP MATERIALIZED VIEW "CollectiveTransactionStats";
+      CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
+
+        WITH "ActiveCollectives" AS (
+          SELECT c."id" as "CollectiveId"
+          FROM "Transactions" t
+          LEFT JOIN  "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL
+          WHERE t."deletedAt" IS NULL
+            AND t."hostCurrency" IS NOT NULL
+            AND c."deactivatedAt" IS NULL
+            -- TODO: not sure why we have those conditions omn guest/incognito, too many accounts?
+            AND (c."data" ->> 'isGuest')::boolean IS NOT TRUE
+            AND c.name != 'incognito'
+            AND c.name != 'anonymous'
+            AND c."isIncognito" = FALSE
+          GROUP BY c."id"
+          HAVING COUNT(DISTINCT t."hostCurrency") = 1 -- no hostCurrency mismatch please!
+        )
+        SELECT
+          ac."CollectiveId" as "id",
+          MAX(t.id) as "LatestTransactionId",
+          COUNT(DISTINCT t.id) AS "count",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT')
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind = 'HOST_FEE'))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalNetAmountSpentInHostCurrency",
+
+          MAX(t."hostCurrency") as  "hostCurrency"
+
+        FROM "ActiveCollectives" ac
+
+        LEFT JOIN "Transactions" t ON t."CollectiveId" = ac."CollectiveId"
+          AND t."deletedAt" IS NULL
+          AND t."RefundTransactionId" IS NULL
+          AND t."isRefund" IS NOT TRUE
+          AND t."isInternal" IS NOT TRUE
+
+        GROUP BY ac."CollectiveId";
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW "CurrentCollectiveTransactionStats" as (
+        SELECT
+          cts."id" as "CollectiveId",
+
+          COALESCE(cts."totalAmountReceivedInHostCurrency", 0) + COALESCE(t."totalAmountReceivedInHostCurrency", 0)
+            AS "totalAmountReceivedInHostCurrency",
+          COALESCE(cts."totalNetAmountReceivedInHostCurrency", 0) + COALESCE(t."totalNetAmountReceivedInHostCurrency", 0)
+            AS "totalNetAmountReceivedInHostCurrency",
+          COALESCE(cts."totalAmountSpentInHostCurrency", 0) + COALESCE(t."totalAmountSpentInHostCurrency", 0)
+            AS "totalAmountSpentInHostCurrency",
+          COALESCE(cts."totalNetAmountSpentInHostCurrency", 0) + COALESCE(t."totalNetAmountSpentInHostCurrency", 0)
+            AS "totalNetAmountSpentInHostCurrency",
+
+          cts."hostCurrency"
+
+        FROM "CollectiveTransactionStats" cts
+
+        LEFT JOIN LATERAL (
+          SELECT
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT')
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind = 'HOST_FEE'))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalNetAmountSpentInHostCurrency"
+
+          FROM "Transactions" t
+          WHERE t."CollectiveId" = cts."id"
+            AND t.id > cts."LatestTransactionId"
+            AND t."deletedAt" is null
+            AND t."RefundTransactionId" IS NULL
+            AND t."isRefund" IS NOT TRUE
+            AND t."isInternal" IS NOT TRUE
+
+          GROUP by t."CollectiveId"
+        ) as t ON TRUE
+      );
+    `);
+  },
+
+  async down(queryInterface) {
+    // Reinstate previous version
+    await queryInterface.sequelize.query(`
+      DROP MATERIALIZED VIEW "CollectiveTransactionStats";
+      CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
+        SELECT
+          c.id,
+          COUNT(DISTINCT t.id) AS "count",
+          SUM(t."amountInHostCurrency") FILTER (WHERE t.type = 'CREDIT') AS "totalAmountReceivedInHostCurrency",
+          SUM(ABS(t."amountInHostCurrency")) FILTER (WHERE t.type = 'DEBIT') AS "totalAmountSpentInHostCurrency"
+        FROM "Collectives" c
+        LEFT JOIN "Transactions" t ON t."CollectiveId" = c.id AND t."deletedAt" IS NULL AND t."RefundTransactionId" IS NULL
+        WHERE c."deletedAt" IS NULL
+        AND c."deactivatedAt" IS NULL
+        AND (c."data" ->> 'isGuest')::boolean IS NOT TRUE
+        AND c.name != 'incognito'
+        AND c.name != 'anonymous'
+        AND c."isIncognito" = FALSE
+        GROUP BY c.id
+    `);
+  },
+};

--- a/migrations/20221213000000-update-collective-transaction-stats-materialized-view.js
+++ b/migrations/20221213000000-update-collective-transaction-stats-materialized-view.js
@@ -3,13 +3,13 @@
 module.exports = {
   async up(queryInterface) {
     await queryInterface.sequelize.query(`
-      DROP MATERIALIZED VIEW IF EXISTS  "CollectiveTransactionStats";
+      DROP MATERIALIZED VIEW IF EXISTS "CollectiveTransactionStats";
       CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
 
         WITH "ActiveCollectives" AS (
           SELECT c."id" as "CollectiveId"
           FROM "Transactions" t
-          LEFT JOIN  "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL
+          LEFT JOIN "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL
           WHERE t."deletedAt" IS NULL
             AND t."hostCurrency" IS NOT NULL
             AND c."deactivatedAt" IS NULL
@@ -54,11 +54,11 @@ module.exports = {
             FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
             AS "totalNetAmountSpentInHostCurrency",
 
-          MAX(t."hostCurrency") as  "hostCurrency"
+          MAX(t."hostCurrency") as "hostCurrency"
 
         FROM "ActiveCollectives" ac
 
-        LEFT JOIN "Transactions" t ON t."CollectiveId" = ac."CollectiveId"
+        INNER JOIN "Transactions" t ON t."CollectiveId" = ac."CollectiveId"
           AND t."deletedAt" IS NULL
           AND t."RefundTransactionId" IS NULL
           AND t."isRefund" IS NOT TRUE

--- a/server/graphql/v2/object/AccountStats.js
+++ b/server/graphql/v2/object/AccountStats.js
@@ -1,7 +1,7 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
-import { get, has, isNil, pick } from 'lodash';
+import { get, has, pick } from 'lodash';
 import moment from 'moment';
 
 import { getCollectiveIds } from '../../../lib/budget';
@@ -174,6 +174,12 @@ export const AccountStats = new GraphQLObjectType({
             'includeChildren',
             'currency',
           ]),
+          useCache: {
+            type: new GraphQLNonNull(GraphQLBoolean),
+            description: 'Set this to true to use cached data',
+            deprecationReason: '2022-12-14: this is not used anymore as results should be fast by default',
+            defaultValue: false,
+          },
         },
         async resolve(collective, args, req) {
           const kind = args.kind && args.kind.length > 0 ? args.kind : undefined;

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -95,7 +95,7 @@ export async function getBalances(
 ) {
   const fastResults =
     fastBalance === true && version === DEFAULT_BUDGET_VERSION && !endDate && !includeChildren
-      ? await getCurrentFastBalances(collectiveIds, { loaders, withBlockedFunds })
+      ? await getCurrentCollectiveBalances(collectiveIds, { loaders, withBlockedFunds })
       : {};
   const missingCollectiveIds = difference(collectiveIds.map(Number), Object.keys(fastResults).map(Number));
 
@@ -786,7 +786,7 @@ export async function getBlockedFunds(collectiveIds) {
 }
 
 // Get current balance for collective using a combination of speed and accuracy.
-export async function getCurrentFastBalances(collectiveIds, { loaders = null, withBlockedFunds = false } = {}) {
+export async function getCurrentCollectiveBalances(collectiveIds, { loaders = null, withBlockedFunds = false } = {}) {
   const fastResults = loaders
     ? await Promise.map(collectiveIds, collectiveId =>
         loaders.Collective.currentCollectiveBalance.load(collectiveId),

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -402,7 +402,7 @@ export async function getSumCollectivesAmountReceived(
     : 'amountInHostCurrency';
   const transactionType = net ? 'CREDIT_WITH_HOST_FEE' : CREDIT;
 
-  const results = sumCollectivesTransactions(missingCollectiveIds, {
+  const results = await sumCollectivesTransactions(missingCollectiveIds, {
     column,
     transactionType,
     kind,

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -191,10 +191,32 @@ export async function getTotalAmountSpentAmount(
   };
 }
 
-export function getSumCollectivesAmountSpent(
+export async function getSumCollectivesAmountSpent(
   collectiveIds,
-  { net, kind, startDate, endDate, includeChildren, includeGiftCards, version = DEFAULT_BUDGET_VERSION } = {},
+  {
+    net,
+    kind,
+    startDate,
+    endDate,
+    includeChildren,
+    includeGiftCards,
+    version = DEFAULT_BUDGET_VERSION,
+    loaders = null,
+  } = {},
 ) {
+  const fastResults =
+    version === DEFAULT_BUDGET_VERSION && !kind && !startDate && !endDate && !includeChildren && !includeGiftCards
+      ? await getCurrentCollectiveTransactionStats(collectiveIds, {
+          loaders,
+          column: net ? 'totalNetAmountSpentInHostCurrency' : 'totalAmountSpentInHostCurrency',
+        })
+      : {};
+  const missingCollectiveIds = difference(collectiveIds.map(Number), Object.keys(fastResults).map(Number));
+
+  if (missingCollectiveIds.length === 0) {
+    return fastResults;
+  }
+
   const column = ['v0', 'v1'].includes(version)
     ? net
       ? 'netAmountInCollectiveCurrency'
@@ -204,7 +226,7 @@ export function getSumCollectivesAmountSpent(
     : 'amountInHostCurrency';
   const transactionType = 'DEBIT_WITHOUT_HOST_FEE';
 
-  return sumCollectivesTransactions(collectiveIds, {
+  const results = await sumCollectivesTransactions(collectiveIds, {
     column,
     transactionType,
     kind,
@@ -216,6 +238,8 @@ export function getSumCollectivesAmountSpent(
     excludeInternals: true,
     hostCollectiveId: version === 'v3' ? { [Op.not]: null } : null,
   });
+
+  return { ...fastResults, ...results };
 }
 
 export async function getTotalAmountPaidExpenses(collective, { startDate, endDate, expenseType, currency } = {}) {
@@ -336,7 +360,7 @@ export async function getTotalAmountReceivedTimeSeries(
   };
 }
 
-export function getSumCollectivesAmountReceived(
+export async function getSumCollectivesAmountReceived(
   collectiveIds,
   {
     net = false,
@@ -347,8 +371,28 @@ export function getSumCollectivesAmountReceived(
     version = DEFAULT_BUDGET_VERSION,
     groupByAttributes,
     extraAttributes,
+    loaders = null,
   } = {},
 ) {
+  const fastResults =
+    version === DEFAULT_BUDGET_VERSION &&
+    !kind &&
+    !startDate &&
+    !endDate &&
+    !includeChildren &&
+    !groupByAttributes?.length &&
+    !extraAttributes?.length
+      ? await getCurrentCollectiveTransactionStats(collectiveIds, {
+          loaders,
+          column: net ? 'totalNetAmountReceivedInHostCurrency' : 'totalAmountReceivedInHostCurrency',
+        })
+      : {};
+  const missingCollectiveIds = difference(collectiveIds.map(Number), Object.keys(fastResults).map(Number));
+
+  if (missingCollectiveIds.length === 0) {
+    return fastResults;
+  }
+
   const column = ['v0', 'v1'].includes(version)
     ? net
       ? 'netAmountInCollectiveCurrency'
@@ -358,7 +402,7 @@ export function getSumCollectivesAmountReceived(
     : 'amountInHostCurrency';
   const transactionType = net ? 'CREDIT_WITH_HOST_FEE' : CREDIT;
 
-  return sumCollectivesTransactions(collectiveIds, {
+  const results = sumCollectivesTransactions(missingCollectiveIds, {
     column,
     transactionType,
     kind,
@@ -371,6 +415,8 @@ export function getSumCollectivesAmountReceived(
     groupByAttributes,
     extraAttributes,
   });
+
+  return { ...fastResults, ...results };
 }
 
 export async function getTotalMoneyManagedAmount(host, { startDate, endDate, collectiveIds, currency, version } = {}) {
@@ -670,7 +716,7 @@ export async function getYearlyIncome(collective) {
           AND s.interval = 'month'
         )
         +
-        ( 
+        (
           SELECT COALESCE(SUM(o."totalAmount"), 0)
           FROM "Orders" o
           INNER JOIN "Subscriptions" s ON o."SubscriptionId" = s.id
@@ -772,6 +818,30 @@ export async function getCurrentFastBalances(collectiveIds, { loaders = null, wi
         totals[CollectiveId].value -= Math.round(value * fxRate);
       }
     }
+  }
+
+  return totals;
+}
+
+export async function getCurrentCollectiveTransactionStats(collectiveIds, { loaders = null, column } = {}) {
+  const results = loaders
+    ? await Promise.map(collectiveIds, collectiveId =>
+        loaders.Collective.currentCollectiveTransactionStats.load(collectiveId),
+      ).then(results => results.filter(el => !!el))
+    : await sequelize.query(
+        `SELECT * FROM "CurrentCollectiveTransactionStats" WHERE "CollectiveId" IN (:collectiveIds)`,
+        {
+          replacements: { collectiveIds },
+          type: sequelize.QueryTypes.SELECT,
+          raw: true,
+        },
+      );
+
+  const totals = {};
+
+  for (const result of results) {
+    const CollectiveId = result['CollectiveId'];
+    totals[CollectiveId] = { CollectiveId, currency: result['hostCurrency'], value: result[column] };
   }
 
   return totals;

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -226,7 +226,7 @@ export async function getSumCollectivesAmountSpent(
     : 'amountInHostCurrency';
   const transactionType = 'DEBIT_WITHOUT_HOST_FEE';
 
-  const results = await sumCollectivesTransactions(collectiveIds, {
+  const results = await sumCollectivesTransactions(missingCollectiveIds, {
     column,
     transactionType,
     kind,

--- a/test/server/lib/budget.test.ts
+++ b/test/server/lib/budget.test.ts
@@ -5,7 +5,7 @@ import { createSandbox } from 'sinon';
 import ExpenseStatuses from '../../../server/constants/expense_status';
 import {
   getBalances,
-  getCurrentFastBalances,
+  getCurrentCollectiveBalances,
   getYearlyIncome,
   sumCollectivesTransactions,
 } from '../../../server/lib/budget';
@@ -134,7 +134,7 @@ describe('server/lib/budget', () => {
     });
   });
 
-  describe('getCurrentFastBalances', () => {
+  describe('getCurrentCollectiveBalances', () => {
     let collective, otherCollective, sandbox;
 
     beforeEach(async () => {
@@ -273,7 +273,9 @@ describe('server/lib/budget', () => {
     it('sums correctly with materialized view and new transactions', async () => {
       await createBalanceData(true);
 
-      const balances = await getCurrentFastBalances([collective.id, otherCollective.id], { withBlockedFunds: true });
+      const balances = await getCurrentCollectiveBalances([collective.id, otherCollective.id], {
+        withBlockedFunds: true,
+      });
       expect(balances[collective.id].value).to.eq(7091);
       expect(balances[otherCollective.id].value).to.eq(130e2);
     });
@@ -281,7 +283,7 @@ describe('server/lib/budget', () => {
     it('sums correctly without materialized view', async () => {
       await createBalanceData(false);
 
-      const fastBalances = await getCurrentFastBalances([collective.id, otherCollective.id], {
+      const fastBalances = await getCurrentCollectiveBalances([collective.id, otherCollective.id], {
         withBlockedFunds: true,
       });
       expect(fastBalances).to.be.empty;
@@ -297,7 +299,9 @@ describe('server/lib/budget', () => {
     it('sums correctly when not excluding blocked balances', async () => {
       await createBalanceData(true);
 
-      const balances = await getCurrentFastBalances([collective.id, otherCollective.id], { withBlockedFunds: false });
+      const balances = await getCurrentCollectiveBalances([collective.id, otherCollective.id], {
+        withBlockedFunds: false,
+      });
       expect(balances[collective.id].value).to.eq(140e2);
       expect(balances[otherCollective.id].value).to.eq(130e2);
     });


### PR DESCRIPTION
Attempt at porting what we've done for fast balances to compute `amountReceived` and `amountSpent`.

TODO:
- [x] helper (equivalent to getCurrentFastBalances)
- [x] loader (equivalent to context.loaders.Collective.currentCollectiveBalance)
- [x] inclusion in getSumCollectivesAmountSpent 
- [x] inclusion in getSumCollectivesAmountReceived

For later:
- [ ] can this also support getContributionsAndContributorsCount ? certainly
