### PR TITLE
Make sure the `amount` is not a required input for tier creation

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -15414,14 +15414,14 @@ input TierUpdateInput {
   The public id identifying the tier (ie: dgm9bnk8-0437xqry-ejpvzeol-jdayw5re)
   """
   id: String!
-  amount: AmountInput!
+  amount: AmountInput
   name: NonEmptyString
   description: String
   button: String
   goal: AmountInput
-  type: TierType!
-  amountType: TierAmountType!
-  frequency: TierFrequency!
+  type: TierType
+  amountType: TierAmountType
+  frequency: TierFrequency
   presets: [Int!]
   maxQuantity: Int
   minimumAmount: AmountInput
@@ -15431,8 +15431,8 @@ input TierUpdateInput {
 }
 
 input TierCreateInput {
-  amount: AmountInput!
-  name: NonEmptyString
+  amount: AmountInput
+  name: NonEmptyString!
   description: String
   button: String
   goal: AmountInput

--- a/server/graphql/v2/enum/TierFrequency.ts
+++ b/server/graphql/v2/enum/TierFrequency.ts
@@ -3,7 +3,7 @@ import { invert } from 'lodash';
 
 import INTERVALS from '../../../constants/intervals';
 
-enum TierFrequencyKey {
+export enum TierFrequencyKey {
   MONTHLY = 'MONTHLY',
   YEARLY = 'YEARLY',
   ONETIME = 'ONETIME',

--- a/server/graphql/v2/input/AmountInput.ts
+++ b/server/graphql/v2/input/AmountInput.ts
@@ -4,6 +4,12 @@ import { isNil } from 'lodash';
 import { floatAmountToCents } from '../../../lib/math';
 import { Currency } from '../enum/Currency';
 
+export type AmountInputType = {
+  value?: number;
+  currency?: string;
+  valueInCents?: number;
+};
+
 export const AmountInput = new GraphQLInputObjectType({
   name: 'AmountInput',
   description: 'Input type for an amount with the value and currency',
@@ -23,7 +29,10 @@ export const AmountInput = new GraphQLInputObjectType({
   }),
 });
 
-export const getValueInCentsFromAmountInput = (input, { expectedCurrency, allowNilCurrency = true } = {}) => {
+export const getValueInCentsFromAmountInput = (
+  input,
+  { expectedCurrency = null, allowNilCurrency = true }: { expectedCurrency?: string; allowNilCurrency?: boolean } = {},
+) => {
   if (expectedCurrency) {
     assertAmountInputCurrency(input, expectedCurrency, { allowNil: allowNilCurrency });
   }

--- a/server/graphql/v2/input/TierCreateInput.ts
+++ b/server/graphql/v2/input/TierCreateInput.ts
@@ -17,7 +17,7 @@ export const TierCreateInput = new GraphQLInputObjectType({
   name: 'TierCreateInput',
   fields: () => ({
     amount: {
-      type: new GraphQLNonNull(AmountInput),
+      type: AmountInput,
     },
     name: {
       type: GraphQLNonEmptyString,

--- a/server/graphql/v2/input/TierCreateInput.ts
+++ b/server/graphql/v2/input/TierCreateInput.ts
@@ -8,10 +8,28 @@ import {
 } from 'graphql';
 import { GraphQLNonEmptyString } from 'graphql-scalars';
 
-import { TierAmountType, TierType } from '../enum';
-import { TierFrequency } from '../enum/TierFrequency';
+import { TierType } from '../../../models/Tier';
+import { TierAmountType, TierType as GraphQLTierType } from '../enum';
+import { TierFrequency, TierFrequencyKey } from '../enum/TierFrequency';
 
-import { AmountInput } from './AmountInput';
+import { AmountInput, AmountInputType } from './AmountInput';
+
+export type TierCreateInputFields = {
+  amount?: AmountInputType;
+  name?: string;
+  description?: string;
+  button?: string;
+  goal?: AmountInputType;
+  type: TierType;
+  amountType: 'FLEXIBLE' | 'FIXED';
+  frequency: TierFrequencyKey;
+  presets?: number[];
+  maxQuantity?: number;
+  minimumAmount?: AmountInputType;
+  useStandalonePage?: boolean;
+  invoiceTemplate?: string;
+  singleTicket?: boolean;
+};
 
 export const TierCreateInput = new GraphQLInputObjectType({
   name: 'TierCreateInput',
@@ -20,7 +38,7 @@ export const TierCreateInput = new GraphQLInputObjectType({
       type: AmountInput,
     },
     name: {
-      type: GraphQLNonEmptyString,
+      type: new GraphQLNonNull(GraphQLNonEmptyString),
     },
     description: {
       type: GraphQLString,
@@ -32,7 +50,7 @@ export const TierCreateInput = new GraphQLInputObjectType({
       type: AmountInput,
     },
     type: {
-      type: new GraphQLNonNull(TierType),
+      type: new GraphQLNonNull(GraphQLTierType),
     },
     amountType: {
       type: new GraphQLNonNull(TierAmountType),

--- a/server/graphql/v2/input/TierReferenceInput.ts
+++ b/server/graphql/v2/input/TierReferenceInput.ts
@@ -1,6 +1,5 @@
 import { GraphQLBoolean, GraphQLInputObjectType, GraphQLInt, GraphQLString } from 'graphql';
 
-import models from '../../../models';
 import Tier from '../../../models/Tier';
 import { NotFound } from '../../errors';
 import { idDecode } from '../identifiers';
@@ -32,7 +31,7 @@ export const fetchTierWithReference = async (
   input,
   { loaders = null, throwIfMissing = false, allowCustomTier = false } = {},
 ): Promise<Tier | 'custom' | null> => {
-  const loadTier = id => (loaders ? loaders.Tier.byId.load(id) : models.Tier.findByPk(id));
+  const loadTier = id => (loaders ? loaders.Tier.byId.load(id) : Tier.findByPk(id));
   let tier;
   if (input.id) {
     const id = idDecode(input.id, 'tier');

--- a/server/graphql/v2/input/TierUpdateInput.ts
+++ b/server/graphql/v2/input/TierUpdateInput.ts
@@ -12,6 +12,9 @@ import { TierAmountType, TierType } from '../enum';
 import { TierFrequency } from '../enum/TierFrequency';
 
 import { AmountInput } from './AmountInput';
+import { TierCreateInputFields } from './TierCreateInput';
+
+export type TierUpdateInputFields = { id: string } & Partial<TierCreateInputFields>;
 
 export const TierUpdateInput = new GraphQLInputObjectType({
   name: 'TierUpdateInput',
@@ -36,13 +39,13 @@ export const TierUpdateInput = new GraphQLInputObjectType({
       type: AmountInput,
     },
     type: {
-      type: new GraphQLNonNull(TierType),
+      type: TierType,
     },
     amountType: {
-      type: new GraphQLNonNull(TierAmountType),
+      type: TierAmountType,
     },
     frequency: {
-      type: new GraphQLNonNull(TierFrequency),
+      type: TierFrequency,
     },
     presets: {
       type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),

--- a/server/graphql/v2/input/TierUpdateInput.ts
+++ b/server/graphql/v2/input/TierUpdateInput.ts
@@ -21,7 +21,7 @@ export const TierUpdateInput = new GraphQLInputObjectType({
       description: 'The public id identifying the tier (ie: dgm9bnk8-0437xqry-ejpvzeol-jdayw5re)',
     },
     amount: {
-      type: new GraphQLNonNull(AmountInput),
+      type: AmountInput,
     },
     name: {
       type: GraphQLNonEmptyString,

--- a/server/graphql/v2/mutation/TierMutations.js
+++ b/server/graphql/v2/mutation/TierMutations.js
@@ -43,7 +43,7 @@ const tierMutations = {
       await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
 
       // Prepare args
-      const amount = getValueInCentsFromAmountInput(args.tier.amount);
+      const amount = args.tier.amount ? getValueInCentsFromAmountInput(args.tier.amount) : null;
       if (args.tier.amountType === 'FIXED') {
         args.tier.presets = null;
         args.tier.minimumAmount = null;
@@ -73,11 +73,13 @@ const tierMutations = {
         tierUpdateData.data.invoiceTemplate = args.tier.invoiceTemplate;
       }
 
+      const updatedTier = await tier.update(tierUpdateData);
+
       // Purge cache
       purgeCacheForCollective(collective.slug);
       purgeCacheForPage(`/${collective.slug}/contribute/${tier.slug}-${tier.id}`);
 
-      return await tier.update(tierUpdateData);
+      return updatedTier;
     },
   },
   createTier: {
@@ -112,7 +114,7 @@ const tierMutations = {
         ...args.tier,
         CollectiveId: account.id,
         currency: account.currency,
-        amount: getValueInCentsFromAmountInput(args.tier.amount),
+        amount: args.tier.amount ? getValueInCentsFromAmountInput(args.tier.amount) : null,
         minimumAmount: args.tier.minimumAmount ? getValueInCentsFromAmountInput(args.tier.minimumAmount) : null,
         goal: args.tier.goal ? getValueInCentsFromAmountInput(args.tier.goal) : null,
         interval: getIntervalFromTierFrequency(args.tier.frequency),
@@ -130,10 +132,12 @@ const tierMutations = {
         tierCreateData.data.invoiceTemplate = args.tier.invoiceTemplate;
       }
 
+      const tier = await models.Tier.create(tierCreateData);
+
       // Purge cache
       purgeCacheForCollective(account.slug);
 
-      return await models.Tier.create(tierCreateData);
+      return tier;
     },
   },
   deleteTier: {

--- a/server/graphql/v2/mutation/TierMutations.ts
+++ b/server/graphql/v2/mutation/TierMutations.ts
@@ -1,20 +1,67 @@
 import { GraphQLBoolean, GraphQLNonNull } from 'graphql';
-import { isNil, uniq } from 'lodash';
+import { isNil, isUndefined, omitBy, pick, uniq } from 'lodash';
 
 import { purgeCacheForCollective } from '../../../lib/cache';
 import { purgeCacheForPage } from '../../../lib/cloudflare';
 import twoFactorAuthLib from '../../../lib/two-factor-authentication';
-import models from '../../../models';
+import models, { Tier as TierModel } from '../../../models';
 import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
 import { NotFound, Unauthorized } from '../../errors';
 import { getIntervalFromTierFrequency } from '../enum/TierFrequency';
 import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
 import { AccountReferenceInput, fetchAccountWithReference } from '../input/AccountReferenceInput';
 import { getValueInCentsFromAmountInput } from '../input/AmountInput';
-import { TierCreateInput } from '../input/TierCreateInput';
+import { TierCreateInput, TierCreateInputFields } from '../input/TierCreateInput';
 import { fetchTierWithReference, TierReferenceInput } from '../input/TierReferenceInput';
-import { TierUpdateInput } from '../input/TierUpdateInput';
+import { TierUpdateInput, TierUpdateInputFields } from '../input/TierUpdateInput';
 import { Tier } from '../object/Tier';
+
+// Makes sure we default to `undefined` if the amount is not set to not override existing values with `null`
+const getAmountWithDefault = (amountInput, existingAmount = undefined) =>
+  (amountInput ? getValueInCentsFromAmountInput(amountInput) : existingAmount) ?? undefined;
+
+const transformTierInputToAttributes = (
+  tierInput: TierCreateInputFields | TierUpdateInputFields,
+  existingTier: TierModel = null,
+) => {
+  // Copy all fields that don't need to be transformed
+  const attributes = pick(tierInput, [
+    'name',
+    'description',
+    'button',
+    'type',
+    'amountType',
+    'presets',
+    'maxQuantity',
+    'useStandalonePage',
+  ]);
+
+  // Transform fields that need to be transformed
+  attributes['amount'] = getAmountWithDefault(tierInput.amount, existingTier?.amount);
+  attributes['minimumAmount'] = getAmountWithDefault(tierInput.minimumAmount, existingTier?.minimumAmount);
+  attributes['goal'] = getAmountWithDefault(tierInput.goal, existingTier?.goal);
+  attributes['interval'] = getIntervalFromTierFrequency(tierInput.frequency);
+  attributes['data'] = existingTier?.data || null;
+
+  // Set data fields
+  if (tierInput.singleTicket !== undefined) {
+    attributes['data'] = { ...attributes['data'], singleTicket: tierInput.singleTicket };
+  }
+
+  if (tierInput.invoiceTemplate !== undefined) {
+    attributes['data'] = { ...attributes['data'], invoiceTemplate: tierInput.invoiceTemplate };
+  }
+
+  // Adjust some fields based on other fields
+  if (attributes.amountType === 'FIXED') {
+    attributes['presets'] = null;
+    attributes['minimumAmount'] = null;
+  } else if (attributes.presets && !isNil(attributes['amount'])) {
+    attributes['presets'] = uniq([attributes['amount'], ...tierInput.presets]); // Make sure default amount is included in presets
+  }
+
+  return omitBy(attributes, isUndefined);
+};
 
 const tierMutations = {
   editTier: {
@@ -29,7 +76,7 @@ const tierMutations = {
       checkRemoteUserCanUseAccount(req);
 
       const tierId = idDecode(args.tier.id, IDENTIFIER_TYPES.TIER);
-      const tier = await models.Tier.findByPk(tierId);
+      const tier = await TierModel.findByPk(tierId);
       if (!tier) {
         throw new NotFound('Tier Not Found');
       }
@@ -42,38 +89,8 @@ const tierMutations = {
       // Check 2FA
       await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
 
-      // Prepare args
-      const amount = args.tier.amount ? getValueInCentsFromAmountInput(args.tier.amount) : null;
-      if (args.tier.amountType === 'FIXED') {
-        args.tier.presets = null;
-        args.tier.minimumAmount = null;
-      } else if (args.tier.presets && !isNil(amount)) {
-        // Make sure default amount is included in presets
-        args.tier.presets = uniq([amount, ...args.tier.presets]);
-      }
-
-      const tierUpdateData = {
-        ...args.tier,
-        id: tierId,
-        amount: amount,
-        minimumAmount: args.tier.minimumAmount ? getValueInCentsFromAmountInput(args.tier.minimumAmount) : null,
-        goal: args.tier.goal ? getValueInCentsFromAmountInput(args.tier.goal) : null,
-        interval: getIntervalFromTierFrequency(args.tier.frequency),
-      };
-
-      if (!tierUpdateData.data && (args.tier.singleTicket !== undefined || args.tier.invoiceTemplate !== undefined)) {
-        tierUpdateData.data = {};
-      }
-
-      if (args.tier.singleTicket !== undefined) {
-        tierUpdateData.data.singleTicket = args.tier.singleTicket;
-      }
-
-      if (args.tier.invoiceTemplate !== undefined) {
-        tierUpdateData.data.invoiceTemplate = args.tier.invoiceTemplate;
-      }
-
-      const updatedTier = await tier.update(tierUpdateData);
+      // Update tier
+      const updatedTier = await tier.update(transformTierInputToAttributes(args.tier));
 
       // Purge cache
       purgeCacheForCollective(collective.slug);
@@ -105,34 +122,8 @@ const tierMutations = {
       // Check 2FA
       await twoFactorAuthLib.enforceForAccountAdmins(req, account, { onlyAskOnLogin: true });
 
-      if (args.tier.amountType === 'FIXED') {
-        args.tier.presets = null;
-        args.tier.minimumAmount = null;
-      }
-
-      const tierCreateData = {
-        ...args.tier,
-        CollectiveId: account.id,
-        currency: account.currency,
-        amount: args.tier.amount ? getValueInCentsFromAmountInput(args.tier.amount) : null,
-        minimumAmount: args.tier.minimumAmount ? getValueInCentsFromAmountInput(args.tier.minimumAmount) : null,
-        goal: args.tier.goal ? getValueInCentsFromAmountInput(args.tier.goal) : null,
-        interval: getIntervalFromTierFrequency(args.tier.frequency),
-      };
-
-      if (args.tier.singleTicket !== undefined || args.tier.invoiceTemplate !== undefined) {
-        tierCreateData.data = {};
-      }
-
-      if (args.tier.singleTicket !== undefined) {
-        tierCreateData.data.singleTicket = args.tier.singleTicket;
-      }
-
-      if (args.tier.invoiceTemplate !== undefined) {
-        tierCreateData.data.invoiceTemplate = args.tier.invoiceTemplate;
-      }
-
-      const tier = await models.Tier.create(tierCreateData);
+      // Create tier
+      const tier = await TierModel.create({ ...transformTierInputToAttributes(args.tier), CollectiveId: account.id });
 
       // Purge cache
       purgeCacheForCollective(account.slug);
@@ -156,6 +147,10 @@ const tierMutations = {
       checkRemoteUserCanUseAccount(req);
 
       const tier = await fetchTierWithReference(args.tier, { throwIfMissing: true });
+      if (tier === 'custom') {
+        throw new Error('Cannot delete custom tier. Set settings.disableCustomContributions to true instead.');
+      }
+
       const collective = await req.loaders.Collective.byId.load(tier.CollectiveId);
       if (!req.remoteUser.isAdminOfCollective(collective)) {
         throw new Unauthorized();

--- a/server/models/Tier.ts
+++ b/server/models/Tier.ts
@@ -26,7 +26,7 @@ const longDescriptionSanitizerOpts = buildSanitizerOptions({
   videoIframes: true,
 });
 
-type TierType = 'TIER' | 'MEMBERSHIP' | 'DONATION' | 'TICKET' | 'PRODUCT' | 'SERVICE';
+export type TierType = 'TIER' | 'MEMBERSHIP' | 'DONATION' | 'TICKET' | 'PRODUCT' | 'SERVICE';
 
 class Tier extends Model<InferAttributes<Tier>, InferCreationAttributes<Tier>> {
   public declare readonly id: CreationOptional<number>;
@@ -257,12 +257,11 @@ Tier.init(
 
     CollectiveId: {
       type: DataTypes.INTEGER,
+      allowNull: false,
       references: {
         model: 'Collectives',
         key: 'id',
       },
-      onDelete: 'SET NULL',
-      onUpdate: 'CASCADE',
     },
 
     // human readable way to uniquely access a tier for a given collective or collective/event combo
@@ -304,6 +303,7 @@ Tier.init(
     type: {
       type: DataTypes.STRING, // TIER, TICKET, DONATION, SERVICE, PRODUCT, MEMBERSHIP
       defaultValue: 'TIER',
+      allowNull: false,
       // TODO validate value
     },
 

--- a/server/models/Tier.ts
+++ b/server/models/Tier.ts
@@ -465,7 +465,12 @@ Tier.init(
         }
       },
       validateFlexibleAmount() {
-        if (this.amountType === 'FLEXIBLE' && this.presets && !this.presets.includes(this.amount)) {
+        if (
+          !isNil(this.amount) &&
+          this.amountType === 'FLEXIBLE' &&
+          this.presets &&
+          !this.presets.includes(this.amount)
+        ) {
           throw new Error(`In ${this.name}'s tier, "Default amount" must be one of suggested values amounts`);
         }
       },

--- a/test/server/graphql/v2/mutation/TransactionMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TransactionMutations.test.ts
@@ -282,7 +282,7 @@ describe('refundTransaction legacy tests', () => {
     const host = await models.User.createUserWithCollective(utils.data('host1'));
     const collective = await models.Collective.create(utils.data('collective1'));
     await collective.addHost(host.collective, host);
-    const tier = await models.Tier.create(utils.data('tier1'));
+    const tier = await models.Tier.create({ ...utils.data('tier1'), CollectiveId: collective.id });
     const paymentMethod = await models.PaymentMethod.create(utils.data('paymentMethod2'));
     await models.ConnectedAccount.create({
       service: 'stripe',

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -122,6 +122,7 @@ describe('server/lib/payments', () => {
   beforeEach('create an order', async () => {
     const tier = await models.Tier.create({
       ...utils.data('tier1'),
+      CollectiveId: collective.id,
       slug: PLAN_NAME,
     });
     const o = await models.Order.create({

--- a/test/server/lib/recurring-contributions.test.js
+++ b/test/server/lib/recurring-contributions.test.js
@@ -26,7 +26,7 @@ async function createOrderWithSubscription(interval, date, quantity = 1) {
   const user = await models.User.createUserWithCollective({ email: randEmail(), name: 'Test McTesterson' });
   const fromCollective = user.collective;
   const collective = await models.Collective.create({ name: 'Parcel' });
-  const tier = await models.Tier.create({ name: 'backer', amount: 0 });
+  const tier = await models.Tier.create({ name: 'backer', amount: 0, CollectiveId: collective.id });
   const subscription = await models.Subscription.create({
     ...payment,
     isActive: true,
@@ -473,7 +473,7 @@ describe('server/lib/recurring-contributions', () => {
       await utils.resetTestDB();
       user = await models.User.createUserWithCollective({ email: randEmail(), name: 'Test McTesterson' });
       collective = await models.Collective.create({ name: 'Parcel' });
-      tier = await models.Tier.create({ name: 'backer', amount: 0 });
+      tier = await models.Tier.create({ name: 'backer', amount: 0, CollectiveId: collective.id });
     });
 
     it('should filter orders with NULL subscription IDs', async () => {

--- a/test/server/models/Order.test.js
+++ b/test/server/models/Order.test.js
@@ -14,7 +14,9 @@ describe('server/models/Order', () => {
     }).then(u => (user = u)),
   );
   before('create a collective', () => models.Collective.create({ name: 'Webpack' }).then(c => (collective = c)));
-  before('create a tier', () => models.Tier.create({ name: 'backer', amount: 0 }).then(t => (tier = t)));
+  before('create a tier', () =>
+    models.Tier.create({ name: 'backer', amount: 0, CollectiveId: collective.id }).then(t => (tier = t)),
+  );
   before('create an order', () =>
     models.Order.create({
       CreatedByUserId: user.id,

--- a/test/server/models/Tier.test.js
+++ b/test/server/models/Tier.test.js
@@ -96,6 +96,7 @@ describe('server/models/Tier', () => {
           name: 'sponsor',
           amount: -5,
           interval: 'year',
+          CollectiveId: collective.id,
         }),
       ).to.be.rejectedWith(SequelizeValidationError, 'Validation min on amount failed');
     });
@@ -107,6 +108,7 @@ describe('server/models/Tier', () => {
           name: 'sponsor',
           amount: 0,
           interval: 'year',
+          CollectiveId: collective.id,
         }),
       ).to.be.fulfilled;
     });

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -468,6 +468,7 @@ export const fakeTier = async (tierData: Record<string, unknown> = {}) => {
     currency,
     maxQuantity: randAmount(),
     ...tierData,
+    CollectiveId: tierData.CollectiveId || (await fakeCollective()).id,
   });
 };
 


### PR DESCRIPTION
Fix creation of tickets as per discussion at https://opencollective.slack.com/archives/GFH4N961L/p1675891486724949?thread_ts=1675101689.930789&cid=GFH4N961L. This fixes some issues with creating tickets. In particular we don't need `amount` input to be mandatory when creating tickets. 

[tier-ticket-creation.webm](https://user-images.githubusercontent.com/12435965/217690981-df61581c-eafe-4538-a835-5c43565ea630.webm)
