### PR TITLE
Pause cards after period of inactivity

### DIFF
--- a/cron/daily/52-pause-virtual-cards-after-period-of-inactivity.ts
+++ b/cron/daily/52-pause-virtual-cards-after-period-of-inactivity.ts
@@ -1,0 +1,102 @@
+import '../../server/env';
+
+import PQueue from 'p-queue';
+
+import { activities } from '../../server/constants';
+import { reportErrorToSentry } from '../../server/lib/sentry';
+import { parseToBoolean } from '../../server/lib/utils';
+import models, { Op, sequelize } from '../../server/models';
+import VirtualCard, { VirtualCardStatus } from '../../server/models/VirtualCard';
+
+const DRY_RUN = process.env.DRY_RUN ? parseToBoolean(process.env.DRY_RUN) : false;
+
+export async function findUnusedVirtualCards() {
+  return models.VirtualCard.findAll({
+    include: [
+      {
+        association: 'host',
+        required: true,
+        where: {
+          'settings.virtualcards.autopauseUnusedCards.enabled': true,
+        },
+      },
+      {
+        association: 'collective',
+        required: true,
+      },
+    ],
+    where: {
+      [Op.and]: [
+        {
+          data: {
+            status: VirtualCardStatus.ACTIVE,
+          },
+        },
+        // has the feature period is larger than zero
+        sequelize.literal(`
+          cast("host".settings#>'{virtualcards,autopauseUnusedCards,period}' as integer) > 0
+        `),
+        // the card exists longer than the period
+        sequelize.literal(`
+          "VirtualCard"."createdAt" <= now() - make_interval(
+            days => cast("host".settings#>'{virtualcards,autopauseUnusedCards,period}' as integer)
+          )
+        `),
+        // the is no charge made in the period
+        sequelize.literal(`
+          NOT EXISTS (
+            SELECT * FROM "Expenses" e 
+            WHERE e."VirtualCardId" = "VirtualCard".id
+            AND 
+              e."createdAt" >= now() - make_interval(
+                days => cast("host".settings#>'{virtualcards,autopauseUnusedCards,period}' as integer)
+              )
+          )
+        `),
+      ],
+    },
+  });
+}
+
+async function pauseVirtualCardDueToInactivity(virtualCard: VirtualCard) {
+  try {
+    console.log('Pausing card', virtualCard.id, virtualCard.name);
+    if (DRY_RUN) {
+      return;
+    }
+
+    await virtualCard.pause();
+    await models.Activity.create({
+      type: activities.COLLECTIVE_VIRTUAL_CARD_SUSPENDED_DUE_TO_INACTIVITY,
+      CollectiveId: virtualCard.collective.id,
+      HostCollectiveId: virtualCard.host.id,
+      data: {
+        virtualCard,
+        host: virtualCard.host.info,
+        collective: virtualCard.collective.info,
+      },
+    });
+  } catch (e) {
+    console.error(e);
+    reportErrorToSentry(e);
+  }
+}
+
+export async function run({ concurrency = 20 } = {}) {
+  const unusedVirtualCards = await findUnusedVirtualCards();
+
+  const queue = new PQueue({ concurrency });
+  await queue.addAll(unusedVirtualCards.map(vc => () => pauseVirtualCardDueToInactivity(vc)));
+}
+
+if (require.main === module) {
+  run()
+    .catch(e => {
+      console.error(e);
+      reportErrorToSentry(e);
+      process.exit(1);
+    })
+    .then(() => {
+      setTimeout(() => sequelize.close(), 2000);
+    });
+}

--- a/server/constants/activities.ts
+++ b/server/constants/activities.ts
@@ -51,6 +51,7 @@ enum ActivityTypes {
   COLLECTIVE_VIRTUAL_CARD_ADDED = 'collective.virtualcard.added',
   COLLECTIVE_VIRTUAL_CARD_MISSING_RECEIPTS = 'collective.virtualcard.missing.receipts',
   COLLECTIVE_VIRTUAL_CARD_SUSPENDED = 'collective.virtualcard.suspended',
+  COLLECTIVE_VIRTUAL_CARD_SUSPENDED_DUE_TO_INACTIVITY = 'collective.virtualcard.suspendedDueToInactivity',
   COLLECTIVE_VIRTUAL_CARD_DELETED = 'collective.virtualcard.deleted',
   VIRTUAL_CARD_REQUESTED = 'virtual_card.requested',
   VIRTUAL_CARD_CHARGE_DECLINED = 'virtualcard.charge.declined',

--- a/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
@@ -86,6 +86,7 @@ const generateTimelineQuery = async (account): Promise<WhereOptions<InferAttribu
             [Op.in]: [
               ActivityTypes.COLLECTIVE_VIRTUAL_CARD_MISSING_RECEIPTS,
               ActivityTypes.COLLECTIVE_VIRTUAL_CARD_SUSPENDED,
+              ActivityTypes.COLLECTIVE_VIRTUAL_CARD_SUSPENDED_DUE_TO_INACTIVITY,
               ActivityTypes.VIRTUAL_CARD_PURCHASE,
             ],
           },

--- a/server/lib/emailTemplates.ts
+++ b/server/lib/emailTemplates.ts
@@ -48,6 +48,7 @@ export const templateNames = [
   'collective.virtualcard.added',
   'collective.virtualcard.missing.receipts',
   'collective.virtualcard.suspended',
+  'collective.virtualcard.suspendedDueToInactivity',
   'collective.virtualcard.deleted',
   'confirm-guest-account',
   'event.reminder.1d',

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -613,6 +613,7 @@ export const notifyByEmail = async (activity: Activity) => {
       break;
 
     case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_SUSPENDED:
+    case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_SUSPENDED_DUE_TO_INACTIVITY:
     case ActivityTypes.COLLECTIVE_VIRTUAL_CARD_DELETED:
       await notify.collective(activity, {
         collectiveId: activity.data.collective.id,

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -131,6 +131,10 @@ type Settings = {
   virtualcards?: {
     reminder?: boolean;
     autopause?: boolean;
+    autopauseUnusedCards?: {
+      enabled: boolean;
+      period: number;
+    };
   };
 };
 

--- a/server/models/VirtualCard.ts
+++ b/server/models/VirtualCard.ts
@@ -60,6 +60,13 @@ class VirtualCard extends Model<InferAttributes<VirtualCard, { omit: 'info' }>, 
         throw new Error(`Can not suspend virtual card provided by ${this.provider}`);
     }
 
+    await this.update({
+      data: {
+        ...this.data,
+        status: VirtualCardStatus.INACTIVE,
+      },
+    });
+
     return this.reload();
   }
 
@@ -71,6 +78,13 @@ class VirtualCard extends Model<InferAttributes<VirtualCard, { omit: 'info' }>, 
       default:
         throw new Error(`Can not resume virtual card provided by ${this.provider}`);
     }
+
+    await this.update({
+      data: {
+        ...this.data,
+        status: VirtualCardStatus.ACTIVE,
+      },
+    });
 
     return this.reload();
   }

--- a/templates/emails/collective.virtualcard.suspendedDueToInactivity.hbs
+++ b/templates/emails/collective.virtualcard.suspendedDueToInactivity.hbs
@@ -14,7 +14,7 @@ Subject: ⚠ {{{collective.name}}}'s {{virtualCard.last4}} card was suspended du
 </p>
 
 <div class="info">
-  For more information or to restore the card, please contact your fiscal host.
+  For more information or to restore the card, <a href="{{config.host.website}}/{{collective.slug}}/admin">visit your settings</a>.
 </div>
 
 {{> footer}}

--- a/templates/emails/collective.virtualcard.suspendedDueToInactivity.hbs
+++ b/templates/emails/collective.virtualcard.suspendedDueToInactivity.hbs
@@ -1,0 +1,20 @@
+Subject: ⚠ {{{collective.name}}}'s {{virtualCard.last4}} card was suspended due to inactivity
+
+
+{{> header}}
+
+<center>
+  <h1>
+    {{collective.name}}'s {{virtualCard.name}} ({{virtualCard.last4}}) card is now suspended.
+  </h1>
+</center>
+
+<p>
+  {{virtualCard.name}} ({{virtualCard.last4}}) card has been suspended due to inactivity.
+</p>
+
+<div class="info">
+  For more information or to restore the card, please contact your fiscal host.
+</div>
+
+{{> footer}}

--- a/test/cron/daily/pause-virtual-cards-after-period-of-inactivity.test.ts
+++ b/test/cron/daily/pause-virtual-cards-after-period-of-inactivity.test.ts
@@ -1,0 +1,166 @@
+import { expect } from 'chai';
+import moment from 'moment';
+import { createSandbox } from 'sinon';
+
+import { run as runCron } from '../../../cron/daily/52-pause-virtual-cards-after-period-of-inactivity';
+import VirtualCardProviders from '../../../server/constants/virtual_card_providers';
+import { VirtualCard } from '../../../server/models';
+import { VirtualCardStatus } from '../../../server/models/VirtualCard';
+import * as stripeVirtualCards from '../../../server/paymentProviders/stripe/virtual-cards';
+import { fakeExpense, fakeHost, fakeVirtualCard } from '../../test-helpers/fake-data';
+import { resetTestDB } from '../../utils';
+
+describe('cron/daily/pause-virtual-cards-after-period-of-inactivity', () => {
+  const sandbox = createSandbox();
+  afterEach(sandbox.restore);
+
+  beforeEach(async () => {
+    await resetTestDB();
+    sandbox.stub(stripeVirtualCards, 'pauseCard').resolves();
+  });
+
+  it('pauses inactive virtual cards', async () => {
+    const expectPaused: VirtualCard[] = [];
+    const expectActive: VirtualCard[] = [];
+
+    async function makeVirtualCardWithExpense({
+      HostCollectiveId,
+      cardCreatedAt,
+      expenseCreatedAt = null,
+      expectIsPaused,
+      name = undefined,
+    }) {
+      const vc = await fakeVirtualCard({
+        provider: VirtualCardProviders.STRIPE,
+        HostCollectiveId: HostCollectiveId,
+        CollectiveId: HostCollectiveId,
+        createdAt: cardCreatedAt,
+        name,
+      });
+
+      if (expenseCreatedAt) {
+        await fakeExpense({
+          VirtualCardId: vc.id,
+          createdAt: expenseCreatedAt,
+        });
+      }
+
+      if (expectIsPaused) {
+        expectPaused.push(vc);
+      } else {
+        expectActive.push(vc);
+      }
+
+      return vc;
+    }
+
+    const hostWith30DaysInactivePolicy = await fakeHost({
+      name: '30DaysInactive',
+      settings: {
+        virtualcards: {
+          autopauseUnusedCards: {
+            enabled: true,
+            period: 30,
+          },
+        },
+      },
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '1',
+      HostCollectiveId: hostWith30DaysInactivePolicy.id,
+      cardCreatedAt: moment().subtract(31, 'days'),
+      expenseCreatedAt: moment().subtract(31, 'days'),
+      expectIsPaused: true,
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '2',
+      HostCollectiveId: hostWith30DaysInactivePolicy.id,
+      cardCreatedAt: moment().subtract(61, 'days'),
+      expenseCreatedAt: moment().subtract(61, 'days'),
+      expectIsPaused: true,
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '3',
+      HostCollectiveId: hostWith30DaysInactivePolicy.id,
+      cardCreatedAt: moment().subtract(2, 'days'),
+      expectIsPaused: false,
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '4',
+      HostCollectiveId: hostWith30DaysInactivePolicy.id,
+      cardCreatedAt: moment().subtract(2, 'days'),
+      expenseCreatedAt: moment(),
+      expectIsPaused: false,
+    });
+
+    const hostWith60DaysInactivePolicy = await fakeHost({
+      name: '60DaysInactive',
+      settings: {
+        virtualcards: {
+          autopauseUnusedCards: {
+            enabled: true,
+            period: 60,
+          },
+        },
+      },
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '5',
+      HostCollectiveId: hostWith60DaysInactivePolicy.id,
+      cardCreatedAt: moment().subtract(31, 'days'),
+      expenseCreatedAt: moment().subtract(31, 'days'),
+      expectIsPaused: false,
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '6',
+      HostCollectiveId: hostWith60DaysInactivePolicy.id,
+      cardCreatedAt: moment().subtract(61, 'days'),
+      expenseCreatedAt: moment().subtract(61, 'days'),
+      expectIsPaused: true,
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '7',
+      HostCollectiveId: hostWith60DaysInactivePolicy.id,
+      cardCreatedAt: moment().subtract(61, 'days'),
+      expectIsPaused: true,
+    });
+
+    const hostWithoutInactivePolicy = await fakeHost({
+      name: 'NoInactivePolicy',
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '8',
+      HostCollectiveId: hostWithoutInactivePolicy.id,
+      cardCreatedAt: moment().subtract(61, 'days'),
+      expenseCreatedAt: moment().subtract(61, 'days'),
+      expectIsPaused: false,
+    });
+
+    await makeVirtualCardWithExpense({
+      name: '9',
+      HostCollectiveId: hostWithoutInactivePolicy.id,
+      cardCreatedAt: moment().subtract(360, 'days'),
+      expectIsPaused: false,
+    });
+
+    await runCron({ concurrency: 1 });
+
+    for (const vc of expectActive) {
+      await vc.reload();
+      expect(vc.data.status, `Card ${vc.name} should be ACTIVE`).to.eql(VirtualCardStatus.ACTIVE);
+    }
+
+    for (const vc of expectPaused) {
+      await vc.reload();
+      expect(vc.data.status, `Card ${vc.name} should be INACTIVE`).to.eql(VirtualCardStatus.INACTIVE);
+    }
+  });
+});


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/6839

Defines host settings:
`settings.virtualcards.autopauseUnusedCards.enabled`
`settings.virtualcards.autopauseUnusedCards.period`

An activity: `COLLECTIVE_VIRTUAL_CARD_SUSPENDED_DUE_TO_INACTIVITY`

And a daily cron job to pause unused cards.