### PR TITLE
Move babel typescript transform plugin to runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/node": "7.20.7",
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/plugin-transform-async-to-generator": "7.20.7",
+        "@babel/plugin-transform-typescript": "^7.21.3",
         "@babel/preset-env": "7.21.5",
         "@escape.tech/graphql-armor": "^1.7.1",
         "@hyperwatch/hyperwatch": "3.9.4",
@@ -119,7 +120,6 @@
       "devDependencies": {
         "@babel/cli": "^7.16.0",
         "@babel/eslint-parser": "^7.16.0",
-        "@babel/plugin-transform-typescript": "^7.17.12",
         "@babel/register": "^7.16.0",
         "@opentelemetry/auto-instrumentations-node": "^0.37.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.39.0",
@@ -1316,7 +1316,6 @@
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
       "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.19.0"
       },
@@ -1777,7 +1776,6 @@
       "version": "7.21.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.21.3.tgz",
       "integrity": "sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.21.0",
@@ -23604,7 +23602,6 @@
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
       "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.19.0"
       }
@@ -23879,7 +23876,6 @@
       "version": "7.21.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.21.3.tgz",
       "integrity": "sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/node": "7.20.7",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-transform-async-to-generator": "7.20.7",
+    "@babel/plugin-transform-typescript": "^7.21.3",
     "@babel/preset-env": "7.21.5",
     "@escape.tech/graphql-armor": "^1.7.1",
     "@hyperwatch/hyperwatch": "3.9.4",
@@ -140,7 +141,6 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/eslint-parser": "^7.16.0",
-    "@babel/plugin-transform-typescript": "^7.17.12",
     "@babel/register": "^7.16.0",
     "@opentelemetry/auto-instrumentations-node": "^0.37.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.39.0",


### PR DESCRIPTION
`@babel/plugin-transform-typescript` was wrongly moved to devDependencies in a previous [PR](https://github.com/opencollective/opencollective-api/pull/8864). 

Its required as a runtime dependency for running cron scripts.
