### PR TITLE
Return paymentMethods for host admins

### DIFF
--- a/server/graphql/v2/interface/Account.js
+++ b/server/graphql/v2/interface/Account.js
@@ -887,9 +887,9 @@ export const AccountFields = {
       },
     },
     description:
-      'The list of payment methods that this collective can use to pay for Orders. Admin only. Scope: "orders".',
+      'The list of payment methods that this collective can use to pay for Orders. Admin or Host only. Scope: "orders".',
     async resolve(collective, args, req) {
-      if (!req.remoteUser?.isAdminOfCollective(collective) || !checkScope(req, 'orders')) {
+      if (!req.remoteUser?.isAdminOfCollectiveOrHost(collective) || !checkScope(req, 'orders')) {
         return null;
       }
 


### PR DESCRIPTION
Allow Host admins to see Collective paymentMethods and ultimately move money on their behalf.