### PR TITLE
Replace axios with node-fetch for webhooks delivery

### DIFF
--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -40,7 +40,7 @@ const publishToWebhook = (activity: Activity, webhookUrl: string) => {
       body: JSON.stringify(enrichedActivity),
       redirect: 'manual' as RequestRedirect,
     };
-    return fetch(webhookUrl, webhookOptions).then(response => response.json());
+    return fetch(webhookUrl, webhookOptions).then(response => response?.json());
   }
 };
 

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import config from 'config';
+import fetch from 'node-fetch';
 
 import { activities, channels } from '../../constants';
 import ActivityTypes from '../../constants/activities';
@@ -31,7 +31,16 @@ const publishToWebhook = (activity: Activity, webhookUrl: string) => {
   } else {
     const sanitizedActivity = sanitizeActivity(activity);
     const enrichedActivity = enrichActivity(sanitizedActivity);
-    return axios.post(webhookUrl, enrichedActivity, { maxRedirects: 0 });
+    const webhookOptions = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify(enrichedActivity),
+      redirect: 'manual',
+    };
+    return fetch(webhookUrl, webhookOptions).then(response => response.json());
   }
 };
 

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -1,5 +1,5 @@
 import config from 'config';
-import fetch from 'node-fetch';
+import fetch, { RequestRedirect } from 'node-fetch';
 
 import { activities, channels } from '../../constants';
 import ActivityTypes from '../../constants/activities';
@@ -38,7 +38,7 @@ const publishToWebhook = (activity: Activity, webhookUrl: string) => {
         'Content-Type': 'application/json;charset=UTF-8',
       },
       body: JSON.stringify(enrichedActivity),
-      redirect: 'manual',
+      redirect: 'manual' as RequestRedirect,
     };
     return fetch(webhookUrl, webhookOptions).then(response => response.json());
   }


### PR DESCRIPTION
it's a bit difficult to juggle between different http libraries, could be a good thing to consolidate on node-fetch.