### PR TITLE
Fix(OSC application): Allow underscores in GitHub handles

### DIFF
--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -257,7 +257,7 @@ export async function getValidatorInfo(githubHandle, accessToken) {
 }
 
 const githubUsernameRegex = new RegExp('[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}', 'i');
-const githubRepositoryRegex = new RegExp('\\.?[a-z\\d](?:[a-z\\.\\d]|-(?=[a-z\\.\\d])){1,100}', 'i');
+const githubRepositoryRegex = new RegExp('\\.?[a-z\\d](?:[a-z\\.\\d]|-|_(?=[a-z\\.\\d])){1,100}', 'i');
 export const githubHandleRegex = new RegExp(
   `^${githubUsernameRegex.source}(/(${githubRepositoryRegex.source})?)?$`,
   'i',

--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -127,7 +127,16 @@ export async function getRepo(name, accessToken) {
   // https://octokit.github.io/rest.js/v18#repos-get
   // https://developer.github.com/v3/repos/#get
   const [owner, repo] = name.split('/');
-  return octokit.repos.get({ owner, repo }).then(getData);
+  return octokit.repos
+    .get({ owner, repo })
+    .then(getData)
+    .catch(err => {
+      if (err.status === 404) {
+        throw new Error(`GitHub repository "${name}" not found`);
+      } else {
+        throw err;
+      }
+    });
 }
 
 export async function getOrg(name, accessToken) {

--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -256,7 +256,7 @@ export async function getValidatorInfo(githubHandle, accessToken) {
   };
 }
 
-const githubUsernameRegex = new RegExp('[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}', 'i');
+const githubUsernameRegex = new RegExp('[a-z\\d](?:[a-z\\d]|-|_(?=[a-z\\d])){0,38}', 'i');
 const githubRepositoryRegex = new RegExp('\\.?[a-z\\d](?:[a-z\\.\\d]|-|_(?=[a-z\\.\\d])){1,100}', 'i');
 export const githubHandleRegex = new RegExp(
   `^${githubUsernameRegex.source}(/(${githubRepositoryRegex.source})?)?$`,

--- a/test/server/lib/github.test.ts
+++ b/test/server/lib/github.test.ts
@@ -9,6 +9,8 @@ const VALID_GITHUB_PROFILES = {
   'https://github.com/my-org/my-repo': 'my-org/my-repo',
   'https://github.com/my-org/my.repo': 'my-org/my.repo',
   'https://github.com/my-org/.my-repo': 'my-org/.my-repo',
+  'https://github.com/my-org/my_repo': 'my-org/my_repo',
+  'https://github.com/my_org/my-repo': 'my_org/my-repo',
 };
 
 const INVALID_GITHUB_URLS = ['https://example.com', 'https://github.com'];


### PR DESCRIPTION
Fix for https://github.com/opencollective/opencollective/issues/6280.

The function to parse GitHub URLs into GitHub handles was not expecting underscores. So `https://github.com/brendan8c/FFMPEG_BAT` became `brendan8c/FFMPEG`.

My modification of the RegEx pattern needs a review, it seems to work as expected but I'm not an expert in RegEx syntax.