### PR TITLE
Wise: Fix Host/Expense currency inconsistency

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1611,8 +1611,10 @@ export const getWiseFxRateInfoFromExpenseData = (
 
   const wiseInfo: WiseTransfer | WiseQuote | WiseQuoteV2 = expense.data?.transfer || expense.data?.quote;
   if (wiseInfo?.rate) {
+    // In this context, the source currency is always the Host currency and the target currency is the Payee currency
     const wiseSourceCurrency = wiseInfo['sourceCurrency'] || wiseInfo['source'];
     const wiseTargetCurrency = wiseInfo['targetCurrency'] || wiseInfo['target'];
+    // This makes the fxRate be the rate for Host -> Payee
     const fxRate = matchFxRateWithCurrency(
       expectedSourceCurrency,
       expectedTargetCurrency,

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1909,10 +1909,10 @@ export const checkHasBalanceToPayExpense = async (
 
 type PayExpenseArgs = {
   id: number;
-  forceManual: boolean;
+  forceManual?: boolean;
   feesPayer?: 'COLLECTIVE' | 'PAYEE'; // Defaults to COLLECTIVE
   paymentProcessorFeeInHostCurrency?: number; // Defaults to 0
-  totalAmountPaidInHostCurrency: number;
+  totalAmountPaidInHostCurrency?: number;
 };
 
 /**

--- a/server/lib/math.js
+++ b/server/lib/math.js
@@ -1,3 +1,5 @@
+import { isNaN, isNil, round } from 'lodash';
+
 /** Convert `v` to negative if possitive, don't touch it otherwise. */
 export function toNegative(v) {
   return v > 0 ? -v : v;
@@ -10,3 +12,11 @@ export function toNegative(v) {
 export function floatAmountToCents(floatAmount) {
   return Math.round(floatAmount * 100);
 }
+
+export const centsAmountToFloat = amount => {
+  if (isNaN(amount) || isNil(amount)) {
+    return null;
+  } else {
+    return round(amount / 100, 2);
+  }
+};

--- a/server/lib/transferwise.ts
+++ b/server/lib/transferwise.ts
@@ -20,6 +20,7 @@ import {
   BalanceV4,
   BatchGroup,
   CurrencyPair,
+  ExchangeRate,
   Profile,
   QuoteV2,
   RecipientAccount,
@@ -398,6 +399,19 @@ export const getAccountRequirements = async (
       params,
     },
     'There was an error while fetching account requirements for Wise',
+  );
+};
+
+export const getExchangeRates = async (
+  connectedAccount: ConnectedAccount,
+  source: string,
+  target: string,
+): Promise<Array<ExchangeRate>> => {
+  return requestDataAndThrowParsedError(
+    axios.get,
+    `/v1/rates?source=${source}&target=${target}`,
+    { connectedAccount },
+    'There was an error while fetching exchange rates from Wise',
   );
 };
 

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -102,7 +102,7 @@ async function quoteExpense(
 
   expense.collective = expense.collective || (await models.Collective.findByPk(expense.CollectiveId));
   expense.host = expense.host || (await expense.collective.getHostCollective());
-  const hasMultiCurrency = expense.currency !== expense.host.currency;
+  const hasMultiCurrency = expense.currency !== expense.collective.currency;
   const targetCurrency = payoutMethod.unfilteredData.currency as string;
   const quoteParams = {
     profileId: connectedAccount.data.id,

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import crypto from 'crypto';
 
 import { isMemberOfTheEuropeanUnion } from '@opencollective/taxes';
@@ -11,6 +12,7 @@ import activities from '../../constants/activities';
 import status from '../../constants/expense_status';
 import { TransferwiseError } from '../../graphql/errors';
 import cache from '../../lib/cache';
+import { getFxRate } from '../../lib/currency';
 import logger from '../../lib/logger';
 import { reportErrorToSentry } from '../../lib/sentry';
 import * as transferwise from '../../lib/transferwise';
@@ -59,10 +61,13 @@ async function getTemporaryQuote(
   payoutMethod: PayoutMethod,
   expense: Expense,
 ): Promise<QuoteV2> {
+  expense.collective = expense.collective || (await models.Collective.findByPk(expense.CollectiveId));
+  expense.host = expense.host || (await expense.collective.getHostCollective());
+  const rate = await getFxRate(expense.currency, expense.host.currency);
   return await transferwise.getTemporaryQuote(connectedAccount, {
-    sourceCurrency: expense.currency,
+    sourceCurrency: expense.host.currency,
     targetCurrency: <string>payoutMethod.unfilteredData.currency,
-    sourceAmount: expense.amount / 100,
+    sourceAmount: (expense.amount * rate) / 100,
   });
 }
 
@@ -96,31 +101,45 @@ async function quoteExpense(
   }
 
   expense.collective = expense.collective || (await models.Collective.findByPk(expense.CollectiveId));
-  const hasMultiCurrency = expense.currency !== expense.collective.currency;
+  expense.host = expense.host || (await expense.collective.getHostCollective());
+  const hasMultiCurrency = expense.currency !== expense.host.currency;
+  const targetCurrency = payoutMethod.unfilteredData.currency as string;
   const quoteParams = {
     profileId: connectedAccount.data.id,
-    sourceCurrency: expense.collective.currency,
-    targetCurrency: <string>payoutMethod.unfilteredData.currency,
+    sourceCurrency: expense.host.currency,
+    targetCurrency,
     targetAccount,
   };
 
-  // Adapt the fees payer
-  if (expense.feesPayer === 'PAYEE') {
-    // We assume that expense.currency is always collective.currency
-    quoteParams['sourceAmount'] = expense.amount / 100;
-    if (hasMultiCurrency) {
-      throw new Error('Putting the fees on the payee is not yet supported for multi-currency expenses');
-    }
-  } else {
-    // Guarantees the target amount if in the same currency of expense
-    const { rate } = await getTemporaryQuote(connectedAccount, payoutMethod, expense);
-    quoteParams['targetAmount'] = (expense.amount / 100) * rate;
-  }
-
-  // Adapt for multi-currency
   if (hasMultiCurrency) {
+    assert(
+      expense.collective.currency === expense.host.currency,
+      'For multi-currency expenses, the host currency must be the same as the collective currency',
+    );
+    assert(
+      expense.currency === payoutMethod.unfilteredData.currency,
+      'For multi-currency expenses, the payout currency must be the same as the expense currency',
+    );
     quoteParams['targetCurrency'] = expense.currency;
     quoteParams['targetAmount'] = expense.amount / 100;
+  } else if (expense.feesPayer === 'PAYEE') {
+    assert(
+      expense.host.currency === expense.currency,
+      'For expenses coverede by the payee, the host currency must be the same as the expense currency',
+    );
+    quoteParams['sourceAmount'] = expense.amount / 100;
+  } else {
+    let rate = 1;
+    if (targetCurrency !== expense.host.currency) {
+      const [exchangeRate] = await transferwise.getExchangeRates(
+        connectedAccount,
+        expense.host.currency,
+        targetCurrency,
+      );
+      assert(exchangeRate, `No exchange rate found for ${expense.host.currency} -> ${targetCurrency}`);
+      rate = exchangeRate.rate;
+    }
+    quoteParams['targetAmount'] = (expense.amount / 100) * rate;
   }
 
   const quote = await transferwise.createQuote(connectedAccount, quoteParams);

--- a/server/paymentProviders/transferwise/webhook.ts
+++ b/server/paymentProviders/transferwise/webhook.ts
@@ -66,7 +66,7 @@ export async function handleTransferStateChange(event: TransferStateChangeEvent)
 
     const hostAmount =
       (expense.data?.transfer as Transfer)?.sourceValue ||
-      (expense.data?.quot as QuoteV2)?.sourceAmount -
+      (expense.data?.quote as QuoteV2)?.sourceAmount -
         ((expense.data?.paymentOption as QuoteV2PaymentOption)?.fee?.total || 0);
     assert(hostAmount, 'Expense is missing transfer and quote information');
     const expenseToHostRate = hostAmount ? (hostAmount * 100) / expense.amount : 'auto';

--- a/server/paymentProviders/transferwise/webhook.ts
+++ b/server/paymentProviders/transferwise/webhook.ts
@@ -11,7 +11,7 @@ import * as libPayments from '../../lib/payments';
 import { createTransactionsFromPaidExpense } from '../../lib/transactions';
 import { verifyEvent } from '../../lib/transferwise';
 import models from '../../models';
-import { TransferStateChangeEvent } from '../../types/transferwise';
+import { QuoteV2, QuoteV2PaymentOption, Transfer, TransferStateChangeEvent } from '../../types/transferwise';
 
 export async function handleTransferStateChange(event: TransferStateChangeEvent): Promise<void> {
   const expense = await models.Expense.findOne({
@@ -65,8 +65,9 @@ export async function handleTransferStateChange(event: TransferStateChangeEvent)
     }
 
     const hostAmount =
-      expense.data?.transfer?.sourceValue ||
-      expense.data?.quote?.sourceAmount - (expense.data?.paymentOption?.fee?.total || 0);
+      (expense.data?.transfer as Transfer)?.sourceValue ||
+      (expense.data?.quot as QuoteV2)?.sourceAmount -
+        ((expense.data?.paymentOption as QuoteV2PaymentOption)?.fee?.total || 0);
     assert(hostAmount, 'Expense is missing transfer and quote information');
     const expenseToHostRate = hostAmount ? (hostAmount * 100) / expense.amount : 'auto';
 

--- a/server/types/transferwise.ts
+++ b/server/types/transferwise.ts
@@ -19,6 +19,13 @@ export type Quote = {
   ofSourceAmount: boolean;
 };
 
+export type ExchangeRate = {
+  source: string;
+  target: string;
+  rate: number;
+  time: string;
+};
+
 export type QuoteV2PaymentOption = {
   disabled: boolean;
   disabledReason?: { message: string };

--- a/test/cron/daily/check-pending-transferwise-transactions.test.js
+++ b/test/cron/daily/check-pending-transferwise-transactions.test.js
@@ -62,7 +62,7 @@ describe('cron/hourly/check-pending-transferwise-transactions', () => {
       type: 'INVOICE',
       description: 'January Invoice',
       data: {
-        transfer: { id: 1234 },
+        transfer: { id: 1234, sourceValue: 100 },
       },
     });
   });

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -163,7 +163,7 @@ describe('server/paymentProviders/transferwise/index', () => {
   describe('quoteExpense', () => {
     let quote;
     before(async () => {
-      getExchangeRates.resolves([{ source: 'USD', target: 'EUR', rate: 0.9044 }]);
+      getExchangeRates.resolves([{ source: host.currency, target: 'EUR', rate: 0.9044 }]);
       quote = await transferwise.quoteExpense(connectedAccount, payoutMethod, expense);
     });
 

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -58,6 +58,7 @@ describe('server/paymentProviders/transferwise/index', () => {
     completeBatchGroup,
     getBatchGroup,
     fundBatchGroup,
+    getExchangeRates,
     createBatchGroupTransfer;
   let connectedAccount, collective, host, payoutMethod, expense;
 
@@ -113,6 +114,7 @@ describe('server/paymentProviders/transferwise/index', () => {
     completeBatchGroup = sandbox.stub(transferwiseLib, 'completeBatchGroup').resolves();
     getBatchGroup = sandbox.stub(transferwiseLib, 'getBatchGroup');
     cancelBatchGroup = sandbox.stub(transferwiseLib, 'cancelBatchGroup');
+    getExchangeRates = sandbox.stub(transferwiseLib, 'getExchangeRates');
 
     cacheSpy = sandbox.spy(cache);
   });
@@ -161,6 +163,7 @@ describe('server/paymentProviders/transferwise/index', () => {
   describe('quoteExpense', () => {
     let quote;
     before(async () => {
+      getExchangeRates.resolves([{ source: 'USD', target: 'EUR', rate: 0.9044 }]);
       quote = await transferwise.quoteExpense(connectedAccount, payoutMethod, expense);
     });
 

--- a/test/server/paymentProviders/transferwise/webhook.test.ts
+++ b/test/server/paymentProviders/transferwise/webhook.test.ts
@@ -90,7 +90,7 @@ describe('server/paymentProviders/transferwise/webhook', () => {
       type: 'INVOICE',
       description: 'January Invoice',
       data: {
-        transfer: { id: event.data.resource.id },
+        transfer: { id: event.data.resource.id, sourceValue: 100 },
         quote: { fee: 1, rate: 1 },
         feesInHostCurrency: {
           hostFeeInHostCurrency: 1,

--- a/test/stories/transferwise.test.ts
+++ b/test/stories/transferwise.test.ts
@@ -1,0 +1,334 @@
+/* eslint-disable camelcase */
+import { expect } from 'chai';
+import { assert, createSandbox } from 'sinon';
+
+import ExpenseStatuses from '../../server/constants/expense_status';
+import { payExpense } from '../../server/graphql/common/expenses';
+import * as transferwiseLib from '../../server/lib/transferwise';
+import { PayoutMethodTypes } from '../../server/models/PayoutMethod';
+import { handleTransferStateChange } from '../../server/paymentProviders/transferwise/webhook';
+import {
+  fakeCollective,
+  fakeConnectedAccount,
+  fakeExpense,
+  fakePayoutMethod,
+  fakeTransaction,
+  fakeUser,
+  randNumber,
+} from '../test-helpers/fake-data';
+import { resetTestDB } from '../utils';
+
+describe('/test/stories/transferwise.test.ts', () => {
+  const sandbox = createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  beforeEach(async () => {
+    await resetTestDB();
+  });
+
+  const rates = {
+    USD: { EUR: 0.9299, GBP: 0.8221, USD: 1 },
+    EUR: { USD: 1 / 0.9299, GBP: 0.89, EUR: 1 },
+    GBP: { USD: 1 / 0.8221, EUR: 1 / 0.89, GBP: 1 },
+  };
+
+  const setupTest = async ({ payeeCurrency, expenseCurrency, collectiveCurrency, hostCurrency }) => {
+    const rate = rates[hostCurrency][payeeCurrency];
+    const expenseAmount = 100e2;
+    // In decimals:
+    const fee = 1;
+    const sourceAmount = (expenseAmount / 100) * rates[expenseCurrency][hostCurrency];
+    const targetAmount = (expenseAmount / 100) * rates[expenseCurrency][payeeCurrency];
+    const quote = {
+      payOut: 'BANK_TRANSFER',
+      paymentOptions: [
+        {
+          payInProduct: 'BALANCE',
+          fee: { total: fee },
+          payIn: 'BALANCE',
+          sourceCurrency: hostCurrency,
+          targetCurrency: payeeCurrency,
+          payOut: 'BANK_TRANSFER',
+          disabled: false,
+        },
+      ],
+    };
+    const hostAdmin = await fakeUser();
+    const host = await fakeCollective({
+      admin: hostAdmin.collective,
+      plan: 'network-host-plan',
+      currency: hostCurrency,
+    });
+    const collective = await fakeCollective({
+      HostCollectiveId: host.id,
+      currency: collectiveCurrency,
+    });
+    const user = await fakeUser();
+
+    await fakeConnectedAccount({
+      CollectiveId: host.id,
+      service: 'transferwise',
+      token: 'faketoken',
+      data: { type: 'business', id: 1 },
+    });
+    await hostAdmin.populateRoles();
+
+    // Stubs
+    sandbox.stub(transferwiseLib, 'fundTransfer').resolves();
+    sandbox.stub(transferwiseLib, 'getToken').resolves('fake-token');
+    const payoutMethod = await fakePayoutMethod({
+      type: PayoutMethodTypes.BANK_ACCOUNT,
+      CollectiveId: user.CollectiveId,
+      data: {
+        accountHolderName: 'Nicolas Cage',
+        currency: payeeCurrency,
+        type: 'iban',
+        legalType: 'PRIVATE',
+        details: {
+          IBAN: 'DE89370400440532013000',
+        },
+      },
+    });
+    await fakeTransaction({
+      CollectiveId: collective.id,
+      amount: 100000000,
+      amountInHostCurrency: Math.round(100000000 * rates[collectiveCurrency][hostCurrency]),
+      currency: collectiveCurrency,
+      hostCurrency: hostCurrency,
+    });
+    const quoteId = randNumber();
+    const transferId = randNumber();
+    sandbox.stub(transferwiseLib, 'createTransfer').resolves({
+      id: transferId,
+      sourceCurrency: 'USD',
+      targetCurrency: 'EUR',
+      rate,
+      sourceValue: sourceAmount,
+      targetValue: targetAmount,
+    });
+    const getTemporaryQuote = sandbox.stub(transferwiseLib, 'getTemporaryQuote').resolves(quote);
+    const createQuote = sandbox.stub(transferwiseLib, 'createQuote').resolves({
+      ...quote,
+      fromCurrency: 'USD',
+      toCurrency: 'EUR',
+      rate,
+      id: quoteId,
+      sourceAmount: sourceAmount + fee,
+      targetAmount,
+    });
+    sandbox.stub(transferwiseLib, 'getExchangeRates').resolves([{ rate }]);
+    sandbox.stub(transferwiseLib, 'createRecipientAccount').resolves(payoutMethod.data);
+
+    const expense = await fakeExpense({
+      payoutMethod: 'transferwise',
+      status: ExpenseStatuses.APPROVED,
+      amount: expenseAmount,
+      FromCollectiveId: user.CollectiveId,
+      CollectiveId: collective.id,
+      UserId: user.id,
+      currency: expenseCurrency,
+      PayoutMethodId: payoutMethod.id,
+      type: 'INVOICE',
+      description: `${payeeCurrency} ${expenseCurrency} ${collectiveCurrency} ${hostCurrency}`,
+    });
+
+    return { expense, getTemporaryQuote, createQuote, transferId, hostAdmin, fee, expenseAmount, sourceAmount };
+  };
+
+  // Payee = Expense = Collective = Host
+  it('payee.currency = expense.currency = collective.currency = host.currency', async () => {
+    const payeeCurrency = 'EUR';
+    const expenseCurrency = 'EUR';
+    const collectiveCurrency = 'EUR';
+    const hostCurrency = 'EUR';
+    const { expense, getTemporaryQuote, createQuote, transferId, hostAdmin, fee, expenseAmount } = await setupTest({
+      payeeCurrency,
+      expenseCurrency,
+      collectiveCurrency,
+      hostCurrency,
+    });
+
+    const paidExpense = await payExpense({ remoteUser: hostAdmin } as any, { id: expense.id });
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PROCESSING);
+    assert.calledWithMatch(getTemporaryQuote, { id: 1 }, { sourceCurrency: 'EUR', targetCurrency: 'EUR' });
+    assert.calledWithMatch(createQuote, { id: 1 }, { sourceCurrency: 'EUR', targetCurrency: 'EUR' });
+
+    await handleTransferStateChange({
+      data: {
+        current_state: 'outgoing_payment_sent',
+        resource: { id: transferId, type: 'transfer', profile_id: 1, account_id: 1 },
+      },
+    } as any);
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PAID);
+    const [debit] = await paidExpense.getTransactions();
+    expect(debit).to.deep.include({
+      currency: collectiveCurrency,
+      netAmountInCollectiveCurrency: -1 * (expenseAmount + fee * 100),
+      hostCurrency: hostCurrency,
+      amountInHostCurrency: -1 * expenseAmount,
+      paymentProcessorFeeInHostCurrency: -1 * fee * 100,
+    });
+  });
+
+  // Payee = Expense = Collective != Host
+  it('payee.currency = expense.currency = collective.currency != host.currency', async () => {
+    const payeeCurrency = 'EUR';
+    const expenseCurrency = 'EUR';
+    const collectiveCurrency = 'EUR';
+    const hostCurrency = 'USD';
+    const { expense, getTemporaryQuote, createQuote, transferId, hostAdmin, fee, expenseAmount } = await setupTest({
+      payeeCurrency,
+      expenseCurrency,
+      collectiveCurrency,
+      hostCurrency,
+    });
+
+    const paidExpense = await payExpense({ remoteUser: hostAdmin } as any, { id: expense.id });
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PROCESSING);
+    assert.calledWithMatch(getTemporaryQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'EUR' });
+    assert.calledWithMatch(createQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'EUR' });
+
+    await handleTransferStateChange({
+      data: {
+        current_state: 'outgoing_payment_sent',
+        resource: { id: transferId, type: 'transfer', profile_id: 1, account_id: 1 },
+      },
+    } as any);
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PAID);
+    const [debit] = await paidExpense.getTransactions();
+    expect(debit).to.deep.include({
+      currency: collectiveCurrency,
+      netAmountInCollectiveCurrency: -1 * (expenseAmount + Math.round(fee * 100 * rates['USD']['EUR'])),
+      hostCurrency: hostCurrency,
+      amountInHostCurrency: -1 * Math.round(expenseAmount * rates['EUR']['USD']),
+      paymentProcessorFeeInHostCurrency: -1 * fee * 100,
+    });
+  });
+
+  // Payee = Expense != Collective = Host
+  it('payee.currency = expense.currency != collective.currency = host.currency', async () => {
+    const payeeCurrency = 'EUR';
+    const expenseCurrency = 'EUR';
+    const collectiveCurrency = 'USD';
+    const hostCurrency = 'USD';
+    const { expense, getTemporaryQuote, createQuote, transferId, hostAdmin, fee, expenseAmount } = await setupTest({
+      payeeCurrency,
+      expenseCurrency,
+      collectiveCurrency,
+      hostCurrency,
+    });
+
+    const paidExpense = await payExpense({ remoteUser: hostAdmin } as any, { id: expense.id });
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PROCESSING);
+    assert.calledWithMatch(getTemporaryQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'EUR' });
+    assert.calledWithMatch(createQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'EUR' });
+
+    await handleTransferStateChange({
+      data: {
+        current_state: 'outgoing_payment_sent',
+        resource: { id: transferId, type: 'transfer', profile_id: 1, account_id: 1 },
+      },
+    } as any);
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PAID);
+    const [debit] = await paidExpense.getTransactions();
+    expect(debit).to.deep.include({
+      currency: 'USD',
+      netAmountInCollectiveCurrency: -1 * (Math.round(expenseAmount * rates['EUR']['USD']) + fee * 100),
+      hostCurrency: 'USD',
+      amountInHostCurrency: -1 * Math.round(expenseAmount * rates['EUR']['USD']),
+      paymentProcessorFeeInHostCurrency: -1 * fee * 100,
+    });
+  });
+
+  // Payee != Expense = Collective = Host
+  it('payee.currency != expense.currency = collective.currency = host.currency', async () => {
+    const payeeCurrency = 'EUR';
+    const expenseCurrency = 'USD';
+    const collectiveCurrency = 'USD';
+    const hostCurrency = 'USD';
+    const { expense, getTemporaryQuote, createQuote, transferId, hostAdmin, fee, expenseAmount } = await setupTest({
+      payeeCurrency,
+      expenseCurrency,
+      collectiveCurrency,
+      hostCurrency,
+    });
+
+    const paidExpense = await payExpense({ remoteUser: hostAdmin } as any, { id: expense.id });
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PROCESSING);
+    assert.calledWithMatch(getTemporaryQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'EUR' });
+    assert.calledWithMatch(createQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'EUR' });
+
+    await handleTransferStateChange({
+      data: {
+        current_state: 'outgoing_payment_sent',
+        resource: { id: transferId, type: 'transfer', profile_id: 1, account_id: 1 },
+      },
+    } as any);
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PAID);
+    const [debit] = await paidExpense.getTransactions();
+    expect(debit).to.deep.include({
+      currency: 'USD',
+      netAmountInCollectiveCurrency: -1 * (expenseAmount + fee * 100),
+      hostCurrency: 'USD',
+      amountInHostCurrency: -1 * expenseAmount,
+      paymentProcessorFeeInHostCurrency: -1 * fee * 100,
+    });
+  });
+
+  // Payee != Expense = Collective != Host
+  it('payee.currency != expense.currency = collective.currency != host.currency', async () => {
+    const payeeCurrency = 'GBP';
+    const expenseCurrency = 'EUR';
+    const collectiveCurrency = 'EUR';
+    const hostCurrency = 'USD';
+    const { expense, getTemporaryQuote, createQuote, transferId, hostAdmin, fee, expenseAmount } = await setupTest({
+      payeeCurrency,
+      expenseCurrency,
+      collectiveCurrency,
+      hostCurrency,
+    });
+
+    const paidExpense = await payExpense({ remoteUser: hostAdmin } as any, { id: expense.id });
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PROCESSING);
+    assert.calledWithMatch(getTemporaryQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'GBP' });
+    assert.calledWithMatch(createQuote, { id: 1 }, { sourceCurrency: 'USD', targetCurrency: 'GBP' });
+
+    await handleTransferStateChange({
+      data: {
+        current_state: 'outgoing_payment_sent',
+        resource: { id: transferId, type: 'transfer', profile_id: 1, account_id: 1 },
+      },
+    } as any);
+    await paidExpense.reload();
+
+    expect(paidExpense.status).to.eq(ExpenseStatuses.PAID);
+    const [debit] = await paidExpense.getTransactions();
+    expect(debit).to.deep.include({
+      currency: 'EUR',
+      netAmountInCollectiveCurrency: -1 * (expenseAmount + Math.round(fee * 100 * rates['USD']['EUR'])),
+      hostCurrency: 'USD',
+      amountInHostCurrency: -1 * Math.round(expenseAmount * rates['EUR']['USD']),
+      paymentProcessorFeeInHostCurrency: -1 * fee * 100,
+    });
+  });
+});


### PR DESCRIPTION
Makes our transactions more consistent with the real value being accounted for on Wise.
We also enforce that expenses should always be paid from the waller matching the Host currency.