### PR TITLE
Create stripe customer on recurring contribution

### DIFF
--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -2,6 +2,7 @@ import config from 'config';
 import { pick, toUpper } from 'lodash';
 import type Stripe from 'stripe';
 
+import { Service } from '../../constants/connected_account';
 import OrderStatuses from '../../constants/order_status';
 import logger from '../../lib/logger';
 import { getApplicationFee } from '../../lib/payments';
@@ -32,14 +33,45 @@ async function processNewOrder(order: typeof models.Order) {
     description: order.description,
   };
 
-  if (applicationFee && isPlatformRevenueDirectlyCollected && hostStripeAccount.username !== config.stripe.accountId) {
+  const isPlatformHost = hostStripeAccount.username === config.stripe.accountId;
+  const isSavePaymentMethod = order.data?.savePaymentMethod || order.interval;
+
+  if (applicationFee && isPlatformRevenueDirectlyCollected && !isPlatformHost) {
     // eslint-disable-next-line camelcase
     paymentIntentParams.application_fee_amount = convertToStripeAmount(order.currency, applicationFee);
   }
 
-  if (order.data?.savePaymentMethod) {
+  if (isSavePaymentMethod) {
     // eslint-disable-next-line camelcase
     paymentIntentParams.setup_future_usage = 'off_session';
+  }
+
+  let stripeCustomerAccount = await order.fromCollective.getCustomerStripeAccount(hostStripeAccount.username);
+  if (isSavePaymentMethod && !stripeCustomerAccount) {
+    const isPlatformHost = hostStripeAccount.username === config.stripe.accountId;
+
+    const customer = await stripe.customers.create(
+      {
+        email: order.createdByUser.email,
+        description: `${config.host.website}/${order.fromCollective.slug}`,
+      },
+      !isPlatformHost
+        ? {
+            stripeAccount: hostStripeAccount.username,
+          }
+        : undefined,
+    );
+
+    stripeCustomerAccount = await models.ConnectedAccount.create({
+      clientId: hostStripeAccount.username,
+      username: customer.id,
+      CollectiveId: order.fromCollective.id,
+      service: Service.STRIPE_CUSTOMER,
+    });
+
+    paymentIntentParams.customer = customer.id;
+  } else if (stripeCustomerAccount) {
+    paymentIntentParams.customer = stripeCustomerAccount.username;
   }
 
   try {

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -47,7 +47,6 @@ async function processNewOrder(order: typeof models.Order) {
 
   let stripeCustomerAccount = await order.fromCollective.getCustomerStripeAccount(hostStripeAccount.username);
   if (isSavePaymentMethod && !stripeCustomerAccount) {
-
     const customer = await stripe.customers.create(
       {
         email: order.createdByUser.email,

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -47,7 +47,6 @@ async function processNewOrder(order: typeof models.Order) {
 
   let stripeCustomerAccount = await order.fromCollective.getCustomerStripeAccount(hostStripeAccount.username);
   if (isSavePaymentMethod && !stripeCustomerAccount) {
-    const isPlatformHost = hostStripeAccount.username === config.stripe.accountId;
 
     const customer = await stripe.customers.create(
       {

--- a/server/paymentProviders/stripe/payment-intent.ts
+++ b/server/paymentProviders/stripe/payment-intent.ts
@@ -3,7 +3,6 @@ import { pick, toUpper } from 'lodash';
 import type Stripe from 'stripe';
 
 import { Service } from '../../constants/connected_account';
-import OrderStatuses from '../../constants/order_status';
 import logger from '../../lib/logger';
 import { getApplicationFee } from '../../lib/payments';
 import { reportMessageToSentry } from '../../lib/sentry';
@@ -78,7 +77,7 @@ async function processNewOrder(order: typeof models.Order) {
     const paymentIntent = await stripe.paymentIntents.update(order.data.paymentIntent.id, paymentIntentParams, {
       stripeAccount: hostStripeAccount.username,
     });
-    await order.update({ status: OrderStatuses.PROCESSING, data: { ...order.data, paymentIntent } });
+    await order.update({ data: { ...order.data, paymentIntent } });
   } catch (e) {
     const sanitizedError = pick(e, ['code', 'message', 'requestId', 'statusCode']);
     const errorMessage = `Error processing Stripe Payment Intent: ${e.message}`;

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -147,6 +147,7 @@ export const paymentIntentProcessing = async (event: Stripe.Event) => {
   await sequelize.transaction(async transaction => {
     const order = await models.Order.findOne({
       where: {
+        status: [OrderStatuses.NEW, OrderStatuses.PROCESSING, OrderStatuses.ERROR, OrderStatuses.ACTIVE],
         data: { paymentIntent: { id: paymentIntent.id } },
       },
       transaction,

--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -147,7 +147,6 @@ export const paymentIntentProcessing = async (event: Stripe.Event) => {
   await sequelize.transaction(async transaction => {
     const order = await models.Order.findOne({
       where: {
-        status: [OrderStatuses.NEW, OrderStatuses.PROCESSING],
         data: { paymentIntent: { id: paymentIntent.id } },
       },
       transaction,

--- a/test/server/paymentProviders/stripe/payment-intent.test.ts
+++ b/test/server/paymentProviders/stripe/payment-intent.test.ts
@@ -73,7 +73,7 @@ describe('stripe/payment-intent', () => {
         );
       });
 
-      it('set order status to PROCESSING and update data.paymentIntent', async () => {
+      it('set order status to NEW and update data.paymentIntent', async () => {
         await paymentIntent.processOrder(order);
 
         await order.reload();
@@ -81,7 +81,7 @@ describe('stripe/payment-intent', () => {
         expect(orderJSON).to.have.nested.property('data.paymentIntent');
         expect(orderJSON).to.have.nested.property('data.paymentIntent.amount');
         expect(orderJSON).to.have.nested.property('data.paymentIntent.description');
-        expect(orderJSON).to.have.property('status', OrderStatuses.PROCESSING);
+        expect(orderJSON).to.have.property('status', OrderStatuses.NEW);
       });
 
       it('destroys the order if something goes wrong', async () => {


### PR DESCRIPTION
When a payment intent is created for a guest, a customer is not attached to it created, by the time the intent is confirmed, we need to create a customer if the payment method is meant to be reused.


