### PR TITLE
Add Funds: make sure taxes are passed to transactions

### DIFF
--- a/server/paymentProviders/opencollective/host.js
+++ b/server/paymentProviders/opencollective/host.js
@@ -74,6 +74,7 @@ paymentMethodProvider.processOrder = async (order, options) => {
     kind: TransactionKind.ADDED_FUNDS,
     OrderId: order.id,
     amount,
+    taxAmount: order.taxAmount,
     currency,
     hostCurrency,
     hostCurrencyFxRate,


### PR DESCRIPTION
I omitted to test the entire chain as I thought the code that was taking the tax amount from the order to the transactions was generic. I was wrong, and it needed to be added to the `opencollective.host` payment method as well. This PR fixes it.