### PR TITLE
Check Wise balance when scheduling expenses for payment

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -837,9 +837,9 @@ export const scheduleExpenseForPayment = async (
     throw new Unauthorized('Multi-currency expenses are not enabled for this collective');
   }
 
-  const payoutMethod = await expense.getPayoutMethod();
-  await checkHasBalanceToPayExpense(host, expense, payoutMethod);
-  if (payoutMethod.type === PayoutMethodTypes.PAYPAL) {
+  expense.PayoutMethod = await req.loaders.PayoutMethod.byId.load(expense.PayoutMethodId);
+  await checkHasBalanceToPayExpense(host, expense, expense.PayoutMethod);
+  if (expense.PayoutMethod.type === PayoutMethodTypes.PAYPAL) {
     const hostHasPayoutTwoFactorAuthenticationEnabled = get(host, 'settings.payoutsTwoFactorAuth.enabled', false);
 
     if (hostHasPayoutTwoFactorAuthenticationEnabled) {
@@ -855,11 +855,11 @@ export const scheduleExpenseForPayment = async (
   }
 
   // If Wise, add expense to a new batch group
-  if (payoutMethod.type === PayoutMethodTypes.BANK_ACCOUNT) {
+  if (expense.PayoutMethod.type === PayoutMethodTypes.BANK_ACCOUNT) {
     await paymentProviders.transferwise.scheduleExpenseForPayment(expense);
   }
   // If PayPal, check if host is connected to PayPal
-  else if (payoutMethod.type === PayoutMethodTypes.PAYPAL) {
+  else if (expense.PayoutMethod.type === PayoutMethodTypes.PAYPAL) {
     await host.getAccountForPaymentProvider('paypal');
   }
 

--- a/server/models/Expense.ts
+++ b/server/models/Expense.ts
@@ -23,6 +23,7 @@ import sequelize, { DataTypes, Model, Op, QueryTypes } from '../lib/sequelize';
 import { sanitizeTags, validateTags } from '../lib/tags';
 import { computeDatesAsISOStrings } from '../lib/utils';
 import CustomDataTypes from '../models/DataTypes';
+import { BatchGroup, ExpenseDataQuoteV2 } from '../types/transferwise';
 
 import Collective from './Collective';
 import { ExpenseAttachedFile } from './ExpenseAttachedFile';
@@ -55,7 +56,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
   public declare RecurringExpenseId: ForeignKey<RecurringExpense['id']>;
 
   public declare payeeLocation: Record<string, unknown>; // TODO This can be typed
-  public declare data: Record<string, unknown>;
+  public declare data: Record<string, unknown> & { batchGroup?: BatchGroup; quote?: ExpenseDataQuoteV2 };
   public declare currency: string;
   public declare amount: number;
   public declare description: string;

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -59,7 +59,8 @@ describe('server/paymentProviders/transferwise/index', () => {
     getBatchGroup,
     fundBatchGroup,
     getExchangeRates,
-    createBatchGroupTransfer;
+    createBatchGroupTransfer,
+    listBalancesAccount;
   let connectedAccount, collective, host, payoutMethod, expense;
 
   after(sandbox.restore);
@@ -108,13 +109,22 @@ describe('server/paymentProviders/transferwise/index', () => {
     validateAccountRequirements = sandbox
       .stub(transferwiseLib, 'validateAccountRequirements')
       .resolves({ success: true });
-    createBatchGroup = sandbox.stub(transferwiseLib, 'createBatchGroup');
+    createBatchGroup = sandbox.stub(transferwiseLib, 'createBatchGroup').resolves({ transferIds: [] });
     fundBatchGroup = sandbox.stub(transferwiseLib, 'fundBatchGroup').resolves();
     createBatchGroupTransfer = sandbox.stub(transferwiseLib, 'createBatchGroupTransfer');
     completeBatchGroup = sandbox.stub(transferwiseLib, 'completeBatchGroup').resolves();
-    getBatchGroup = sandbox.stub(transferwiseLib, 'getBatchGroup');
+    getBatchGroup = sandbox.stub(transferwiseLib, 'getBatchGroup').resolves({ transferIds: [] });
     cancelBatchGroup = sandbox.stub(transferwiseLib, 'cancelBatchGroup');
-    getExchangeRates = sandbox.stub(transferwiseLib, 'getExchangeRates');
+    getExchangeRates = sandbox
+      .stub(transferwiseLib, 'getExchangeRates')
+      .resolves([{ source: 'USD', target: 'EUR', rate: 0.9044 }]);
+    listBalancesAccount = sandbox.stub(transferwiseLib, 'listBalancesAccount').resolves(
+      ['EUR', 'USD'].map(currency => ({
+        currency,
+        type: 'STANDARD',
+        amount: { value: 1000000, currency },
+      })),
+    );
 
     cacheSpy = sandbox.spy(cache);
   });
@@ -231,7 +241,7 @@ describe('server/paymentProviders/transferwise/index', () => {
     let expense;
     const batchGroupId = 'zs987sad89y1hubnc89h12h892s';
 
-    beforeEach(async () => {
+    before(async () => {
       sandbox.resetHistory();
       expense = await fakeExpense({
         payoutMethod: 'transferwise',
@@ -246,10 +256,18 @@ describe('server/paymentProviders/transferwise/index', () => {
         description: 'January Invoice',
       });
       expense.PayoutMethod = payoutMethod;
-      createBatchGroup.resolves({ id: batchGroupId });
+      createBatchGroup.resolves({ id: batchGroupId, transferIds: [], status: 'NEW' });
       getBatchGroup.resolves({ id: batchGroupId, version: 1, transferIds: [800], status: 'NEW' });
+      listBalancesAccount.resolves(
+        ['EUR', 'USD'].map(currency => ({
+          currency,
+          type: 'STANDARD',
+          amount: { value: 300, currency },
+        })),
+      );
       createBatchGroupTransfer.resolves({ id: 800 });
       await transferwise.scheduleExpenseForPayment(expense);
+      await expense.update({ status: 'SCHEDULED_FOR_PAYMENT' });
     });
 
     it('creates a new batchGroup', () => {
@@ -267,7 +285,7 @@ describe('server/paymentProviders/transferwise/index', () => {
         payoutMethod: 'transferwise',
         PayoutMethodId: payoutMethod.id,
         status: 'APPROVED',
-        amount: 2000,
+        amount: 10000,
         CollectiveId: collective.id,
         currency: 'USD',
         FromCollectiveId: payoutMethod.id,
@@ -278,9 +296,31 @@ describe('server/paymentProviders/transferwise/index', () => {
       newExpense.PayoutMethod = payoutMethod;
       await transferwise.scheduleExpenseForPayment(newExpense);
 
+      await newExpense.reload();
+      expect(newExpense.data.batchGroup.id).to.be.equal(batchGroupId);
       assert.calledWithMatch(createBatchGroupTransfer, { id: connectedAccount.id }, batchGroupId, {
         details: { reference: newExpense.id.toString() },
       });
+    });
+
+    it('should throw if the host has not enough balance to cover for the batched expenses', async () => {
+      const newExpense = await fakeExpense({
+        payoutMethod: 'transferwise',
+        PayoutMethodId: payoutMethod.id,
+        status: 'APPROVED',
+        amount: 10000,
+        CollectiveId: collective.id,
+        currency: 'USD',
+        FromCollectiveId: payoutMethod.id,
+        category: 'Engineering',
+        type: 'INVOICE',
+        description: 'January Invoice #2',
+      });
+      newExpense.PayoutMethod = payoutMethod;
+
+      await expect(transferwise.scheduleExpenseForPayment(newExpense)).to.be.rejectedWith(
+        'Insufficient balance in USD to cover the existing batch plus this expense amount, you need 303.42 USD and you currently have 300 USD.',
+      );
     });
   });
 


### PR DESCRIPTION
UX improvement based on a conversation I had with Ivan. Basically, we want to make sure the host admin doesn't batch a bunch of expenses and reach the payment action to realize they don't have enough funds to cover the transfers and need to reschedule everything again.