### PR TITLE
Fix frequency when creating tiers

### DIFF
--- a/server/graphql/v2/mutation/TierMutations.js
+++ b/server/graphql/v2/mutation/TierMutations.js
@@ -97,7 +97,7 @@ const tierMutations = {
         amount: getValueInCentsFromAmountInput(args.tier.amount),
         minimumAmount: args.tier.minimumAmount ? getValueInCentsFromAmountInput(args.tier.minimumAmount) : null,
         goal: args.tier.goal ? getValueInCentsFromAmountInput(args.tier.goal) : null,
-        interval: getIntervalFromTierFrequency(args.tier.interval),
+        interval: getIntervalFromTierFrequency(args.tier.frequency),
       });
 
       // Purge cache


### PR DESCRIPTION
Required by https://github.com/opencollective/opencollective-frontend/pull/8544

Before this PR, passing a `frequency` to `createTier` had no effect