### PR TITLE
Fix host-settlement script default PayoutMethod account for bank transfers and others

### DIFF
--- a/test/cron/monthly/host-settlement.test.js
+++ b/test/cron/monthly/host-settlement.test.js
@@ -255,10 +255,6 @@ describe('cron/monthly/host-settlement', () => {
     expect(gphHostSettlementExpense).to.have.nested.property('data.isPlatformTipSettlement', true);
   });
 
-  it('should use a payout method compatible with the host currency', () => {
-    expect(gphHostSettlementExpense).to.have.property('PayoutMethodId', 2956);
-  });
-
   it('should invoice platform tips not collected through Stripe', async () => {
     const platformTipsItem = gphHostSettlementExpense.items.find(p => p.description === 'Platform Tips');
     expect(platformTipsItem).to.have.property('amount', Math.round(1000 / 1.23));

--- a/test/cron/monthly/host-settlement.test.js
+++ b/test/cron/monthly/host-settlement.test.js
@@ -260,6 +260,10 @@ describe('cron/monthly/host-settlement', () => {
     expect(platformTipsItem).to.have.property('amount', Math.round(1000 / 1.23));
   });
 
+  it('should use our preferred payout bank info despite host currency', () => {
+    expect(gphHostSettlementExpense).to.have.property('PayoutMethodId', 2955);
+  });
+
   it('should invoice pending shared host revenue', async () => {
     const sharedRevenueItem = gphHostSettlementExpense.items.find(p => p.description === 'Shared Revenue');
     const expectedRevenue = Math.round(1600 * 0.15);

--- a/test/stories/ledger.test.ts
+++ b/test/stories/ledger.test.ts
@@ -93,6 +93,12 @@ const setupTestData = async (
   const contributorCollective = await fakeCollective({ name: 'Webpack', HostCollectiveId: host.id });
   const ocInc = await fakeHost({ name: 'OC Inc', id: PLATFORM_TIP_TRANSACTION_PROPERTIES.CollectiveId });
   await fakePayoutMethod({ type: PayoutMethodTypes.OTHER, CollectiveId: ocInc.id }); // For the settlement expense
+  await fakePayoutMethod({
+    type: PayoutMethodTypes.BANK_ACCOUNT,
+    CollectiveId: ocInc.id,
+    data: { currency: 'USD' },
+    isSaved: true,
+  }); // For the settlement expense
   await fakeUser({ id: SETTLEMENT_EXPENSE_PROPERTIES.UserId, name: 'Pia' });
   let FromCollectiveId;
   if (selfContribution) {

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -347,32 +347,39 @@ export const fakeUploadedFile = async (fileData: Partial<InferCreationAttributes
 /**
  * Fake a Payout Method (defaults to PayPal)
  */
-export const fakePayoutMethod = async (data: Partial<InferCreationAttributes<PayoutMethod>> = {}) => {
+export const fakePayoutMethod = async ({
+  data,
+  type,
+  CollectiveId,
+  CreatedByUserId,
+  ...props
+}: Partial<InferCreationAttributes<PayoutMethod>> = {}) => {
   const generateData = type => {
     if (type === PayoutMethodTypes.PAYPAL) {
-      return { email: randEmail() };
+      return { email: randEmail(), ...data };
     } else if (type === PayoutMethodTypes.OTHER) {
-      return { content: randStr() };
+      return { content: randStr(), ...data };
     } else if (type === PayoutMethodTypes.BANK_ACCOUNT) {
       return {
         accountHolderName: 'Jesse Pinkman',
         currency: 'EUR',
         type: 'iban',
         details: { iban: 'DE1237812738192OK' },
+        ...data,
       };
     } else {
       return {};
     }
   };
 
-  const type = (data && data.type) || PayoutMethodTypes.PAYPAL;
+  type = type || PayoutMethodTypes.PAYPAL;
   return models.PayoutMethod.create({
     name: randStr('Fake Payout Method '),
     data: generateData(type),
-    ...data,
+    ...props,
     type: type as PayoutMethodTypes,
-    CollectiveId: data.CollectiveId || (await fakeCollective()).id,
-    CreatedByUserId: <number>data.CreatedByUserId || (await fakeUser()).id,
+    CollectiveId: CollectiveId || (await fakeCollective()).id,
+    CreatedByUserId: <number>CreatedByUserId || (await fakeUser()).id,
   });
 };
 


### PR DESCRIPTION
1. Settle all bank transfers using our USD bank account;
2. Fixes empty array of transactionIds in the settlement expense;
3. Improves debug info in DRY mode