### PR TITLE
ExpenseInvite notification to direct user to sign-in page

### DIFF
--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -428,7 +428,11 @@ const expenseMutations = {
         status: expenseStatus.DRAFT,
       });
 
-      const inviteUrl = `${config.host.website}/${collective.slug}/expenses/${expense.id}?key=${draftKey}`;
+      // If the payee is already an user, we redirect the action button in the email to signin first and later redirect to the expense
+      const inviteUrl = payee.id
+        ? `${config.host.website}/signin?next=/${collective.slug}/expenses/${expense.id}?key=${draftKey}`
+        : `${config.host.website}/${collective.slug}/expenses/${expense.id}?key=${draftKey}`;
+
       expense
         .createActivity(activities.COLLECTIVE_EXPENSE_INVITE_DRAFTED, remoteUser, { ...expense.data, inviteUrl })
         .catch(e => {

--- a/server/models/RecurringExpense.ts
+++ b/server/models/RecurringExpense.ts
@@ -104,7 +104,8 @@ export class RecurringExpense extends Model<RecurringExpenseAttributes, Recurrin
     const draftedExpense = await models.Expense.create(draft);
     await this.update({ lastDraftedAt: incurredAt });
 
-    const inviteUrl = `${config.host.website}/${expense.collective.slug}/expenses/${draftedExpense.id}?key=${draft.data.draftKey}`;
+    // Payee is always an user of the website, we can redirect them to the signin page to make sure they're logged in
+    const inviteUrl = `${config.host.website}/signin?next=/${expense.collective.slug}/expenses/${draftedExpense.id}?key=${draft.data.draftKey}`;
     await draftedExpense
       .createActivity(activities.COLLECTIVE_EXPENSE_RECURRING_DRAFTED, expense.User, {
         ...draftedExpense.data,


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/6013

This effectively guarantees the user is logged in when it reaches the expense edit page.
If the user is already logged-in, it will redirect straight to the expense page.