### PR TITLE
Fix(tags): Order tagStats by count

### DIFF
--- a/server/lib/search.js
+++ b/server/lib/search.js
@@ -403,6 +403,7 @@ export const getTagFrequencies = async args => {
         FROM "CollectiveTagStats"
         WHERE "HostCollectiveId" ${args.hostCollectiveId ? '= :hostCollectiveId' : 'IS NULL'} 
         ${args.tagSearchTerm ? `AND "tag" ILIKE :sanitizedTerm` : ``}
+        ORDER BY count DESC
         LIMIT :limit
         OFFSET :offset`,
       {


### PR DESCRIPTION
After introducing a unique index on the tagStats materialized view (#8552) it did not retain it's inherent order when querying it, causing random tags to be shown on the `/search` page.

Fixed by an `ORDER BY count DESC` statement to the query that asks the materialized view, that should be there since (#todayilearned) row order is not guaranteed in SQL.