### PR TITLE
fix: add Authorization header to csrf configuration

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -248,7 +248,7 @@ export default async app => {
   const graphqlServerOptions = {
     introspection: true,
     playground: isDevelopment,
-    csrfPrevention: true,
+    csrfPrevention: { requestHeaders: ['Authorization'] },
     ...graphqlProtection,
     debug: !['production', 'staging'].includes(config.env), // Keep stracktraces in dev & CI
     plugins: graphqlPlugins,


### PR DESCRIPTION
This was breaking our NextAuth integration used in the frontend-template, funders-dashboard and oauth-mode.