### PR TITLE
Use loader when `net` is true for total amount spent

### DIFF
--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -171,7 +171,7 @@ export async function getTotalAmountSpentAmount(
     includeGiftCards,
   };
 
-  if (loaders && version === DEFAULT_BUDGET_VERSION && !net) {
+  if (loaders && version === DEFAULT_BUDGET_VERSION) {
     const amountSpentLoader = loaders.Collective.amountSpent.buildLoader(transactionArgs);
     result = await amountSpentLoader.load(collective.id);
   } else {


### PR DESCRIPTION
Allow using the loader for total amount spent when getting total net amount spent, which is what we want to use for the Discover dashboard.