### PR TITLE
Fix images test for forks

### DIFF
--- a/test/server/routes/images.test.js
+++ b/test/server/routes/images.test.js
@@ -15,8 +15,9 @@ const application = utils.data('application');
 describe('server/routes/images', () => {
   let user, expressApp;
 
-  before(async () => {
+  before(async function () {
     if (!config.aws.s3.key) {
+      console.warn('Skipping images tests because AWS credentials are not set');
       this.skip();
     }
 


### PR DESCRIPTION
https://github.com/opencollective/opencollective-api/pull/3148 implemented `this.skip()` but `this` will not be set on arrow functions. 