### PR TITLE
Stringify Axios notification errors

### DIFF
--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import config from 'config';
 
 import { activities, channels } from '../../constants';
@@ -72,11 +72,13 @@ const dispatch = async (activity: Activity) => {
     }),
   ).catch(err => {
     reportErrorToSentry(err);
+    const stringifiedError =
+      err instanceof AxiosError ? `${err.response?.status} ${err.response?.statusText} ${err.config?.url}` : err;
     console.error(
       `Error while publishing activity type ${activity.type} for collective ${activity.CollectiveId}`,
       activity,
       'error: ',
-      err,
+      stringifiedError,
     );
   });
 };


### PR DESCRIPTION
So we stop logging extensive JSON objects.