### PR TITLE
Add host collective to virtual card deletion email

### DIFF
--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -578,12 +578,7 @@ export const notifyByEmail = async (activity: Activity) => {
 
     case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_SUSPENDED:
     case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_DELETED: {
-      const collective = await models.Collective.findByPk(activity.CollectiveId);
-      const HostCollectiveId = await collective.getHostCollectiveId();
-      if (HostCollectiveId) {
-        const hostCollective = await models.Collective.findByPk(HostCollectiveId);
-        activity.data.hostCollective = hostCollective.info;
-      }
+      activity.data.hostCollective = activity.data.host;
       await notify.collective(activity, {
         collectiveId: activity.data.collective.id,
       });

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -577,7 +577,13 @@ export const notifyByEmail = async (activity: Activity) => {
       break;
 
     case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_SUSPENDED:
-    case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_DELETED:
+    case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_DELETED: {
+      const collective = await models.Collective.findByPk(activity.CollectiveId);
+      const HostCollectiveId = await collective.getHostCollectiveId();
+      if (HostCollectiveId) {
+        const hostCollective = await models.Collective.findByPk(HostCollectiveId);
+        activity.data.hostCollective = hostCollective.info;
+      }
       await notify.collective(activity, {
         collectiveId: activity.data.collective.id,
       });
@@ -585,7 +591,7 @@ export const notifyByEmail = async (activity: Activity) => {
         collectiveId: activity.data.host.id,
       });
       break;
-
+    }
     case ActivityTypes.VIRTUAL_CARD_REQUESTED:
       await notify.collective(activity, {
         collectiveId: activity.data.host.id,

--- a/templates/emails/collective.virtualcard.deleted.hbs
+++ b/templates/emails/collective.virtualcard.deleted.hbs
@@ -4,6 +4,10 @@ Subject: ⚠ {{{collective.name}}}'s {{virtualCard.last4}} card was deleted
 
 <p style="font-size: 17px; padding: 1em;">
 {{> linkCollective collective=collective}}'s {{virtualCard.name}} ({{virtualCard.last4}}) card was deleted by {{> linkCollective collective=deletedBy}}.
+<br/><br/>
+{{#if hostCollective}}
+Host Collective: {{> linkCollective collective=hostCollective}}
+{{/if}}
 
 {{#if message}}
   {{> linkCollective collective=deletedBy}} included the following message:
@@ -12,10 +16,6 @@ Subject: ⚠ {{{collective.name}}}'s {{virtualCard.last4}} card was deleted
 
 {{#if message}}
 <blockquote style="color: #6a737d;font-size: 16px;text-align: left;padding: 0.5em 0.75em;margin: 0 24px;border-left: 3px solid #e4e4e4;white-space: pre-line;font-style: italic;">{{message}}</blockquote>
-{{/if}}
-
-{{#if hostCollective}}
-  <p>Host Collective: {{> linkCollective collective=hostCollective}}</p>
 {{/if}}
 
 {{> footer}}

--- a/templates/emails/collective.virtualcard.deleted.hbs
+++ b/templates/emails/collective.virtualcard.deleted.hbs
@@ -14,4 +14,8 @@ Subject: ⚠ {{{collective.name}}}'s {{virtualCard.last4}} card was deleted
 <blockquote style="color: #6a737d;font-size: 16px;text-align: left;padding: 0.5em 0.75em;margin: 0 24px;border-left: 3px solid #e4e4e4;white-space: pre-line;font-style: italic;">{{message}}</blockquote>
 {{/if}}
 
+{{#if hostCollective}}
+  <p>Host Collective: {{> linkCollective collective=hostCollective}}</p>
+{{/if}}
+
 {{> footer}}


### PR DESCRIPTION
Something that was requested by some members of the support team due to dealing with virtual card deletions and not knowing which host they belong to. I've added the host to the virtual card deletion email here. 

Related to https://opencollective.freshdesk.com/a/tickets/179940

![image](https://user-images.githubusercontent.com/12435965/234988888-13eca307-a9e2-4109-9290-6f47f821fbd8.png)
