### PR TITLE
Fix Pending Contribution email notifications

### DIFF
--- a/templates/emails/order.pending.created.hbs
+++ b/templates/emails/order.pending.created.hbs
@@ -1,4 +1,4 @@
-Subject: We've been notified of incoming funds to {{collective.name}}
+Subject: We've been notified of incoming funds to {{toCollective.name}}
 
 {{> header}}
 
@@ -6,7 +6,7 @@ Subject: We've been notified of incoming funds to {{collective.name}}
 
 <center>
   <h1>
-    We've been notified of incoming funds to {{collective.name}}
+    We've been notified of incoming funds to {{toCollective.name}}
   </h1>
 </center>
 
@@ -31,5 +31,15 @@ Subject: We've been notified of incoming funds to {{collective.name}}
   Info: <br /> {{order.memo}}<br />
   {{/if}}
 </p>
+
+<br />
+<br />
+<br />
+
+<center>
+  <a class="btn blue" href="{{config.host.website}}/{{toCollective.slug}}/orders/{{order.id}}">
+    <div>Open Pending Contribution</div>
+  </a>
+</center>
 
 {{> footer}}

--- a/templates/emails/order.pending.received.hbs
+++ b/templates/emails/order.pending.received.hbs
@@ -26,4 +26,13 @@ Subject: Funds from {{fromCollective.name}} are now available
   {{/if}}
 </p>
 
+<br />
+<br />
+<br />
+<center>
+  <a class="btn blue" href="{{config.host.website}}/{{toCollective.slug}}/orders/{{order.id}}">
+    <div>Open Contribution</div>
+  </a>
+</center>
+
 {{> footer}}


### PR DESCRIPTION
Fixes a small bug where the collective name is not displayed in the email.
Also includes a button linking to the order page.