### PR TITLE
Revert "Send Tax Forms for previous year in January"

### DIFF
--- a/cron/hourly/40-send-tax-form-requests.js
+++ b/cron/hourly/40-send-tax-form-requests.js
@@ -3,7 +3,6 @@ import '../../server/env';
 
 import config from 'config';
 import HelloWorks from 'helloworks-sdk';
-import { uniqBy } from 'lodash';
 import moment from 'moment';
 import pThrottle from 'p-throttle';
 
@@ -29,19 +28,7 @@ const throttle = pThrottle({ limit: MAX_REQUESTS_PER_SECOND, interval: ONE_SECON
 
 const init = async () => {
   console.log('>>>> Running tax form job');
-
-  // In January, we keep looking at tax forms for the previous year as they might have been missed because of the limit
-  let accountsFromLastYear = [];
-  if (moment().month() === 0) {
-    accountsFromLastYear = await findAccountsThatNeedToBeSentTaxForm(year - 1);
-    if (accountsFromLastYear.length > 0) {
-      console.log(`>> Found ${accountsFromLastYear.length} accounts from last year that still need their tax form`);
-    }
-  }
-
-  const accountsFromThisYear = await findAccountsThatNeedToBeSentTaxForm(year);
-  const allAccounts = uniqBy([...accountsFromLastYear, ...accountsFromThisYear], 'id'); // The order is important here, we want to prioritize accounts from last year
-
+  const accounts = await findAccountsThatNeedToBeSentTaxForm(year);
   const throttledFunc = throttle(account => {
     console.log(`>> Sending tax form to account: ${account.name} (@${account.slug})`);
     if (!process.env.DRY_RUN) {
@@ -49,7 +36,7 @@ const init = async () => {
     }
   });
 
-  return Promise.all(allAccounts.map(throttledFunc));
+  return Promise.all(accounts.map(throttledFunc));
 };
 
 init()


### PR DESCRIPTION
Reverts opencollective/opencollective-api#8361

All tax forms from last year have now been sent and we suspect this change to send duplicate tax forms.