### PR TITLE
GraphQLV2: add oppositeTransaction to Transaction

### DIFF
--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -795,6 +795,7 @@ export const loaders = req => {
     ),
     hostFeeAmountForTransaction: transactionLoaders.generateHostFeeAmountForTransactionLoader(),
     relatedTransactions: transactionLoaders.generateRelatedTransactionsLoader(),
+    oppositeTransaction: transactionLoaders.generateOppositeTransactionLoader(),
     balanceById: new DataLoader(async transactionIds => {
       const transactionBalances = await sequelize.query(
         ` SELECT      id, balance

--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -795,7 +795,6 @@ export const loaders = req => {
     ),
     hostFeeAmountForTransaction: transactionLoaders.generateHostFeeAmountForTransactionLoader(),
     relatedTransactions: transactionLoaders.generateRelatedTransactionsLoader(),
-    oppositeTransaction: transactionLoaders.generateOppositeTransactionLoader(),
     balanceById: new DataLoader(async transactionIds => {
       const transactionBalances = await sequelize.query(
         ` SELECT      id, balance

--- a/server/graphql/loaders/transactions.ts
+++ b/server/graphql/loaders/transactions.ts
@@ -4,58 +4,91 @@ import { groupBy } from 'lodash';
 import { TransactionKind } from '../../constants/transaction-kind';
 import models, { Op } from '../../models';
 
-export const generateHostFeeAmountForTransactionLoader = (): DataLoader<number, number[]> =>
-  new DataLoader(async (transactions: (typeof models.Transaction)[]) => {
-    const transactionsWithoutHostFee = transactions.filter(transaction => {
-      // Legacy transactions have their host fee set on `hostFeeInHostCurrency`. No need to fetch for them
-      // Also only contributions and added funds can have host fees
-      return !transaction.hostFeeInHostCurrency && ['CONTRIBUTION', 'ADDED_FUNDS'].includes(transaction.kind);
-    });
+export const generateHostFeeAmountForTransactionLoader = (): DataLoader<typeof models.Transaction, number> =>
+  new DataLoader(
+    async (transactions: (typeof models.Transaction)[]) => {
+      const transactionsWithoutHostFee = transactions.filter(transaction => {
+        // Legacy transactions have their host fee set on `hostFeeInHostCurrency`. No need to fetch for them
+        // Also only contributions and added funds can have host fees
+        return !transaction.hostFeeInHostCurrency && ['CONTRIBUTION', 'ADDED_FUNDS'].includes(transaction.kind);
+      });
 
-    const hostFeeTransactions = await models.Transaction.findAll({
-      attributes: ['TransactionGroup', 'type', 'amount'],
-      mapToModel: false,
-      raw: true,
-      where: {
-        kind: TransactionKind.HOST_FEE,
-        [Op.or]: transactionsWithoutHostFee.map(transaction => ({
-          TransactionGroup: transaction.TransactionGroup,
-          type: transaction.type,
-        })),
-      },
-    });
+      const hostFeeTransactions = await models.Transaction.findAll({
+        attributes: ['TransactionGroup', 'type', 'amount'],
+        mapToModel: false,
+        raw: true,
+        where: {
+          kind: TransactionKind.HOST_FEE,
+          [Op.or]: transactionsWithoutHostFee.map(transaction => ({
+            TransactionGroup: transaction.TransactionGroup,
+            type: transaction.type,
+          })),
+        },
+      });
 
-    const keyBuilder = transaction => `${transaction.TransactionGroup}-${transaction.type}`;
-    const groupedTransactions: Record<string, typeof models.Transaction> = groupBy(hostFeeTransactions, keyBuilder);
-    return transactions.map(transaction => {
-      if (transaction.hostFeeInHostCurrency) {
-        return transaction.hostFeeInHostCurrency;
-      } else {
-        const key = keyBuilder(transaction);
-        const hostFeeTransactions = groupedTransactions[key];
-        if (hostFeeTransactions) {
-          const amount = hostFeeTransactions[0].amount;
-          return transaction.isRefund ? amount : -amount;
+      const keyBuilder = transaction => `${transaction.TransactionGroup}-${transaction.type}`;
+      const groupedTransactions: Record<string, typeof models.Transaction> = groupBy(hostFeeTransactions, keyBuilder);
+      return transactions.map(transaction => {
+        if (transaction.hostFeeInHostCurrency) {
+          return transaction.hostFeeInHostCurrency;
         } else {
-          return 0;
+          const key = keyBuilder(transaction);
+          const hostFeeTransactions = groupedTransactions[key];
+          if (hostFeeTransactions) {
+            const amount = hostFeeTransactions[0].amount;
+            return transaction.isRefund ? amount : -amount;
+          } else {
+            return 0;
+          }
         }
-      }
-    });
-  });
+      });
+    },
+    {
+      cacheKeyFn: transaction => transaction.id,
+    },
+  );
 
 export const generateRelatedTransactionsLoader = (): DataLoader<
   typeof models.Transaction,
   (typeof models.Transaction)[]
 > =>
-  new DataLoader(async (transactions: (typeof models.Transaction)[]) => {
-    const transactionGroups = transactions.map(transaction => transaction.TransactionGroup);
-    const relatedTransactions = await models.Transaction.findAll({ where: { TransactionGroup: transactionGroups } });
-    const groupedTransactions = groupBy(relatedTransactions, 'TransactionGroup');
-    return transactions.map(transaction => {
-      if (groupedTransactions[transaction.TransactionGroup]) {
-        return groupedTransactions[transaction.TransactionGroup].filter(t => t.id !== transaction.id);
-      } else {
-        return [];
-      }
-    });
-  });
+  new DataLoader(
+    async (transactions: (typeof models.Transaction)[]) => {
+      const transactionGroups = transactions.map(transaction => transaction.TransactionGroup);
+      const relatedTransactions = await models.Transaction.findAll({ where: { TransactionGroup: transactionGroups } });
+      const groupedTransactions = groupBy(relatedTransactions, 'TransactionGroup');
+      return transactions.map(transaction => {
+        if (groupedTransactions[transaction.TransactionGroup]) {
+          return groupedTransactions[transaction.TransactionGroup].filter(t => t.id !== transaction.id);
+        } else {
+          return [];
+        }
+      });
+    },
+    {
+      cacheKeyFn: transaction => transaction.id,
+    },
+  );
+
+export const generateOppositeTransactionLoader = (): DataLoader<typeof models.Transaction, typeof models.Transaction> =>
+  new DataLoader(
+    async (transactions: (typeof models.Transaction)[]) => {
+      const allConditions = transactions.map(transaction => ({
+        TransactionGroup: transaction.TransactionGroup,
+        type: transaction.type === 'CREDIT' ? 'DEBIT' : 'CREDIT',
+        kind: transaction.kind,
+        isDebt: transaction.isDebt,
+      }));
+
+      const oppositeTransactions = await models.Transaction.findAll({ where: { [Op.or]: allConditions } });
+      const getKey = t => `${t.TransactionGroup}-${t.type}-${t.kind}-${Boolean(t.isDebt)}`;
+      const groupedTransactions = groupBy(oppositeTransactions, getKey);
+      return allConditions.map(transactionConditions => {
+        const key = getKey(transactionConditions);
+        return groupedTransactions[key]?.[0] || null;
+      });
+    },
+    {
+      cacheKeyFn: transaction => transaction.id,
+    },
+  );

--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -98,8 +98,8 @@ interface CollectiveInterface {
   List of all collectives that are related to this collective with their membership relationship. Can filter by role (BACKER/MEMBER/ADMIN/HOST/FOLLOWER)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
 
     """
     Type of User: USER/ORGANIZATION
@@ -2301,8 +2301,8 @@ type Collective implements CollectiveInterface {
   Get all the members of this collective (admins, members, backers, followers)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
     type: String
     role: String
     TierId: Int
@@ -2567,8 +2567,8 @@ type Event implements CollectiveInterface {
   Get all the members of this collective (admins, members, backers, followers)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
     type: String
     role: String
     TierId: Int
@@ -2833,8 +2833,8 @@ type Fund implements CollectiveInterface {
   Get all the members of this collective (admins, members, backers, followers)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
     type: String
     role: String
     TierId: Int
@@ -3099,8 +3099,8 @@ type Organization implements CollectiveInterface {
   Get all the members of this collective (admins, members, backers, followers)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
     type: String
     role: String
     TierId: Int
@@ -3366,8 +3366,8 @@ type Project implements CollectiveInterface {
   Get all the members of this collective (admins, members, backers, followers)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
     type: String
     role: String
     TierId: Int
@@ -3877,8 +3877,8 @@ type User implements CollectiveInterface {
   Get all the members of this collective (admins, members, backers, followers)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
     type: String
     role: String
     TierId: Int
@@ -4145,8 +4145,8 @@ type Vendor implements CollectiveInterface {
   Get all the members of this collective (admins, members, backers, followers)
   """
   members(
-    limit: Int! = 100
-    offset: Int! = 0
+    limit: Int = 100
+    offset: Int = 0
     type: String
     role: String
     TierId: Int

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -1021,6 +1021,11 @@ interface Transaction {
   permissions: TransactionPermissions
   isOrderRejected: Boolean!
   refundTransaction: Transaction
+
+  """
+  The opposite transaction (CREDIT -> DEBIT, DEBIT -> CREDIT)
+  """
+  oppositeTransaction: Transaction
   relatedTransactions(
     """
     Filter by kind
@@ -6500,6 +6505,11 @@ type Credit implements Transaction {
   permissions: TransactionPermissions!
   isOrderRejected: Boolean!
   refundTransaction: Transaction
+
+  """
+  The opposite transaction (CREDIT -> DEBIT, DEBIT -> CREDIT)
+  """
+  oppositeTransaction: Transaction
   relatedTransactions(
     """
     Filter by kind
@@ -6608,6 +6618,11 @@ type Debit implements Transaction {
   permissions: TransactionPermissions!
   isOrderRejected: Boolean!
   refundTransaction: Transaction
+
+  """
+  The opposite transaction (CREDIT -> DEBIT, DEBIT -> CREDIT)
+  """
+  oppositeTransaction: Transaction
   relatedTransactions(
     """
     Filter by kind
@@ -13729,7 +13744,7 @@ type Mutation {
   """
   Creates a Stripe payment intent
   """
-  createPaymentIntent(paymentIntent: PaymentIntentInput!): PaymentIntent!
+  createPaymentIntent(paymentIntent: PaymentIntentInput!, guestInfo: GuestInfoInput): PaymentIntent!
 
   """
   To submit a new order. Scope: "orders".

--- a/server/graphql/v2/interface/Transaction.js
+++ b/server/graphql/v2/interface/Transaction.js
@@ -541,8 +541,11 @@ export const TransactionFields = () => {
     oppositeTransaction: {
       type: Transaction,
       description: 'The opposite transaction (CREDIT -> DEBIT, DEBIT -> CREDIT)',
-      resolve(transaction, _, req) {
-        return req.loaders.Transaction.oppositeTransaction.load(transaction);
+      async resolve(transaction, _, req) {
+        const relatedTransactions = await req.loaders.Transaction.relatedTransactions.load(transaction);
+        return relatedTransactions.find(
+          t => t.kind === transaction.kind && t.isDebt === transaction.isDebt && t.type !== transaction.type,
+        );
       },
     },
     relatedTransactions: {

--- a/server/graphql/v2/interface/Transaction.js
+++ b/server/graphql/v2/interface/Transaction.js
@@ -204,6 +204,10 @@ const transactionFieldsDefinition = () => ({
   refundTransaction: {
     type: Transaction,
   },
+  oppositeTransaction: {
+    type: Transaction,
+    description: 'The opposite transaction (CREDIT -> DEBIT, DEBIT -> CREDIT)',
+  },
   relatedTransactions: {
     type: new GraphQLNonNull(new GraphQLList(Transaction)),
     args: {
@@ -532,6 +536,13 @@ export const TransactionFields = () => {
         } else {
           return null;
         }
+      },
+    },
+    oppositeTransaction: {
+      type: Transaction,
+      description: 'The opposite transaction (CREDIT -> DEBIT, DEBIT -> CREDIT)',
+      resolve(transaction, _, req) {
+        return req.loaders.Transaction.oppositeTransaction.load(transaction);
       },
     },
     relatedTransactions: {

--- a/server/routes.js
+++ b/server/routes.js
@@ -220,7 +220,7 @@ export default async app => {
       onReject: [logRejection],
       ignoreIntrospection: true,
       propagateOnRejection: false,
-      maxCost: 10000, // Currently identified max: around 7500 on expense form
+      maxCost: 12500, // Currently identified max: around 10000 on the PDF service (transaction receipt), around 7500 on expense form
     },
     // Tokens are the number of fields in a query
     maxTokens: {


### PR DESCRIPTION
To facilitate the [migration](https://github.com/opencollective/opencollective-pdf/pull/912) to GraphQL V2 on the PDF service where we have a query like this that makes sure we always generate the receipt from the credit:

```gql
query TransactionInvoice($transactionId: String!) {
  transaction(id: $transactionId) {
    id
    ... on Credit {
      ...ReceiptTransactionFragment
    }
    ... on Debit {
      oppositeTransaction {
        ...ReceiptTransactionFragment
      }
    }
  }
}
```

This query was previously implemented using `relatedTransactions`, but fetching the receipts fields on all transactions has a cost that we can easily avoid by introducing this new field.