### PR TITLE
Fix crash in `generateCountAdminMembersOfCollective`

### DIFF
--- a/server/graphql/loaders/members.ts
+++ b/server/graphql/loaders/members.ts
@@ -65,7 +65,7 @@ export const generateCountAdminMembersOfCollective = () => {
       },
     });
     const result = _.keyBy(adminsByCollective, 'CollectiveId');
-    return collectiveIds.map(collectiveId => result[collectiveId].dataValues.adminCount);
+    return collectiveIds.map(collectiveId => result[collectiveId]?.dataValues?.adminCount || 0);
   });
 };
 


### PR DESCRIPTION
Resolve https://open-collective.sentry.io/issues/3983605149/?project=5199682&referrer=slack

Due to the release of admins inheritance, many events/projects now have 0 admins. `generateCountAdminMembersOfCollective` was built before that, in a world where admins inheritance didn't exist.

This PR is a hotfix; I'll document the issue so we can follow-up with a real fix.