### PR TITLE
Fix error message when balance's too low to pay expense

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -2070,7 +2070,7 @@ export const checkHasBalanceToPayExpense = async (
         `Collective does not have enough funds to pay this expense. Current balance: ${formatCurrency(
           balanceInHostCurrency,
           host.currency,
-        )}, Expense amount: ${formatCurrency(balanceInHostCurrency, host.currency)}`,
+        )}, Expense amount: ${formatCurrency(totalAmountPaidInHostCurrency, host.currency)}`,
       );
     }
     return {


### PR DESCRIPTION
Fixes the error message for https://open-collective.sentry.io/issues/4223984593