### PR TITLE
Make Sure Collective Admins has no Permission to Edit Expense

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -332,9 +332,9 @@ export const canEditExpense: ExpensePermissionEvaluator = async (
 ) => {
   const nonEditableStatuses = ['PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT', 'CANCELED'];
 
-  // Host and Collective Admin can attach receipts to paid charge expenses
+  // Host and expense owner can attach receipts to paid charge expenses
   if (expense.type === EXPENSE_TYPE.CHARGE && ['PAID', 'PROCESSING'].includes(expense.status)) {
-    return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin, isCollectiveAdmin], options);
+    return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin], options);
   } else if (expense.status === 'DRAFT') {
     return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin, isDraftPayee], options);
   } else if (nonEditableStatuses.includes(expense.status)) {
@@ -348,7 +348,7 @@ export const canEditExpense: ExpensePermissionEvaluator = async (
     }
     return false;
   } else {
-    return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin, isCollectiveAdmin], options);
+    return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin], options);
   }
 };
 

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -177,7 +177,7 @@ describe('server/graphql/common/expenses', () => {
       await expense.update({ status: 'REJECTED' });
       expect(await canEditExpense(publicReq, expense)).to.be.false;
       expect(await canEditExpense(randomUserReq, expense)).to.be.false;
-      expect(await canEditExpense(collectiveAdminReq, expense)).to.be.true;
+      expect(await canEditExpense(collectiveAdminReq, expense)).to.be.false;
       expect(await canEditExpense(hostAdminReq, expense)).to.be.true;
       expect(await canEditExpense(collectiveAccountantReq, expense)).to.be.false;
       expect(await canEditExpense(hostAccountantReq, expense)).to.be.false;

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -482,16 +482,6 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         expect(result.errors[0].message).to.equal('Two factor authentication must be configured');
       });
 
-      it("doesn't ask if only admin of the collective, and 2FA is enforced on the host", async () => {
-        const host = await fakeHost({ data: { policies: { REQUIRE_2FA_FOR_ADMINS: true } } });
-        const collectiveAdminUser = await fakeUser();
-        const collective = await fakeCollective({ admin: collectiveAdminUser, HostCollectiveId: host.id });
-        const expense = await fakeExpense({ status: 'PENDING', CollectiveId: collective.id });
-        const newExpenseData = { id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE), description: randStr() };
-        const result = await graphqlQueryV2(editExpenseMutation, { expense: newExpenseData }, collectiveAdminUser);
-        expect(result.errors).to.not.exist;
-      });
-
       it("doesn't ask for the payee, even if enforced by the host AND collective", async () => {
         const host = await fakeCollective({ data: { policies: { REQUIRE_2FA_FOR_ADMINS: true } } });
         const collective = await fakeCollective({


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6597

[collective-admins-no-edit.webm](https://user-images.githubusercontent.com/12435965/227072943-8f778348-f87a-4fb5-9477-e268b0992313.webm)
