### PR TITLE
Remove node-slack package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
         "moment-timezone": "0.5.43",
         "multer": "1.4.4",
         "node-fetch": "2.6.11",
-        "node-slack": "0.0.7",
         "nodemailer": "6.9.3",
         "p-filter": "2.1.0",
         "p-map": "4.0.0",
@@ -11161,13 +11160,6 @@
         "@commitlint/load": ">6.1.1"
       }
     },
-    "node_modules/d": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "license": "MIT",
@@ -11321,15 +11313,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deferred": {
-      "version": "0.7.1",
-      "dependencies": {
-        "d": "~0.1.1",
-        "es5-ext": "~0.10.2",
-        "event-emitter": "~0.3.1",
-        "next-tick": "~0.2.2"
       }
     },
     "node_modules/define-properties": {
@@ -17529,10 +17512,6 @@
       "version": "2.6.2",
       "license": "MIT"
     },
-    "node_modules/next-tick": {
-      "version": "0.2.2",
-      "license": "MIT"
-    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "dev": true,
@@ -17839,14 +17818,6 @@
     "node_modules/node-releases": {
       "version": "2.0.12",
       "license": "MIT"
-    },
-    "node_modules/node-slack": {
-      "version": "0.0.7",
-      "license": "BSD",
-      "dependencies": {
-        "deferred": "0.7.1",
-        "request": "~2.x"
-      }
     },
     "node_modules/nodemailer": {
       "version": "6.9.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "moment-timezone": "0.5.43",
     "multer": "1.4.4",
     "node-fetch": "2.6.11",
-    "node-slack": "0.0.7",
     "nodemailer": "6.9.3",
     "p-filter": "2.1.0",
     "p-map": "4.0.0",


### PR DESCRIPTION
HTTP post from `node-slack` was using the `request` package without setting content-type:
![image](https://github.com/opencollective/opencollective-api/assets/5448927/52b665e5-707a-4413-829f-08367cba3716)

Using axios to make same post request
Slack/Discord webhook for a contribution:
![image](https://github.com/opencollective/opencollective-api/assets/5448927/513f26fb-4bc1-44e0-8c8f-13f02092dbdb)
![image](https://github.com/opencollective/opencollective-api/assets/5448927/eeb21519-e863-4c64-827c-3e5573a38a76)
