### PR TITLE
Fix broken lodash import

### DIFF
--- a/server/lib/handlebars.js
+++ b/server/lib/handlebars.js
@@ -1,5 +1,5 @@
 import handlebars from 'handlebars';
-import { isNil, lowercase } from 'lodash';
+import { isNil, lowerCase } from 'lodash';
 import moment from 'moment-timezone';
 
 import {
@@ -171,7 +171,7 @@ handlebars.registerHelper('pluralize', (str, props) => pluralize(str, props.hash
  * From totalAmountToBeRaised, return "Total amount to be raised"
  */
 handlebars.registerHelper('prettifyVariableName', str => {
-  return capitalize(lowercase(str));
+  return capitalize(lowerCase(str));
 });
 
 handlebars.registerHelper('encodeURIComponent', str => {


### PR DESCRIPTION
Resolve https://open-collective.sentry.io/issues/4218294741/?project=5199682&query=is%3Aunresolved+lowercase&referrer=issue-stream&statsPeriod=14d&stream_index=0

The previous integration with `babel-lodash` apparently supported this import, but it is incorrect with the latest lodash.