### PR TITLE
fix(OSC application): Add back requirement to have 100 stars for automatic approval

### DIFF
--- a/server/lib/osc-validator.ts
+++ b/server/lib/osc-validator.ts
@@ -48,8 +48,8 @@ export function OSCValidator(repositoryInfo?: RepositoryInfo): ValidatedReposito
     },
     starsCount: {
       value: starsCount,
-      // any star count is valid
-      isValid: true,
+      // 100 stars or more
+      isValid: starsCount >= 100,
     },
     isFork: {
       value: isFork,


### PR DESCRIPTION
This PR adds back the previous requirement to have 100 GitHub stars for automatic approval, projects with less than 100 stars can still apply, but will need manual review from the OSC team.