### PR TITLE
Make orders query faster

### DIFF
--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -24,13 +24,16 @@ const getJoinCondition = (
   association: OrderAssociation,
   includeHostedAccounts = false,
 ): Record<string, unknown> => {
+  const associationFields = { collective: 'CollectiveId', fromCollective: 'FromCollectiveId' };
+  const field = associationFields[association] || `$${association}.id$`;
+
   if (!includeHostedAccounts) {
-    return { [`$${association}.id$`]: account.id };
+    return { [field]: account.id };
   } else {
     return {
       [Op.or]: [
         {
-          [`$${association}.id$`]: account.id,
+          [field]: account.id,
         },
         {
           [`$${association}.HostCollectiveId$`]: account.id,


### PR DESCRIPTION
<img width="1447" alt="Screenshot 2023-03-02 at 21 56 28" src="https://user-images.githubusercontent.com/806/222550522-8a0f3ec0-c629-4967-ae7d-fd5719a5943e.png">

Looks like:

```
WHERE ("Order"."deletedAt" IS NULL
        AND (("Order"."FromCollectiveId" = $1
        OR "Order"."CollectiveId" = $2)))
```

is faster than:

```
WHERE ("Order"."deletedAt" IS NULL
        AND (("fromCollective"."id" = $1
        OR "collective"."id" = $2)))
```