### PR TITLE
Wise: Invalidate cached quote if paymentOption is disabled

### DIFF
--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -96,8 +96,12 @@ async function quoteExpense(
   const isExistingQuoteValid =
     expense.feesPayer !== 'PAYEE' &&
     expense.data?.quote &&
+    // We want a paymentOption to be there
     expense.data.quote['paymentOption'] &&
-    !expense.data.transfer && // We can not reuse quotes if a Transfer was already created
+    // We cannot use quotes that don't have a valid paymentOption
+    expense.data.quote['paymentOption'].disabled === false &&
+    // We can not reuse quotes if a Transfer was already created
+    !expense.data.transfer &&
     moment.utc().subtract(60, 'seconds').isBefore(expense.data.quote['expirationTime']);
   if (isExistingQuoteValid) {
     logger.debug(`quoteExpense(): reusing existing quote...`);


### PR DESCRIPTION
Edge-case reported by one of our users. If the host has no balance to cover the transaction, we'll persist a quote that has no valid quote.paymentMethod and throws the invalid balance error persisted there until the quote expires.