### PR TITLE
Send Tax Forms for previous year in January

### DIFF
--- a/cron/hourly/40-send-tax-form-requests.js
+++ b/cron/hourly/40-send-tax-form-requests.js
@@ -3,6 +3,7 @@ import '../../server/env';
 
 import config from 'config';
 import HelloWorks from 'helloworks-sdk';
+import { uniqBy } from 'lodash';
 import moment from 'moment';
 import pThrottle from 'p-throttle';
 
@@ -28,7 +29,19 @@ const throttle = pThrottle({ limit: MAX_REQUESTS_PER_SECOND, interval: ONE_SECON
 
 const init = async () => {
   console.log('>>>> Running tax form job');
-  const accounts = await findAccountsThatNeedToBeSentTaxForm(year);
+
+  // In January, we keep looking at tax forms for the previous year as they might have been missed because of the limit
+  let accountsFromLastYear = [];
+  if (moment().month() === 0) {
+    accountsFromLastYear = await findAccountsThatNeedToBeSentTaxForm(year - 1);
+    if (accountsFromLastYear.length > 0) {
+      console.log(`>> Found ${accountsFromLastYear.length} accounts from last year that still need their tax form`);
+    }
+  }
+
+  const accountsFromThisYear = await findAccountsThatNeedToBeSentTaxForm(year);
+  const allAccounts = uniqBy([...accountsFromLastYear, ...accountsFromThisYear], 'id'); // The order is important here, we want to prioritize accounts from last year
+
   const throttledFunc = throttle(account => {
     console.log(`>> Sending tax form to account: ${account.name} (@${account.slug})`);
     if (!process.env.DRY_RUN) {
@@ -36,7 +49,7 @@ const init = async () => {
     }
   });
 
-  return Promise.all(accounts.map(throttledFunc));
+  return Promise.all(allAccounts.map(throttledFunc));
 };
 
 init()


### PR DESCRIPTION
We have an issue where multiple tax forms for December haven't been sent because we only look at the current year. This PR will ensure we keep looking into last year's tax forms in January.