### PR TITLE
Increase default 2FA session duration to 4h

### DIFF
--- a/server/lib/two-factor-authentication/lib.ts
+++ b/server/lib/two-factor-authentication/lib.ts
@@ -11,7 +11,7 @@ import { hasPolicy } from '../policies';
 
 import totp from './totp';
 
-const DEFAULT_TWO_FACTOR_AUTH_SESSION_DURATION = 60 * 60; // 1 hour
+const DEFAULT_TWO_FACTOR_AUTH_SESSION_DURATION = 4 * 60 * 60; // 1 hour
 
 type ValidateRequestOptions = {
   // require user configured 2FA


### PR DESCRIPTION
I'm afraid that requiring ops/support teams to re-enter their 2FA every hour can be time-consuming, and the pain could push them to use less secure behaviors (like having their 2FA validated on their local machine rather than a 2nd device).

We could have more frequent requests with [Yubikeys](https://github.com/opencollective/opencollective/issues/5294) in place as it's faster to complete the process, but for now, 4h sounds like a safe enough value to me.