### PR TITLE
Introduce GraphQL armor to monitor queries complexity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/plugin-transform-async-to-generator": "7.20.7",
         "@babel/preset-env": "7.20.2",
         "@babel/preset-typescript": "7.18.6",
+        "@escape.tech/graphql-armor": "^1.7.1",
         "@hyperwatch/hyperwatch": "3.9.4",
         "@node-oauth/oauth2-server": "4.3.0",
         "@octokit/auth-oauth-app": "5.0.5",
@@ -181,9 +182,9 @@
       }
     },
     "node_modules/@apollo/protobufjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.6.tgz",
+      "integrity": "sha512-Wqo1oSHNUj/jxmsVp4iR3I480p6qdqHikn38lKrFhfzcDJ7lwd7Ck7cHRl4JE81tWNArl77xhnG/OkZhxKBYOw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2337,6 +2338,137 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "node_modules/@envelop/core": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-3.0.6.tgz",
+      "integrity": "sha512-06t1xCPXq6QFN7W1JUEf68aCwYN0OUDNAIoJe7bAqhaoa2vn7NCcuX1VHkJ/OWpmElUgCsRO6RiBbIru1in0Ig==",
+      "optional": true,
+      "dependencies": {
+        "@envelop/types": "3.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@envelop/core/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@envelop/types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-3.0.2.tgz",
+      "integrity": "sha512-pOFea9ha0EkURWxJ/35axoH9fDGP5S2cUu/5Mmo9pb8zUf+TaEot8vB670XXihFEn/92759BMjLJNWBKmNhyng==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@envelop/types/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
+    },
+    "node_modules/@escape.tech/graphql-armor": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor/-/graphql-armor-1.7.1.tgz",
+      "integrity": "sha512-KsIRfxGUyobJyv7LSRv47f2v22YIqK00dTHX8o35XcJ92Kej7zkw8+mKsKjJU79TFfmZOJHNDCyic4isTMswxw==",
+      "dependencies": {
+        "@escape.tech/graphql-armor-block-field-suggestions": "1.4.0",
+        "@escape.tech/graphql-armor-cost-limit": "1.7.0",
+        "@escape.tech/graphql-armor-max-aliases": "1.6.1",
+        "@escape.tech/graphql-armor-max-depth": "1.8.1",
+        "@escape.tech/graphql-armor-max-directives": "1.6.3",
+        "@escape.tech/graphql-armor-max-tokens": "1.3.1",
+        "graphql": "^16.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0",
+        "apollo-server-core": "^3.10.0",
+        "apollo-server-types": "^3.6.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-block-field-suggestions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-block-field-suggestions/-/graphql-armor-block-field-suggestions-1.4.0.tgz",
+      "integrity": "sha512-PkGxPCOXWuVA+NlF/aSSFVMravhUm6fP+oVXiq1GOVS5mPVhEKoyHk9j1UeF96/qHzkIsEUsfbLKP3IkygpSLA==",
+      "dependencies": {
+        "graphql": "^16.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^3.0.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-cost-limit": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-cost-limit/-/graphql-armor-cost-limit-1.7.0.tgz",
+      "integrity": "sha512-pMO4S6P1OUe8PuZE1o3dpyzfgTgIpRUieG5Urgb1e0ZyAH29xA0T6LUzhLtnMJHKobe4gpCQDybzi/dr6+wjwQ==",
+      "dependencies": {
+        "graphql": "^16.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-max-aliases": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-aliases/-/graphql-armor-max-aliases-1.6.1.tgz",
+      "integrity": "sha512-vqYb2EG4NpCo4cRBhreGHiztFopLlz+Pr65swqJUjnsjKaQwQwZMea5YZ9j0FV5nWkrbe4Gv5PoYIpJ7ZyBrwg==",
+      "dependencies": {
+        "graphql": "^16.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-max-depth": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-depth/-/graphql-armor-max-depth-1.8.1.tgz",
+      "integrity": "sha512-WXJI1mQz9iRPk5H6e+cvMHqAm6p3xO6g8aR8u1IgmlmlkzJq9Ejx8qISuvlMmYmkEHBlPnIFs59L0Cf9ikzWDQ==",
+      "dependencies": {
+        "graphql": "^16.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-max-directives": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-directives/-/graphql-armor-max-directives-1.6.3.tgz",
+      "integrity": "sha512-pRRwwluMe8BbZfjXgF7uOJpQdk8qIymvvHo3IihjBEGPZwVB53Cuo1oV66xFA8bi+xiosDOmk2EtiHYndYorKQ==",
+      "dependencies": {
+        "graphql": "^16.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-max-tokens": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-tokens/-/graphql-armor-max-tokens-1.3.1.tgz",
+      "integrity": "sha512-RvK9xnG4+1M6XH0TxwKb4cLvKN1EN2Auuh5Qq5IaoPGQzSvMjCfLa7d2v/j3mO3+68Pdsj6Y4MVzow/VBYBfDw==",
+      "dependencies": {
+        "graphql": "^16.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-types/-/graphql-armor-types-0.4.0.tgz",
+      "integrity": "sha512-E78TUacOz70tFK4mKOTrJE/ar2Z9hiDM0dcxau3GBffozWVGNqLmCt4JJeahlJieldJuXfhaJestRJuVVCWm5g==",
+      "optional": true,
+      "dependencies": {
+        "graphql": "^16.0.0"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -6868,17 +7000,19 @@
       }
     },
     "node_modules/apollo-reporting-protobuf": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
-      "integrity": "sha512-tyvj3Vj71TCh6c8PtdHOLgHHBSJ05DF/A/Po3q8yfHTBkOPcOJZE/GGN/PT/pwKg7HHxKcAeHDw7+xciVvGx0w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.4.0.tgz",
+      "integrity": "sha512-h0u3EbC/9RpihWOmcSsvTW2O6RXVaD/mPEjfrPkxRPTEPWqncsgOoRJw+wih4OqfH3PvTJvoEIf4LwKrUaqWog==",
+      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
       "dependencies": {
-        "@apollo/protobufjs": "1.2.2"
+        "@apollo/protobufjs": "1.2.6"
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.9.0.tgz",
-      "integrity": "sha512-WS54C33cTriDaBIcj7ijWv/fgeJICcrQKlP1Cn6pnZp/eumpMraezLeJ3gFWAXprOuR2E3fZe64lNlup0fMu8w==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.12.0.tgz",
+      "integrity": "sha512-hq7iH6Cgldgmnjs9FVSZeKWRpi0/ZR+iJ1arzeD2VXGxxgk1mAm/cz1Tx0TYgegZI+FvvrRl0UhKEx7sLnIxIg==",
+      "deprecated": "The `apollo-server-core` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -6889,18 +7023,19 @@
         "@graphql-tools/schema": "^8.0.0",
         "@josephg/resolvable": "^1.0.0",
         "apollo-datasource": "^3.3.2",
-        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-reporting-protobuf": "^3.4.0",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.6.1",
-        "apollo-server-types": "^3.6.1",
+        "apollo-server-plugin-base": "^3.7.2",
+        "apollo-server-types": "^3.8.0",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.1.0",
         "graphql-tag": "^2.11.0",
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
+        "node-abort-controller": "^3.0.1",
         "sha.js": "^2.4.11",
-        "uuid": "^8.0.0",
+        "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
@@ -6919,14 +7054,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/apollo-server-env": {
@@ -6977,11 +7104,12 @@
       }
     },
     "node_modules/apollo-server-plugin-base": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.1.tgz",
-      "integrity": "sha512-bFpxzWO0LTTtSAkGVBeaAtnQXJ5ZCi8eaLN/eMSju8RByifmF3Kr6gAqcOZhOH/geQEt3Y6G8n3bR0eHTGxljQ==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.2.tgz",
+      "integrity": "sha512-wE8dwGDvBOGehSsPTRZ8P/33Jan6/PmL0y0aN/1Z5a5GcbFhDaaJCjK5cav6npbbGL2DPKK0r6MPXi3k3N45aw==",
+      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
       "dependencies": {
-        "apollo-server-types": "^3.6.1"
+        "apollo-server-types": "^3.8.0"
       },
       "engines": {
         "node": ">=12.0"
@@ -6991,13 +7119,14 @@
       }
     },
     "node_modules/apollo-server-types": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.1.tgz",
-      "integrity": "sha512-XOPlBlRdwP00PrG03OffGGWuzyei+J9t1rAnvyHsSdP0JCgQWigHJfvL1N9Bhgi4UTjl9JadKOJh1znLNlqIFQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.8.0.tgz",
+      "integrity": "sha512-ZI/8rTE4ww8BHktsVpb91Sdq7Cb71rdSkXELSwdSR0eXu600/sY+1UXhTWdiJvk+Eq5ljqoHLwLbY2+Clq2b9A==",
+      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
-        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-reporting-protobuf": "^3.4.0",
         "apollo-server-env": "^4.2.1"
       },
       "engines": {
@@ -15943,6 +16072,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+    },
     "node_modules/node-addon-api": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
@@ -22119,9 +22253,9 @@
       }
     },
     "@apollo/protobufjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
-      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.6.tgz",
+      "integrity": "sha512-Wqo1oSHNUj/jxmsVp4iR3I480p6qdqHikn38lKrFhfzcDJ7lwd7Ck7cHRl4JE81tWNArl77xhnG/OkZhxKBYOw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -23607,6 +23741,127 @@
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
+      }
+    },
+    "@envelop/core": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-3.0.6.tgz",
+      "integrity": "sha512-06t1xCPXq6QFN7W1JUEf68aCwYN0OUDNAIoJe7bAqhaoa2vn7NCcuX1VHkJ/OWpmElUgCsRO6RiBbIru1in0Ig==",
+      "optional": true,
+      "requires": {
+        "@envelop/types": "3.0.2",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@envelop/types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-3.0.2.tgz",
+      "integrity": "sha512-pOFea9ha0EkURWxJ/35axoH9fDGP5S2cUu/5Mmo9pb8zUf+TaEot8vB670XXihFEn/92759BMjLJNWBKmNhyng==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
+        }
+      }
+    },
+    "@escape.tech/graphql-armor": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor/-/graphql-armor-1.7.1.tgz",
+      "integrity": "sha512-KsIRfxGUyobJyv7LSRv47f2v22YIqK00dTHX8o35XcJ92Kej7zkw8+mKsKjJU79TFfmZOJHNDCyic4isTMswxw==",
+      "requires": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-block-field-suggestions": "1.4.0",
+        "@escape.tech/graphql-armor-cost-limit": "1.7.0",
+        "@escape.tech/graphql-armor-max-aliases": "1.6.1",
+        "@escape.tech/graphql-armor-max-depth": "1.8.1",
+        "@escape.tech/graphql-armor-max-directives": "1.6.3",
+        "@escape.tech/graphql-armor-max-tokens": "1.3.1",
+        "@escape.tech/graphql-armor-types": "0.4.0",
+        "apollo-server-core": "^3.10.0",
+        "apollo-server-types": "^3.6.0",
+        "graphql": "^16.0.0"
+      }
+    },
+    "@escape.tech/graphql-armor-block-field-suggestions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-block-field-suggestions/-/graphql-armor-block-field-suggestions-1.4.0.tgz",
+      "integrity": "sha512-PkGxPCOXWuVA+NlF/aSSFVMravhUm6fP+oVXiq1GOVS5mPVhEKoyHk9j1UeF96/qHzkIsEUsfbLKP3IkygpSLA==",
+      "requires": {
+        "@envelop/core": "^3.0.0",
+        "graphql": "^16.0.0"
+      }
+    },
+    "@escape.tech/graphql-armor-cost-limit": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-cost-limit/-/graphql-armor-cost-limit-1.7.0.tgz",
+      "integrity": "sha512-pMO4S6P1OUe8PuZE1o3dpyzfgTgIpRUieG5Urgb1e0ZyAH29xA0T6LUzhLtnMJHKobe4gpCQDybzi/dr6+wjwQ==",
+      "requires": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0",
+        "graphql": "^16.0.0"
+      }
+    },
+    "@escape.tech/graphql-armor-max-aliases": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-aliases/-/graphql-armor-max-aliases-1.6.1.tgz",
+      "integrity": "sha512-vqYb2EG4NpCo4cRBhreGHiztFopLlz+Pr65swqJUjnsjKaQwQwZMea5YZ9j0FV5nWkrbe4Gv5PoYIpJ7ZyBrwg==",
+      "requires": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0",
+        "graphql": "^16.0.0"
+      }
+    },
+    "@escape.tech/graphql-armor-max-depth": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-depth/-/graphql-armor-max-depth-1.8.1.tgz",
+      "integrity": "sha512-WXJI1mQz9iRPk5H6e+cvMHqAm6p3xO6g8aR8u1IgmlmlkzJq9Ejx8qISuvlMmYmkEHBlPnIFs59L0Cf9ikzWDQ==",
+      "requires": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0",
+        "graphql": "^16.0.0"
+      }
+    },
+    "@escape.tech/graphql-armor-max-directives": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-directives/-/graphql-armor-max-directives-1.6.3.tgz",
+      "integrity": "sha512-pRRwwluMe8BbZfjXgF7uOJpQdk8qIymvvHo3IihjBEGPZwVB53Cuo1oV66xFA8bi+xiosDOmk2EtiHYndYorKQ==",
+      "requires": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0",
+        "graphql": "^16.0.0"
+      }
+    },
+    "@escape.tech/graphql-armor-max-tokens": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-tokens/-/graphql-armor-max-tokens-1.3.1.tgz",
+      "integrity": "sha512-RvK9xnG4+1M6XH0TxwKb4cLvKN1EN2Auuh5Qq5IaoPGQzSvMjCfLa7d2v/j3mO3+68Pdsj6Y4MVzow/VBYBfDw==",
+      "requires": {
+        "@envelop/core": "^3.0.0",
+        "@escape.tech/graphql-armor-types": "0.4.0",
+        "graphql": "^16.0.0"
+      }
+    },
+    "@escape.tech/graphql-armor-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-types/-/graphql-armor-types-0.4.0.tgz",
+      "integrity": "sha512-E78TUacOz70tFK4mKOTrJE/ar2Z9hiDM0dcxau3GBffozWVGNqLmCt4JJeahlJieldJuXfhaJestRJuVVCWm5g==",
+      "optional": true,
+      "requires": {
+        "graphql": "^16.0.0"
       }
     },
     "@eslint/eslintrc": {
@@ -27101,17 +27356,17 @@
       }
     },
     "apollo-reporting-protobuf": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
-      "integrity": "sha512-tyvj3Vj71TCh6c8PtdHOLgHHBSJ05DF/A/Po3q8yfHTBkOPcOJZE/GGN/PT/pwKg7HHxKcAeHDw7+xciVvGx0w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.4.0.tgz",
+      "integrity": "sha512-h0u3EbC/9RpihWOmcSsvTW2O6RXVaD/mPEjfrPkxRPTEPWqncsgOoRJw+wih4OqfH3PvTJvoEIf4LwKrUaqWog==",
       "requires": {
-        "@apollo/protobufjs": "1.2.2"
+        "@apollo/protobufjs": "1.2.6"
       }
     },
     "apollo-server-core": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.9.0.tgz",
-      "integrity": "sha512-WS54C33cTriDaBIcj7ijWv/fgeJICcrQKlP1Cn6pnZp/eumpMraezLeJ3gFWAXprOuR2E3fZe64lNlup0fMu8w==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.12.0.tgz",
+      "integrity": "sha512-hq7iH6Cgldgmnjs9FVSZeKWRpi0/ZR+iJ1arzeD2VXGxxgk1mAm/cz1Tx0TYgegZI+FvvrRl0UhKEx7sLnIxIg==",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -27122,18 +27377,19 @@
         "@graphql-tools/schema": "^8.0.0",
         "@josephg/resolvable": "^1.0.0",
         "apollo-datasource": "^3.3.2",
-        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-reporting-protobuf": "^3.4.0",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.6.1",
-        "apollo-server-types": "^3.6.1",
+        "apollo-server-plugin-base": "^3.7.2",
+        "apollo-server-types": "^3.8.0",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.1.0",
         "graphql-tag": "^2.11.0",
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
+        "node-abort-controller": "^3.0.1",
         "sha.js": "^2.4.11",
-        "uuid": "^8.0.0",
+        "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
@@ -27144,11 +27400,6 @@
           "requires": {
             "yallist": "^4.0.0"
           }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -27184,21 +27435,21 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.1.tgz",
-      "integrity": "sha512-bFpxzWO0LTTtSAkGVBeaAtnQXJ5ZCi8eaLN/eMSju8RByifmF3Kr6gAqcOZhOH/geQEt3Y6G8n3bR0eHTGxljQ==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.2.tgz",
+      "integrity": "sha512-wE8dwGDvBOGehSsPTRZ8P/33Jan6/PmL0y0aN/1Z5a5GcbFhDaaJCjK5cav6npbbGL2DPKK0r6MPXi3k3N45aw==",
       "requires": {
-        "apollo-server-types": "^3.6.1"
+        "apollo-server-types": "^3.8.0"
       }
     },
     "apollo-server-types": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.1.tgz",
-      "integrity": "sha512-XOPlBlRdwP00PrG03OffGGWuzyei+J9t1rAnvyHsSdP0JCgQWigHJfvL1N9Bhgi4UTjl9JadKOJh1znLNlqIFQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.8.0.tgz",
+      "integrity": "sha512-ZI/8rTE4ww8BHktsVpb91Sdq7Cb71rdSkXELSwdSR0eXu600/sY+1UXhTWdiJvk+Eq5ljqoHLwLbY2+Clq2b9A==",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
-        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-reporting-protobuf": "^3.4.0",
         "apollo-server-env": "^4.2.1"
       }
     },
@@ -34053,6 +34304,11 @@
           }
         }
       }
+    },
+    "node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node-addon-api": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/plugin-transform-async-to-generator": "7.20.7",
     "@babel/preset-env": "7.20.2",
     "@babel/preset-typescript": "7.18.6",
+    "@escape.tech/graphql-armor": "^1.7.1",
     "@hyperwatch/hyperwatch": "3.9.4",
     "@node-oauth/oauth2-server": "4.3.0",
     "@octokit/auth-oauth-app": "5.0.5",


### PR DESCRIPTION
Report-only mode for now; we'll see to enforce if it looks safe.

I picked this library over others because it has out-of-the-box compatibility with Apollo Server, is quite popular, is actively maintained, and has good documentation. They are trying to cover multiple aspects of GraphQL APIs security, which is nice as we should get more features in the future.

The company behind it offers a service to monitor GraphQL APIs to spot security issues automatically.

The only downside I found is that it is not yet possible to customize the complexity calculation. But it is not a blocker for now, and they are working on it: https://github.com/Escape-Technologies/graphql-armor/issues/167.
