### PR TITLE
Migration to fix "null" locations

### DIFF
--- a/migrations/20230526091422-fix-null-locations.js
+++ b/migrations/20230526091422-fix-null-locations.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    /**
+     * Some Locations were not migrated correctly, where a null value from Collective.data.address
+     * became the string "null" in the structured jsonb column
+     *
+     * This migration fixes that and makes sure to set the name and address from the Collective data
+     * which was not set due to the previous migration skipping those since it found a structured value ("null")
+     */
+    await queryInterface.sequelize.query(`
+      UPDATE "Locations" l
+      SET 
+        "name" = COALESCE(c."locationName", c."address"),
+        "address" = c."address",
+        "structured" = NULL
+      FROM 
+        "Collectives" c
+      WHERE 
+        l."CollectiveId" = c.id AND 
+        l."structured" = 'null';
+    `);
+  },
+
+  async down() {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+};


### PR DESCRIPTION
Fix for https://github.com/opencollective/opencollective/issues/6754

### Description
Some Locations were not migrated correctly, where a null value from Collective.data.address became the string "null" in the structured jsonb column, since the migration script thought it had found a structured location it skipped migrating the name and address from the Collective data.

This migration fixes that and sets the name and address from the Collective data on locations that have the string "null" as their structured field, and setting a real null value for the structured field.