### PR TITLE
Add conditions to tag frequency search in order to use index

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -399,6 +399,12 @@ export const getTagFrequencies = async args => {
     `SELECT  UNNEST(tags) AS id, UNNEST(tags) AS tag, COUNT(id)
       FROM "Collectives"
       WHERE "deletedAt" IS NULL
+      AND "deactivatedAt" IS NULL 
+      AND ((data ->> 'isGuest'::text)::boolean) IS NOT TRUE 
+      AND ((data ->> 'hideFromSearch'::text)::boolean) IS NOT TRUE 
+      AND name::text <> 'incognito'::text 
+      AND name::text <> 'anonymous'::text 
+      AND "isIncognito" = false
       ${searchConditions.sqlConditions}
       GROUP BY UNNEST(tags)
       ORDER BY count DESC


### PR DESCRIPTION
An index on `tsSearchVector` exists:

```sql
"collective_search_index" gin ("searchTsVector") WHERE "deletedAt" IS NULL AND "deactivatedAt" IS NULL AND ((data ->> 'isGuest'::text)::boolean) IS NOT TRUE AND ((data ->> 'hideFromSearch'::text)::boolean) IS NOT TRUE AND name::text <> 'incognito'::text AND name::text <> 'anonymous'::text AND "isIncognito" = false
```

But its not used in the tag frequency query due to conditions on the index. Seems like it would be fine to ignore these collectives in the tag frequency search?

---
Differences in query plan

before

```
Limit  (cost=67794.24..67794.25 rows=10 width=72) (actual time=1909.933..1949.472 rows=10 loops=1)
   ->  Sort  (cost=67794.24..67800.28 rows=12070 width=72) (actual time=1909.932..1949.470 rows=10 loops=1)
         Sort Key: (count(id)) DESC
         Sort Method: top-N heapsort  Memory: 25kB
         ->  Finalize GroupAggregate  (cost=66390.24..67742.08 rows=12070 width=72) (actual time=1892.688..1947.315 rows=10400 loops=1)
               Group Key: (unnest(tags))
               ->  Gather Merge  (cost=66390.24..67681.73 rows=12070 width=94) (actual time=1892.664..1942.032 rows=12286 loops=1)
                     Workers Planned: 1
                     Workers Launched: 1
                     ->  Sort  (cost=65390.23..65396.27 rows=12070 width=94) (actual time=1887.012..1887.654 rows=6143 loops=2)
                           Sort Key: (unnest(tags))
                           Sort Method: quicksort  Memory: 2373kB
                           Worker 0:  Sort Method: quicksort  Memory: 1963kB
                           ->  Partial HashAggregate  (cost=65184.33..65226.58 rows=12070 width=94) (actual time=1864.406..1866.827 rows=6143 loops=2)
                                 Group Key: unnest(tags)
                                 Batches: 1  Memory Usage: 4497kB
                                 Worker 0:  Batches: 1  Memory Usage: 2449kB
                                 ->  ProjectSet  (cost=1705.41..65042.26 rows=142070 width=90) (actual time=25.297..1845.117 rows=16243 loops=2)
                                       ->  Parallel Bitmap Heap Scan on "Collectives"  (cost=1705.41..64800.74 rows=14207 width=58) (actual time=25.294..1837.085 rows=4976 loops=2)
                                             Recheck Cond: ("deletedAt" IS NULL)
                                             Filter: (("searchTsVector" @@ to_tsquery('english'::regconfig, concat('open', ':*'))) OR ("searchTsVector" @@ to_tsquery('simple'::regconfig, concat('open', ':*'))))
                                             Rows Removed by Filter: 265428
                                             Heap Blocks: exact=15456
                                             ->  Bitmap Index Scan on collectives__host_collective_id  (cost=0.00..1704.20 rows=530114 width=0) (actual time=22.604..22.604 rows=555658 loops=1)
```

after

```
Limit  (cost=9721.87..9721.87 rows=10 width=72) (actual time=67.110..67.114 rows=10 loops=1)
   ->  Sort  (cost=9721.87..9727.85 rows=11970 width=72) (actual time=67.109..67.111 rows=10 loops=1)
         Sort Key: (count(id)) DESC
         Sort Method: top-N heapsort  Memory: 25kB
         ->  HashAggregate  (cost=9622.25..9670.13 rows=11970 width=72) (actual time=64.321..65.616 rows=10073 loops=1)
               Group Key: unnest(tags)
               Batches: 1  Memory Usage: 1425kB
               ->  ProjectSet  (cost=396.91..9564.45 rows=57800 width=90) (actual time=11.285..56.864 rows=31086 loops=1)
                     ->  Bitmap Heap Scan on "Collectives"  (cost=396.91..9466.19 rows=5780 width=58) (actual time=11.281..52.058 rows=9565 loops=1)
                           Recheck Cond: ((("searchTsVector" @@ to_tsquery('english'::regconfig, concat('open', ':*'))) AND ("deletedAt" IS NULL) AND ("deactivatedAt" IS NULL) AND (((data ->> 'isGuest'::text))::boolean IS NOT TRUE) AND (((data ->> 'hideFromSearch'::text))::boolean IS NOT TRUE) AND ((name)::text <> 'incognito'::text) AND ((name)::text <> 'anonymous'::text) AND (NOT "isIncognito")) OR (("searchTsVector" @@ to_tsquery('simple'::regconfig, concat('open', ':*'))) AND ("deletedAt" IS NULL) AND ("deactivatedAt" IS NULL) AND (((data ->> 'isGuest'::text))::boolean IS NOT TRUE) AND (((data ->> 'hideFromSearch'::text))::boolean IS NOT TRUE) AND ((name)::text <> 'incognito'::text) AND ((name)::text <> 'anonymous'::text) AND (NOT "isIncognito")))
                           Filter: (("searchTsVector" @@ to_tsquery('english'::regconfig, concat('open', ':*'))) OR ("searchTsVector" @@ to_tsquery('simple'::regconfig, concat('open', ':*'))))
                           Heap Blocks: exact=6815
                           ->  BitmapOr  (cost=396.91..396.91 rows=5847 width=0) (actual time=10.184..10.185 rows=0 loops=1)
                                 ->  Bitmap Index Scan on collective_search_index  (cost=0.00..198.16 rows=2923 width=0) (actual time=5.894..5.895 rows=12067 loops=1)
                                       Index Cond: ("searchTsVector" @@ to_tsquery('english'::regconfig, concat('open', ':*')))
                                 ->  Bitmap Index Scan on collective_search_index  (cost=0.00..198.16 rows=2923 width=0) (actual time=4.288..4.288 rows=12067 loops=1)
                                       Index Cond: ("searchTsVector" @@ to_tsquery('simple'::regconfig, concat('open', ':*')))
```