### PR TITLE
Fix Order fraud analysis query

### DIFF
--- a/server/paymentProviders/stripe/webhook.ts
+++ b/server/paymentProviders/stripe/webhook.ts
@@ -584,9 +584,9 @@ export const reviewClosed = async (event: Stripe.Event) => {
     if (closedReason === 'refunded_as_fraud' || closedReason === 'refunded') {
       if (order.status === OrderStatuses.IN_REVIEW) {
         if (order.SubscriptionId) {
-          await order.update({ status: OrderStatuses.CANCELLED });
+          await order.update({ status: OrderStatuses.CANCELLED, data: { ...order.data, closedReason } });
         } else {
-          await order.update({ status: OrderStatuses.REFUNDED });
+          await order.update({ status: OrderStatuses.REFUNDED, data: { ...order.data, closedReason } });
         }
       }
 


### PR DESCRIPTION
This query was broken by the implementation of the payment intent payments.
Since payment intent donations are opaque towards the actual card/account numbers, this query is now falling-back to the number of payment intents used.
