### PR TITLE
Use generator for UserHasTwoFactorAuthEnabled loader

### DIFF
--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -33,7 +33,7 @@ import {
 import { generateCollectivePayoutMethodsLoader, generateCollectivePaypalPayoutMethodsLoader } from './payout-method';
 import * as transactionLoaders from './transactions';
 import updatesLoader from './updates';
-import { generateUserByCollectiveIdLoader, userHasTwoFactorAuthEnabled } from './user';
+import { generateUserByCollectiveIdLoader, generateUserHasTwoFactorAuthEnabled } from './user';
 import { generateCollectiveVirtualCardLoader, generateHostCollectiveVirtualCardLoader } from './virtual-card';
 
 export const loaders = req => {
@@ -93,7 +93,7 @@ export const loaders = req => {
 
   // User
   context.loaders.User.byCollectiveId = generateUserByCollectiveIdLoader(req, cache);
-  context.loaders.userHasTwoFactorAuthEnabled = userHasTwoFactorAuthEnabled;
+  context.loaders.userHasTwoFactorAuthEnabled = generateUserHasTwoFactorAuthEnabled(req, cache);
 
   // Location
   context.loaders.Location.byCollectiveId = locationLoaders.byCollectiveId(req, cache);

--- a/server/graphql/loaders/user.ts
+++ b/server/graphql/loaders/user.ts
@@ -12,22 +12,23 @@ export const generateUserByCollectiveIdLoader = (): DataLoader<number, User> => 
   });
 };
 
-export const userHasTwoFactorAuthEnabled: DataLoader<number, boolean> = new DataLoader(async (userIds: number[]) => {
-  const results: { id: number; hasTwoFactorAuthEnabled: boolean }[] = await sequelize.query(
-    `
+export const generateUserHasTwoFactorAuthEnabled = (): DataLoader<number, boolean> =>
+  new DataLoader(async (userIds: number[]) => {
+    const results: { id: number; hasTwoFactorAuthEnabled: boolean }[] = await sequelize.query(
+      `
     SELECT u.id "UserId", (count(utfm.id) > 0) "hasTwoFactorAuthEnabled"
     FROM "Users" u
     LEFT JOIN "UserTwoFactorMethods" utfm ON u.id = utfm."UserId" AND utfm."deletedAt" IS NULL
     WHERE u.id IN (:userIds)
     GROUP BY u.id
   `,
-    {
-      type: sequelize.QueryTypes.SELECT,
-      replacements: {
-        userIds,
+      {
+        type: sequelize.QueryTypes.SELECT,
+        replacements: {
+          userIds,
+        },
       },
-    },
-  );
+    );
 
-  return sortResultsSimple(userIds, results, result => result.UserId).map(result => result.hasTwoFactorAuthEnabled);
-});
+    return sortResultsSimple(userIds, results, result => result.UserId).map(result => result.hasTwoFactorAuthEnabled);
+  });

--- a/test/server/graphql/loaders/user.test.ts
+++ b/test/server/graphql/loaders/user.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { userHasTwoFactorAuthEnabled } from '../../../../server/graphql/loaders/user';
+import { generateUserHasTwoFactorAuthEnabled } from '../../../../server/graphql/loaders/user';
 import { TwoFactorMethod } from '../../../../server/lib/two-factor-authentication';
 import UserTwoFactorMethod from '../../../../server/models/UserTwoFactorMethod';
 import { fakeUser } from '../../../test-helpers/fake-data';
@@ -28,11 +28,8 @@ describe('server/graphql/loaders/user', () => {
         deletedAt: new Date(),
       });
 
-      const results = await userHasTwoFactorAuthEnabled.loadMany([
-        userWith2FA.id,
-        userWithout2FA.id,
-        userWithDeleted2FA.id,
-      ]);
+      const loader = generateUserHasTwoFactorAuthEnabled();
+      const results = await loader.loadMany([userWith2FA.id, userWithout2FA.id, userWithDeleted2FA.id]);
       expect(results).to.eql([true, false, false]);
     });
   });


### PR DESCRIPTION
Instantiating loaders globally is discouraged because:
- It can lead to security issues (since all information is stored in the same loader) - see https://github.com/graphql/dataloader#creating-a-new-dataloader-per-request
- The cache is never cleared, which can lead to outdated data being returned or memory exhaustion issues (though, storing only booleans, this one is probably ok)