### PR TITLE
Add EU to country iso enum

### DIFF
--- a/server/graphql/v2/enum/CountryISO.ts
+++ b/server/graphql/v2/enum/CountryISO.ts
@@ -247,6 +247,7 @@ const COUNTRY_CODES = {
   VI: 'US Virgin Islands',
   WF: 'Wallis and Futuna',
   EH: 'Western Sahara',
+  EU: 'European Union',
 };
 
 // Build GraphQL values map


### PR DESCRIPTION
Adding EU as a valid ISO value, its used by the CountryInput on frontend.