### PR TITLE
getHostCollective: by default, don't return if not approved

### DIFF
--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -324,6 +324,9 @@ export async function createOrder(order, req) {
     }
 
     const host = await collective.getHostCollective();
+    if (!host && !collective.isPledged) {
+      throw new Error('This collective has no host and cannot accept financial contributions at this time.');
+    }
     if (order.hostFeePercent) {
       if (!remoteUser?.isAdmin(host.id)) {
         throw new Error('Only an admin of the host can change the hostFeePercent');

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -2845,7 +2845,11 @@ class Collective extends Model<
   };
 
   // get the host of the parent collective if any, or of this collective
-  getHostCollective = function () {
+  getHostCollective = async function ({ returnEvenIfNotApproved = false } = {}) {
+    if (!this.isActive && !returnEvenIfNotApproved) {
+      return null;
+    }
+
     if (this.HostCollectiveId) {
       return models.Collective.findByPk(this.HostCollectiveId);
     }
@@ -2861,7 +2865,11 @@ class Collective extends Model<
     });
   };
 
-  getHostCollectiveId = function () {
+  getHostCollectiveId = async function ({ returnEvenIfNotApproved = false } = {}) {
+    if (!this.isActive && !returnEvenIfNotApproved) {
+      return null;
+    }
+
     if (this.HostCollectiveId) {
       return Promise.resolve(this.HostCollectiveId);
     }

--- a/test/mocks/data.js
+++ b/test/mocks/data.js
@@ -64,6 +64,7 @@ export default {
     hostFeePercent: 10,
     tags: ['open source', 'test'],
     isActive: true,
+    approvedAt: new Date(2020, 1, 1),
   },
 
   collective2: {
@@ -77,6 +78,7 @@ export default {
     hostFeePercent: 0,
     tags: ['meetup', 'test'],
     isActive: true,
+    approvedAt: new Date(2020, 1, 1),
   },
 
   collective3: {
@@ -613,6 +615,7 @@ export default {
     type: 'EVENT',
     name: 'January meetup',
     isActive: true,
+    approvedAt: new Date(2020, 1, 1),
     slug: 'jan-meetup',
     description: 'January monthly meetup',
     startsAt: '2017-01-06 UTC+0300',

--- a/test/server/graphql/v1/createOrder.test.js
+++ b/test/server/graphql/v1/createOrder.test.js
@@ -112,7 +112,7 @@ describe('server/graphql/v1/createOrder', () => {
     // And the above collective's host has a stripe account
     await store.stripeConnectedAccount(fearlesscitiesbrussels.HostCollectiveId);
     // And given that the above collective is active
-    await fearlesscitiesbrussels.update({ isActive: true });
+    await fearlesscitiesbrussels.update({ isActive: true, approvedAt: new Date() });
     // And given that the endpoint for creating customers on Stripe
     // is patched
     utils.stubStripeCreate(sandbox, {
@@ -138,6 +138,7 @@ describe('server/graphql/v1/createOrder', () => {
       slug: 'test',
       name: 'test',
       isActive: false,
+      approvedAt: null,
       isPledged: true,
       website: 'https://github.com/opencollective/frontend',
     });
@@ -221,6 +222,7 @@ describe('server/graphql/v1/createOrder', () => {
       name: 'test',
       currency: 'USD',
       isActive: true,
+      approvedAt: new Date(),
     });
     const event = await models.Collective.create({
       slug: 'meetup-ev1',
@@ -228,6 +230,7 @@ describe('server/graphql/v1/createOrder', () => {
       type: 'EVENT',
       ParentCollectiveId: collective.id,
       isActive: true,
+      approvedAt: new Date(),
     });
     const tier = await models.Tier.create({
       slug: 'backer',
@@ -237,11 +240,8 @@ describe('server/graphql/v1/createOrder', () => {
       CollectiveId: event.id,
     });
     await collective.addHost(host, hostAdmin, { shouldAutomaticallyApprove: true });
-    await collective.update({ isActive: true });
+    await collective.update({ isActive: true, approvedAt: new Date() });
 
-    await utils.waitForCondition(() => emailSendMessageSpy.callCount === 1, {
-      tag: 'fearlesscitiesbrussels would love to be hosted ',
-    });
     emailSendMessageSpy.resetHistory();
 
     const thisOrder = cloneDeep(baseOrder);
@@ -795,9 +795,9 @@ describe('server/graphql/v1/createOrder', () => {
       await store.stripeConnectedAccount(hostCollective.id);
       // And given two collectives in that host
       const fromCollective = (await store.newCollectiveInHost('opensource', 'USD', hostCollective)).collective;
-      await fromCollective.update({ isActive: true });
+      await fromCollective.update({ isActive: true, approvedAt: new Date() });
       const { collective } = await store.newCollectiveInHost('apex', 'USD', hostCollective);
-      await collective.update({ isActive: true });
+      await collective.update({ isActive: true, approvedAt: new Date() });
       // And given a payment method for the host
       const paymentMethod = await models.PaymentMethod.create({
         service: 'opencollective',
@@ -844,9 +844,9 @@ describe('server/graphql/v1/createOrder', () => {
     const order = cloneDeep(baseOrder);
     const { hostCollective } = await store.newHost('Host Collective', 'USD', 10);
     const fromCollective = (await store.newCollectiveInHost('opensource', 'USD', hostCollective)).collective;
-    await fromCollective.update({ isActive: true });
+    await fromCollective.update({ isActive: true, approvedAt: new Date() });
     const collective = (await store.newCollectiveInHost('apex', 'USD', hostCollective)).collective;
-    await collective.update({ isActive: true });
+    await collective.update({ isActive: true, approvedAt: new Date() });
 
     await models.Member.create({
       CreatedByUserId: xdamman.id,

--- a/test/server/graphql/v1/paymentMethods.test.js
+++ b/test/server/graphql/v1/paymentMethods.test.js
@@ -54,6 +54,7 @@ describe('server/graphql/v1/paymentMethods', () => {
       name: 'tipbox',
       type: 'COLLECTIVE',
       isActive: true,
+      approvedAt: new Date(),
       currency: 'EUR',
       hostFeePercent: 5,
       HostCollectiveId: host.id,

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -515,6 +515,21 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
         config.captcha.enabled = captchaDefaultValue;
       });
     });
+
+    describe('Common checks', () => {
+      it('collective must be approved by fiscal host', async () => {
+        const host = await fakeHost();
+        const collective = await fakeCollective({ HostCollectiveId: host.id, isActive: false, approvedAt: null });
+        const fromUser = await fakeUser();
+        const orderData = { ...validOrderParams, toAccount: { legacyId: collective.id } };
+
+        const result = await callCreateOrder({ order: orderData }, fromUser);
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.equal(
+          'This collective has no host and cannot accept financial contributions at this time.',
+        );
+      });
+    });
   });
 
   describe('moveOrders', () => {

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -133,10 +133,11 @@ describe('server/lib/payments', () => {
       currency: CURRENCY,
       TierId: tier.id,
     });
+
     order = await o.setPaymentMethod({ token: STRIPE_TOKEN });
   });
-  beforeEach('add host to collective', () => collective.addHost(host.collective, host));
-  beforeEach('add host to collective2', () => collective2.addHost(host.collective, host));
+  beforeEach('add host to collective', () => collective.addHost(host, user, { shouldAutomaticallyApprove: true }));
+  beforeEach('add host to collective2', () => collective2.addHost(host, user, { shouldAutomaticallyApprove: true }));
 
   beforeEach('create stripe account', async () => {
     await models.ConnectedAccount.create({
@@ -327,12 +328,10 @@ describe('server/lib/payments', () => {
               expect(subscription).to.have.property('currency', CURRENCY);
             }));
 
-          it('successfully sends out an email to donor', done => {
-            setTimeout(() => {
-              expect(emailSendSpy.lastCall.args[0]).to.equal(activities.ORDER_THANKYOU);
-              expect(emailSendSpy.lastCall.args[1]).to.equal(user2.email);
-              done();
-            }, 80);
+          it('successfully sends out an email to donor', async () => {
+            await utils.waitForCondition(() => emailSendSpy.callCount > 0);
+            expect(emailSendSpy.lastCall.args[0]).to.equal(activities.ORDER_THANKYOU);
+            expect(emailSendSpy.lastCall.args[1]).to.equal(user2.email);
           });
         });
       });

--- a/test/server/models/Notification.test.js
+++ b/test/server/models/Notification.test.js
@@ -328,6 +328,8 @@ describe('server/models/Notification', () => {
         tag: 'webpack would love to be hosted by host',
       });
 
+      await collective.update({ isActive: true, approvedAt: new Date() });
+
       emailSendMessageSpy.resetHistory();
     });
 

--- a/test/server/paymentProviders/opencollective/collective.test.js
+++ b/test/server/paymentProviders/opencollective/collective.test.js
@@ -77,6 +77,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         name: 'Host 1',
         currency: 'USD',
         isActive: true,
+        approvedAt: new Date(),
       }).then(c => (host1 = c)),
     );
 
@@ -85,6 +86,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         name: 'Host 2',
         currency: 'USD',
         isActive: true,
+        approvedAt: new Date(),
       }).then(c => (host2 = c)),
     );
 
@@ -93,6 +95,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         name: 'Host 3',
         currency: 'EUR',
         isActive: true,
+        approvedAt: new Date(),
       }).then(c => (host3 = c)),
     );
 
@@ -102,6 +105,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         currency: 'USD',
         HostCollectiveId: host1.id,
         isActive: true,
+        approvedAt: new Date(),
       }).then(c => (collective1 = c)),
     );
 
@@ -111,6 +115,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         currency: 'USD',
         HostCollectiveId: host1.id,
         isActive: true,
+        approvedAt: new Date(),
       }).then(c => (collective2 = c)),
     );
 
@@ -120,6 +125,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         currency: 'USD',
         HostCollectiveId: host2.id,
         isActive: true,
+        approvedAt: new Date(),
       }).then(c => (collective3 = c)),
     );
 
@@ -129,6 +135,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         currency: 'USD',
         HostCollectiveId: host3.id,
         isActive: true,
+        approvedAt: new Date(),
       }).then(c => (collective5 = c)),
     );
 
@@ -495,6 +502,7 @@ describe('server/paymentProviders/opencollective/collective', () => {
         currency: 'USD',
         HostCollectiveId: host.id,
         isActive: true,
+        approvedAt: new Date(),
         type: 'COLLECTIVE',
         CreatedByUserId: user.id,
       };

--- a/test/server/paymentProviders/opencollective/giftcard.test.js
+++ b/test/server/paymentProviders/opencollective/giftcard.test.js
@@ -132,6 +132,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'collective1',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (collective1 = c)),
       );
       before('creates User 1', () =>
@@ -249,6 +250,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'collective1',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (collective1 = c)),
       );
       before('create a credit card payment method', () =>
@@ -332,6 +334,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'Host 1',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => {
           host1 = c;
           // Create stripe connected account to host
@@ -345,6 +348,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           currency: 'USD',
           HostCollectiveId: host1.id,
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (collective1 = c)),
       );
       before('create collective2', () =>
@@ -353,6 +357,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           currency: 'USD',
           HostCollectiveId: host1.id,
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (collective2 = c)),
       );
 
@@ -596,6 +601,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'Test HOST',
           currency: CURRENCY,
           isActive: true,
+          approvedAt: new Date(),
         });
         await store.stripeConnectedAccount(hostCollective.id);
       });
@@ -625,6 +631,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'Test Collective',
           currency: CURRENCY,
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (targetCollective = c));
         await targetCollective.addHost(hostCollective, user, { shouldAutomaticallyApprove: true });
       });
@@ -683,6 +690,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'collective1',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (collective1 = c)),
       );
       before('create collective2(currency USD, No Host)', () =>
@@ -690,6 +698,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'collective2',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (collective2 = c)),
       );
       before('creates User 1', () =>
@@ -784,6 +793,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           currency: 'USD',
           image: 'https://cldup.com/rdmBCmH20l.png',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => (collective1 = c)),
       );
 
@@ -941,6 +951,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'Host 1',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => {
           host1 = c;
           // Create stripe connected account to host
@@ -952,6 +963,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'Host 2',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
         }).then(c => {
           host2 = c;
           // Create stripe connected account to host
@@ -963,6 +975,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'collective1',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
           tags: ['open source'],
         }).then(c => (collective1 = c)),
       );
@@ -971,6 +984,7 @@ describe('server/paymentProviders/opencollective/giftcard', () => {
           name: 'collective2',
           currency: 'USD',
           isActive: true,
+          approvedAt: new Date(),
           tags: ['meetup'],
         }).then(c => (collective2 = c)),
       );

--- a/test/server/paymentProviders/opencollective/manual.test.js
+++ b/test/server/paymentProviders/opencollective/manual.test.js
@@ -40,6 +40,7 @@ describe('server/paymentProviders/opencollective/manual', () => {
       currency: 'USD',
       HostCollectiveId: host.id,
       isActive: true,
+      approvedAt: new Date(),
       hostFeePercent,
     });
   });

--- a/test/stores/index.js
+++ b/test/stores/index.js
@@ -165,6 +165,7 @@ export async function newCollectiveWithHost(name, currency, hostCurrency, hostFe
   await collective.addHost(hostCollective, hostAdmin);
   // We activate the collective
   collective.isActive = true;
+  collective.approvedAt = new Date();
   // when adding the host, the collective.currency becomes the currency of the host
   // so if we explicitly want a different currency for the collective, we need to update it again
   if (currency !== hostCurrency) {

--- a/test/stories/ledger.test.ts
+++ b/test/stories/ledger.test.ts
@@ -81,7 +81,7 @@ const setupTestData = async (
     plan: 'grow-plan-2021', // Use a plan with 15% host share
   });
   await hostAdmin.populateRoles();
-  await host.update({ HostCollectiveId: host.id, isActive: true });
+  await host.update({ HostCollectiveId: host.id, isActive: true, approvedAt: new Date() });
   const collective = await fakeCollective({
     HostCollectiveId: host.id,
     name: 'ESLint',


### PR DESCRIPTION
Todo before merging: check if we have cases of collectives where only one of `isApproved` or `approvedAt` is set.