### PR TITLE
Return parent agreements by default

### DIFF
--- a/server/graphql/v2/interface/AccountWithHost.ts
+++ b/server/graphql/v2/interface/AccountWithHost.ts
@@ -149,7 +149,7 @@ export const AccountWithHostFields = {
           return Agreement.findAll({
             where: {
               HostCollectiveId: account.HostCollectiveId,
-              CollectiveId: account.id,
+              CollectiveId: [account.id, account.ParentCollectiveId].filter(Boolean),
             },
             limit: limit,
             offset: offset,

--- a/test/server/graphql/loaders/agreements.test.js
+++ b/test/server/graphql/loaders/agreements.test.js
@@ -29,7 +29,8 @@ describe('server/graphql/loaders/agreements', () => {
     it('loads total agreement count for many', async () => {
       const host = await fakeHost();
       const account = await fakeCollective({ HostCollectiveId: host.id });
-      const account2 = await fakeCollective({ HostCollectiveId: host.id });
+      const account2Parent = await fakeCollective({ HostCollectiveId: host.id });
+      const account2 = await fakeCollective({ HostCollectiveId: host.id, ParentCollectiveId: account2Parent.id });
 
       await Agreement.create({
         CollectiveId: account.id,
@@ -45,6 +46,12 @@ describe('server/graphql/loaders/agreements', () => {
       });
 
       await Agreement.create({
+        CollectiveId: account2Parent.id,
+        HostCollectiveId: host.id,
+        title: 'Test 2 parent',
+      });
+
+      await Agreement.create({
         CollectiveId: account2.id,
         HostCollectiveId: host.id,
         title: 'Test 2',
@@ -56,7 +63,9 @@ describe('server/graphql/loaders/agreements', () => {
         title: 'Test 3',
       });
 
-      expect(await generateTotalAccountHostAgreementsLoader().loadMany([account.id, account2.id])).to.eql([1, 2]);
+      expect(
+        await generateTotalAccountHostAgreementsLoader().loadMany([account.id, account2Parent.id, account2.id]),
+      ).to.eql([1, 1, 3]);
     });
   });
 });


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/4894

By default, we want the agreements of the parent collectives to always apply to their children.