### PR TITLE
Add method to redact sensitive fields from sentry logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "express-limiter": "1.6.1",
         "express-session": "1.17.3",
         "express-ws": "5.0.2",
+        "fast-redact": "3.1.2",
         "fs-extra": "11.1.0",
         "get-urls": "10.0.1",
         "graphql": "16.6.0",
@@ -11187,6 +11188,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw== sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -29986,6 +29995,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw== sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
     },
     "fast-safe-stringify": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "express-limiter": "1.6.1",
     "express-session": "1.17.3",
     "express-ws": "5.0.2",
+    "fast-redact": "3.1.2",
     "fs-extra": "11.1.0",
     "get-urls": "10.0.1",
     "graphql": "16.6.0",

--- a/server/lib/sentry.ts
+++ b/server/lib/sentry.ts
@@ -18,6 +18,7 @@ import FEATURE from '../constants/feature';
 
 import logger from './logger';
 import { safeJsonStringify, sanitizeObjectForJSON } from './safe-json-stringify';
+import * as utils from './utils';
 
 const getIntegrations = (expressApp = null): Integration[] => {
   const integrations: Integration[] = [new Sentry.Integrations.Http({ tracing: true })];
@@ -29,6 +30,26 @@ const getIntegrations = (expressApp = null): Integration[] => {
 
 export const initSentry = (expressApp = null) => {
   Sentry.init({
+    beforeSend(event) {
+      try {
+        const reqBody = JSON.parse(event.request.data);
+        event.request.data = utils.redactSensitiveFields(reqBody);
+      } catch (e) {
+        // request data is not a json
+      }
+
+      return event;
+    },
+    beforeSendTransaction(event) {
+      try {
+        const reqBody = JSON.parse(event.request.data);
+        event.request.data = utils.redactSensitiveFields(reqBody);
+      } catch (e) {
+        // request data is not a json
+      }
+
+      return event;
+    },
     dsn: config.sentry.dsn,
     environment: config.env,
     attachStacktrace: true,

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -5,6 +5,7 @@ import { URL } from 'url';
 
 import Promise from 'bluebird';
 import config from 'config';
+import fastRedact from 'fast-redact';
 import pdf from 'html-pdf';
 import { filter, get, isEqual, padStart, sumBy } from 'lodash';
 
@@ -573,3 +574,7 @@ export const computeDatesAsISOStrings = (startDate, endDate) => {
  * @returns string
  */
 export const ifStr = (condition, expression) => (condition ? expression : '');
+
+export const redactSensitiveFields = fastRedact({
+  paths: ['variables.password', 'variables.newPassword', 'password', 'newPassword'],
+});


### PR DESCRIPTION
Here is an example transaction in sentry if the field `variables.paymentIntent.fromAccount.legacyId` was redacted:

https://sentry.io/organizations/open-collective/performance/oc-api:b02a61a3047c4a4dbb17ba25c0dbb895/?breakdown=none&project=5199682&query=http.method%3APOST&showTransactions=p95&sort=-timestamp&statsPeriod=24h&transaction=GraphQL%3A+CreatePaymentIntent

![image](https://user-images.githubusercontent.com/5448927/214101190-e0e0af54-0593-43d3-9d76-6b5800529a20.png)
 