### PR TITLE
Add loader for Expense comments count

### DIFF
--- a/server/graphql/v2/object/Expense.ts
+++ b/server/graphql/v2/object/Expense.ts
@@ -182,16 +182,21 @@ const Expense = new GraphQLObjectType({
             return null;
           }
 
-          const { count, rows } = await models.Comment.findAndCountAll({
-            where: {
-              ExpenseId: { [Op.eq]: expense.id },
-            },
-            order: [[orderBy.field, orderBy.direction]],
+          return {
             offset,
             limit,
-          });
-
-          return { offset, limit, totalCount: count, nodes: rows };
+            totalCount: async () => {
+              return req.loaders.Comment.countByExpenseId.load(expense.id);
+            },
+            nodes: async () => {
+              return models.Comment.findAll({
+                where: { ExpenseId: { [Op.eq]: expense.id } },
+                order: [[orderBy.field, orderBy.direction]],
+                offset,
+                limit,
+              });
+            },
+          };
         },
       },
       account: {


### PR DESCRIPTION
This will make loading the expense comments counts in lists safe, thus unblocking https://github.com/opencollective/opencollective/issues/5803.