### PR TITLE
Make Sure `arg` Currencies are Checked in Order Mutations

### DIFF
--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -393,8 +393,8 @@ const orderMutations = {
 
           // Ensure amounts are provided with the right currency
           ['amount', 'paymentProcessorFee', 'platformTip'].forEach(field => {
-            if (!isNil(order[field])) {
-              assertAmountInputCurrency(order[field], order.currency, { name: field });
+            if (!isNil(args.order[field])) {
+              assertAmountInputCurrency(args.order[field], order.currency, { name: field });
             }
           });
 


### PR DESCRIPTION
The condition in question seems to not check for anything if it only considers the `order[field]`. I believe this is an error. We should check `arg.order[field]` with `order.currency` instead here. 