### PR TITLE
GraphQL: only cache slow queries

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -175,7 +175,8 @@
   "graphql": {
     "cache": {
       "enabled": false,
-      "ttl": 300
+      "ttl": 300,
+      "minExecutionTimeToCache": 1500
     }
   },
   "pdfService": {


### PR DESCRIPTION
Rationale: We don't need to cache collective page queries for empty profiles and things that already load really fast. This will limit the number of keys evicted from Redis, making it store more valuable information on average.