### PR TITLE
Handle Stripe mandate.updated webhook

### DIFF
--- a/migrations/20230130124611-add-payment-method-stripe-payment-id-unique-index.js
+++ b/migrations/20230130124611-add-payment-method-stripe-payment-id-unique-index.js
@@ -4,8 +4,8 @@
 module.exports = {
   async up(queryInterface) {
     await queryInterface.sequelize.query(`
-      CREATE UNIQUE INDEX "PaymentMethods__stripePaymentMethodId" ON "PaymentMethods"(("data"->>'stripePaymentMethodId'))
-      WHERE "data"->>'stripePaymentMethodId' IS NOT NULL
+      CREATE UNIQUE INDEX "PaymentMethods__stripePaymentMethodId" ON "PaymentMethods"(("data"#>>'{stripePaymentMethodId}'))
+      WHERE "data"#>>'{stripePaymentMethodId}' IS NOT NULL AND "deletedAt" IS NULL
     `);
   },
 

--- a/migrations/20230130124611-add-payment-method-stripe-payment-id-unique-index.js
+++ b/migrations/20230130124611-add-payment-method-stripe-payment-id-unique-index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX "PaymentMethods__stripePaymentMethodId" ON "PaymentMethods"(("data"->>'stripePaymentMethodId'))
+      WHERE "data"->>'stripePaymentMethodId' IS NOT NULL
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('PaymentMethods', 'PaymentMethods__stripePaymentMethodId');
+  },
+};

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -679,7 +679,7 @@ async function paymentMethodAttached(event: Stripe.Event) {
       await pm.update({
         customerId: stripeCustomerId,
         CollectiveId: stripeCustomerAccount.CollectiveId,
-      })
+      });
       return;
     }
 

--- a/test/server/graphql/v1/tiers.test.js
+++ b/test/server/graphql/v1/tiers.test.js
@@ -8,7 +8,7 @@ import { VAT_OPTIONS } from '../../../../server/constants/vat';
 import stripe from '../../../../server/lib/stripe';
 import models from '../../../../server/models';
 import { randEmail } from '../../../stores';
-import { fakeCollective, fakeHost, fakeTier, fakeUser } from '../../../test-helpers/fake-data';
+import { fakeCollective, fakeHost, fakeTier, fakeUser, randStr } from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
 describe('server/graphql/v1/tiers', () => {
@@ -95,12 +95,13 @@ describe('server/graphql/v1/tiers', () => {
     sandbox.stub(stripe.customers, 'create').callsFake(() => Promise.resolve({ id: 'cus_B5s4wkqxtUtNyM' }));
     sandbox.stub(stripe.customers, 'retrieve').callsFake(() => Promise.resolve({ id: 'cus_B5s4wkqxtUtNyM' }));
 
+    const paymentMethodId = randStr('pm_');
     sandbox
       .stub(stripe.paymentMethods, 'create')
-      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
     sandbox
       .stub(stripe.paymentMethods, 'attach')
-      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
 
     /* eslint-disable camelcase */
 

--- a/test/server/graphql/v2/mutation/TransactionMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TransactionMutations.test.ts
@@ -10,7 +10,7 @@ import * as payments from '../../../../../server/lib/payments';
 import stripe, { convertFromStripeAmount, convertToStripeAmount, extractFees } from '../../../../../server/lib/stripe';
 import models from '../../../../../server/models';
 import stripeMocks from '../../../../mocks/stripe';
-import { fakeCollective, fakeOrder, fakeUser } from '../../../../test-helpers/fake-data';
+import { fakeCollective, fakeOrder, fakeUser, randStr } from '../../../../test-helpers/fake-data';
 import { graphqlQueryV2 } from '../../../../utils';
 import * as utils from '../../../../utils';
 
@@ -63,12 +63,13 @@ describe('server/graphql/v2/mutation/TransactionMutations', () => {
     sandbox.stub(stripe.refunds, 'create').callsFake(() => Promise.resolve('foo'));
     sandbox.stub(stripe.charges, 'retrieve').callsFake(() => Promise.resolve('foo'));
 
+    const paymentMethodId = randStr('pm_');
     sandbox
       .stub(stripe.paymentMethods, 'create')
-      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
     sandbox
       .stub(stripe.paymentMethods, 'attach')
-      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
 
     sendEmailSpy = sandbox.spy(emailLib, 'send');
     refundTransactionSpy = sandbox.spy(TransactionMutationHelpers, 'refundTransaction');

--- a/test/server/graphql/v2/mutation/TransactionMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TransactionMutations.test.ts
@@ -63,13 +63,12 @@ describe('server/graphql/v2/mutation/TransactionMutations', () => {
     sandbox.stub(stripe.refunds, 'create').callsFake(() => Promise.resolve('foo'));
     sandbox.stub(stripe.charges, 'retrieve').callsFake(() => Promise.resolve('foo'));
 
-    const paymentMethodId = randStr('pm_');
     sandbox
       .stub(stripe.paymentMethods, 'create')
-      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
+      .callsFake(() => Promise.resolve({ id: randStr('pm_'), type: 'card', card: { fingerprint: 'fingerprint' } }));
     sandbox
       .stub(stripe.paymentMethods, 'attach')
-      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
+      .callsFake(id => Promise.resolve({ id, type: 'card', card: { fingerprint: 'fingerprint' } }));
 
     sendEmailSpy = sandbox.spy(emailLib, 'send');
     refundTransactionSpy = sandbox.spy(TransactionMutationHelpers, 'refundTransaction');

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -15,7 +15,7 @@ import stripe from '../../../server/lib/stripe';
 import models from '../../../server/models';
 import { PayoutMethodTypes } from '../../../server/models/PayoutMethod';
 import stripeMocks from '../../mocks/stripe';
-import { fakeCollective, fakeHost, fakeOrder, fakePayoutMethod, fakeUser } from '../../test-helpers/fake-data';
+import { fakeCollective, fakeHost, fakeOrder, fakePayoutMethod, fakeUser, randStr } from '../../test-helpers/fake-data';
 import * as utils from '../../utils';
 
 const AMOUNT = 1099;
@@ -71,12 +71,14 @@ describe('server/lib/payments', () => {
       id;
     });
     sandbox.stub(stripe.tokens, 'create').callsFake(() => Promise.resolve({ id: 'tok_1AzPXGD8MNtzsDcgwaltZuvp' }));
+
+    const paymentMethodId = randStr('pm_');
     sandbox
       .stub(stripe.paymentMethods, 'create')
-      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
     sandbox
       .stub(stripe.paymentMethods, 'attach')
-      .resolves({ id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } });
+      .resolves({ id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } });
     sandbox.stub(stripe.paymentIntents, 'create').callsFake(() =>
       Promise.resolve({
         id: 'pi_1F82vtBYycQg1OMfS2Rctiau',

--- a/test/server/paymentProviders/stripe/payment-intent.test.ts
+++ b/test/server/paymentProviders/stripe/payment-intent.test.ts
@@ -96,17 +96,19 @@ describe('stripe/payment-intent', () => {
 
     describe('recurring orders', () => {
       let order;
+      let stripePaymentMethodId;
 
       const sandbox = createSandbox();
       afterEach(sandbox.restore);
 
       beforeEach(async () => {
+        stripePaymentMethodId = randStr('pm_');
         const paymentMethod = await fakePaymentMethod({
           type: PAYMENT_METHOD_TYPE.US_BANK_ACCOUNT,
           service: PAYMENT_METHOD_SERVICE.STRIPE,
           customerId: 'cus_test',
           data: {
-            stripePaymentMethodId: 'pm_test',
+            stripePaymentMethodId,
           },
         });
         order = await fakeOrder(
@@ -144,7 +146,7 @@ describe('stripe/payment-intent', () => {
             amount: 10000,
             description: 'Recurring contribution',
             payment_method_types: ['us_bank_account'],
-            payment_method: 'pm_test',
+            payment_method: stripePaymentMethodId,
             customer: 'cus_test',
           },
           { stripeAccount: 'testUserName' },
@@ -170,7 +172,7 @@ describe('stripe/payment-intent', () => {
             amount: 10000,
             description: 'Recurring contribution',
             payment_method_types: ['us_bank_account'],
-            payment_method: 'pm_test',
+            payment_method: stripePaymentMethodId,
             customer: 'cus_test',
           },
           { stripeAccount: 'testUserName' },
@@ -196,7 +198,7 @@ describe('stripe/payment-intent', () => {
             amount: 10000,
             description: 'Recurring contribution',
             payment_method_types: ['us_bank_account'],
-            payment_method: 'pm_test',
+            payment_method: stripePaymentMethodId,
             customer: 'cus_test',
           },
           { stripeAccount: 'testUserName' },
@@ -224,7 +226,7 @@ describe('stripe/payment-intent', () => {
             amount: 10000,
             description: 'Recurring contribution',
             payment_method_types: ['us_bank_account'],
-            payment_method: 'pm_test',
+            payment_method: stripePaymentMethodId,
             customer: 'cus_test',
           },
           { stripeAccount: 'testUserName' },

--- a/test/utils.js
+++ b/test/utils.js
@@ -25,6 +25,7 @@ import models, { sequelize } from '../server/models';
 
 /* Test data */
 import jsonData from './mocks/data';
+import { randStr } from './test-helpers/fake-data';
 
 if (process.env.RECORD) {
   nock.recorder.rec();
@@ -250,13 +251,14 @@ export const createStripeToken = async () => {
  *  and the one that *must* be reset after the test is done.
  */
 export function stubStripeCreate(sandbox, overloadDefaults) {
+  const paymentMethodId = randStr('pm_');
   const values = {
     customer: { id: 'cus_BM7mGwp1Ea8RtL' },
     token: { id: 'tok_1AzPXGD8MNtzsDcgwaltZuvp' },
     charge: { id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' },
     paymentIntent: { id: 'pi_1F82vtBYycQg1OMfS2Rctiau', status: 'requires_confirmation' },
     paymentIntentConfirmed: { charges: { data: [{ id: 'ch_1AzPXHD8MNtzsDcgXpUhv4pm' }] }, status: 'succeeded' },
-    paymentMethod: { id: 'pm_123456789012345678901234', type: 'card', card: { fingerprint: 'fingerprint' } },
+    paymentMethod: { id: paymentMethodId, type: 'card', card: { fingerprint: 'fingerprint' } },
     ...overloadDefaults,
   };
   /* Little helper function that returns the stub with a given


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/4974

Handle a payment method mandate update, some payment methods (such as Bacs) require mandates to confirm a new payment.

https://stripe.com/docs/payments/payment-methods/bacs-debit#mandates