### PR TITLE
Always create tier with collective currency

### DIFF
--- a/migrations/20230217131657-fix-tier-currencies-different-from-collective.js
+++ b/migrations/20230217131657-fix-tier-currencies-different-from-collective.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    queryInterface.sequelize.query(`
+      UPDATE "Tiers"
+      SET currency = "affectedTier"."collectiveCurrency"
+      FROM (
+        select t.id as "TierId", c.currency as "collectiveCurrency"
+        from "Tiers" t inner join "Collectives" c on c.id = t."CollectiveId" 
+        where t.currency <> c.currency and t."deletedAt" is null and t."createdAt" >= '2023-01-01'
+      ) AS "affectedTier"
+      WHERE "Tiers".id = "affectedTier"."TierId";
+    `);
+  },
+
+  async down() {
+    // no rollback
+  },
+};

--- a/migrations/20230217131657-fix-tier-currencies-different-from-collective.js
+++ b/migrations/20230217131657-fix-tier-currencies-different-from-collective.js
@@ -9,7 +9,7 @@ module.exports = {
       FROM (
         select t.id as "TierId", c.currency as "collectiveCurrency"
         from "Tiers" t inner join "Collectives" c on c.id = t."CollectiveId" 
-        where t.currency <> c.currency and t."deletedAt" is null and t."createdAt" >= '2023-01-01'
+        where t.currency <> c.currency and t."deletedAt" is null and t."createdAt" >= '2023-02-07'
       ) AS "affectedTier"
       WHERE "Tiers".id = "affectedTier"."TierId";
     `);

--- a/server/graphql/v2/mutation/TierMutations.ts
+++ b/server/graphql/v2/mutation/TierMutations.ts
@@ -123,7 +123,11 @@ const tierMutations = {
       await twoFactorAuthLib.enforceForAccountAdmins(req, account, { onlyAskOnLogin: true });
 
       // Create tier
-      const tier = await TierModel.create({ ...transformTierInputToAttributes(args.tier), CollectiveId: account.id });
+      const tier = await TierModel.create({
+        ...transformTierInputToAttributes(args.tier),
+        CollectiveId: account.id,
+        currency: account.currency,
+      });
 
       // Purge cache
       purgeCacheForCollective(account.slug);

--- a/test/server/graphql/v2/mutation/TierMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TierMutations.test.ts
@@ -196,7 +196,7 @@ describe('server/graphql/v2/mutation/TierMutations', () => {
             name: 'New name',
             amount: {
               valueInCents: 5000,
-              currency: "USD",
+              currency: 'USD',
             },
           },
         },

--- a/test/server/graphql/v2/mutation/TierMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TierMutations.test.ts
@@ -104,6 +104,35 @@ describe('server/graphql/v2/mutation/TierMutations', () => {
       const createdTier = await models.Tier.findByPk(result.data.createTier.legacyId);
       expect(createdTier).to.exist;
     });
+
+    it('Always creates tier with collective currency', async () => {
+      collective = await fakeCollective({ admin: adminUser, currency: 'EUR' });
+      await fakeMember({ CollectiveId: memberUser.id, MemberCollectiveId: collective.id, role: roles.MEMBER });
+
+      const result = await graphqlQueryV2(
+        CREATE_TIER_MUTATION,
+        {
+          account: { legacyId: collective.id },
+          tier: {
+            name: 'fake tier',
+            type: 'TIER',
+            amountType: 'FIXED',
+            frequency: 'ONETIME',
+            amount: {
+              valueInCents: 1000,
+              currency: 'USD',
+            },
+          },
+        },
+        adminUser,
+      );
+      expect(result.errors).to.not.exist;
+      expect(result.data.createTier.legacyId).to.exist;
+
+      const createdTier = await models.Tier.findByPk(result.data.createTier.legacyId);
+      expect(createdTier).to.exist;
+      expect(createdTier.currency).to.eql('EUR');
+    });
   });
 
   describe('editTierMutation', () => {
@@ -149,6 +178,43 @@ describe('server/graphql/v2/mutation/TierMutations', () => {
 
       // Partial updates: other fields must not have changed
       expect(editedTier.minimumAmount).to.equal(42);
+      expect(editedTier.interval).to.equal(existingTier.interval);
+    });
+
+    it('does not update tier currency', async () => {
+      collective = await fakeCollective({ admin: adminUser, currency: 'EUR' });
+
+      memberUser = await fakeUser();
+      existingTier = await fakeTier({ CollectiveId: collective.id, minimumAmount: 42, currency: 'EUR' });
+      await fakeMember({ CollectiveId: memberUser.id, MemberCollectiveId: collective.id, role: roles.MEMBER });
+
+      const result = await graphqlQueryV2(
+        EDIT_TIER_MUTATION,
+        {
+          tier: {
+            id: idEncode(existingTier.id, IDENTIFIER_TYPES.TIER),
+            name: 'New name',
+            amount: {
+              valueInCents: 5000,
+              currency: "USD",
+            },
+          },
+        },
+        adminUser,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.editTier.legacyId).to.exist;
+      expect(result.data.editTier.name).to.equal('New name');
+
+      const editedTier = await models.Tier.findByPk(result.data.editTier.legacyId);
+      expect(editedTier).to.exist;
+      expect(editedTier.name).to.equal('New name');
+
+      // Partial updates: other fields must not have changed
+      expect(editedTier.minimumAmount).to.equal(42);
+      expect(editedTier.amount).to.equal(5000);
+      expect(editedTier.currency).to.equal('EUR');
       expect(editedTier.interval).to.equal(existingTier.interval);
     });
   });


### PR DESCRIPTION
Enforce tier currency to match collective currency on creation, test that edit tier does not update tier currency.