### PR TITLE
Fix host-settlement test time inconsistency

### DIFF
--- a/test/cron/monthly/host-settlement.test.js
+++ b/test/cron/monthly/host-settlement.test.js
@@ -21,7 +21,7 @@ import {
 import * as utils from '../../utils';
 
 describe('cron/monthly/host-settlement', () => {
-  const lastMonth = moment.utc().subtract(1, 'month');
+  const lastMonth = moment.utc().subtract(1, 'month').startOf('month');
 
   let gbpHost, eurHost, eurCollective, gphHostSettlementExpense, eurHostSettlementExpense;
 


### PR DESCRIPTION
Astrologists would say it has to do with the day the test execution was born.

![](https://media.giphy.com/media/SpoV1pB4g7gXvWo3Up/giphy-downsized.gif)