### PR TITLE
Fix event migration the clears attendees

### DIFF
--- a/migrations/20230116210000-purge-children-collective-members.js
+++ b/migrations/20230116210000-purge-children-collective-members.js
@@ -8,6 +8,7 @@ module.exports = {
       SET "deletedAt" = NOW()
       WHERE
       "CollectiveId" IN (SELECT id FROM "Collectives" WHERE "deletedAt" IS NULL AND "ParentCollectiveId" IS NOT NULL)
+      AND "role" IN ('ADMIN', 'MEMBER', 'ACCOUNTANT')
       AND "deletedAt" IS NULL
     `);
   },


### PR DESCRIPTION
This was corrected in DB through a simple query but it turns out this migration is affecting the REST repo tests and needs to be fixed.