### PR TITLE
Add stripe username to connected account graphql schema

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -4785,6 +4785,7 @@ type TimeSeriesAmountWithKindNode {
 Stripe connected account properties
 """
 type StripeConnectedAccount {
+  username: String
   issuingBalance: Amount
 }
 

--- a/server/graphql/v2/object/StripeConnectedAccount.ts
+++ b/server/graphql/v2/object/StripeConnectedAccount.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType } from 'graphql';
+import { GraphQLObjectType, GraphQLString } from 'graphql';
 
 import { reportErrorToSentry } from '../../../lib/sentry';
 import stripe from '../../../lib/stripe';
@@ -10,6 +10,9 @@ export const GraphQLStripeConnectedAccount = new GraphQLObjectType({
   name: 'StripeConnectedAccount',
   description: 'Stripe connected account properties',
   fields: () => ({
+    username: {
+      type: GraphQLString,
+    },
     issuingBalance: {
       type: GraphQLAmount,
       async resolve(connectedAccount: ConnectedAccount) {


### PR DESCRIPTION
Used to generate links to correct stripe accounts in frontend.

Related: https://github.com/opencollective/opencollective-frontend/pull/9037