### PR TITLE
VirtualCards: 30 days grace for missing receipts

### DIFF
--- a/server/models/VirtualCard.ts
+++ b/server/models/VirtualCard.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import type {
   BelongsToGetAssociationMixin,
   CreationOptional,
@@ -9,7 +10,7 @@ import type {
 
 import VirtualCardProviders from '../constants/virtual_card_providers';
 import { crypto } from '../lib/encryption';
-import sequelize, { DataTypes, Model } from '../lib/sequelize';
+import sequelize, { DataTypes, Model, Op } from '../lib/sequelize';
 import privacyVirtualCards from '../paymentProviders/privacy';
 import * as stripeVirtualCards from '../paymentProviders/stripe/virtual-cards';
 
@@ -41,7 +42,7 @@ class VirtualCard extends Model<InferAttributes<VirtualCard, { omit: 'info' }>, 
 
   async getExpensesMissingDetails(): Promise<Array<any>> {
     return sequelize.models.Expense.findPendingCardCharges({
-      where: { VirtualCardId: this.id },
+      where: { VirtualCardId: this.id, createdAt: { [Op.lte]: moment.utc().subtract(30, 'days') } },
     });
   }
 

--- a/test/server/models/VirtualCard.test.js
+++ b/test/server/models/VirtualCard.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import moment from 'moment';
 
 import { fakeExpense, fakeVirtualCard } from '../../test-helpers/fake-data';
 
@@ -10,7 +11,7 @@ describe('server/models/VirtualCard', () => {
       virtualCard = await fakeVirtualCard();
     });
 
-    it('finds expenses missing details', async () => {
+    it('finds expenses missing details older than 30 days', async () => {
       let missing = await virtualCard.getExpensesMissingDetails();
       expect(missing).to.have.length(0);
 
@@ -18,6 +19,7 @@ describe('server/models/VirtualCard', () => {
         VirtualCardId: virtualCard.id,
         type: 'CHARGE',
         status: 'PAID',
+        createdAt: moment.utc().subtract(31, 'days'),
         items: [{ amount: 10000 }],
       });
       const chargeItem = expense.items[0];


### PR DESCRIPTION
This behavior was inconsistent with the email we send and the policy on our website.