### PR TITLE
Allow setting `settings.earlyAccess` through the API

### DIFF
--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -69,6 +69,7 @@ export const COLLECTIVE_SETTINGS_KEYS_LIST = [
   'disableCustomContributions',
   'dismissedHelpMessages',
   'disableCryptoContributions',
+  'earlyAccess',
   'editor',
   'enableWebhooks',
   'features',


### PR DESCRIPTION
Adding `earlyAccess` to allowed settings keys, so that it can be set using the API.