### PR TITLE
Bring back delegated links for HelloWorks

### DIFF
--- a/server/lib/tax-forms.ts
+++ b/server/lib/tax-forms.ts
@@ -139,7 +139,7 @@ export async function sendHelloWorksUsTaxForm(
       workflowId,
       documentDelivery: true,
       documentDeliveryType: 'link',
-      // delegatedAuthentication: true, // See "authenticated link" below.
+      delegatedAuthentication: true, // See "authenticated link" below.
       participants,
       metadata: {
         accountType: accountToSubmitRequestTo.type,
@@ -157,20 +157,23 @@ export async function sendHelloWorksUsTaxForm(
     });
 
     // Get the authenticated link ("delegated authentication")
-    // We currently don't have access to this feature with our pricing plan
-    // try {
-    //   documentLink = await client.workflowInstances.getAuthenticatedLinkForStep({
-    //     instanceId: instance.id,
-    //     step: step.step,
-    //   });
-    // } catch (e) {
-    //   // Fallback to the default `step.url` (unauthenticated link)
-    //   logger.warn(`Tax form: error getting authenticated link for ${instance.id}: ${e.message}`);
-    // }
+    const step = instance.steps[0];
+    let documentLink = step.url;
+    try {
+      documentLink = await client.workflowInstances.getAuthenticatedLinkForStep({
+        instanceId: instance.id,
+        step: step.step,
+      });
+    } catch (e) {
+      // Fallback to the default `step.url` (unauthenticated link)
+      reportErrorToSentry(e, {
+        severity: 'warning',
+        transactionName: 'taxForm.sendHelloWorksUsTaxForm.getAuthenticatedLinkForStep',
+        extra: { instanceId: instance.id, step: JSON.stringify(step) },
+      });
+    }
 
     // Save the authenticated link to the database, in case we want to send it again later
-    const step = instance.steps[0];
-    const documentLink = step.url;
     await document.update({ data: deepMerge(document.data, { helloWorks: { documentLink } }) });
 
     // Send the actual email

--- a/test/server/lib/tax-forms.test.js
+++ b/test/server/lib/tax-forms.test.js
@@ -437,7 +437,7 @@ describe('server/lib/tax-forms', () => {
       expect(client.workflowInstances.createInstance.called).to.be.true;
       const callArgs = client.workflowInstances.createInstance.firstCall.args;
       expect(callArgs[0].participants['participant_swVuvW'].fullName).to.eq('Mr. Legal Name');
-      // when we'll activate authenticated links  expect(client.workflowInstances.getAuthenticatedLinkForStep.called).to.be.true;
+      expect(client.workflowInstances.getAuthenticatedLinkForStep.called).to.be.true;
       expect(doc.requestStatus).to.eq(REQUESTED);
 
       assert.callCount(sendMessageSpy, 1);


### PR DESCRIPTION
Reverts https://github.com/opencollective/opencollective-api/pull/6956
Should be resolving https://github.com/opencollective/opencollective/issues/5234, but we'll wait for production to close the issue.

Now that we moved to a higher plan, this should be working without further changes. Otherwise, there's a fallback: we'll send the normal link and report the error to Sentry.