### PR TITLE
Add script to refund host fees

### DIFF
--- a/scripts/ledger/refund-host-fee-on-transaction.ts
+++ b/scripts/ledger/refund-host-fee-on-transaction.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+import '../../server/env';
+
+import { Command } from 'commander';
+import { v4 as uuid } from 'uuid';
+
+import { refundHostFee } from '../../server/lib/payments';
+import models from '../../server/models';
+
+const DRY_RUN = process.env.DRY_RUN !== 'false';
+
+if (DRY_RUN) {
+  console.log('DRY RUN: No changes will be made');
+}
+
+const program = new Command()
+  .description('Helper to refund host fees on a given transaction')
+  .arguments('TransactionGroup UserCollectiveSlug')
+  .parse();
+
+const main = async () => {
+  const transactionGroup = program.args[0];
+  const userCollectiveSlug = program.args[1];
+  const user = await models.User.findOne({
+    include: [
+      {
+        association: 'collective',
+        attributes: [],
+        where: { slug: userCollectiveSlug },
+        required: true,
+      },
+    ],
+  });
+
+  if (!user) {
+    throw new Error(`User ${userCollectiveSlug} not found`);
+  }
+
+  // Any kind would do the job since refund is then calling `transaction.getHostFeeTransaction()` but
+  // we want to stay as close as possible to the original flow
+  const transaction = await models.Transaction.findOne({
+    where: { TransactionGroup: transactionGroup, type: 'CREDIT', kind: ['CONTRIBUTION', 'ADDED_FUNDS'] },
+  });
+
+  if (!transaction) {
+    throw new Error(`Transaction ${transactionGroup} not found`);
+  }
+
+  console.log(
+    `Refunding host fee for transaction ${transactionGroup} (${transaction.description}) on behalf of ${userCollectiveSlug}`,
+  );
+  if (!DRY_RUN) {
+    await refundHostFee(transaction, user, 0, uuid(), null);
+  }
+};
+
+// Only run script if called directly (to allow unit tests)
+if (!module.parent) {
+  main()
+    .then(() => process.exit(0))
+    .catch(e => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/server/graphql/loaders/helpers.ts
+++ b/server/graphql/loaders/helpers.ts
@@ -151,7 +151,7 @@ export function buildLoaderForAssociation<AssociatedModel extends Model>(
       if (associationsIdsToLoad.length > 0) {
         let loadedAssociations: Model[];
         if (options.loader) {
-          // If a loader is provided, use it to load the associations using the IDs we've collective
+          // If a loader is provided, use it to load the associations using the IDs we've collected
           loadedAssociations = await options.loader(associationsIdsToLoad);
         } else {
           // Otherwise fallback on making a query using the model + foreign key

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -264,6 +264,56 @@ export const refundPaymentProcessorFeeToCollective = async (transaction, refundT
   });
 };
 
+export async function refundHostFee(transaction, user, refundedPaymentProcessorFee, transactionGroup, data) {
+  const hostFeeTransaction = await transaction.getHostFeeTransaction();
+  const buildRefund = transaction => {
+    return {
+      ...buildRefundForTransaction(transaction, user, data, refundedPaymentProcessorFee),
+      TransactionGroup: transactionGroup,
+    };
+  };
+
+  if (hostFeeTransaction) {
+    const hostFeeRefund = buildRefund(hostFeeTransaction);
+    const hostFeeRefundTransaction = await models.Transaction.createDoubleEntry(hostFeeRefund);
+    await associateTransactionRefundId(hostFeeTransaction, hostFeeRefundTransaction, data);
+
+    // Refund Host Fee Share
+    const hostFeeShareTransaction = await transaction.getHostFeeShareTransaction();
+    if (hostFeeShareTransaction) {
+      const hostFeeShareRefund = buildRefund(hostFeeShareTransaction);
+      const hostFeeShareRefundTransaction = await models.Transaction.createDoubleEntry(hostFeeShareRefund);
+      await associateTransactionRefundId(hostFeeShareTransaction, hostFeeShareRefundTransaction, data);
+
+      // Refund Host Fee Share Debt
+      const hostFeeShareDebtTransaction = await transaction.getHostFeeShareDebtTransaction();
+      if (hostFeeShareDebtTransaction) {
+        const hostFeeShareSettlement = await models.TransactionSettlement.findOne({
+          where: {
+            TransactionGroup: transaction.TransactionGroup,
+            kind: TransactionKind.HOST_FEE_SHARE_DEBT,
+          },
+        });
+        let hostFeeShareRefundSettlementStatus = TransactionSettlementStatus.OWED;
+        if (hostFeeShareSettlement.status === TransactionSettlementStatus.OWED) {
+          // If the Host Fee Share is not INVOICED or SETTLED, we don't need to care about recording it.
+          // Otherwise, the Host Fee Share refund will be marked as OWED and deduced from the next invoice
+          await hostFeeShareSettlement.update({ status: TransactionSettlementStatus.SETTLED });
+          hostFeeShareRefundSettlementStatus = TransactionSettlementStatus.SETTLED;
+        }
+
+        const hostFeeShareDebtRefund = buildRefund(hostFeeShareDebtTransaction);
+        const hostFeeShareDebtRefundTransaction = await models.Transaction.createDoubleEntry(hostFeeShareDebtRefund);
+        await associateTransactionRefundId(hostFeeShareDebtTransaction, hostFeeShareDebtRefundTransaction, data);
+        await TransactionSettlement.createForTransaction(
+          hostFeeShareDebtRefundTransaction,
+          hostFeeShareRefundSettlementStatus,
+        );
+      }
+    }
+  }
+}
+
 /** Create refund transactions
  *
  * This function creates the negative transactions after refunding an
@@ -376,46 +426,7 @@ export async function createRefundTransaction(
   }
 
   // Refund Host Fee
-  const hostFeeTransaction = await transaction.getHostFeeTransaction();
-  if (hostFeeTransaction) {
-    const hostFeeRefund = buildRefund(hostFeeTransaction);
-    const hostFeeRefundTransaction = await models.Transaction.createDoubleEntry(hostFeeRefund);
-    await associateTransactionRefundId(hostFeeTransaction, hostFeeRefundTransaction, data);
-
-    // Refund Host Fee Share
-    const hostFeeShareTransaction = await transaction.getHostFeeShareTransaction();
-    if (hostFeeShareTransaction) {
-      const hostFeeShareRefund = buildRefund(hostFeeShareTransaction);
-      const hostFeeShareRefundTransaction = await models.Transaction.createDoubleEntry(hostFeeShareRefund);
-      await associateTransactionRefundId(hostFeeShareTransaction, hostFeeShareRefundTransaction, data);
-
-      // Refund Host Fee Share Debt
-      const hostFeeShareDebtTransaction = await transaction.getHostFeeShareDebtTransaction();
-      if (hostFeeShareDebtTransaction) {
-        const hostFeeShareSettlement = await models.TransactionSettlement.findOne({
-          where: {
-            TransactionGroup: transaction.TransactionGroup,
-            kind: TransactionKind.HOST_FEE_SHARE_DEBT,
-          },
-        });
-        let hostFeeShareRefundSettlementStatus = TransactionSettlementStatus.OWED;
-        if (hostFeeShareSettlement.status === TransactionSettlementStatus.OWED) {
-          // If the Host Fee Share is not INVOICED or SETTLED, we don't need to care about recording it.
-          // Otherwise, the Host Fee Share refund will be marked as OWED and deduced from the next invoice
-          await hostFeeShareSettlement.update({ status: TransactionSettlementStatus.SETTLED });
-          hostFeeShareRefundSettlementStatus = TransactionSettlementStatus.SETTLED;
-        }
-
-        const hostFeeShareDebtRefund = buildRefund(hostFeeShareDebtTransaction);
-        const hostFeeShareDebtRefundTransaction = await models.Transaction.createDoubleEntry(hostFeeShareDebtRefund);
-        await associateTransactionRefundId(hostFeeShareDebtTransaction, hostFeeShareDebtRefundTransaction, data);
-        await TransactionSettlement.createForTransaction(
-          hostFeeShareDebtRefundTransaction,
-          hostFeeShareRefundSettlementStatus,
-        );
-      }
-    }
-  }
+  await refundHostFee(transaction, user, refundedPaymentProcessorFee, transactionGroup);
 
   // Refund contribution
   const creditTransactionRefund = buildRefund(transaction);

--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -105,7 +105,7 @@ export async function processOrder(order, options) {
  *  associated to the refund transaction as who performed the refund.
  * @param {string} message a optional message to explain why the transaction is rejected
  */
-export async function refundTransaction(transaction, user, message) {
+export async function refundTransaction(transaction, user, message, opts = {}) {
   // Make sure to fetch PaymentMethod
   // Fetch PaymentMethod even if it's deleted
   if (!transaction.PaymentMethod && transaction.PaymentMethodId) {
@@ -127,7 +127,7 @@ export async function refundTransaction(transaction, user, message) {
   let result;
 
   try {
-    result = await paymentMethodProvider.refundTransaction(transaction, user, message);
+    result = await paymentMethodProvider.refundTransaction(transaction, user, message, opts);
   } catch (e) {
     if (
       (e.message.includes('has already been refunded') || e.message.includes('has been charged back')) &&
@@ -363,11 +363,11 @@ export async function createRefundTransaction(
     throw new Error('This transaction has already been refunded');
   }
 
-  const transactionGroup = uuid();
+  const transactionGroup = transactionGroupId || uuid();
   const buildRefund = transaction => {
     return {
       ...buildRefundForTransaction(transaction, user, data, refundedPaymentProcessorFee),
-      TransactionGroup: transactionGroupId || transactionGroup,
+      TransactionGroup: transactionGroup,
     };
   };
 

--- a/server/paymentProviders/opencollective/manual.js
+++ b/server/paymentProviders/opencollective/manual.js
@@ -101,8 +101,8 @@ async function processOrder(order) {
  * There's nothing more to do because it's up to the host/collective to see how
  * they want to actually refund the money.
  */
-const refundTransaction = async (transaction, user) => {
-  return await createRefundTransaction(transaction, 0, null, user);
+const refundTransaction = async (transaction, user, _, opts = null) => {
+  return await createRefundTransaction(transaction, 0, null, user, opts?.TransactionGroup);
 };
 
 /* Expected API of a Payment Method Type */

--- a/test/cron/monthly/host-settlement.test.js.snap
+++ b/test/cron/monthly/host-settlement.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cron/monthly/host-settlement should update all settlement status 1`] = `
+"
+| Group     | kind                | type   | amount | isRefund | Settlement |
+| --------- | ------------------- | ------ | ------ | -------- | ---------- |
+| #00000001 | HOST_FEE_SHARE_DEBT | DEBIT  | -90    | false    | INVOICED   |
+| #00000001 | HOST_FEE_SHARE_DEBT | CREDIT | 90     | false    | INVOICED   |
+| #00000002 | HOST_FEE_SHARE_DEBT | DEBIT  | -60    | false    | INVOICED   |
+| #00000002 | HOST_FEE_SHARE_DEBT | CREDIT | 60     | false    | INVOICED   |
+| #00000003 | HOST_FEE_SHARE_DEBT | DEBIT  | -90    | false    | INVOICED   |
+| #00000003 | HOST_FEE_SHARE_DEBT | CREDIT | 90     | false    | INVOICED   |
+| #00000004 | HOST_FEE_SHARE_DEBT | DEBIT  | -90    | false    | SETTLED    |
+| #00000004 | HOST_FEE_SHARE_DEBT | CREDIT | 90     | false    | SETTLED    |
+| #00000005 | HOST_FEE_SHARE_DEBT | DEBIT  | -63    | false    | SETTLED    |
+| #00000005 | HOST_FEE_SHARE_DEBT | CREDIT | 63     | false    | SETTLED    |
+| #00000006 | PLATFORM_TIP_DEBT   | CREDIT | 813    | false    | INVOICED   |
+| #00000008 | HOST_FEE_SHARE_DEBT | DEBIT  | -90    | true     | SETTLED    |
+| #00000008 | HOST_FEE_SHARE_DEBT | CREDIT | 90     | true     | SETTLED    |
+| #00000009 | HOST_FEE_SHARE_DEBT | DEBIT  | -63    | true     | INVOICED   |
+| #00000009 | HOST_FEE_SHARE_DEBT | CREDIT | 63     | true     | INVOICED   |"
+`;

--- a/test/utils.js
+++ b/test/utils.js
@@ -490,8 +490,8 @@ export const snapshotTransactions = (transactions, params = {}) => {
 /**
  * Makes a full snapshot of the ledger
  */
-export const snapshotLedger = async columns => {
-  const transactions = await models.Transaction.findAll({ order: [['id', 'DESC']] });
+export const snapshotLedger = async (columns, { where = null, order = [['id', 'DESC']] } = {}) => {
+  const transactions = await models.Transaction.findAll({ where, order });
   await preloadAssociationsForTransactions(transactions, columns);
   if (columns.includes('settlementStatus')) {
     await models.TransactionSettlement.attachStatusesToTransactions(transactions);


### PR DESCRIPTION
For https://opencollective.freshdesk.com/a/tickets/180091
Tickets TLDR ; Wrongffully added funds with host fees, cannot refund then re-add because expenses have been paid and there's not enough balance to refund (see https://github.com/opencollective/opencollective/issues/6591)

The manual alternative is:
- Delete the HOST_FEE + HOST_FEE_SHARE + HOST_FEE_SHARE_DEBT transactions
- Delete the matching TransactionSellements entry (group = 'eec0c658-53e9-45e1-b8c7-9e23448c4994')
- Create an expense on https://opencollective.com/opencollective/ with https://opencollective.com/giftcollective as the payee, to make sure OC refunds the settled amount ($245.48USD or $396NZD)

It seemed simpler and less error-prone to add a script for that.