### PR TITLE
dx: extend oauth sessions to 90 days

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -16,6 +16,7 @@ export const TOKEN_EXPIRATION_RESET_PASSWORD = minutesToSeconds(75);
 export const TOKEN_EXPIRATION_2FA = minutesToSeconds(15);
 export const TOKEN_EXPIRATION_CONNECTED_ACCOUNT = daysToSeconds(1);
 export const TOKEN_EXPIRATION_SESSION = daysToSeconds(30);
+export const TOKEN_EXPIRATION_SESSION_OAUTH = daysToSeconds(90);
 export const TOKEN_EXPIRATION_PDF = minutesToSeconds(5);
 export const TOKEN_EXPIRATION_CSV = minutesToSeconds(5);
 

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -27,7 +27,7 @@ class CustomTokenHandler extends TokenHandler {
             // eslint-disable-next-line camelcase
             access_token: model.accessToken,
           },
-          auth.TOKEN_EXPIRATION_SESSION,
+          auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
         );
         // eslint-disable-next-line camelcase
         return { access_token: accessToken };
@@ -76,7 +76,7 @@ class CustomOAuth2Server extends OAuth2Server {
   token = function (request, response, options): Promise<OAuth2Server.Token> {
     options = assign(
       {
-        accessTokenLifetime: auth.TOKEN_EXPIRATION_SESSION, // 30 days
+        accessTokenLifetime: auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days
         refreshTokenLifetime: 60 * 60 * 24 * 365, // 1 year
         allowExtendedTokenAttributes: false,
         requireClientAuthentication: {}, // defaults to true for all grant types

--- a/test/server/routes/oauth.test.ts
+++ b/test/server/routes/oauth.test.ts
@@ -75,7 +75,7 @@ describe('server/routes/oauth', () => {
     expect(decodedToken.access_token.startsWith('test_oauth_')).to.be.true;
     const iat = fakeNow.getTime() / 1000;
     expect(decodedToken.iat).to.eq(iat); // 1640995200
-    expect(decodedToken.exp).to.eq(iat + 2592000);
+    expect(decodedToken.exp).to.eq(iat + 7776000); // 90 days
 
     // Test OAuth token with a real query
     const gqlRequestResult = await request(expressApp)


### PR DESCRIPTION
Was discussed as a temporary measure while we work on proper refresh token support.