### PR TITLE
Add bancontact payment method type handling

### DIFF
--- a/server/constants/paymentMethods.ts
+++ b/server/constants/paymentMethods.ts
@@ -24,6 +24,7 @@ export enum PAYMENT_METHOD_TYPE {
   US_BANK_ACCOUNT = 'us_bank_account',
   SEPA_DEBIT = 'sepa_debit',
   BACS_DEBIT = 'bacs_debit',
+  BANCONTACT = 'bancontact',
 }
 
 export const PAYMENT_METHOD_TYPES = Object.values(PAYMENT_METHOD_TYPE);

--- a/server/paymentProviders/stripe/bancontact.ts
+++ b/server/paymentProviders/stripe/bancontact.ts
@@ -1,0 +1,92 @@
+import config from 'config';
+import { pick, toUpper } from 'lodash';
+import type Stripe from 'stripe';
+
+import OrderStatuses from '../../constants/order_status';
+import logger from '../../lib/logger';
+import { getApplicationFee } from '../../lib/payments';
+import { reportMessageToSentry } from '../../lib/sentry';
+import stripe, { convertToStripeAmount } from '../../lib/stripe';
+import models from '../../models';
+
+import { APPLICATION_FEE_INCOMPATIBLE_CURRENCIES, refundTransaction, refundTransactionOnlyInDatabase } from './common';
+
+const processOrder = async (order: typeof models.Order): Promise<void> => {
+  const generatedSepaDebit = order.paymentMethod?.data?.generated_sepa_debit;
+  if (!generatedSepaDebit) {
+    throw new Error(
+      'Bancontact cannot be charged off_session if a sepa debit payment method was not generated for it.',
+    );
+  }
+
+  const hostStripeAccount = await order.collective.getHostStripeAccount();
+  const host = await order.collective.getHostCollective();
+  const isPlatformRevenueDirectlyCollected = APPLICATION_FEE_INCOMPATIBLE_CURRENCIES.includes(toUpper(host.currency))
+    ? false
+    : host?.settings?.isPlatformRevenueDirectlyCollected ?? true;
+  const applicationFee = await getApplicationFee(order, host);
+
+  const paymentIntentParams: Stripe.PaymentIntentCreateParams = {
+    customer: order.paymentMethod.customerId,
+    currency: order.currency,
+    amount: convertToStripeAmount(order.currency, order.totalAmount),
+    description: order.description,
+    metadata: {
+      from: `${config.host.website}/${order.fromCollective.slug}`,
+      to: `${config.host.website}/${order.collective.slug}`,
+      orderId: order.id,
+    },
+    // eslint-disable-next-line camelcase
+    payment_method: generatedSepaDebit,
+    // bancontact is charged as a sepa_debit
+    // eslint-disable-next-line camelcase
+    payment_method_types: ['sepa_debit'],
+  };
+
+  if (applicationFee && isPlatformRevenueDirectlyCollected && hostStripeAccount.username !== config.stripe.accountId) {
+    // eslint-disable-next-line camelcase
+    paymentIntentParams.application_fee_amount = convertToStripeAmount(order.currency, applicationFee);
+  }
+
+  try {
+    let paymentIntent = await stripe.paymentIntents.create(paymentIntentParams, {
+      stripeAccount: hostStripeAccount.username,
+    });
+
+    await order.update({
+      data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } },
+    });
+
+    paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
+      stripeAccount: hostStripeAccount.username,
+    });
+
+    await order.update({
+      status: OrderStatuses.PROCESSING,
+      data: { ...order.data, paymentIntent },
+    });
+
+    if (paymentIntent.status === 'processing') {
+      return;
+    } else if (paymentIntent.status !== 'succeeded') {
+      logger.error('Unknown error with Stripe Payment Intent.');
+      reportMessageToSentry('Unknown error with Stripe Payment Intent', { extra: { paymentIntent } });
+      throw new Error('Something went wrong with the payment, please contact support@opencollective.com.');
+    }
+  } catch (e) {
+    const sanitizedError = pick(e, ['code', 'message', 'requestId', 'statusCode']);
+    const errorMessage = `Error processing Stripe bacs_debit: ${e.message}`;
+    logger.error(errorMessage, sanitizedError);
+    throw new Error(errorMessage);
+  }
+};
+
+export default {
+  features: {
+    recurring: true,
+    waitToCharge: false,
+  },
+  processOrder,
+  refundTransaction,
+  refundTransactionOnlyInDatabase,
+};

--- a/server/paymentProviders/stripe/index.ts
+++ b/server/paymentProviders/stripe/index.ts
@@ -15,6 +15,7 @@ import { addParamsToUrl } from '../../lib/utils';
 import models from '../../models';
 
 import bacsdebit from './bacsdebit';
+import bancontact from './bancontact';
 import creditcard from './creditcard';
 import paymentintent from './payment-intent';
 import { webhook } from './webhook';
@@ -28,6 +29,7 @@ export default {
   types: {
     // eslint-disable-next-line camelcase
     bacs_debit: bacsdebit,
+    bancontact: bancontact,
     default: creditcard,
     creditcard,
     paymentintent,


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/4974

Bancontact is a bank redirect method.
For one time charges the payment is handled by the Stripe Payment Element flow.
For recurring charges, a SEPA Debit is generated on the first successful charge and reused in following payments by this provider.
