### PR TITLE
CreateCollective: fix activity for logged out users

### DIFF
--- a/server/graphql/v2/mutation/CreateCollectiveMutation.js
+++ b/server/graphql/v2/mutation/CreateCollectiveMutation.js
@@ -207,7 +207,7 @@ async function createCollective(_, args, req) {
       // - tell them the status of their host application
       if (!args.skipDefaultAdmin) {
         const remoteUserCollective = await loaders.Collective.byId.load(user.CollectiveId);
-        collective.generateCollectiveCreatedActivity(req.remoteUser, req.userToken, {
+        collective.generateCollectiveCreatedActivity(user, req.userToken, {
           collective: collective.info,
           host: get(host, 'info'),
           hostPending: collective.approvedAt ? false : true,


### PR DESCRIPTION
Resolve https://open-collective.sentry.io/issues/4219897962/?project=5199682&referrer=slack

We were missing an activity when creating a collective as a logged-out user.