### PR TITLE
Allow to use slug for expense invites

### DIFF
--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -551,6 +551,9 @@ export const notifyByEmail = async (activity: Activity) => {
         await notify.collective(activity, {
           collectiveId: activity.data.payee.id,
         });
+      } else if (activity.data.payee.slug) {
+        const collective = await models.Collective.findBySlug(activity.data.payee.slug);
+        await notify.collective(activity, { collective });
       }
       break;
 


### PR DESCRIPTION
Fix for https://opencollective.slack.com/archives/C6JTTA4SK/p1681217531812429

Goes with https://github.com/opencollective/opencollective-frontend/pull/8794