### PR TITLE
Lock npm version in e2e CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,6 +73,10 @@ jobs:
         with:
           node-version-file: 'package.json'
 
+      - name: Force NPM version (this step can be moved once Vercel defaults to node 18.14)
+        shell: bash
+        run: npm install -g npm@8.19.2
+
       # Npm cache
 
       - name: Restore .npm cache


### PR DESCRIPTION
Similar to what we did in https://github.com/opencollective/opencollective-frontend/pull/8631 then https://github.com/opencollective/opencollective-frontend/pull/8631 