### PR TITLE
Pass Current Date if Transaction Not Created Yet

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -676,7 +676,7 @@ const sendOrderConfirmedEmail = async (order, transaction) => {
     // normal order
     const data = {
       order: order.info,
-      transaction: transaction ? transaction.info : null,
+      transaction: transaction ? transaction.info : { createdAt: new Date() },
       user: user.info,
       collective: collective.info,
       host: host ? host.info : {},

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -388,7 +388,7 @@ export async function sendThankYouEmail(order, transaction, isFirstPayment = fal
 
   const data = {
     order: order.info,
-    transaction: transaction ? transaction.info : null,
+    transaction: transaction ? transaction.info : { createdAt: new Date() },
     user: user.info,
     firstPayment: isFirstPayment,
     collective: order.collective.info,


### PR DESCRIPTION
Related to the ticket; https://opencollective.freshdesk.com/a/tickets/184569

These orders that are mentioned in the ticket is for stripe recurring bank transfers. When the user initiates a bank transfer an order is created in `PROCESSING` status and transaction doesn't exist at this point; hence we return an invalid date (as we calculate it based on `transaction.createdAt`. In this case we need to return the current date, as an acknowledgement that we received the order. 