### PR TITLE
Better apply 2FA with expense mutations

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1247,11 +1247,8 @@ export async function editExpense(req: express.Request, expenseData: ExpenseData
 
   // Check if 2FA is enforced on any of the account remote user is admin of, stop the loop if 2FA gets validated for any of them
   if (req.remoteUser) {
-    for (const account of [expense.fromCollective, collective, host].filter(Boolean)) {
-      if (await twoFactorAuthLib.enforceForAccountAdmins(req, account, { onlyAskOnLogin: true })) {
-        break;
-      }
-    }
+    const accountsFor2FA = [expense.fromCollective, collective, host].filter(Boolean);
+    await twoFactorAuthLib.enforceForAccountsUserIsAdminOf(req, accountsFor2FA);
   }
 
   // When changing the type, we must make sure that the new type is allowed
@@ -2003,7 +2000,7 @@ export async function payExpense(req: express.Request, args: PayExpenseArgs): Pr
       await validateExpensePayout2FALimit(req, host, expense, totalPaidExpensesAmountKey);
     } else {
       // Not using rolling limit, but still enforcing 2FA for all admins
-      await twoFactorAuthLib.enforceForAccountAdmins(req, host, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });
     }
 
     try {

--- a/server/graphql/common/members.ts
+++ b/server/graphql/common/members.ts
@@ -23,7 +23,7 @@ export async function editPublicMessage(_, { fromAccount, toAccount, FromCollect
     throw new Unauthorized("You don't have the permission to edit member public message");
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, fromAccount, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, fromAccount, { onlyAskOnLogin: true });
 
   const [quantityUpdated, updatedMembers] = await models.Member.update(
     {

--- a/server/graphql/common/transactions.ts
+++ b/server/graphql/common/transactions.ts
@@ -213,11 +213,11 @@ export async function refundTransaction(
   // Check 2FA
   const collective = transaction.type === 'CREDIT' ? transaction.collective : transaction.fromCollective;
   if (collective && req.remoteUser.isAdminOfCollective(collective)) {
-    await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+    await twoFactorAuthLib.enforceForAccount(req, collective);
   } else {
     const creditTransaction = transaction.type === 'CREDIT' ? transaction : await transaction.getOppositeTransaction();
     if (req.remoteUser.isAdmin(creditTransaction?.HostCollectiveId)) {
-      await twoFactorAuthLib.enforceForAccountAdmins(req, await creditTransaction.getHostCollective());
+      await twoFactorAuthLib.enforceForAccount(req, await creditTransaction.getHostCollective());
     }
   }
 

--- a/server/graphql/common/update.ts
+++ b/server/graphql/common/update.ts
@@ -23,7 +23,7 @@ export async function createUpdate(_, args, req) {
     throw new Forbidden('Only root users can create changelog updates.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   const update = await models.Update.create({
     title: args.update.title,
@@ -58,7 +58,7 @@ async function fetchUpdateForEdit(id, req) {
     throw new Forbidden("You don't have sufficient permissions to edit this update");
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, update.collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, update.collective, { onlyAskOnLogin: true });
 
   return update;
 }

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -241,7 +241,7 @@ const mutations = {
       } else if (!req.remoteUser || !req.remoteUser.isAdminOfCollective(collective)) {
         throw new Unauthorized();
       } else {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+        await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
         await collective.editMembers(args.members, {
           CreatedByUserId: req.remoteUser.id,
@@ -415,7 +415,7 @@ const mutations = {
         throw new Error('User must be admin of collective');
       }
 
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
       if (numberOfGiftCards) {
         return bulkCreateGiftCards(collective, args, req.remoteUser, numberOfGiftCards);

--- a/server/graphql/v1/mutations/applications.js
+++ b/server/graphql/v1/mutations/applications.js
@@ -34,7 +34,7 @@ export async function createApplication(_, args, req) {
     throw new RateLimitExceeded('You have reached the maximum number of applications for this user');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, req.remoteUser.collective);
+  await twoFactorAuthLib.enforceForAccount(req, req.remoteUser.collective);
 
   const app = await Application.create({
     ...args.application,
@@ -57,7 +57,7 @@ export async function deleteApplication(_, args, req) {
     throw new Forbidden('Authenticated user is not the application owner.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, app.collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, app.collective, { onlyAskOnLogin: true });
 
   return await app.destroy();
 }

--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -398,7 +398,7 @@ export function editCollective(_, args, req) {
           }
           return Promise.reject(new Unauthorized(errorMsg));
         } else {
-          return twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+          return twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
         }
       })
       .then(async () => {
@@ -529,7 +529,7 @@ export async function archiveCollective(_, args, req) {
     throw new Unauthorized('You need to be logged in as an Admin.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   if (await collective.isHost()) {
     throw new Error(
@@ -607,7 +607,7 @@ export async function unarchiveCollective(_, args, req) {
     throw new Unauthorized('You need to be logged in as an Admin.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   if (collective.type === types.EVENT || collective.type === types.PROJECT) {
     const parentCollective = await models.Collective.findByPk(collective.ParentCollectiveId);
@@ -652,7 +652,7 @@ export async function deleteCollective(_, args, req) {
     );
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { alwaysAskForToken: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { alwaysAskForToken: true });
 
   return collectivelib.deleteCollective(collective);
 }
@@ -671,7 +671,7 @@ export async function activateCollectiveAsHost(_, args, req) {
     throw new Unauthorized('You need to be logged in as an Admin.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   return collective.becomeHost();
 }
@@ -690,7 +690,7 @@ export async function deactivateCollectiveAsHost(_, args, req) {
     throw new Unauthorized('You need to be logged in as an Admin.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   return collective.deactivateAsHost();
 }
@@ -709,7 +709,7 @@ export async function activateBudget(_, args, req) {
     throw new Unauthorized('You need to be logged in as an Admin.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   return collective.activateBudget();
 }
@@ -728,7 +728,7 @@ export async function deactivateBudget(_, args, req) {
     throw new Unauthorized('You need to be logged in as an Admin.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   return collective.deactivateBudget();
 }

--- a/server/graphql/v1/mutations/connectedAccounts.js
+++ b/server/graphql/v1/mutations/connectedAccounts.js
@@ -21,7 +21,7 @@ export async function editConnectedAccount(req, connectedAccountData) {
     throw new Unauthorized("You don't have permission to edit this connected account");
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, connectedAccount.collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, connectedAccount.collective, { onlyAskOnLogin: true });
 
   await connectedAccount.update(pick(connectedAccountData, editableAttributes));
   return connectedAccount;

--- a/server/graphql/v1/mutations/notifications.js
+++ b/server/graphql/v1/mutations/notifications.js
@@ -29,7 +29,7 @@ export async function editWebhooks(args, req) {
     throw NotificationPermissionError;
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   if (!args.notifications) {
     return Promise.resolve();
@@ -102,7 +102,7 @@ export async function createWebhook(args, req) {
     throw new Unauthorized('You do not have permissions to create webhooks for this collective.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   // Check limits
   const { maxWebhooksPerUserPerCollective } = config.limits;
@@ -140,7 +140,7 @@ export async function deleteNotification(args, req) {
     throw new Unauthorized('You need to be logged in as admin to delete this notification.');
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, notification.Collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, notification.Collective, { onlyAskOnLogin: true });
 
   await notification.destroy();
   return notification;

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -394,9 +394,9 @@ export async function createOrder(order, req) {
 
       // We only allow to add funds on behalf of a collective if the user is an admin of that collective or an admin of the host of the collective that receives the money
       if (remoteUser?.isAdminOfCollective(fromCollective)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, fromCollective, { onlyAskOnLogin: true });
+        await twoFactorAuthLib.enforceForAccount(req, fromCollective, { onlyAskOnLogin: true });
       } else if (remoteUser?.isAdminOfCollective(host)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, host, { onlyAskOnLogin: true });
+        await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });
       } else {
         throw new Error(
           `You don't have sufficient permissions to create an order on behalf of the ${

--- a/server/graphql/v1/mutations/paymentMethods.js
+++ b/server/graphql/v1/mutations/paymentMethods.js
@@ -177,7 +177,7 @@ export async function removePaymentMethod(paymentMethodId, req) {
     throw PaymentMethodPermissionError;
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, paymentMethod.Collective);
+  await twoFactorAuthLib.enforceForAccount(req, paymentMethod.Collective);
 
   // Block the removal if the payment method has subscriptions linked
   const subscriptions = await paymentMethod.getOrders({
@@ -208,7 +208,7 @@ export async function updatePaymentMethod(args, req) {
     throw PaymentMethodPermissionError;
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, paymentMethod.Collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, paymentMethod.Collective, { onlyAskOnLogin: true });
 
   return paymentMethod.update(pick(args, allowedFields));
 }
@@ -223,7 +223,7 @@ export async function replaceCreditCard(args, req) {
     throw PaymentMethodPermissionError;
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, oldPaymentMethod.Collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, oldPaymentMethod.Collective, { onlyAskOnLogin: true });
 
   const createArgs = {
     ...pick(args, ['CollectiveId', 'name', 'token', 'data']),

--- a/server/graphql/v1/mutations/tiers.js
+++ b/server/graphql/v1/mutations/tiers.js
@@ -22,7 +22,7 @@ export function editTiers(_, args, req) {
           `You need to be logged in as a core contributor or as a host of the ${collective.name} collective`,
         );
       } else {
-        return twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+        return twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
       }
     })
     .then(() => collective.editTiers(args.tiers));
@@ -43,7 +43,7 @@ export async function editTier(_, args, req) {
     throw new Unauthorized();
   }
 
-  await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+  await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
   return tier.update(args.tier);
 }

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -393,7 +393,7 @@ const accountMutations = {
         throw new Forbidden();
       }
 
-      await TwoFactorAuthLib.enforceForAccountAdmins(req, account, { onlyAskOnLogin: true });
+      await TwoFactorAuthLib.enforceForAccount(req, account, { onlyAskOnLogin: true });
 
       for (const key of Object.keys(args.account)) {
         switch (key) {
@@ -488,7 +488,7 @@ const accountMutations = {
         throw new Unauthorized('You need to be logged in as an Admin of the account.');
       }
 
-      await TwoFactorAuthLib.enforceForAccountAdmins(req, account, { alwaysAskForToken: true });
+      await TwoFactorAuthLib.enforceForAccount(req, account, { alwaysAskForToken: true });
 
       if (await account.isHost()) {
         throw new Error(

--- a/server/graphql/v2/mutation/AddFundsMutations.ts
+++ b/server/graphql/v2/mutation/AddFundsMutations.ts
@@ -67,7 +67,7 @@ export const addFundsMutation = {
     }
 
     // Enforce 2FA
-    await twoFactorAuthLib.enforceForAccountAdmins(req, host, { onlyAskOnLogin: true });
+    await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });
 
     return addFunds(
       {

--- a/server/graphql/v2/mutation/ApplicationMutations.js
+++ b/server/graphql/v2/mutation/ApplicationMutations.js
@@ -27,7 +27,7 @@ const createApplication = {
       : req.remoteUser.collective;
 
     // Enforce 2FA
-    await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+    await twoFactorAuthLib.enforceForAccount(req, collective);
 
     if (!req.remoteUser.isAdminOfCollective(collective)) {
       throw new Forbidden();

--- a/server/graphql/v2/mutation/ConnectedAccountMutations.ts
+++ b/server/graphql/v2/mutation/ConnectedAccountMutations.ts
@@ -42,7 +42,7 @@ const connectedAccountMutations = {
         throw new Unauthorized("You don't have permission to edit this collective");
       }
 
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+      await twoFactorAuthLib.enforceForAccount(req, collective);
 
       if ([Service.TRANSFERWISE, Service.PAYPAL, Service.PRIVACY].includes(args.connectedAccount.service)) {
         if (!args.connectedAccount.token) {
@@ -119,7 +119,7 @@ const connectedAccountMutations = {
         throw new Unauthorized("You don't have permission to edit this collective");
       }
 
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { alwaysAskForToken: true });
+      await twoFactorAuthLib.enforceForAccount(req, collective, { alwaysAskForToken: true });
 
       await connectedAccount.destroy({ force: true });
 

--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -81,7 +81,7 @@ const HostApplicationMutations = {
         throw new Forbidden('You need to be an Admin of the account');
       }
 
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+      await twoFactorAuthLib.enforceForAccount(req, collective);
 
       const host = await fetchAccountWithReference(args.host);
       if (!host) {
@@ -195,7 +195,7 @@ const HostApplicationMutations = {
       }
 
       // Enforce 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, host, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });
 
       switch (args.action) {
         case 'APPROVE':

--- a/server/graphql/v2/mutation/IndividualMutations.ts
+++ b/server/graphql/v2/mutation/IndividualMutations.ts
@@ -61,7 +61,7 @@ const individualMutations = {
 
       // Enforce 2FA
       const account = await req.remoteUser.getCollective();
-      await TwoFactorAuthLib.enforceForAccountAdmins(req, account, { alwaysAskForToken: true });
+      await TwoFactorAuthLib.enforceForAccount(req, account, { alwaysAskForToken: true });
 
       // Check current password if one already set
       if (req.remoteUser.passwordHash && req.jwtPayload?.scope !== 'reset-password') {

--- a/server/graphql/v2/mutation/MemberInvitationMutations.js
+++ b/server/graphql/v2/mutation/MemberInvitationMutations.js
@@ -59,7 +59,7 @@ const memberInvitationMutations = {
         throw new Forbidden('You can only invite users.');
       }
 
-      await twoFactorAuthLib.enforceForAccountAdmins(req, account);
+      await twoFactorAuthLib.enforceForAccount(req, account);
 
       const memberParams = {
         ...pick(args, ['role', 'description', 'since']),
@@ -110,7 +110,7 @@ const memberInvitationMutations = {
         throw new Forbidden('You can only edit accountants, admins, or members.');
       }
 
-      await twoFactorAuthLib.enforceForAccountAdmins(req, account);
+      await twoFactorAuthLib.enforceForAccount(req, account);
 
       // Edit member invitation
       const editableAttributes = pick(args, ['role', 'description', 'since']);

--- a/server/graphql/v2/mutation/MemberMutations.js
+++ b/server/graphql/v2/mutation/MemberMutations.js
@@ -155,7 +155,7 @@ const memberMutations = {
       }
 
       // Enforce 2FA if enabled on the account
-      await twoFactorAuthLib.enforceForAccountAdmins(req, account);
+      await twoFactorAuthLib.enforceForAccount(req, account);
 
       // Edit member
       const editableAttributes = pick(args, ['role', 'description', 'since']);
@@ -249,7 +249,7 @@ const memberMutations = {
       }
 
       // Check 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, account);
+      await twoFactorAuthLib.enforceForAccount(req, account);
 
       // Remove member
       if (args.isInvitation) {

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -147,7 +147,7 @@ const orderMutations = {
 
       // Check 2FA for non-guest contributions
       if (req.remoteUser) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, fromCollective, { onlyAskOnLogin: true });
+        await twoFactorAuthLib.enforceForAccount(req, fromCollective, { onlyAskOnLogin: true });
       }
 
       const result = await createOrderLegacy(legacyOrderObj, req);
@@ -197,7 +197,7 @@ const orderMutations = {
       }
 
       // Check 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, order.fromCollective, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, order.fromCollective, { onlyAskOnLogin: true });
 
       await order.update({ status: OrderStatuses.CANCELLED });
       await order.Subscription.deactivate();
@@ -283,7 +283,7 @@ const orderMutations = {
       }
 
       // Check 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, order.fromCollective, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, order.fromCollective, { onlyAskOnLogin: true });
 
       let previousOrderValues, previousSubscriptionValues;
       if (haveDetailsChanged) {
@@ -380,7 +380,7 @@ const orderMutations = {
       }
 
       // Enforce 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, host, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });
 
       if (args.action === 'MARK_AS_PAID') {
         if (!(await canMarkAsPaid(req, order))) {

--- a/server/graphql/v2/mutation/PaymentMethodMutations.js
+++ b/server/graphql/v2/mutation/PaymentMethodMutations.js
@@ -58,7 +58,7 @@ const addCreditCard = {
     }
 
     // Check 2FA
-    await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+    await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
     const token = await stripe.tokens.retrieve(args.creditCardInfo.token);
     const newPaymentMethodData = {

--- a/server/graphql/v2/mutation/PayoutMethodMutations.ts
+++ b/server/graphql/v2/mutation/PayoutMethodMutations.ts
@@ -37,7 +37,7 @@ const payoutMethodMutations = {
       }
 
       // Enforce 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+      await twoFactorAuthLib.enforceForAccount(req, collective);
 
       if (args.payoutMethod.data.isManualBankTransfer) {
         try {

--- a/server/graphql/v2/mutation/PersonalTokenMutations.ts
+++ b/server/graphql/v2/mutation/PersonalTokenMutations.ts
@@ -29,7 +29,7 @@ const createPersonalToken = {
       : req.remoteUser.collective;
 
     // Enforce 2FA
-    await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+    await twoFactorAuthLib.enforceForAccount(req, collective);
 
     if (!req.remoteUser.isAdminOfCollective(collective)) {
       throw new Forbidden();

--- a/server/graphql/v2/mutation/TierMutations.ts
+++ b/server/graphql/v2/mutation/TierMutations.ts
@@ -87,7 +87,7 @@ const tierMutations = {
       }
 
       // Check 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, collective, { onlyAskOnLogin: true });
 
       // Update tier
       const updatedTier = await tier.update(transformTierInputToAttributes(args.tier));
@@ -120,7 +120,7 @@ const tierMutations = {
       }
 
       // Check 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, account, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, account, { onlyAskOnLogin: true });
 
       // Create tier
       const tier = await TierModel.create({
@@ -161,7 +161,7 @@ const tierMutations = {
       }
 
       // Check 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+      await twoFactorAuthLib.enforceForAccount(req, collective);
 
       if (args.stopRecurringContributions) {
         await models.Order.cancelActiveOrdersByTierId(tier.id);

--- a/server/graphql/v2/mutation/TransactionMutations.ts
+++ b/server/graphql/v2/mutation/TransactionMutations.ts
@@ -67,7 +67,7 @@ const transactionMutations = {
       const host = await models.Collective.findByPk(transaction.HostCollectiveId);
 
       // Enforce 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, host, { onlyAskOnLogin: true });
+      await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });
 
       const { platformTipTransaction } = await models.Transaction.createPlatformTipTransactions(transactionData, host);
 
@@ -145,10 +145,10 @@ const transactionMutations = {
       }
 
       if (req.remoteUser.isAdminOfCollective(toAccount)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, toAccount, { onlyAskOnLogin: true });
+        await twoFactorAuthLib.enforceForAccount(req, toAccount, { onlyAskOnLogin: true });
       } else if (req.remoteUser.isAdmin(transaction.HostCollectiveId)) {
         const host = await models.Collective.findByPk(transaction.HostCollectiveId);
-        await twoFactorAuthLib.enforceForAccountAdmins(req, host, { onlyAskOnLogin: true });
+        await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });
       }
 
       if (orderToUpdate.SubscriptionId) {

--- a/server/graphql/v2/mutation/VirtualCardMutations.ts
+++ b/server/graphql/v2/mutation/VirtualCardMutations.ts
@@ -50,7 +50,7 @@ const virtualCardMutations = {
       }
 
       // Enforce 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, host);
+      await twoFactorAuthLib.enforceForAccount(req, host);
 
       const assignee = await fetchAccountWithReference(args.assignee, {
         loaders: req.loaders,
@@ -160,7 +160,7 @@ const virtualCardMutations = {
       }
 
       // Enforce 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, host);
+      await twoFactorAuthLib.enforceForAccount(req, host);
 
       const assignee = await fetchAccountWithReference(args.assignee, {
         loaders: req.loaders,
@@ -244,9 +244,9 @@ const virtualCardMutations = {
       if (args.limitAmount && !req.remoteUser.isAdmin(virtualCard.HostCollectiveId)) {
         throw new Unauthorized("You don't have permission to update this Virtual Card's limit");
       } else if (req.remoteUser.isAdminOfCollective(virtualCard.collective)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, virtualCard.collective);
+        await twoFactorAuthLib.enforceForAccount(req, virtualCard.collective);
       } else if (req.remoteUser.isAdminOfCollective(virtualCard.host)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, virtualCard.host);
+        await twoFactorAuthLib.enforceForAccount(req, virtualCard.host);
       } else {
         throw new Unauthorized("You don't have permission to update this Virtual Card");
       }
@@ -336,7 +336,7 @@ const virtualCardMutations = {
       }
 
       // Check 2FA
-      await twoFactorAuthLib.enforceForAccountAdmins(req, collective);
+      await twoFactorAuthLib.enforceForAccount(req, collective);
 
       const host = await collective.getHostCollective();
       const userCollective = await req.remoteUser.getCollective();
@@ -391,9 +391,9 @@ const virtualCardMutations = {
       }
 
       if (req.remoteUser.isAdmin(virtualCard.HostCollectiveId)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, virtualCard.host);
+        await twoFactorAuthLib.enforceForAccount(req, virtualCard.host);
       } else if (req.remoteUser.isAdmin(virtualCard.CollectiveId)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, virtualCard.collective);
+        await twoFactorAuthLib.enforceForAccount(req, virtualCard.collective);
       } else {
         throw new Unauthorized("You don't have permission to pause this Virtual Card");
       }
@@ -473,9 +473,9 @@ const virtualCardMutations = {
       }
 
       if (req.remoteUser.isAdminOfCollective(virtualCard.collective)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, virtualCard.collective);
+        await twoFactorAuthLib.enforceForAccount(req, virtualCard.collective);
       } else if (req.remoteUser.isAdminOfCollective(virtualCard.host)) {
-        await twoFactorAuthLib.enforceForAccountAdmins(req, virtualCard.host);
+        await twoFactorAuthLib.enforceForAccount(req, virtualCard.host);
       } else {
         throw new Unauthorized("You don't have permission to edit this Virtual Card");
       }

--- a/server/graphql/v2/mutation/WebhookMutations.js
+++ b/server/graphql/v2/mutation/WebhookMutations.js
@@ -30,7 +30,7 @@ const createWebhook = {
     }
 
     // Check 2FA
-    await twoFactorAuthLib.enforceForAccountAdmins(req, account);
+    await twoFactorAuthLib.enforceForAccount(req, account);
 
     const createParams = {
       channel: 'webhook',
@@ -67,7 +67,7 @@ const updateWebhook = {
     }
 
     // Check 2FA
-    await twoFactorAuthLib.enforceForAccountAdmins(req, account);
+    await twoFactorAuthLib.enforceForAccount(req, account);
 
     const updateParams = {};
 
@@ -105,7 +105,7 @@ const deleteWebhook = {
     }
 
     // Check 2FA
-    await twoFactorAuthLib.enforceForAccountAdmins(req, account, { onlyAskOnLogin: true });
+    await twoFactorAuthLib.enforceForAccount(req, account, { onlyAskOnLogin: true });
 
     return notification.destroy();
   },


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/8572

To resolve a similar issue happening on edit.