### PR TITLE
Expenses 2FA rolling limit enhancements

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -853,6 +853,14 @@ async function validateExpensePayout2FALimit(req, host, expense, expensePaidAmou
     sessionDuration: ROLLING_LIMIT_CACHE_VALIDITY, // duration of a auth session after a token is presented
     sessionKey: `2fa_expense_payout_${host.id}_${twoFactorSession}`, // key of the 2fa session where the 2fa will be valid for the duration
     FromCollectiveId: host.id,
+    customData: {
+      rollingLimit: {
+        expenseAmount: expense.amount,
+        expenseCurrency: expense.currency,
+        currentPaidExpenseAmount,
+        hostPayoutTwoFactorAuthenticationRollingLimit,
+      },
+    },
   });
 
   if (use2FAToken) {

--- a/server/lib/two-factor-authentication/lib.ts
+++ b/server/lib/two-factor-authentication/lib.ts
@@ -33,6 +33,8 @@ type ValidateRequestOptions = {
   sessionKey?: (() => string) | string;
   // to document which account requested the 2FA token. Defaults to the user's account
   FromCollectiveId?: number;
+  // Some additional data to be stored in the activity
+  customData?: Record<string, unknown>;
 };
 
 export const TwoFactorAuthenticationHeader = 'x-two-factor-authentication';
@@ -182,7 +184,7 @@ async function validateRequest(
         ip: req.ip,
         userAgent: req.get('user-agent'),
         context: inferContextFromRequest(req),
-        ...pick(options, ['alwaysAskForToken', 'sessionDuration']),
+        ...pick(options, ['alwaysAskForToken', 'sessionDuration', 'customData']),
       },
     });
 


### PR DESCRIPTION
- Resolve https://github.com/opencollective/opencollective/issues/6777
- Store rolling limit info in 2FA activity