### PR TITLE
Fix Suspend cron-job to only suspend parent collectives

### DIFF
--- a/cron/daily/41-suspend-accounts-without-minimum-amount-of-admins.ts
+++ b/cron/daily/41-suspend-accounts-without-minimum-amount-of-admins.ts
@@ -10,6 +10,10 @@ import models, { sequelize } from '../../server/models';
 
 const run = async () => {
   const collectives = await models.Collective.findAll({
+    where: {
+      // Since children automatically inherit the policies, features and admins of their parent, we only need to check the parent collectives
+      ParentCollectiveId: null,
+    },
     include: [
       { model: models.Member, as: 'members', where: { role: roles.ADMIN } },
       {


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/6665

After reviewing the code, I notice that `enable/disableFeature` already takes care of the children collectives.
I found this instead, which could justify why a child collective is being suspended.