### PR TITLE
Fix stripe virtual card reconciliation job

### DIFF
--- a/server/paymentProviders/stripe/virtual-cards.ts
+++ b/server/paymentProviders/stripe/virtual-cards.ts
@@ -260,8 +260,7 @@ export const processDeclinedAuthorization = async (event: Stripe.Event) => {
   });
 };
 
-export const processTransaction = async (event: Stripe.Event) => {
-  const stripeTransaction = <Stripe.Issuing.Transaction>event.data.object;
+export const processTransaction = async (stripeTransaction: Stripe.Issuing.Transaction) => {
   const virtualCard = await getVirtualCardForTransaction(stripeTransaction.card);
   if (!virtualCard) {
     logger.error(

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -613,7 +613,7 @@ async function handleIssuingWebhooks(request: Request<unknown, Stripe.Event>) {
     case 'issuing_authorization.updated':
       return virtualcard.processUpdatedTransaction(event);
     case 'issuing_transaction.created':
-      return virtualcard.processTransaction(event);
+      return virtualcard.processTransaction(<Stripe.Issuing.Transaction>event.data.object);
     case 'issuing_card.updated':
       return virtualcard.processCardUpdate(event);
     default:


### PR DESCRIPTION
Sentry: https://sentry.io/organizations/open-collective/issues/3857865787/?referrer=slack

See: https://github.com/opencollective/opencollective-api/blob/main/cron/hourly/reconcile-transactions.js#L102

Reconciliation job uses the `processTransaction` which expects a Stripe issuing transaction as argument, this was changed in the webhook refactor and broke reconciliation.