### PR TITLE
Update chai to 4.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8466,14 +8466,14 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw== sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -9818,15 +9818,15 @@
       "dev": true
     },
     "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -29089,14 +29089,14 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw== sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -30164,9 +30164,9 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "apollo-opentracing": "3.0.45",
-    "chai": "^4.3.4",
+    "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "chai-jest-snapshot": "^2.0.0",
     "chai-sorted": "^0.2.0",

--- a/test/server/lib/search.test.js
+++ b/test/server/lib/search.test.js
@@ -351,29 +351,11 @@ describe('server/lib/search', () => {
     };
 
     const testBuildSearchConditionsWithCustomConfig = (searchTerm, fieldsConfig, options) => {
-      const conditions = buildSearchConditions(searchTerm, fieldsConfig, options);
-      conditions.forEach(condition => {
-        Object.keys(condition).forEach(field => {
-          // We must operators like the ILIKE operator, as toString/expect is not parsing these flag
-          if (condition[field][Op.iLike]) {
-            condition[field]['ILIKE'] = condition[field][Op.iLike];
-          }
-          if (condition[field][Op.overlap]) {
-            condition[field]['OVERLAP'] = condition[field][Op.overlap];
-          }
-        });
-      });
-
-      return conditions;
+      return buildSearchConditions(searchTerm, fieldsConfig, options);
     };
 
-    const testBuildSearchConditions = (searchTerm, expectedResults) => {
-      return testBuildSearchConditionsWithCustomConfig(
-        searchTerm,
-        TEST_FIELDS_CONFIGURATION,
-        undefined,
-        expectedResults,
-      );
+    const testBuildSearchConditions = searchTerm => {
+      return testBuildSearchConditionsWithCustomConfig(searchTerm, TEST_FIELDS_CONFIGURATION);
     };
 
     it('returns no condition for an empty search', () => {
@@ -393,11 +375,11 @@ describe('server/lib/search', () => {
 
     it('build conditions for numbers', () => {
       expect(testBuildSearchConditions('4242')).to.deep.eq([
-        { slug: { ILIKE: '%4242%' } },
-        { '$fromCollective.slug$': { ILIKE: '%4242%' } },
-        { name: { ILIKE: '%4242%' } },
-        { '$fromCollective.name$': { ILIKE: '%4242%' } },
-        { tags: { OVERLAP: ['4242'] } },
+        { slug: { [Op.iLike]: '%4242%' } },
+        { '$fromCollective.slug$': { [Op.iLike]: '%4242%' } },
+        { name: { [Op.iLike]: '%4242%' } },
+        { '$fromCollective.name$': { [Op.iLike]: '%4242%' } },
+        { tags: { [Op.overlap]: ['4242'] } },
         { id: 4242 },
         { '$fromCollective.id$': 4242 },
         { amount: 424200 },
@@ -405,11 +387,11 @@ describe('server/lib/search', () => {
       ]);
 
       expect(testBuildSearchConditions('4242.66')).to.deep.eq([
-        { slug: { ILIKE: '%4242.66%' } },
-        { '$fromCollective.slug$': { ILIKE: '%4242.66%' } },
-        { name: { ILIKE: '%4242.66%' } },
-        { '$fromCollective.name$': { ILIKE: '%4242.66%' } },
-        { tags: { OVERLAP: ['4242.66'] } },
+        { slug: { [Op.iLike]: '%4242.66%' } },
+        { '$fromCollective.slug$': { [Op.iLike]: '%4242.66%' } },
+        { name: { [Op.iLike]: '%4242.66%' } },
+        { '$fromCollective.name$': { [Op.iLike]: '%4242.66%' } },
+        { tags: { [Op.overlap]: ['4242.66'] } },
         { amount: 424266 },
         { '$order.totalAmount$': 424266 },
       ]);
@@ -417,11 +399,11 @@ describe('server/lib/search', () => {
 
     it('build conditions for full text', () => {
       expect(testBuildSearchConditions('   hello world   ')).to.deep.eq([
-        { slug: { ILIKE: '%hello world%' } },
-        { '$fromCollective.slug$': { ILIKE: '%hello world%' } },
-        { name: { ILIKE: '%hello world%' } },
-        { '$fromCollective.name$': { ILIKE: '%hello world%' } },
-        { tags: { OVERLAP: ['hello world'] } },
+        { slug: { [Op.iLike]: '%hello world%' } },
+        { '$fromCollective.slug$': { [Op.iLike]: '%hello world%' } },
+        { name: { [Op.iLike]: '%hello world%' } },
+        { '$fromCollective.name$': { [Op.iLike]: '%hello world%' } },
+        { tags: { [Op.overlap]: ['hello world'] } },
       ]);
     });
 
@@ -430,7 +412,7 @@ describe('server/lib/search', () => {
 
       // No transform: will only trim
       expect(testBuildSearchConditionsWithCustomConfig('   hello   WorlD   ', fieldsConfig)).to.deep.eq([
-        { tags: { OVERLAP: ['hello WorlD'] } },
+        { tags: { [Op.overlap]: ['hello WorlD'] } },
       ]);
 
       // Uppercase
@@ -439,7 +421,7 @@ describe('server/lib/search', () => {
           ...fieldsConfig,
           stringArrayTransformFn: value => value.toUpperCase(),
         }),
-      ).to.deep.eq([{ tags: { OVERLAP: ['HELLO WORLD'] } }]);
+      ).to.deep.eq([{ tags: { [Op.overlap]: ['HELLO WORLD'] } }]);
     });
   });
 });


### PR DESCRIPTION
See https://www.chaijs.com/releases/

Symbols are now supported by deep eq, we don't need the adapter anymore.