### PR TITLE
Add "dashboard" to reserved slugs

### DIFF
--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -200,6 +200,7 @@ export const collectiveSlugReservedList = [
   'conversations',
   'create',
   'create-account',
+  'dashboard',
   'delete',
   'deleteCollective',
   'discover',


### PR DESCRIPTION
Adding `dashboard` to the reserved slugs list for the new workspace/dashboard page.