### PR TITLE
Fix amount checks in `createOrder`

### DIFF
--- a/test/server/graphql/v1/mutation.test.js
+++ b/test/server/graphql/v1/mutation.test.js
@@ -496,9 +496,7 @@ describe('server/graphql/v1/mutation', () => {
           };
           const result = await utils.graphqlQuery(createOrderMutation, { order }, user2);
           expect(result.errors.length).to.equal(1);
-          expect(result.errors[0].message).to.equal(
-            `No tier found with tier id: 1002 for collective slug ${event1.slug}`,
-          );
+          expect(result.errors[0].message).to.equal(`A tier must be provided when totalAmount is not set`);
         });
       });
 


### PR DESCRIPTION
We missed updating this code when we introduced flexible amounts for PRODUCT/SERVICE tiers and let some orders go without being properly checked, resulting in issues like https://github.com/opencollective/opencollective/issues/6365 not being detected.