### PR TITLE
Improve performance for truncating tables in tests

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -45,7 +45,10 @@ export const resetCaches = () => cache.clear();
 
 export const resetTestDB = async () => {
   const resetFn = async () => {
-    await sequelize.truncate({ cascade: true, force: true, restartIdentity: true });
+    // Using a manual query rather than `await sequelize.truncate({ cascade: true,  restartIdentity: true });`
+    // for performance reasons: https://github.com/sequelize/sequelize/issues/15865
+    const tableNames = values(sequelize.models).map(m => `"${m.tableName}"`);
+    await sequelize.query(`TRUNCATE TABLE ${tableNames.join(', ')} RESTART IDENTITY CASCADE`);
     await sequelize.query(`REFRESH MATERIALIZED VIEW "TransactionBalances"`);
     await sequelize.query(`REFRESH MATERIALIZED VIEW "CollectiveBalanceCheckpoint"`);
   };


### PR DESCRIPTION
A 99% performance enhancement on `resetTestDB`. Opened an issue to suggest making this the default behavior in sequelize: https://github.com/sequelize/sequelize/issues/15865.

More importantly, this will resolve the timeout issues we've seen recently with some tests (e.g. `loaders/collective`) failing because they were taking more than 20s to reset the DB (https://github.com/opencollective/opencollective/issues/6564#issuecomment-1471679060, https://github.com/opencollective/opencollective/issues/6564#issuecomment-1471718314, https://github.com/opencollective/opencollective/issues/6564#issuecomment-1482954776).

## Benchmark (compared to https://github.com/opencollective/opencollective-api/pull/8728)

- Unit tests

Total time: 45.237s (-293s)
Min time: 0.001s (=)
Max time: 0.283s (-20.4s)
Median time: 0.158s (-0.8s)
Average time: 0.154s (-1s)

- GraphQL tests

Total time: 49.434s (-202.5s)
Min time: 0.002s (=)
Max time: 0.316s (-13s)
Median time: 0.246s (-0.8s)
Average time: 0.240s (-1s)

