### PR TITLE
Cache npm in setup-node action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       - name: Restore node_modules
         uses: actions/cache@v3
@@ -39,16 +40,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-api-node-modules-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Restore .npm cache
-        if: steps.api-node-modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            - ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-            - ${{ runner.os }}-api-npm-cache-
 
       - name: Install dependencies
         if: steps.api-node-modules.outputs.cache-hit != 'true'
@@ -68,6 +59,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       - name: Restore node_modules
         uses: actions/cache@v3
@@ -75,16 +67,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-api-node-modules-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Restore .npm cache
-        if: steps.api-node-modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            - ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-            - ${{ runner.os }}-api-npm-cache-
 
       - name: Install dependencies
         if: steps.api-node-modules.outputs.cache-hit != 'true'
@@ -104,6 +86,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       - name: Restore node_modules
         uses: actions/cache@v3
@@ -111,16 +94,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-api-node-modules-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Restore .npm cache
-        if: steps.api-node-modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            - ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-            - ${{ runner.os }}-api-npm-cache-
 
       - name: Install dependencies
         if: steps.api-node-modules.outputs.cache-hit != 'true'
@@ -177,6 +150,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       - name: Restore node_modules
         uses: actions/cache@v3
@@ -184,16 +158,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-api-node-modules-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Restore .npm cache
-        if: steps.api-node-modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            - ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-            - ${{ runner.os }}-api-npm-cache-
 
       - name: Install dependencies
         if: steps.api-node-modules.outputs.cache-hit != 'true'
@@ -237,6 +201,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       - name: Restore node_modules
         uses: actions/cache@v3
@@ -244,16 +209,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-api-node-modules-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Restore .npm cache
-        if: steps.api-node-modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            - ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-            - ${{ runner.os }}-api-npm-cache-
 
       - name: Install dependencies
         if: steps.api-node-modules.outputs.cache-hit != 'true'
@@ -294,6 +249,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       - name: Restore node_modules
         uses: actions/cache@v3
@@ -301,16 +257,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-api-node-modules-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Restore .npm cache
-        if: steps.api-node-modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            - ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-            - ${{ runner.os }}-api-npm-cache-
 
       - name: Install dependencies
         if: steps.api-node-modules.outputs.cache-hit != 'true'
@@ -333,6 +279,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       - name: Restore node_modules
         uses: actions/cache@v3
@@ -340,16 +287,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-api-node-modules-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Restore .npm cache
-        if: steps.api-node-modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            - ${{ runner.os }}-api-npm-cache-${{ hashFiles('package-lock.json') }}-${{ secrets.CACHE_VERSION }}
-            - ${{ runner.os }}-api-npm-cache-
 
       - name: Install dependencies
         if: steps.api-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,17 +80,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
-
-      # Npm cache
-
-      - name: Restore .npm cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-cache-${{ github.sha }}
-          restore-keys: |
-            - ${{ runner.os }}-npm-cache-${{ github.sha }}
-            - ${{ runner.os }}-npm-cache-
+          cache: 'npm'
 
       # Checkouts
 


### PR DESCRIPTION
Small simplification. See https://github.com/actions/setup-node#caching-global-packages-data

![image](https://github.com/opencollective/opencollective-api/assets/1556356/17a509b0-f72a-4127-96d3-ce91370af121)
