### PR TITLE
Match or create payment method on payment intent success

### DIFF
--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -64,7 +64,7 @@ async function createOrUpdateOrderStripePaymentMethod(
   }
 
   const stripePaymentMethod = await stripe.paymentMethods.retrieve(
-    typeof paymentIntent.payment_method === 'string' ? paymentIntent.payment_method : paymentIntent.payment_method?.id,
+   stripePaymentMethodId,
     {
       stripeAccount,
     },

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -63,12 +63,9 @@ async function createOrUpdateOrderStripePaymentMethod(
     return matchingPaymentMethod;
   }
 
-  const stripePaymentMethod = await stripe.paymentMethods.retrieve(
-   stripePaymentMethodId,
-    {
-      stripeAccount,
-    },
-  );
+  const stripePaymentMethod = await stripe.paymentMethods.retrieve(stripePaymentMethodId, {
+    stripeAccount,
+  });
 
   // new payment method
   const pm = await models.PaymentMethod.create({


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/4974

This is a base for handling card payment made using the Stripe Payment Element.

When a payment is made using the element, we get the payment method data on the intent succeeded event.