### PR TITLE
graphql: deprecate parentAccount

### DIFF
--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -184,6 +184,7 @@ const accountFieldsDefinition = () => ({
   },
   parentAccount: {
     type: Account,
+    deprecationReason: '2022-12-16: use parent on AccountWithParent instead',
     async resolve(collective, _, req) {
       if (!collective.ParentCollectiveId) {
         return null;


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/4549

Whatever our ultimate decision on naming, we need to deprecate the generic property and favor the one on AccountWithParent.