### PR TITLE
Fix Privacy card token update

### DIFF
--- a/cron/hourly/80-reconcile-virtualcard-transactions.js
+++ b/cron/hourly/80-reconcile-virtualcard-transactions.js
@@ -54,7 +54,9 @@ async function reconcileConnectedAccount(connectedAccount) {
           logger.debug(JSON.stringify(transactions, null, 2));
         } else {
           logger.info(`Syncing ${transactions.length} pending transactions...`);
-          await Promise.all(transactions.map(transaction => privacy.processTransaction(transaction)));
+          await Promise.all(
+            transactions.map(transaction => privacy.processTransaction(transaction, undefined, { card })),
+          );
 
           logger.info(`Refreshing card details'...`);
           const [privacyCard] = await privacyLib.listCards(connectedAccount.token, card.id);

--- a/scripts/privacy-resync-card.js
+++ b/scripts/privacy-resync-card.js
@@ -37,7 +37,7 @@ const run = async cardId => {
       } else {
         console.log(`Charge ${pt.token} from ${pt.created} not synced`);
         console.log(pt);
-        await privacy.processTransaction(pt);
+        await privacy.processTransaction(pt, undefined, { card });
       }
     }
   }

--- a/server/paymentProviders/privacy/index.ts
+++ b/server/paymentProviders/privacy/index.ts
@@ -14,11 +14,16 @@ import { getVirtualCardForTransaction, persistTransaction } from '../utils';
 
 const providerName = 'privacy';
 
-const processTransaction = async (privacyTransaction: Transaction, privacyEvent: any): Promise<Expense | undefined> => {
-  const virtualCard = await getVirtualCardForTransaction(privacyTransaction.card.token);
+const processTransaction = async (
+  privacyTransaction: Transaction,
+  privacyEvent: any,
+  options: { card?: VirtualCardModel } = {},
+): Promise<Expense | undefined> => {
+  const cardToken = privacyTransaction.card_token || privacyTransaction.card.token;
+  const virtualCard = options?.card || (await getVirtualCardForTransaction(cardToken));
 
   if (!virtualCard) {
-    logger.error(`Privacy: could not find virtual card ${privacyTransaction.card.token}`, privacyEvent);
+    logger.error(`Privacy: could not find virtual card ${cardToken}`, privacyEvent);
     reportMessageToSentry('Privacy: could not find virtual card', { extra: { privacyEvent, privacyTransaction } });
     return;
   }

--- a/server/types/privacy.ts
+++ b/server/types/privacy.ts
@@ -73,7 +73,8 @@ export type Merchant = {
 export type Transaction = {
   // Absolute value in USD cents
   amount: number;
-  card: Card;
+  card?: Card;
+  card_token: string;
   // ISOString
   created: string;
   events: any[];


### PR DESCRIPTION
Resolves https://open-collective.sentry.io/issues/3964501287/?project=5199682

It seems Privacy is returning a different object structure from the one they present on their outdated documentation. I updated the code to try parsing the card token from their actual transaction object and fallback to the previous type.

I also worked a bit on performance so we don't fetch the card twice from the DB.