### PR TITLE
PayPal unified & indexed charge ID

### DIFF
--- a/migrations/20230131115800-index-paypal-transaction-id.js
+++ b/migrations/20230131115800-index-paypal-transaction-id.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // Copy all IDs to the new standard field (took 40s against a local prod dump)
+    await queryInterface.sequelize.query(`
+      UPDATE "Transactions"
+      SET "data" = JSONB_SET(
+          "data",
+          '{paypalCaptureId}',
+          TO_JSON(
+            COALESCE(
+              "data" -> 'capture' ->> 'id',
+              "data" -> 'paypalSale' ->> 'id',
+              "data" -> 'paypalTransaction' ->> 'id'
+            )::text
+          )::jsonb
+        )
+      WHERE "data" ->> 'paypalCaptureId' IS NULL
+      AND (
+        "data" -> 'capture' ->> 'id' IS NOT NULL
+        OR "data" -> 'paypalSale' ->> 'id' IS NOT NULL
+        OR "data" -> 'paypalTransaction' ->> 'id' IS NOT NULL
+      )
+    `);
+
+    // Create index
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "transactions__data_paypal_capture_id"
+      ON "Transactions"
+      USING BTREE (("data"->>'paypalCaptureId') ASC)
+      WHERE "data"->>'paypalCaptureId' IS NOT NULL
+      AND "deletedAt" IS NULL
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "transactions__data_paypal_capture_id";
+    `);
+  },
+};

--- a/migrations/20230131115800-index-paypal-transaction-id.js
+++ b/migrations/20230131115800-index-paypal-transaction-id.js
@@ -29,8 +29,8 @@ module.exports = {
     await queryInterface.sequelize.query(`
       CREATE INDEX CONCURRENTLY IF NOT EXISTS "transactions__data_paypal_capture_id"
       ON "Transactions"
-      USING BTREE (("data"->>'paypalCaptureId') ASC)
-      WHERE "data"->>'paypalCaptureId' IS NOT NULL
+      USING BTREE (("data"#>>'{paypalCaptureId}') ASC)
+      WHERE "data"#>>'{paypalCaptureId}' IS NOT NULL
       AND "deletedAt" IS NULL
     `);
   },

--- a/scripts/fixes/create-missing-paypal-transactions.ts
+++ b/scripts/fixes/create-missing-paypal-transactions.ts
@@ -6,6 +6,7 @@ import { omit } from 'lodash';
 import models, { sequelize } from '../../server/models';
 import { paypalRequestV2 } from '../../server/paymentProviders/paypal/api';
 import { recordPaypalCapture } from '../../server/paymentProviders/paypal/payment';
+import { PaypalCapture } from '../../server/types/paypal';
 
 const migrate = async () => {
   const orders = await sequelize.query(
@@ -43,7 +44,8 @@ const migrate = async () => {
     const paypalOrderUrl = `checkout/orders/${paypalOrderId}`;
     const paypalOrderDetails = await paypalRequestV2(paypalOrderUrl, hostCollective, 'GET');
     const captureId = paypalOrderDetails.purchase_units[0].payments.captures[0].id;
-    const captureDetails = await paypalRequestV2(`payments/captures/${captureId}`, hostCollective, 'GET');
+    const captureUrl = `payments/captures/${captureId}`;
+    const captureDetails = (await paypalRequestV2(captureUrl, hostCollective, 'GET')) as PaypalCapture;
 
     // Record payment info
     if (process.env.DRY) {

--- a/scripts/paypal/cancel-all-subscriptions.ts
+++ b/scripts/paypal/cancel-all-subscriptions.ts
@@ -28,8 +28,7 @@ import {
 const getUnrecordedTransactions = async (host, order) => {
   const paypalSubscriptionId = order.Subscription.paypalSubscriptionId;
   const responseTransactions = await fetchPaypalTransactionsForSubscription(host, paypalSubscriptionId);
-  const totalPages = <number>responseTransactions['totalPages'];
-
+  const totalPages = responseTransactions.total_pages;
   if (totalPages > 1) {
     throw new Error('Pagination not supported yet');
   }

--- a/scripts/paypal/payment-reconciliator.ts
+++ b/scripts/paypal/payment-reconciliator.ts
@@ -22,6 +22,7 @@ import {
   fetchPaypalSubscription,
   fetchPaypalTransactionsForSubscription,
 } from '../../server/paymentProviders/paypal/subscription';
+import { PaypalTransaction } from '../../server/types/paypal';
 
 // TODO: Move these to command-line options
 const START_DATE = new Date(process.env.START_DATE || '2022-02-01');
@@ -310,7 +311,7 @@ const reconcileSubscription = async (paypalSubscriptionId: string, _, commander)
       where: { type: 'CREDIT', kind: 'CONTRIBUTION' },
       order: [['createdAt', 'ASC']],
     });
-    const paypalTransactions = (responseTransactions['transactions'] as Record<string, unknown>[]) || [];
+    const paypalTransactions = (responseTransactions['transactions'] as PaypalTransaction[]) || [];
     if (dbTransactions.length !== paypalTransactions.length) {
       console.log(
         `Order #${order.id} has ${dbTransactions.length} transactions in DB but ${paypalTransactions.length} in PayPal`,
@@ -460,7 +461,7 @@ const findOrphanSubscriptions = async (_, commander) => {
       }
 
       // Make sure all transactions exist in the ledger
-      for (const paypalTransaction of <Record<string, unknown>[]>response['transactions']) {
+      for (const paypalTransaction of <PaypalTransaction[]>response['transactions']) {
         const paypalTransactionId = <string>paypalTransaction['id'];
         const ledgerTransaction = await findTransactionByPaypalId(paypalTransactionId, {
           HostCollectiveId: host.id,

--- a/scripts/paypal/refund.ts
+++ b/scripts/paypal/refund.ts
@@ -23,10 +23,6 @@ const main = async () => {
   program.option('--run', 'Actually run the script');
   program.option('--host <hostSlug>', 'Host that holds the transaction (to speed up the search)');
   program.option('--paypalOnly', 'Do not look for the transaction in DB, only refund PayPal');
-  program.option(
-    '--is-sale',
-    'If the transaction ID is stored in data.paypalSale.id, you can pass this option to speed up the query',
-  );
 
   // Parse arguments
   program.parse();
@@ -41,10 +37,7 @@ const main = async () => {
     for (const captureId of captureIds) {
       let ledgerTransaction;
       if (!options['paypalOnly']) {
-        ledgerTransaction = await findTransactionByPaypalId(captureId, {
-          searchSaleIdOnly: options['isSale'],
-          HostCollectiveId: host?.id,
-        });
+        ledgerTransaction = await findTransactionByPaypalId(captureId, { HostCollectiveId: host?.id });
 
         if (!ledgerTransaction) {
           throw new Error(`No transaction found for PayPal capture ${captureId}`);

--- a/server/paymentProviders/paypal/subscription.ts
+++ b/server/paymentProviders/paypal/subscription.ts
@@ -12,6 +12,7 @@ import models from '../../models';
 import PaypalPlan from '../../models/PaypalPlan';
 import Tier from '../../models/Tier';
 import User from '../../models/User';
+import { SubscriptionTransactions } from '../../types/paypal';
 import { PaymentProviderService } from '../types';
 
 import { paypalRequest } from './api';
@@ -294,12 +295,15 @@ export const fetchPaypalSubscription = async (hostCollective, subscriptionId) =>
   return paypalRequest(`billing/subscriptions/${subscriptionId}`, null, hostCollective, 'GET');
 };
 
-export const fetchPaypalTransactionsForSubscription = async (host, subscriptionId) => {
+export const fetchPaypalTransactionsForSubscription = async (
+  host,
+  subscriptionId,
+): Promise<SubscriptionTransactions> => {
   const urlParams = new URLSearchParams();
   urlParams.append('start_time', moment('2020-01-01').toISOString());
   urlParams.append('end_time', moment().toISOString());
   const apiUrl = `billing/subscriptions/${subscriptionId}/transactions?${urlParams.toString()}`;
-  return paypalRequest(apiUrl, null, host, 'GET');
+  return paypalRequest(apiUrl, null, host, 'GET') as Promise<SubscriptionTransactions>;
 };
 
 /**

--- a/server/types/paypal.ts
+++ b/server/types/paypal.ts
@@ -169,3 +169,241 @@ export type PaypalWebhookPatch = {
   path: string;
   value: string | PaypalWebhookEventType[];
 }[];
+
+export type PaypalTransactionAmount = {
+  currency_code: string;
+  value: string;
+};
+
+export type PaypalTransactionSearchResult = {
+  account_number: string;
+  last_refreshed_datetime: string;
+  page: number;
+  total_items: number;
+  total_pages: number;
+  transaction_details: {
+    transaction_info: {
+      paypal_account_id: string;
+      transaction_id: string;
+      transaction_event_code: string;
+      transaction_initiation_date: string;
+      transaction_updated_date: string;
+      transaction_amount: PaypalTransactionAmount;
+      fee_amount: PaypalTransactionAmount;
+      insurance_amount: PaypalTransactionAmount;
+      shipping_amount: PaypalTransactionAmount;
+      shipping_discount_amount: PaypalTransactionAmount;
+      transaction_status: string;
+      transaction_subject: string;
+      transaction_note: string;
+      invoice_id: string;
+      custom_field: string;
+      protection_eligibility: string;
+    };
+    payer_info: {
+      account_id: string;
+      email_address: string;
+      address_status: string;
+      payer_status: string;
+      payer_name: {
+        given_name: string;
+        surname: string;
+        alternate_full_name: string;
+      };
+      country_code: string;
+    };
+    shipping_info: {
+      name: string;
+      address: {
+        line1: string;
+        line2: string;
+        city: string;
+        country_code: string;
+        postal_code: string;
+      };
+    };
+    cart_info: {
+      item_details: Array<{
+        item_code?: string;
+        item_name: string;
+        item_description?: string;
+        item_quantity: string;
+        item_unit_price: PaypalTransactionAmount;
+        item_amount: PaypalTransactionAmount;
+        tax_amounts?: Array<{
+          tax_amount: PaypalTransactionAmount;
+        }>;
+        total_item_amount: PaypalTransactionAmount;
+        invoice_number: string;
+      }>;
+    };
+    store_info: Record<string, never>;
+    auction_info: Record<string, never>;
+    incentive_info: Record<string, never>;
+  }[];
+};
+
+export type PaypalCapture = {
+  id: string;
+  amount: PaypalTransactionAmount;
+  final_capture: boolean;
+  seller_protection: {
+    status: string;
+    dispute_categories: Array<string>;
+  };
+  seller_receivable_breakdown: {
+    gross_amount: PaypalTransactionAmount;
+    paypal_fee: PaypalTransactionAmount;
+    net_amount: PaypalTransactionAmount;
+  };
+  status: string;
+  supplementary_data: {
+    related_ids: {
+      order_id: string;
+    };
+  };
+  create_time: string;
+  update_time: string;
+  links: Array<{
+    href: string;
+    rel: string;
+    method: string;
+  }>;
+};
+
+export type PaypalOrder = {
+  id: string;
+  intent: string;
+  status: string;
+  payment_source: {
+    paypal: {
+      email_address: string;
+      account_id: string;
+      name: {
+        given_name: string;
+        surname: string;
+      };
+      phone_number: {
+        national_number: string;
+      };
+      address: {
+        country_code: string;
+      };
+    };
+  };
+  purchase_units: Array<{
+    reference_id: string;
+    amount: {
+      currency_code: string;
+      value: string;
+      breakdown: {
+        item_total: PaypalTransactionAmount;
+        shipping: PaypalTransactionAmount;
+        handling: PaypalTransactionAmount;
+        insurance: PaypalTransactionAmount;
+        shipping_discount: PaypalTransactionAmount;
+        discount: PaypalTransactionAmount;
+      };
+    };
+    payee: {
+      email_address: string;
+      merchant_id: string;
+    };
+    soft_descriptor: string;
+    shipping: {
+      name: {
+        full_name: string;
+      };
+    };
+    payments: {
+      captures: Array<{
+        id: string;
+        status: string;
+        amount: PaypalTransactionAmount;
+        final_capture: boolean;
+        seller_protection: {
+          status: string;
+          dispute_categories: Array<string>;
+        };
+        seller_receivable_breakdown: {
+          gross_amount: PaypalTransactionAmount;
+          paypal_fee: PaypalTransactionAmount;
+          net_amount: PaypalTransactionAmount;
+        };
+        links: Array<{
+          href: string;
+          rel: string;
+          method: string;
+        }>;
+        create_time: string;
+        update_time: string;
+      }>;
+    };
+  }>;
+  payer: {
+    name: {
+      given_name: string;
+      surname: string;
+    };
+    email_address: string;
+    payer_id: string;
+    phone: {
+      phone_number: {
+        national_number: string;
+      };
+    };
+    address: {
+      country_code: string;
+    };
+  };
+  update_time: string;
+  links: Array<{
+    href: string;
+    rel: string;
+    method: string;
+  }>;
+};
+
+export type PaypalTransaction = {
+  id: string;
+  time: string;
+  status: string;
+  payer_name: {
+    surname: string;
+    given_name: string;
+  };
+  payer_email: string;
+  amount_with_breakdown: {
+    fee_amount: PaypalTransactionAmount;
+    net_amount: PaypalTransactionAmount;
+    gross_amount: PaypalTransactionAmount;
+  };
+};
+
+export type PaypalSale = {
+  id: string;
+  links: Array<{
+    rel: string;
+    href: string;
+    method: string;
+  }>;
+  state: string;
+  amount: {
+    total: string;
+    details: {
+      subtotal: string;
+    };
+    currency: string;
+  };
+  create_time: string;
+  update_time: string;
+  payment_mode: string;
+  invoice_number: string;
+  transaction_fee: {
+    value: string;
+    currency: string;
+  };
+  billing_agreement_id: string;
+  protection_eligibility: string;
+  protection_eligibility_type: string;
+};

--- a/server/types/paypal.ts
+++ b/server/types/paypal.ts
@@ -407,3 +407,18 @@ export type PaypalSale = {
   protection_eligibility: string;
   protection_eligibility_type: string;
 };
+
+/**
+ * When fetching transactions from /v1/billing/subscriptions/{id}/transactions
+ * See https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_transactions
+ */
+export type SubscriptionTransactions = {
+  transactions: Array<PaypalTransaction>;
+  total_pages: number;
+  total_items: number;
+  links: Array<{
+    href: string;
+    rel: string;
+    method: string;
+  }>;
+};


### PR DESCRIPTION
As part of https://github.com/opencollective/opencollective/issues/6342, a recurring challenge with PayPal transactions is that they can be stored with different structures depending on what PayPal returns (a charge, a sale or a transaction).

This PRs keeps the existing behavior but introduces a new `data.paypalCaptureId` field that will be indexed, a performance improvement that is much needed for the reconciliation job.