### PR TITLE
Ability to search for expenses by custom data

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -801,7 +801,7 @@ async function validateExpensePayout2FALimit(req, host, expense, expensePaidAmou
   }
 }
 
-const validateExpenseCustomData = (value: Record<string, unknown> | null): void => {
+export const validateExpenseCustomData = (value: Record<string, unknown> | null): void => {
   if (!value) {
     return;
   }

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -9622,6 +9622,11 @@ type Query {
     Whether to include expenses from children of the account (Events and Projects)
     """
     includeChildrenExpenses: Boolean! = false
+
+    """
+    Only return expenses that contains this custom data. Requires being an admin of the collective, payee or host.
+    """
+    customData: JSON
   ): ExpenseCollection!
   fund(
     """


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/8654
Part of https://github.com/opencollective/opencollective/issues/6451

This will let API consumers search for expenses by `customData`.

Usage:

```gql
# Will return all expenses where customData.my.nested.key = 42
expenses(host: $host, customData: $customData) {
   ...
}
```

```es6
variables = {
  host: ...,
  customData: { my: { nested: { key: 42 } } }
}