### PR TITLE
Fix total amount reported in taxes-on-host-fee script

### DIFF
--- a/scripts/taxes/taxes-on-host-fee.ts
+++ b/scripts/taxes/taxes-on-host-fee.ts
@@ -172,7 +172,7 @@ program
         host.currency AS "hostCurrency",
         collective.slug AS "collectiveSlug",
         SUM(t."amountInHostCurrency") AS "hostFeeInHostCurrency",
-        SUM((t."data" -> 'fixHostFeeWithTaxes' -> 'previousValues' ->> 'amountInHostCurrency')::numeric) AS "previousHostFeeInHostCurrency"
+        SUM((t."data" -> 'fixHostFeeWithTaxes' -> 'previousValues' ->> 'amountInHostCurrency')::integer) AS "previousHostFeeInHostCurrency"
       FROM "Transactions" t
       INNER JOIN "Collectives" host ON host.id = t."HostCollectiveId"
       INNER JOIN "Collectives" collective ON collective.id = t."CollectiveId"

--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -864,7 +864,7 @@ Transaction.createHostFeeShareTransactions = async (
   }
 
   // We use the Host Fee amountInHostCurrency/hostCurrency as a basis
-  const amount = calcFee(hostFeeTransaction.amountInHostCurrency, hostFeeSharePercent); // TODO without taxes
+  const amount = calcFee(hostFeeTransaction.amountInHostCurrency, hostFeeSharePercent);
   const currency = hostFeeTransaction.hostCurrency;
 
   // Skip if the amount is zero (e.g.: 15% * 0.03 = 0.0045 and rounded to 0)


### PR DESCRIPTION
The issue doesn't appear with my local postgres, but in production returning a `numeric` made sequelize consider the value as a string, which would display `NaN` in summary. Apparently, that's because node-postgres returns a string for the value when its type might be of BIGINT.

> Total amount refunded by script: NZ$NaN