### PR TITLE
perf(Expense): Optimize expense amounts stats query

### DIFF
--- a/server/lib/security/expense.ts
+++ b/server/lib/security/expense.ts
@@ -7,7 +7,7 @@ import {
   first,
   isEqual,
   isUndefined,
-  // keyBy,
+  keyBy,
   max,
   startCase,
   uniq,
@@ -17,13 +17,13 @@ import moment from 'moment';
 
 import status from '../../constants/expense_status';
 import expenseType from '../../constants/expense_type';
-// import type { ConvertToCurrencyArgs } from '../../graphql/loaders/currency-exchange-rate';
+import type { ConvertToCurrencyArgs } from '../../graphql/loaders/currency-exchange-rate';
 import models, { Op, sequelize } from '../../models';
 import Expense from '../../models/Expense';
 import { PayoutMethodTypes } from '../../models/PayoutMethod';
 import { RecipientAccount as BankAccountPayoutMethodData } from '../../types/transferwise';
 import { expenseMightBeSubjectToTaxForm } from '../tax-forms';
-// import { formatCurrency } from '../utils';
+import { formatCurrency } from '../utils';
 
 export enum Scope {
   USER = 'USER',
@@ -57,14 +57,14 @@ const isDefinedButNotEqual = (a, b) => !isUndefined(a) && !isEqual(a, b);
 
 type ExpenseStats = { count: number; lastCreatedAt: Date; status: status; CollectiveId: number };
 
-// type ExpenseAmountStats = {
-//   amountInHostCurrency: number;
-//   totalApprovedAmountForCollective: number;
-//   totalApprovedCountForCollective: number;
-//   averageAmountForCollective: number;
-//   paidAmountP95ForCollective: number;
-//   isConvertedCurrency: boolean;
-// };
+type ExpenseAmountStats = {
+  amountInHostCurrency: number;
+  totalApprovedAmountForCollective: number;
+  totalApprovedCountForCollective: number;
+  averageAmountForCollective: number;
+  paidAmountP95ForCollective: number;
+  isConvertedCurrency: boolean;
+};
 
 const addBooleanCheck = (
   checks: Array<SecurityCheck>,
@@ -153,46 +153,46 @@ const checkExpenseStats = (
   });
 };
 
-// const checkExpenseAmountStats = (
-//   checks: Array<SecurityCheck>,
-//   expenseStats: ExpenseAmountStats,
-//   collectiveBalanceInDisplayCurrency: number,
-//   displayCurrency: string,
-// ) => {
-//   // Add warning if total approved is above the balance of the collective
-//   addBooleanCheck(checks, expenseStats.totalApprovedAmountForCollective > collectiveBalanceInDisplayCurrency, {
-//     scope: Scope.COLLECTIVE,
-//     level: Level.MEDIUM,
-//     message: `The total amount of approved expenses is higher than the collective balance`,
-//     details: `There are ${
-//       expenseStats.totalApprovedCountForCollective
-//     } approved expenses for this collective for a total of ${formatCurrency(
-//       expenseStats.totalApprovedAmountForCollective,
-//       displayCurrency,
-//     )}, which is higher than the collective balance of ${formatCurrency(
-//       collectiveBalanceInDisplayCurrency,
-//       displayCurrency,
-//     )}.`,
-//   });
+const checkExpenseAmountStats = (
+  checks: Array<SecurityCheck>,
+  expenseStats: ExpenseAmountStats,
+  collectiveBalanceInDisplayCurrency: number,
+  displayCurrency: string,
+) => {
+  // Add warning if total approved is above the balance of the collective
+  addBooleanCheck(checks, expenseStats.totalApprovedAmountForCollective > collectiveBalanceInDisplayCurrency, {
+    scope: Scope.COLLECTIVE,
+    level: Level.MEDIUM,
+    message: `The total amount of approved expenses is higher than the collective balance`,
+    details: `There are ${
+      expenseStats.totalApprovedCountForCollective
+    } approved expenses for this collective for a total of ${formatCurrency(
+      expenseStats.totalApprovedAmountForCollective,
+      displayCurrency,
+    )}, which is higher than the collective balance of ${formatCurrency(
+      collectiveBalanceInDisplayCurrency,
+      displayCurrency,
+    )}.`,
+  });
 
-//   // Unless it's the 1st expense, add a warning if amount is above p95 for this collective
-//   if (expenseStats.paidAmountP95ForCollective) {
-//     addBooleanCheck(checks, expenseStats.amountInHostCurrency >= expenseStats.paidAmountP95ForCollective, {
-//       scope: Scope.COLLECTIVE,
-//       level: Level.MEDIUM,
-//       message: `Amount is higher than usual`,
-//       details: `The amount of this expense (${formatCurrency(
-//         expenseStats.amountInHostCurrency,
-//         displayCurrency,
-//         2,
-//         expenseStats.isConvertedCurrency,
-//       )}) is in the top 5% of expenses for this collective. The average amount of paid expenses is ${formatCurrency(
-//         expenseStats.averageAmountForCollective,
-//         displayCurrency,
-//       )}, with the top 5% being above ${formatCurrency(expenseStats.paidAmountP95ForCollective, displayCurrency)}.`,
-//     });
-//   }
-// };
+  // Unless it's the 1st expense, add a warning if amount is above p95 for this collective
+  if (expenseStats.paidAmountP95ForCollective) {
+    addBooleanCheck(checks, expenseStats.amountInHostCurrency >= expenseStats.paidAmountP95ForCollective, {
+      scope: Scope.COLLECTIVE,
+      level: Level.MEDIUM,
+      message: `Amount is higher than usual`,
+      details: `The amount of this expense (${formatCurrency(
+        expenseStats.amountInHostCurrency,
+        displayCurrency,
+        2,
+        expenseStats.isConvertedCurrency,
+      )}) is in the top 5% of expenses for this collective. The average amount of paid expenses is ${formatCurrency(
+        expenseStats.averageAmountForCollective,
+        displayCurrency,
+      )}, with the top 5% being above ${formatCurrency(expenseStats.paidAmountP95ForCollective, displayCurrency)}.`,
+    });
+  }
+};
 
 const getGroupedExpensesStats = (expenses: Array<Expense>) => {
   const expensesStatsConditions = [];
@@ -228,113 +228,113 @@ const getGroupedExpensesStats = (expenses: Array<Expense>) => {
 /**
  * Get some stats about the collectives of the expenses. Returns an object with the expense id as key and the stats as value.
  */
-// const getExpensesAmountsStats = async (
-//   expenses: Array<Expense>,
-//   displayCurrency,
-// ): Promise<Record<string, ExpenseAmountStats>> => {
-//   const collectiveIds = uniq(expenses.map(e => e.CollectiveId));
-//   const expenseIds = uniq(expenses.map(e => e.id));
-//   const result: Array<ExpenseAmountStats> = await sequelize.query(
-//     `
-//       WITH all_expenses AS (
-//         SELECT
-//           e.*,
-//           e.currency != :displayCurrency AS "isConvertedCurrency",
-//           CASE
-//             -- Simple case: expense is already in display currency
-//             WHEN e.currency = :displayCurrency THEN e.amount
-//             -- Convert expense to display currency
-//             ELSE e.amount * COALESCE((
-//                 SELECT rate
-//                 FROM "CurrencyExchangeRates" r
-//                 WHERE r."from" = e.currency
-//                 AND r."to" = :displayCurrency
-//                 AND r."createdAt" <= e."createdAt"
-//                 ORDER BY e."createdAt" DESC -- Most recent rate that is older than the expense
-//                 LIMIT 1
-//               ), (
-//                 -- Fix for old expenses where we didn't have an exchange rate stored yet: just use the oldest rate available
-//                 SELECT rate
-//                 FROM "CurrencyExchangeRates" r
-//                 WHERE r."from" = e.currency
-//                 AND r."to" = :displayCurrency
-//                 ORDER BY e."createdAt" ASC -- Oldest rate
-//                 LIMIT 1
-//             ))
-//             END AS "amountInHostCurrency"
-//         FROM "Expenses" e
-//         WHERE e."deletedAt" IS NULL
-//         AND (e.id IN (:expenseIds) OR e."CollectiveId" IN (:collectiveIds))
-//         ORDER BY e."createdAt" ASC
-//       ), all_expenses_stats AS (
-//         SELECT
-//           "id",
-//           "isConvertedCurrency",
-//           "amountInHostCurrency",
-//           AVG("amountInHostCurrency") FILTER (WHERE status = 'PAID') OVER (PARTITION BY "CollectiveId") AS "averageAmountForCollective",
-//           SUM("amountInHostCurrency") FILTER (WHERE status = 'APPROVED') OVER (PARTITION BY "CollectiveId") AS "totalApprovedAmountForCollective",
-//           COUNT("id") FILTER (WHERE status = 'APPROVED') OVER (PARTITION BY "CollectiveId") AS "totalApprovedCountForCollective",
-//           (SELECT PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY "amountInHostCurrency") FROM all_expenses WHERE "CollectiveId" = e."CollectiveId" AND status = 'PAID') AS "paidAmountP95ForCollective"
-//         FROM all_expenses e
-//       ) SELECT * FROM all_expenses_stats
-//       WHERE id IN (:expenseIds)
-//     `,
-//     {
-//       type: sequelize.QueryTypes.SELECT,
-//       replacements: { displayCurrency, collectiveIds, expenseIds },
-//     },
-//   );
+const getExpensesAmountsStats = async (
+  expenses: Array<Expense>,
+  displayCurrency,
+): Promise<Record<string, ExpenseAmountStats>> => {
+  const collectiveIds = uniq(expenses.map(e => e.CollectiveId));
+  const expenseIds = uniq(expenses.map(e => e.id));
+  const result: Array<ExpenseAmountStats> = await sequelize.query(
+    `
+      WITH all_expenses AS (
+        SELECT
+          e.*,
+          e.currency != :displayCurrency AS "isConvertedCurrency",
+          CASE
+            -- Simple case: expense is already in display currency
+            WHEN e.currency = :displayCurrency THEN e.amount
+            -- Convert expense to display currency
+            ELSE e.amount * COALESCE((
+                SELECT rate
+                FROM "CurrencyExchangeRates" r
+                WHERE r."from" = e.currency
+                AND r."to" = :displayCurrency
+                AND r."createdAt" <= e."createdAt"
+                ORDER BY e."createdAt" DESC -- Most recent rate that is older than the expense
+                LIMIT 1
+              ), (
+                -- Fix for old expenses where we didn't have an exchange rate stored yet: just use the oldest rate available
+                SELECT rate
+                FROM "CurrencyExchangeRates" r
+                WHERE r."from" = e.currency
+                AND r."to" = :displayCurrency
+                ORDER BY e."createdAt" ASC -- Oldest rate
+                LIMIT 1
+            ))
+            END AS "amountInHostCurrency"
+        FROM "Expenses" e
+        WHERE e."deletedAt" IS NULL
+        AND (e.id IN (:expenseIds) OR e."CollectiveId" IN (:collectiveIds))
+        ORDER BY e."createdAt" ASC
+      ), all_expenses_stats AS (
+        SELECT
+          "id",
+          "isConvertedCurrency",
+          "amountInHostCurrency",
+          AVG("amountInHostCurrency") FILTER (WHERE status = 'PAID') OVER (PARTITION BY "CollectiveId") AS "averageAmountForCollective",
+          SUM("amountInHostCurrency") FILTER (WHERE status = 'APPROVED') OVER (PARTITION BY "CollectiveId") AS "totalApprovedAmountForCollective",
+          COUNT("id") FILTER (WHERE status = 'APPROVED') OVER (PARTITION BY "CollectiveId") AS "totalApprovedCountForCollective",
+          (SELECT PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY "amountInHostCurrency") FROM all_expenses WHERE "CollectiveId" = e."CollectiveId" AND status = 'PAID') AS "paidAmountP95ForCollective"
+        FROM all_expenses e
+      ) SELECT * FROM all_expenses_stats
+      WHERE id IN (:expenseIds)
+    `,
+    {
+      type: sequelize.QueryTypes.SELECT,
+      replacements: { displayCurrency, collectiveIds, expenseIds },
+    },
+  );
 
-//   return keyBy(result, 'id');
-// };
+  return keyBy(result, 'id');
+};
 
 /**
  * The currency that needs to be used will depend on the context. Since, for now, we're only
  * displaying these warnings for fiscal hosts, the assumption is that the currency of the
  * host is the one that should be used; regardless of the other expenses in the batch.
  */
-// const getDisplayCurrency = async expenses => {
-//   const host = await expenses[0].collective.getHostCollective();
-//   return host?.currency || expenses[0].collective.currency;
-// };
+const getDisplayCurrency = async expenses => {
+  const host = await expenses[0].collective.getHostCollective();
+  return host?.currency || expenses[0].collective.currency;
+};
 
-// const getCollectiveBalances = async (
-//   req: Request,
-//   expenses: Expense[],
-//   displayCurrency: string,
-// ): Promise<Record<string, { currency: string; value: number }>> => {
-//   const collectiveIds = uniq(expenses.map(e => e.CollectiveId));
-//   const balanceLoader = req.loaders.Collective.balance.buildLoader({ withBlockedFunds: true }); // Use the same loader as https://github.com/opencollective/opencollective-api/blob/main/server/graphql/v2/object/AccountStats.js#L70 to make sure we don't hit the DB twice
-//   const collectiveBalances = await balanceLoader.loadMany(collectiveIds);
-//   const balancesInHostCurrency = await Promise.all(
-//     collectiveBalances.map(async balance => {
-//       if (balance.currency === displayCurrency) {
-//         return balance;
-//       } else {
-//         const convertParams: ConvertToCurrencyArgs = {
-//           amount: balance.value,
-//           fromCurrency: balance.currency,
-//           toCurrency: displayCurrency,
-//         };
-//         return {
-//           value: await req.loaders.CurrencyExchangeRate.convert.load(convertParams),
-//           currency: displayCurrency,
-//         };
-//       }
-//     }),
-//   );
+const getCollectiveBalances = async (
+  req: Request,
+  expenses: Expense[],
+  displayCurrency: string,
+): Promise<Record<string, { currency: string; value: number }>> => {
+  const collectiveIds = uniq(expenses.map(e => e.CollectiveId));
+  const balanceLoader = req.loaders.Collective.balance.buildLoader({ withBlockedFunds: true }); // Use the same loader as https://github.com/opencollective/opencollective-api/blob/main/server/graphql/v2/object/AccountStats.js#L70 to make sure we don't hit the DB twice
+  const collectiveBalances = await balanceLoader.loadMany(collectiveIds);
+  const balancesInHostCurrency = await Promise.all(
+    collectiveBalances.map(async balance => {
+      if (balance.currency === displayCurrency) {
+        return balance;
+      } else {
+        const convertParams: ConvertToCurrencyArgs = {
+          amount: balance.value,
+          fromCurrency: balance.currency,
+          toCurrency: displayCurrency,
+        };
+        return {
+          value: await req.loaders.CurrencyExchangeRate.convert.load(convertParams),
+          currency: displayCurrency,
+        };
+      }
+    }),
+  );
 
-//   return keyBy(balancesInHostCurrency, 'CollectiveId');
-// };
+  return keyBy(balancesInHostCurrency, 'CollectiveId');
+};
 
 export const checkExpensesBatch = async (
   req: Request,
   expenses: Array<Expense>,
 ): Promise<Array<Array<SecurityCheck>>> => {
-  // const displayCurrency = await getDisplayCurrency(expenses);
+  const displayCurrency = await getDisplayCurrency(expenses);
   const expensesStats = await getGroupedExpensesStats(expenses);
-  // const expensesAmountsStats = await getExpensesAmountsStats(expenses, displayCurrency);
-  // const collectiveBalances = await getCollectiveBalances(req, expenses, displayCurrency);
+  const expensesAmountsStats = await getExpensesAmountsStats(expenses, displayCurrency);
+  const collectiveBalances = await getCollectiveBalances(req, expenses, displayCurrency);
   const usersByIpConditions = expenses.map(expense => {
     const ip = expense.User.getLastKnownIp();
     return {
@@ -447,8 +447,8 @@ export const checkExpensesBatch = async (
       }
 
       // Check amounts
-      // const balanceInHostCurrency = collectiveBalances[expense.CollectiveId]?.value || 0;
-      // checkExpenseAmountStats(checks, expensesAmountsStats[expense.id], balanceInHostCurrency, displayCurrency);
+      const balanceInHostCurrency = collectiveBalances[expense.CollectiveId]?.value || 0;
+      checkExpenseAmountStats(checks, expensesAmountsStats[expense.id], balanceInHostCurrency, displayCurrency);
 
       const payoutMethod = expense.PayoutMethod;
       // Add checks on payout method


### PR DESCRIPTION
Revert https://github.com/opencollective/opencollective-api/pull/9135

Planning time: `3.364 ms` => `0.690 ms`
Execution Time: `4187.671 ms` => `14.216 ms`

<details><summary>Details</summary>
<p>

**Before**

```
Subquery Scan on all_expenses_stats  (cost=19906.88..111807.88 rows=362 width=45) (actual time=152.209..4150.911 rows=20 loops=1)
  Filter: (all_expenses_stats.id = ANY ('{146807,146806,146771,146764,146745,146701,146623,146577,146546,146544,146541,146533,146532,146531,146529,146527,146526,146525,146517,146508}'::integer[]))
  Rows Removed by Filter: 3430
  CTE all_expenses
    ->  Sort  (cost=19840.51..19842.32 rows=3622 width=754) (actual time=120.176..120.554 rows=3450 loops=1)
"          Sort Key: e_1.""createdAt"""
          Sort Method: quicksort  Memory: 3424kB
"          ->  Bitmap Heap Scan on ""Expenses"" e_1  (cost=88.65..19797.69 rows=3622 width=754) (actual time=38.290..115.950 rows=3450 loops=1)"
"                Recheck Cond: ((id = ANY ('{146807,146806,146771,146764,146745,146701,146623,146577,146546,146544,146541,146533,146532,146531,146529,146527,146526,146525,146517,146508}'::integer[])) OR ((""CollectiveId"" = ANY ('{524421,524421,497074,244850,554041,471437,529867,643128,580244,111048,207166,428727,100611,221300,566394,566394,566394,566394,645371,560145}'::integer[])) AND (""deletedAt"" IS NULL)))"
"                Filter: (""deletedAt"" IS NULL)"
                Heap Blocks: exact=2586
                ->  BitmapOr  (cost=88.65..88.65 rows=3624 width=0) (actual time=1.158..1.159 rows=0 loops=1)
"                      ->  Bitmap Index Scan on ""Expenses_pkey""  (cost=0.00..41.71 rows=20 width=0) (actual time=0.052..0.052 rows=21 loops=1)"
                            Index Cond: (id = ANY ('{146807,146806,146771,146764,146745,146701,146623,146577,146546,146544,146541,146533,146532,146531,146529,146527,146526,146525,146517,146508}'::integer[]))
                      ->  Bitmap Index Scan on expenses_collective_id  (cost=0.00..46.58 rows=3604 width=0) (actual time=1.105..1.105 rows=3530 loops=1)
"                            Index Cond: (""CollectiveId"" = ANY ('{524421,524421,497074,244850,554041,471437,529867,643128,580244,111048,207166,428727,100611,221300,566394,566394,566394,566394,645371,560145}'::integer[]))"
                SubPlan 1
                  ->  Limit  (cost=0.09..2.11 rows=1 width=16) (actual time=1.199..1.200 rows=1 loops=2)
"                        ->  Index Scan using currency_exchange_rates_from_to_created_at on ""CurrencyExchangeRates"" r  (cost=0.09..395.16 rows=195 width=16) (actual time=1.196..1.196 rows=1 loops=2)"
"                              Index Cond: (((""from"")::text = (e_1.currency)::text) AND ((""to"")::text = 'USD'::text) AND (""createdAt"" <= e_1.""createdAt""))"
                SubPlan 2
                  ->  Limit  (cost=0.09..2.10 rows=1 width=16) (never executed)
"                        ->  Index Scan using currency_exchange_rates_from_to_created_at on ""CurrencyExchangeRates"" r_1  (cost=0.09..1177.00 rows=584 width=16) (never executed)"
"                              Index Cond: (((""from"")::text = (e_1.currency)::text) AND ((""to"")::text = 'USD'::text))"
  ->  WindowAgg  (cost=64.55..91936.58 rows=3622 width=49) (actual time=125.471..4149.445 rows=3450 loops=1)
        ->  Sort  (cost=64.55..66.36 rows=3622 width=533) (actual time=124.656..125.012 rows=3450 loops=1)
"              Sort Key: e.""CollectiveId"""
              Sort Method: quicksort  Memory: 366kB
              ->  CTE Scan on all_expenses e  (cost=0.00..21.73 rows=3622 width=533) (actual time=120.190..124.065 rows=3450 loops=1)
        SubPlan 4
          ->  Aggregate  (cost=25.35..25.36 rows=1 width=8) (actual time=1.164..1.164 rows=1 loops=3450)
                ->  CTE Scan on all_expenses  (cost=0.00..25.35 rows=1 width=8) (actual time=0.113..0.720 rows=985 loops=3450)
"                      Filter: ((""CollectiveId"" = e.""CollectiveId"") AND ((status)::text = 'PAID'::text))"
                      Rows Removed by Filter: 2465
Planning Time: 3.364 ms
JIT:
  Functions: 54
  Options: Inlining false, Optimization false, Expressions true, Deforming true
  Timing: Generation 4.627 ms, Inlining 0.000 ms, Optimization 2.298 ms, Emission 33.797 ms, Total 40.722 ms
Execution Time: 4187.671 ms
```

**After**
```
Hash Left Join  (cost=19927.69..19967.73 rows=362 width=49) (actual time=13.897..13.916 rows=20 loops=1)
"  Hash Cond: (e.""CollectiveId"" = s.""CollectiveId"")"
  CTE all_expenses
    ->  Sort  (cost=19840.51..19842.32 rows=3622 width=754) (actual time=7.791..8.130 rows=3450 loops=1)
"          Sort Key: e_2.""createdAt"""
          Sort Method: quicksort  Memory: 3424kB
"          ->  Bitmap Heap Scan on ""Expenses"" e_2  (cost=88.65..19797.69 rows=3622 width=754) (actual time=0.685..5.492 rows=3450 loops=1)"
"                Recheck Cond: ((id = ANY ('{146807,146806,146771,146764,146745,146701,146623,146577,146546,146544,146541,146533,146532,146531,146529,146527,146526,146525,146517,146508}'::integer[])) OR ((""CollectiveId"" = ANY ('{524421,524421,497074,244850,554041,471437,529867,643128,580244,111048,207166,428727,100611,221300,566394,566394,566394,566394,645371,560145}'::integer[])) AND (""deletedAt"" IS NULL)))"
"                Filter: (""deletedAt"" IS NULL)"
                Heap Blocks: exact=2586
                ->  BitmapOr  (cost=88.65..88.65 rows=3624 width=0) (actual time=0.387..0.388 rows=0 loops=1)
"                      ->  Bitmap Index Scan on ""Expenses_pkey""  (cost=0.00..41.71 rows=20 width=0) (actual time=0.037..0.037 rows=20 loops=1)"
                            Index Cond: (id = ANY ('{146807,146806,146771,146764,146745,146701,146623,146577,146546,146544,146541,146533,146532,146531,146529,146527,146526,146525,146517,146508}'::integer[]))
                      ->  Bitmap Index Scan on expenses_collective_id  (cost=0.00..46.58 rows=3604 width=0) (actual time=0.350..0.350 rows=3530 loops=1)
"                            Index Cond: (""CollectiveId"" = ANY ('{524421,524421,497074,244850,554041,471437,529867,643128,580244,111048,207166,428727,100611,221300,566394,566394,566394,566394,645371,560145}'::integer[]))"
                SubPlan 1
                  ->  Limit  (cost=0.09..2.11 rows=1 width=16) (actual time=0.029..0.030 rows=1 loops=2)
"                        ->  Index Scan using currency_exchange_rates_from_to_created_at on ""CurrencyExchangeRates"" r  (cost=0.09..395.16 rows=195 width=16) (actual time=0.027..0.027 rows=1 loops=2)"
"                              Index Cond: (((""from"")::text = (e_2.currency)::text) AND ((""to"")::text = 'USD'::text) AND (""createdAt"" <= e_2.""createdAt""))"
                SubPlan 2
                  ->  Limit  (cost=0.09..2.10 rows=1 width=16) (never executed)
"                        ->  Index Scan using currency_exchange_rates_from_to_created_at on ""CurrencyExchangeRates"" r_1  (cost=0.09..1177.00 rows=584 width=16) (never executed)"
"                              Index Cond: (((""from"")::text = (e_2.currency)::text) AND ((""to"")::text = 'USD'::text))"
  ->  CTE Scan on all_expenses e  (cost=0.00..39.84 rows=362 width=17) (actual time=11.074..11.081 rows=20 loops=1)
        Filter: (id = ANY ('{146807,146806,146771,146764,146745,146701,146623,146577,146546,146544,146541,146533,146532,146531,146529,146527,146526,146525,146517,146508}'::integer[]))
        Rows Removed by Filter: 3430
  ->  Hash  (cost=84.66..84.66 rows=200 width=36) (actual time=2.813..2.814 rows=16 loops=1)
        Buckets: 1024  Batches: 1  Memory Usage: 10kB
        ->  Subquery Scan on s  (cost=64.55..84.66 rows=200 width=36) (actual time=1.626..2.808 rows=16 loops=1)
              ->  GroupAggregate  (cost=64.55..84.06 rows=200 width=36) (actual time=1.625..2.805 rows=16 loops=1)
"                    Group Key: e_1.""CollectiveId"""
                    ->  Sort  (cost=64.55..66.36 rows=3622 width=532) (actual time=1.589..1.747 rows=3450 loops=1)
"                          Sort Key: e_1.""CollectiveId"""
                          Sort Method: quicksort  Memory: 366kB
                          ->  CTE Scan on all_expenses e_1  (cost=0.00..21.73 rows=3622 width=532) (actual time=0.003..1.083 rows=3450 loops=1)
                    SubPlan 4
                      ->  Result  (cost=0.00..0.00 rows=1 width=8) (actual time=0.000..0.000 rows=1 loops=16)
Planning Time: 0.690 ms
Execution Time: 14.216 ms
```

</p>
</details> 