### PR TITLE
performance: update approach at graphql cache

### DIFF
--- a/server/graphql/cache.js
+++ b/server/graphql/cache.js
@@ -3,23 +3,6 @@ import { difference, isEqual } from 'lodash';
 import { TransactionKind } from '../constants/transaction-kind';
 import { md5 } from '../lib/utils';
 
-export const purgeCacheForCollectiveOperationNames = [
-  'CollectivePage',
-  'ContributePage',
-  'BudgetSection',
-  'BudgetSectionWithHost',
-  'UpdatesSection',
-  'TransactionsSection',
-  'TransactionsPage',
-  'ExpensesPage',
-  'CollectiveBannerIframe',
-  'CollectiveCover',
-  'RecurringContributions',
-  'ContributionsSectionStatic',
-  'Members_Users',
-  'Members_Organizations',
-];
-
 export function checkSupportedVariables(req, variableNames) {
   if (!req.body.variables) {
     return false;
@@ -71,7 +54,7 @@ export function getGraphqlCacheKey(req) {
       if (req.body.variables.nbContributorsPerContributeCard !== 4) {
         return;
       }
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.slug}`;
+      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
     case 'BudgetSection':
     case 'BudgetSectionWithHost':
       if (!checkSupportedVariables(req, ['slug', 'limit', 'kind'])) {
@@ -80,7 +63,7 @@ export function getGraphqlCacheKey(req) {
       if (req.body.variables.limit !== 3) {
         return;
       }
-      return getCacheKeyForBudgetOrTransactionsSections(req, queryHash);
+      return [getCacheKeyForBudgetOrTransactionsSections(req, queryHash), req.body.variables.slug];
     case 'UpdatesSection':
       if (!checkSupportedVariables(req, ['slug', 'onlyPublishedUpdates'])) {
         return;
@@ -88,7 +71,7 @@ export function getGraphqlCacheKey(req) {
       if (req.body.variables.onlyPublishedUpdates !== true) {
         return;
       }
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.slug}`;
+      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
     case 'TransactionsSection':
       if (!checkSupportedVariables(req, ['slug', 'limit', 'kind'])) {
         return;
@@ -96,7 +79,7 @@ export function getGraphqlCacheKey(req) {
       if (req.body.variables.limit !== 10) {
         return;
       }
-      return getCacheKeyForBudgetOrTransactionsSections(req, queryHash);
+      return [getCacheKeyForBudgetOrTransactionsSections(req, queryHash), req.body.variables.slug];
     case 'TransactionsPage':
       if (!checkSupportedVariables(req, ['slug', 'offset', 'limit'])) {
         return;
@@ -104,7 +87,7 @@ export function getGraphqlCacheKey(req) {
       if (req.body.variables.offset !== 0 || req.body.variables.limit !== 15) {
         return;
       }
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.slug}`;
+      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
     case 'ExpensesPage':
       if (!checkSupportedVariables(req, ['collectiveSlug', 'offset', 'limit'])) {
         return;
@@ -112,19 +95,25 @@ export function getGraphqlCacheKey(req) {
       if (req.body.variables.offset !== 0 || req.body.variables.limit !== 10) {
         return;
       }
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.collectiveSlug}`;
+      return [
+        `${req.body.operationName}_${queryHash}_${req.body.variables.collectiveSlug}`,
+        req.body.variables.collectiveSlug,
+      ];
     case 'CollectiveBannerIframe':
       if (!checkSupportedVariables(req, ['collectiveSlug'])) {
         return;
       }
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.collectiveSlug}`;
+      return [
+        `${req.body.operationName}_${queryHash}_${req.body.variables.collectiveSlug}`,
+        req.body.variables.collectiveSlug,
+      ];
     case 'CollectiveCover':
     case 'RecurringContributions':
     case 'ContributionsSectionStatic':
       if (!checkSupportedVariables(req, ['slug'])) {
         return;
       }
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.slug}`;
+      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
     case 'Members':
       if (!checkSupportedVariables(req, ['collectiveSlug', 'offset', 'limit', 'type', 'role', 'orderBy'])) {
         return;
@@ -136,9 +125,15 @@ export function getGraphqlCacheKey(req) {
         return;
       }
       if (req.body.variables.type === 'ORGANIZATION,COLLECTIVE') {
-        return `${req.body.operationName}_${queryHash}_Organizations_${req.body.variables.collectiveSlug}`;
+        return [
+          `${req.body.operationName}_${queryHash}_Organizations_${req.body.variables.collectiveSlug}`,
+          req.body.variables.collectiveSlug,
+        ];
       } else if (req.body.variables.type === 'USER') {
-        return `${req.body.operationName}_${queryHash}_Users_${req.body.variables.collectiveSlug}`;
+        return [
+          `${req.body.operationName}_${queryHash}_Users_${req.body.variables.collectiveSlug}`,
+          req.body.variables.collectiveSlug,
+        ];
       } else {
         return;
       }
@@ -159,8 +154,11 @@ export function getGraphqlCacheKey(req) {
       if (!req.body.variables.accountType || req.body.variables.accountType.length !== 1) {
         return;
       }
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.role[0]}_${req.body.variables.accountType[0]}_${req.body.variables.slug}`;
 
+      return [
+        `${req.body.operationName}_${queryHash}_${req.body.variables.role[0]}_${req.body.variables.accountType[0]}_${req.body.variables.slug}`,
+        req.body.variables.slug,
+      ];
     case 'BudgetSectionExpenseQuery':
     case 'BudgetSectionContributionsQuery':
       if (!checkSupportedVariables(req, ['slug', 'from', 'to'])) {
@@ -171,6 +169,6 @@ export function getGraphqlCacheKey(req) {
         return;
       }
 
-      return `${req.body.operationName}_${queryHash}_${req.body.variables.slug}`;
+      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
   }
 }

--- a/server/graphql/cache.js
+++ b/server/graphql/cache.js
@@ -1,174 +1,38 @@
-import { difference, isEqual } from 'lodash';
-
-import { TransactionKind } from '../constants/transaction-kind';
 import { md5 } from '../lib/utils';
 
-export function checkSupportedVariables(req, variableNames) {
-  if (!req.body.variables) {
-    return false;
-  }
-  // Check missing variables
-  if (difference(variableNames, Object.keys(req.body.variables)).length > 0) {
-    return false;
-  }
-  // Check extra variables
-  if (difference(Object.keys(req.body.variables), variableNames).length > 0) {
-    return false;
-  }
-
-  return true;
-}
-
-function getCacheKeyForBudgetOrTransactionsSections(req, queryHash) {
-  if (
-    req.body.variables.kind &&
-    !isEqual(req.body.variables.kind.sort(), [
-      TransactionKind.ADDED_FUNDS,
-      TransactionKind.BALANCE_TRANSFER,
-      TransactionKind.CONTRIBUTION,
-      TransactionKind.EXPENSE,
-      TransactionKind.PLATFORM_TIP,
-    ])
-  ) {
-    return;
-  }
-  return `${req.body.operationName}_${queryHash}_${req.body.variables.slug}`;
-}
-
-export function getGraphqlCacheKey(req) {
+export function getGraphqlCacheProperties(req) {
   if (req.remoteUser) {
     return;
   }
-  if (!req.body || !req.body.operationName || !req.body.query) {
+
+  // If it's not a GraphQL query with such properties, no cache
+  if (!req.body || !req.body.operationName || !req.body.query || !req.body.variables) {
+    return;
+  }
+
+  // If it's not a GraphQL query, starting with the 'query' keyword, opt-out
+  // This implicitely discard mutations, starting with the keyword 'mutation'
+  if (!req.body.query.startsWith('query')) {
+    return;
+  }
+
+  // We don't want to cache a query with such variable
+  // Would not be bad right now for security, because the variables are part of the cache key
+  if (req.body.variables.draftKey) {
+    return;
+  }
+
+  // We only want to cache queries with an Account slug
+  const slug = req.body.variables.slug || req.body.variables.collectiveSlug || req.body.variables.CollectiveSlug;
+  if (!slug) {
     return;
   }
 
   const queryHash = md5(req.body.query);
+  const variablesHash = md5(JSON.stringify(req.body.variables));
 
-  switch (req.body.operationName) {
-    case 'CollectivePage':
-    case 'ContributePage':
-      if (!checkSupportedVariables(req, ['slug', 'nbContributorsPerContributeCard'])) {
-        return;
-      }
-      if (req.body.variables.nbContributorsPerContributeCard !== 4) {
-        return;
-      }
-      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
-    case 'BudgetSection':
-    case 'BudgetSectionWithHost':
-      if (!checkSupportedVariables(req, ['slug', 'limit', 'kind'])) {
-        return;
-      }
-      if (req.body.variables.limit !== 3) {
-        return;
-      }
-      return [getCacheKeyForBudgetOrTransactionsSections(req, queryHash), req.body.variables.slug];
-    case 'UpdatesSection':
-      if (!checkSupportedVariables(req, ['slug', 'onlyPublishedUpdates'])) {
-        return;
-      }
-      if (req.body.variables.onlyPublishedUpdates !== true) {
-        return;
-      }
-      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
-    case 'TransactionsSection':
-      if (!checkSupportedVariables(req, ['slug', 'limit', 'kind'])) {
-        return;
-      }
-      if (req.body.variables.limit !== 10) {
-        return;
-      }
-      return [getCacheKeyForBudgetOrTransactionsSections(req, queryHash), req.body.variables.slug];
-    case 'TransactionsPage':
-      if (!checkSupportedVariables(req, ['slug', 'offset', 'limit'])) {
-        return;
-      }
-      if (req.body.variables.offset !== 0 || req.body.variables.limit !== 15) {
-        return;
-      }
-      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
-    case 'ExpensesPage':
-      if (!checkSupportedVariables(req, ['collectiveSlug', 'offset', 'limit'])) {
-        return;
-      }
-      if (req.body.variables.offset !== 0 || req.body.variables.limit !== 10) {
-        return;
-      }
-      return [
-        `${req.body.operationName}_${queryHash}_${req.body.variables.collectiveSlug}`,
-        req.body.variables.collectiveSlug,
-      ];
-    case 'CollectiveBannerIframe':
-      if (!checkSupportedVariables(req, ['collectiveSlug'])) {
-        return;
-      }
-      return [
-        `${req.body.operationName}_${queryHash}_${req.body.variables.collectiveSlug}`,
-        req.body.variables.collectiveSlug,
-      ];
-    case 'CollectiveCover':
-    case 'RecurringContributions':
-    case 'ContributionsSectionStatic':
-      if (!checkSupportedVariables(req, ['slug'])) {
-        return;
-      }
-      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
-    case 'Members':
-      if (!checkSupportedVariables(req, ['collectiveSlug', 'offset', 'limit', 'type', 'role', 'orderBy'])) {
-        return;
-      }
-      if (req.body.variables.offset !== 0 || req.body.variables.limit !== 100) {
-        return;
-      }
-      if (req.body.variables.role !== 'BACKER') {
-        return;
-      }
-      if (req.body.variables.type === 'ORGANIZATION,COLLECTIVE') {
-        return [
-          `${req.body.operationName}_${queryHash}_Organizations_${req.body.variables.collectiveSlug}`,
-          req.body.variables.collectiveSlug,
-        ];
-      } else if (req.body.variables.type === 'USER') {
-        return [
-          `${req.body.operationName}_${queryHash}_Users_${req.body.variables.collectiveSlug}`,
-          req.body.variables.collectiveSlug,
-        ];
-      } else {
-        return;
-      }
-
-    case 'ContributionsSection':
-      if (!checkSupportedVariables(req, ['slug', 'offset', 'limit', 'role', 'accountType', 'orderBy'])) {
-        return;
-      }
-      if (req.body.variables.offset !== 0 || req.body.variables.limit !== 15) {
-        return;
-      }
-      if (req.body.variables.orderBy.field !== 'MEMBER_COUNT' || req.body.variables.orderBy.direction !== 'DESC') {
-        return;
-      }
-      if (!req.body.variables.role || req.body.variables.role.length !== 1) {
-        return;
-      }
-      if (!req.body.variables.accountType || req.body.variables.accountType.length !== 1) {
-        return;
-      }
-
-      return [
-        `${req.body.operationName}_${queryHash}_${req.body.variables.role[0]}_${req.body.variables.accountType[0]}_${req.body.variables.slug}`,
-        req.body.variables.slug,
-      ];
-    case 'BudgetSectionExpenseQuery':
-    case 'BudgetSectionContributionsQuery':
-      if (!checkSupportedVariables(req, ['slug', 'from', 'to'])) {
-        return;
-      }
-
-      if (req.body.variables.from || req.body.variables.to) {
-        return;
-      }
-
-      return [`${req.body.operationName}_${queryHash}_${req.body.variables.slug}`, req.body.variables.slug];
-  }
+  return {
+    cacheKey: `${slug}_${req.body.operationName}_${queryHash}_${variablesHash}`,
+    cacheSlug: slug,
+  };
 }

--- a/server/graphql/cache.js
+++ b/server/graphql/cache.js
@@ -23,7 +23,11 @@ export function getGraphqlCacheProperties(req) {
   }
 
   // We only want to cache queries with an Account slug
-  const slug = req.body.variables.slug || req.body.variables.collectiveSlug || req.body.variables.CollectiveSlug;
+  const slug =
+    req.body.variables.slug ||
+    req.body.variables.accountSlug ||
+    req.body.variables.collectiveSlug ||
+    req.body.variables.CollectiveSlug;
   if (!slug) {
     return;
   }

--- a/server/graphql/v2/mutation/RootMutations.ts
+++ b/server/graphql/v2/mutation/RootMutations.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { isNil, uniqBy } from 'lodash';
 
-import { purgeAllCachesForAccount, purgeGQLCacheForCollective } from '../../../lib/cache';
+import { purgeAllCachesForAccount, purgeGraphqlCacheForCollective } from '../../../lib/cache';
 import { purgeCacheForPage } from '../../../lib/cloudflare';
 import { invalidateContributorsCache } from '../../../lib/contributors';
 import { mergeAccounts, simulateMergeAccounts } from '../../../lib/merge-accounts';
@@ -127,7 +127,7 @@ export default {
         asyncActions.push(purgeCacheForPage(`/${account.slug}`));
       }
       if (args.type.includes('GRAPHQL_QUERIES')) {
-        asyncActions.push(purgeGQLCacheForCollective(account.slug));
+        asyncActions.push(purgeGraphqlCacheForCollective(account.slug));
       }
       if (args.type.includes('CONTRIBUTORS')) {
         asyncActions.push(invalidateContributorsCache(account.id));

--- a/server/lib/cache/index.js
+++ b/server/lib/cache/index.js
@@ -2,7 +2,6 @@ import config from 'config';
 import debug from 'debug';
 import { get } from 'lodash';
 
-import { purgeCacheForCollectiveOperationNames } from '../../graphql/cache';
 import models from '../../models';
 import { purgeCacheForPage } from '../cloudflare';
 import { invalidateContributorsCache } from '../contributors';
@@ -144,6 +143,7 @@ export function memoize(func, { key, maxAge = 0, serialize, unserialize }) {
 export async function purgeGraphqlCacheForCollective(slug) {
   return cache.get(`graphqlCacheKeys_${slug}`).then(keys => {
     if (keys) {
+      cache.delete(`graphqlCacheKeys_${slug}`);
       for (const key of keys) {
         cache.delete(key);
       }

--- a/server/lib/cache/index.js
+++ b/server/lib/cache/index.js
@@ -141,18 +141,19 @@ export function memoize(func, { key, maxAge = 0, serialize, unserialize }) {
   return memoizedFunction;
 }
 
-export async function purgeGQLCacheForCollective(slug) {
-  // TODO: This doesn't work as expected cause many operations include the hash of the query in their keys
-  return Promise.all(
-    purgeCacheForCollectiveOperationNames.map(operationName => {
-      return cache.delete(`${operationName}_${slug}`);
-    }),
-  );
+export async function purgeGraphqlCacheForCollective(slug) {
+  return cache.get(`graphqlCacheKeys_${slug}`).then(keys => {
+    if (keys) {
+      for (const key of keys) {
+        cache.delete(key);
+      }
+    }
+  });
 }
 
 export function purgeCacheForCollective(slug) {
   purgeCacheForPage(`/${slug}`);
-  purgeGQLCacheForCollective(slug);
+  purgeGraphqlCacheForCollective(slug);
 }
 
 /**

--- a/server/routes.js
+++ b/server/routes.js
@@ -19,7 +19,7 @@ import {
   thegivingblockWebhook,
   transferwiseWebhook,
 } from './controllers/webhooks';
-import { getGraphqlCacheKey } from './graphql/cache';
+import { getGraphqlCacheProperties } from './graphql/cache';
 // import { Unauthorized } from './graphql/errors';
 import graphqlSchemaV1 from './graphql/v1/schema';
 import graphqlSchemaV2 from './graphql/v2/schema';
@@ -149,7 +149,7 @@ export default async app => {
    */
   app.use('/graphql', async (req, res, next) => {
     req.startAt = req.startAt || new Date();
-    const [cacheKey, cacheSlug] = getGraphqlCacheKey(req) || []; // Returns null if not cacheable (e.g. if logged in)
+    const { cacheKey, cacheSlug } = getGraphqlCacheProperties(req) || {}; // Returns null if not cacheable (e.g. if logged in)
     const enabled = parseToBoolean(config.graphql.cache.enabled);
     if (cacheKey && enabled) {
       const fromCache = await cache.get(cacheKey);
@@ -158,10 +158,11 @@ export default async app => {
         req.endAt = req.endAt || new Date();
         const executionTime = req.endAt - req.startAt;
         res.set('Execution-Time', executionTime);
-        res.set('GraphQLCacheHit', true);
+        res.set('GraphQL-Cache', 'HIT');
         res.send(fromCache);
         return;
       }
+      res.set('GraphQL-Cache', 'MISS');
       req.cacheKey = cacheKey;
       req.cacheSlug = cacheSlug;
     }


### PR DESCRIPTION
- Cache everything that has an account slug.
- Keep a list of all cache keys used. 
- Flush them all when we receive a cache clear for that slug