### PR TITLE
Standardize contribution URLs

### DIFF
--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -448,7 +448,7 @@ export async function createPaymentCreditCardConfirmationActivity(order) {
       order: order.info,
       collective: order.collective.info,
       fromCollective: order.fromCollective.minimal,
-      confirmOrderLink: `${config.host.website}/${order.fromCollective.slug}/orders/${order.id}/confirm`,
+      confirmOrderLink: `${config.host.website}/${order.fromCollective.slug}/contributions/${order.id}/confirm`,
       paymentMethod: order.paymentMethod?.info,
     },
   });

--- a/templates/emails/order.pending.created.hbs
+++ b/templates/emails/order.pending.created.hbs
@@ -37,7 +37,7 @@ Subject: We've been notified of incoming funds to {{toCollective.name}}
 <br />
 
 <center>
-  <a class="btn blue" href="{{config.host.website}}/{{toCollective.slug}}/orders/{{order.id}}">
+  <a class="btn blue" href="{{config.host.website}}/{{toCollective.slug}}/contributions/{{order.id}}">
     <div>Open Pending Contribution</div>
   </a>
 </center>

--- a/templates/emails/order.pending.received.hbs
+++ b/templates/emails/order.pending.received.hbs
@@ -30,7 +30,7 @@ Subject: Funds from {{fromCollective.name}} are now available
 <br />
 <br />
 <center>
-  <a class="btn blue" href="{{config.host.website}}/{{toCollective.slug}}/orders/{{order.id}}">
+  <a class="btn blue" href="{{config.host.website}}/{{toCollective.slug}}/contributions/{{order.id}}">
     <div>Open Contribution</div>
   </a>
 </center>


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-frontend/pull/8993 (for `/contributions/id/confirm`)