### PR TITLE
Add status change to mark as unpaid

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -2100,6 +2100,21 @@ enum CommentType {
 }
 
 """
+All supported comment contexts
+"""
+enum CommentType {
+  """
+  Default regular comment
+  """
+  COMMENT
+
+  """
+  Comment is visible only to host admins
+  """
+  PRIVATE_NOTE
+}
+
+"""
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSON
@@ -4949,6 +4964,7 @@ type ExpensePermissions {
   canUsePrivateNote: Boolean!
   canHold: Boolean!
   canRelease: Boolean!
+  canUsePrivateNote: Boolean!
   edit: Permission!
   editTags: Permission!
   delete: Permission!
@@ -15021,6 +15037,11 @@ input ProcessExpensePaymentParams {
   shouldRefundPaymentProcessorFee: Boolean
 
   """
+  New expense status when triggering MARK_AS_UNPAID
+  """
+  markAsUnPaidStatus: MarkAsUnPaidExpenseStatus = APPROVED
+
+  """
   Bypass automatic integrations (ie. PayPal, Transferwise) to process the expense manually
   """
   forceManual: Boolean
@@ -15029,6 +15050,12 @@ input ProcessExpensePaymentParams {
   Who is responsible for paying any due fees.
   """
   feesPayer: FeesPayer = COLLECTIVE
+}
+
+enum MarkAsUnPaidExpenseStatus {
+  APPROVED
+  INCOMPLETE
+  ERROR
 }
 
 input ExpenseInviteDraftInput {

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -2100,21 +2100,6 @@ enum CommentType {
 }
 
 """
-All supported comment contexts
-"""
-enum CommentType {
-  """
-  Default regular comment
-  """
-  COMMENT
-
-  """
-  Comment is visible only to host admins
-  """
-  PRIVATE_NOTE
-}
-
-"""
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSON
@@ -4964,7 +4949,6 @@ type ExpensePermissions {
   canUsePrivateNote: Boolean!
   canHold: Boolean!
   canRelease: Boolean!
-  canUsePrivateNote: Boolean!
   edit: Permission!
   editTags: Permission!
   delete: Permission!

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -1,6 +1,13 @@
 import config from 'config';
 import express from 'express';
-import { GraphQLBoolean, GraphQLInputObjectType, GraphQLInt, GraphQLNonNull, GraphQLString } from 'graphql';
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLString,
+} from 'graphql';
 import { pick, size } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
@@ -249,6 +256,18 @@ const expenseMutations = {
               type: GraphQLBoolean,
               description: 'Whether the payment processor fees should be refunded when triggering MARK_AS_UNPAID',
             },
+            markAsUnPaidStatus: {
+              type: new GraphQLEnumType({
+                name: 'MarkAsUnPaidExpenseStatus',
+                values: {
+                  [expenseStatus.APPROVED]: { value: expenseStatus.APPROVED },
+                  [expenseStatus.INCOMPLETE]: { value: expenseStatus.INCOMPLETE },
+                  [expenseStatus.ERROR]: { value: expenseStatus.ERROR },
+                },
+              }),
+              description: 'New expense status when triggering MARK_AS_UNPAID',
+              defaultValue: expenseStatus.APPROVED,
+            },
             forceManual: {
               type: GraphQLBoolean,
               description: 'Bypass automatic integrations (ie. PayPal, Transferwise) to process the expense manually',
@@ -299,6 +318,7 @@ const expenseMutations = {
             req,
             expense.id,
             args.paymentParams?.shouldRefundPaymentProcessorFee || args.paymentParams?.paymentProcessorFee,
+            args.paymentParams?.markAsUnPaidStatus,
           );
           break;
         case 'SCHEDULE_FOR_PAYMENT':


### PR DESCRIPTION
Related: https://github.com/opencollective/opencollective/issues/6701

Adds optional argument to move expense to new status when marking expense as unpaid.