### PR TITLE
Expense: rename to ledgerTransaction

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -2260,7 +2260,9 @@ export async function markExpenseAsUnpaid(
     return { expense, transaction };
   });
 
-  await expense.createActivity(activities.COLLECTIVE_EXPENSE_MARKED_AS_UNPAID, remoteUser, { transaction });
+  await expense.createActivity(activities.COLLECTIVE_EXPENSE_MARKED_AS_UNPAID, remoteUser, {
+    ledgerTransaction: transaction,
+  });
   return expense;
 }
 

--- a/server/models/Expense.ts
+++ b/server/models/Expense.ts
@@ -114,7 +114,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
     const payoutMethod = await this.getPayoutMethod();
     const items = this.items || this.data?.items || (await this.getItems());
     const transaction =
-      data?.transaction ||
+      data?.ledgerTransaction ||
       (this.status === ExpenseStatus.PAID &&
         (await models.Transaction.findOne({ where: { type: 'DEBIT', ExpenseId: this.id } })));
     return models.Activity.create({


### PR DESCRIPTION
Resolve https://open-collective.sentry.io/issues/4079532336/?project=5199682&referrer=slack

We are storing the stripe transaction in `data.transaction`: https://github.com/opencollective/opencollective-api/blob/4f9521b2a30be139365d819759aaae5bce14fa88/server/paymentProviders/stripe/virtual-cards.ts#L287.

