### PR TITLE
Fast Balance: transactions should be ordered by date and not by id

### DIFF
--- a/migrations/20230213080003-fast-balance-update.js
+++ b/migrations/20230213080003-fast-balance-update.js
@@ -1,0 +1,132 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`DROP VIEW IF EXISTS "CurrentCollectiveBalance"`);
+
+    await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "CollectiveBalanceCheckpoint"`);
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS "CollectiveBalanceCheckpoint" AS (
+        WITH "LatestTransactions" AS (
+          SELECT "CollectiveId", MAX("createdAt") AS "createdAt" FROM "TransactionBalances" GROUP BY "CollectiveId"
+        )
+        SELECT *
+        FROM "TransactionBalances"
+        WHERE id IN (
+          SELECT MAX(tb."id") FROM "TransactionBalances" tb
+          INNER JOIN "LatestTransactions" lt ON lt."CollectiveId" = tb."CollectiveId" AND lt."createdAt" = tb."createdAt"
+          GROUP BY tb."CollectiveId"
+        )
+       )
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "collective_balance_checkpoint__collective_id"
+      ON "CollectiveBalanceCheckpoint"("CollectiveId")
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW "CurrentCollectiveBalance" as (
+        SELECT
+          cbc."CollectiveId",
+          cbc."balance" + coalesce(t."netAmountInHostCurrency", 0) "netAmountInHostCurrency",
+          coalesce(disputed."netAmountInHostCurrency", 0) "disputedNetAmountInHostCurrency",
+          cbc."hostCurrency"
+        FROM "CollectiveBalanceCheckpoint" cbc
+        LEFT JOIN LATERAL (
+          SELECT
+            SUM(t."amountInHostCurrency") +
+              SUM(coalesce(t."platformFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."hostFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."paymentProcessorFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."taxAmount" * t."hostCurrencyFxRate", 0)) "netAmountInHostCurrency"
+          FROM "Transactions" t
+          WHERE t."CollectiveId" = cbc."CollectiveId"
+            AND t."createdAt" > cbc."createdAt"
+            AND t."deletedAt" is null
+          GROUP by t."CollectiveId"
+        ) as t ON TRUE
+        LEFT JOIN LATERAL (
+          SELECT
+            SUM(t."amountInHostCurrency") +
+              SUM(coalesce(t."platformFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."hostFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."paymentProcessorFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."taxAmount" * t."hostCurrencyFxRate", 0)) "netAmountInHostCurrency"
+          FROM "Transactions" t
+          where t."CollectiveId" = cbc."CollectiveId"
+            AND t."deletedAt" is null
+            AND t."isDisputed"
+            AND t."RefundTransactionId" is null
+          GROUP BY t."CollectiveId"
+        ) as disputed ON TRUE
+      );
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`DROP VIEW IF EXISTS "CurrentCollectiveBalance"`);
+
+    await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "CollectiveBalanceCheckpoint"`);
+
+    // IMPORTANT: reveert to the older version with known problems!
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS "CollectiveBalanceCheckpoint" AS (
+        WITH "LatestTransactionIds" AS (
+          SELECT MAX("id") as "id"
+          FROM "TransactionBalances"
+          GROUP BY "CollectiveId"
+        )
+        SELECT tb.*
+        FROM "TransactionBalances" tb
+        INNER JOIN "LatestTransactionIds" lb ON tb."id" = lb."id"
+       )
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "collective_balance_checkpoint__collective_id"
+      ON "CollectiveBalanceCheckpoint"("CollectiveId")
+    `);
+
+    // IMPORTANT: revert to the older version with known problems!
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW "CurrentCollectiveBalance" as (
+        SELECT
+          tb."CollectiveId",
+          tb."balance" + coalesce(t."netAmountInHostCurrency", 0) "netAmountInHostCurrency",
+          coalesce(disputed."netAmountInHostCurrency", 0) "disputedNetAmountInHostCurrency",
+          tb."hostCurrency"
+        FROM "TransactionBalances" tb
+        INNER JOIN "CollectiveBalanceCheckpoint" cbc ON tb."id" = cbc."id"
+        LEFT JOIN LATERAL (
+          SELECT
+            SUM(t."amountInHostCurrency") +
+              SUM(coalesce(t."platformFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."hostFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."paymentProcessorFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."taxAmount" * t."hostCurrencyFxRate", 0)) "netAmountInHostCurrency"
+          FROM "Transactions" t
+          WHERE t."CollectiveId" = tb."CollectiveId"
+            AND t.id > tb."id"
+            AND t."deletedAt" is null
+          GROUP by t."CollectiveId"
+        ) as t ON TRUE
+        LEFT JOIN LATERAL (
+          SELECT
+            SUM(t."amountInHostCurrency") +
+              SUM(coalesce(t."platformFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."hostFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."paymentProcessorFeeInHostCurrency", 0)) +
+              SUM(coalesce(t."taxAmount" * t."hostCurrencyFxRate", 0)) "netAmountInHostCurrency"
+          FROM "Transactions" t
+          where t."CollectiveId" = tb."CollectiveId"
+            AND t."deletedAt" is null
+            AND t."isDisputed"
+            AND t."RefundTransactionId" is null
+          GROUP BY t."CollectiveId"
+        ) as disputed ON TRUE
+      );
+    `);
+  },
+};

--- a/migrations/20230213094215-update-collective-transaction-stats-materialized-view.js
+++ b/migrations/20230213094215-update-collective-transaction-stats-materialized-view.js
@@ -1,0 +1,267 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`DROP VIEW IF EXISTS "CurrentCollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "CollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
+
+        WITH "ActiveCollectives" AS (
+          SELECT c."id" as "CollectiveId"
+          FROM "Transactions" t
+          LEFT JOIN "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL
+          WHERE t."deletedAt" IS NULL
+            AND t."hostCurrency" IS NOT NULL
+            AND c."deactivatedAt" IS NULL
+            -- TODO: not sure why we have those conditions omn guest/incognito, too many accounts?
+            AND (c."data" ->> 'isGuest')::boolean IS NOT TRUE
+            AND c.name != 'incognito'
+            AND c.name != 'anonymous'
+            AND c."isIncognito" = FALSE
+          GROUP BY c."id"
+          HAVING COUNT(DISTINCT t."hostCurrency") = 1 -- no hostCurrency mismatch please!
+        )
+        SELECT
+          ac."CollectiveId" as "id",
+          MAX(t."createdAt") as "LatestTransactionCreatedAt",
+          COUNT(DISTINCT t.id) AS "count",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT')
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind = 'HOST_FEE'))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalNetAmountSpentInHostCurrency",
+
+          MAX(t."hostCurrency") as "hostCurrency"
+
+        FROM "ActiveCollectives" ac
+
+        INNER JOIN "Transactions" t ON t."CollectiveId" = ac."CollectiveId"
+          AND t."deletedAt" IS NULL
+          AND t."RefundTransactionId" IS NULL
+          AND t."isRefund" IS NOT TRUE
+          AND t."isInternal" IS NOT TRUE
+
+        GROUP BY ac."CollectiveId";
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW "CurrentCollectiveTransactionStats" as (
+        SELECT
+          cts."id" as "CollectiveId",
+
+          COALESCE(cts."totalAmountReceivedInHostCurrency", 0) + COALESCE(t."totalAmountReceivedInHostCurrency", 0)
+            AS "totalAmountReceivedInHostCurrency",
+          COALESCE(cts."totalNetAmountReceivedInHostCurrency", 0) + COALESCE(t."totalNetAmountReceivedInHostCurrency", 0)
+            AS "totalNetAmountReceivedInHostCurrency",
+          COALESCE(cts."totalAmountSpentInHostCurrency", 0) + COALESCE(t."totalAmountSpentInHostCurrency", 0)
+            AS "totalAmountSpentInHostCurrency",
+          COALESCE(cts."totalNetAmountSpentInHostCurrency", 0) + COALESCE(t."totalNetAmountSpentInHostCurrency", 0)
+            AS "totalNetAmountSpentInHostCurrency",
+
+          cts."hostCurrency"
+
+        FROM "CollectiveTransactionStats" cts
+
+        LEFT JOIN LATERAL (
+          SELECT
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT')
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind = 'HOST_FEE'))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalNetAmountSpentInHostCurrency"
+
+          FROM "Transactions" t
+          WHERE t."CollectiveId" = cts."id"
+            AND t."createdAt" > cts."LatestTransactionCreatedAt"
+            AND t."deletedAt" is null
+            AND t."RefundTransactionId" IS NULL
+            AND t."isRefund" IS NOT TRUE
+            AND t."isInternal" IS NOT TRUE
+
+          GROUP by t."CollectiveId"
+        ) as t ON TRUE
+      );
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`DROP VIEW IF EXISTS "CurrentCollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "CollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
+
+        WITH "ActiveCollectives" AS (
+          SELECT c."id" as "CollectiveId"
+          FROM "Transactions" t
+          LEFT JOIN "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL
+          WHERE t."deletedAt" IS NULL
+            AND t."hostCurrency" IS NOT NULL
+            AND c."deactivatedAt" IS NULL
+            -- TODO: not sure why we have those conditions omn guest/incognito, too many accounts?
+            AND (c."data" ->> 'isGuest')::boolean IS NOT TRUE
+            AND c.name != 'incognito'
+            AND c.name != 'anonymous'
+            AND c."isIncognito" = FALSE
+          GROUP BY c."id"
+          HAVING COUNT(DISTINCT t."hostCurrency") = 1 -- no hostCurrency mismatch please!
+        )
+        SELECT
+          ac."CollectiveId" as "id",
+          MAX(t.id) as "LatestTransactionId",
+          COUNT(DISTINCT t.id) AS "count",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT')
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind = 'HOST_FEE'))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalNetAmountSpentInHostCurrency",
+
+          MAX(t."hostCurrency") as "hostCurrency"
+
+        FROM "ActiveCollectives" ac
+
+        INNER JOIN "Transactions" t ON t."CollectiveId" = ac."CollectiveId"
+          AND t."deletedAt" IS NULL
+          AND t."RefundTransactionId" IS NULL
+          AND t."isRefund" IS NOT TRUE
+          AND t."isInternal" IS NOT TRUE
+
+        GROUP BY ac."CollectiveId";
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW "CurrentCollectiveTransactionStats" as (
+        SELECT
+          cts."id" as "CollectiveId",
+
+          COALESCE(cts."totalAmountReceivedInHostCurrency", 0) + COALESCE(t."totalAmountReceivedInHostCurrency", 0)
+            AS "totalAmountReceivedInHostCurrency",
+          COALESCE(cts."totalNetAmountReceivedInHostCurrency", 0) + COALESCE(t."totalNetAmountReceivedInHostCurrency", 0)
+            AS "totalNetAmountReceivedInHostCurrency",
+          COALESCE(cts."totalAmountSpentInHostCurrency", 0) + COALESCE(t."totalAmountSpentInHostCurrency", 0)
+            AS "totalAmountSpentInHostCurrency",
+          COALESCE(cts."totalNetAmountSpentInHostCurrency", 0) + COALESCE(t."totalNetAmountSpentInHostCurrency", 0)
+            AS "totalNetAmountSpentInHostCurrency",
+
+          cts."hostCurrency"
+
+        FROM "CollectiveTransactionStats" cts
+
+        LEFT JOIN LATERAL (
+          SELECT
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT')
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind = 'HOST_FEE'))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE')
+            AS "totalNetAmountSpentInHostCurrency"
+
+          FROM "Transactions" t
+          WHERE t."CollectiveId" = cts."id"
+            AND t.id > cts."LatestTransactionId"
+            AND t."deletedAt" is null
+            AND t."RefundTransactionId" IS NULL
+            AND t."isRefund" IS NOT TRUE
+            AND t."isInternal" IS NOT TRUE
+
+          GROUP by t."CollectiveId"
+        ) as t ON TRUE
+      );
+    `);
+  },
+};

--- a/migrations/20230213094215-update-collective-transaction-stats-materialized-view.js
+++ b/migrations/20230213094215-update-collective-transaction-stats-materialized-view.js
@@ -203,6 +203,11 @@ module.exports = {
     `);
 
     await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "collective_transaction_stats__id"
+      ON "CollectiveTransactionStats"("id")
+    `);
+
+    await queryInterface.sequelize.query(`
       CREATE OR REPLACE VIEW "CurrentCollectiveTransactionStats" as (
         SELECT
           cts."id" as "CollectiveId",


### PR DESCRIPTION
We had a problem reported, related to inconsistency in how we order Transactions.

To accommodate how we use the ledger currently, we should assume transactions are ordered by date and not by id.

To be looked at, how does these changes affect speed and indexes?

`CurrentCollectiveTransactionStats` seems also impacted by a similar problem.