### PR TITLE
Do not identify user as impersonating itself

### DIFF
--- a/server/lib/security/expense.ts
+++ b/server/lib/security/expense.ts
@@ -366,7 +366,11 @@ export const checkExpensesBatch = async (
       const relatedUsersByIp = uniqBy(
         filter(usersByIp, u => {
           const ip = expense.User.getLastKnownIp();
-          return ip && (u.data?.creationRequest?.ip === ip || u.data?.lastSignInRequest?.ip === ip);
+          return (
+            u.id !== expense.User.id &&
+            ip &&
+            (u.data?.creationRequest?.ip === ip || u.data?.lastSignInRequest?.ip === ip)
+          );
         }),
         'id',
       );


### PR DESCRIPTION
The `This user may be impersonating multiple profiles` was matching against the expense user itself.

![image](https://github.com/opencollective/opencollective-api/assets/5448927/026ab482-4797-4c67-934e-ea6c6eb3ea86)
