### PR TITLE
Fix: Wise use consistent source for amountInHostCurrency

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1858,7 +1858,7 @@ export const getExpenseFees = async (
     collectiveToHostFxRate * (<number>resultFees['paymentProcessorFeeInCollectiveCurrency'] || 0),
   );
   feesInHostCurrency.hostFeeInHostCurrency = Math.round(
-    collectiveToHostFxRate * (<number>fees['hostFeeInCollectiveCurrency'] || 0),
+    collectiveToHostFxRate * (<number>resultFees['hostFeeInCollectiveCurrency'] || 0),
   );
   feesInHostCurrency.platformFeeInHostCurrency = Math.round(
     collectiveToHostFxRate * (<number>resultFees['platformFeeInCollectiveCurrency'] || 0),

--- a/test/cron/daily/check-pending-transferwise-transactions.test.js
+++ b/test/cron/daily/check-pending-transferwise-transactions.test.js
@@ -62,7 +62,8 @@ describe('cron/hourly/check-pending-transferwise-transactions', () => {
       type: 'INVOICE',
       description: 'January Invoice',
       data: {
-        transfer: { id: 1234, sourceValue: 100 },
+        transfer: { id: 1234 },
+        paymentOption: { fee: { total: 10 }, sourceAmount: 110 },
       },
     });
   });

--- a/test/server/paymentProviders/transferwise/webhook.test.ts
+++ b/test/server/paymentProviders/transferwise/webhook.test.ts
@@ -90,13 +90,13 @@ describe('server/paymentProviders/transferwise/webhook', () => {
       type: 'INVOICE',
       description: 'January Invoice',
       data: {
-        transfer: { id: event.data.resource.id, sourceValue: 100 },
+        transfer: { id: event.data.resource.id },
         quote: { fee: 1, rate: 1 },
         feesInHostCurrency: {
           hostFeeInHostCurrency: 1,
           platformFeeInHostCurrency: 1,
         },
-        paymentOption: { fee: { total: 10 } },
+        paymentOption: { fee: { total: 10 }, sourceAmount: 110 },
       },
     });
   });

--- a/test/stories/transferwise.test.ts
+++ b/test/stories/transferwise.test.ts
@@ -122,7 +122,7 @@ describe('/test/stories/transferwise.test.ts', () => {
     } as any);
     await expense.reload();
     const fee = round(expense.data.paymentOption.fee.total * 100);
-    const amountInHostCurrency = expense.data.transfer.sourceValue * 100;
+    const amountInHostCurrency = expense.data.paymentOption.sourceAmount * 100 - fee;
 
     expect(expense.status).to.eq(ExpenseStatuses.PAID);
     const [debit] = await expense.getTransactions({ where: { type: 'DEBIT' } });


### PR DESCRIPTION
This is required because sometimes the transfer has a transfer.sourceValue that does not match the amount debited from the account.

- [ ] Fix impacted transactions in:
    ```
    SELECT e.id, e."CollectiveId", e."createdAt", e."data"#>>'{quote,sourceAmount}' as "quoteAmount", e."data"#>>'{quote,sourceCurrency}' as "sourceCurrency", e."data"#>>'{transfer,sourceValue}' as "transferValue", e."data"#>>'{quote,targetCurrency}' as "targetCurrency", e."data"#>>'{quote,rateType}' as "rateType", t."amountInHostCurrency"
    FROM "Expenses" e
    LEFT JOIN "Transactions" t ON t."ExpenseId" = e."id" AND t."type" = 'DEBIT'
    WHERE
    (e."data"#>>'{transfer,sourceValue}')::NUMERIC < (e."data"#>>'{quote,sourceAmount}')::NUMERIC
    AND ((e."data"#>>'{transfer,sourceValue}')::NUMERIC * -100) != t."amountInHostCurrency"
    ```