### PR TITLE
Enable automatic stripe payment types

### DIFF
--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -663,7 +663,6 @@ const orderMutations = {
 
       const toAccount = await fetchAccountWithReference(paymentIntentInput.toAccount, { throwIfMissing: true });
       const hostStripeAccount = await toAccount.getHostStripeAccount();
-      const host = await toAccount.getHostCollective();
 
       const isPlatformHost = hostStripeAccount.username === config.stripe.accountId;
 
@@ -708,14 +707,6 @@ const orderMutations = {
 
       const currency = paymentIntentInput.currency;
 
-      const paymentMethodTypes =
-        host.settings.stripe?.payment_method_types ||
-        (paymentIntentInput.amount.currency === 'USD'
-          ? ['us_bank_account']
-          : paymentIntentInput.amount.currency === 'EUR'
-          ? ['sepa_debit']
-          : undefined);
-
       try {
         const paymentIntent = await stripe.paymentIntents.create(
           {
@@ -724,7 +715,7 @@ const orderMutations = {
             amount: convertToStripeAmount(currency, totalOrderAmount),
             currency: paymentIntentInput.amount.currency.toLowerCase(),
             // eslint-disable-next-line camelcase
-            payment_method_types: paymentMethodTypes,
+            automatic_payment_methods: { enabled: true },
             metadata: {
               from: fromAccount ? `${config.host.website}/${fromAccount.slug}` : undefined,
               to: `${config.host.website}/${toAccount.slug}`,


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/4974

Requires https://github.com/opencollective/opencollective-api/pull/8429
Requires https://github.com/opencollective/opencollective-frontend/pull/8568

Enables payment methods are determined by Stripe when the payment intent is created. This will be based on:
- Platform configuration
- Host country
- Presentment Currency
- Amount