### PR TITLE
Locations migration followup

### DIFF
--- a/migrations/20230503114054-update-location-migration.js
+++ b/migrations/20230503114054-update-location-migration.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    /**
+     * Updates the migrated Locations to only set the name and address when structured address was missing
+     * and also set address as locationName if missing (enabling slightly better migration to autocomplete input)
+     */
+    await queryInterface.sequelize.query(`
+      UPDATE "Locations" l
+      SET 
+        "name" = CASE
+                  WHEN l."structured" IS NULL THEN COALESCE(c."locationName", c."address")
+                  ELSE NULL
+                END,
+        "address" = CASE
+                      WHEN l."structured" IS NULL THEN c."address"
+                      ELSE NULL
+                    END
+      FROM "Collectives" c
+      WHERE 
+        l."CollectiveId" = c.id AND (
+          c."locationName" IS NOT NULL OR 
+          c."address" IS NOT NULL OR 
+          c."countryISO" IS NOT NULL OR 
+          c."geoLocationLatLong" IS NOT NULL OR
+          c."data"->'address' IS NOT NULL
+        )
+    `);
+  },
+
+  async down() {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -1886,6 +1886,11 @@ class Collective extends Model<
 
       structured = omitBy(structured, isNil);
 
+      // If structured is empty, set it to null
+      if (Object.keys(structured).length === 0) {
+        structured = null;
+      }
+
       // Set Collective.countryISO
       await this.update({ countryISO: country }, sequelizeParams);
 


### PR DESCRIPTION
Two follow up fixes from the migration in #8626 (not yet deployed to production).
- Updates the migrated Locations 
  - only set `name` and `address` if structured address (collective.data.address) is missing - to prevent having two different addresses saved in the new Location
  - set `address` as `name` if there is no locationName - enabling a better migration to the autocomplete input where the name will be prefilled in the input
- Makes sure to never save an empty `structured` object - but rather use `null` if it is empty.