### PR TITLE
Misc Sentry improvements

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,20 +9,12 @@ import throng from 'throng';
 
 import expressLib from './lib/express';
 import logger from './lib/logger';
-import { initSentry, Sentry } from './lib/sentry';
 import routes from './routes';
 
 const workers = process.env.WEB_CONCURRENCY || 1;
 
 async function start(i) {
   const expressApp = express();
-
-  // Re-initializing Sentry with express app
-  initSentry(expressApp);
-
-  // Sentry's request handler must be the first middleware on the app
-  expressApp.use(Sentry.Handlers.requestHandler());
-  expressApp.use(Sentry.Handlers.tracingHandler());
 
   await expressLib(expressApp);
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -15,7 +15,6 @@ import * as transferwise from './controllers/transferwise';
 import * as users from './controllers/users';
 import { paypalWebhook, stripeWebhook, thegivingblockWebhook, transferwiseWebhook } from './controllers/webhooks';
 import { getGraphqlCacheProperties } from './graphql/cache';
-// import { Unauthorized } from './graphql/errors';
 import graphqlSchemaV1 from './graphql/v1/schema';
 import graphqlSchemaV2 from './graphql/v2/schema';
 import cache from './lib/cache';


### PR DESCRIPTION
Work around the Sentry memory leak by getting rid of default Sentry middleware that is [known](https://github.com/getsentry/sentry-javascript/issues/4611#issuecomment-1049216287) to keep references to `req`, which in our case holds very heavy `remoteUser` and `loaders` objects.