### PR TITLE
Sentry: Improve config & handlers

### DIFF
--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -564,6 +564,7 @@ export const redactSensitiveFields = fastRedact({
     'AUTHORIZATION',
     'token',
     'accessToken',
+    'access_token',
     'refreshToken',
     '["Personal-Token"]',
     'password',

--- a/server/middleware/error_handler.js
+++ b/server/middleware/error_handler.js
@@ -62,14 +62,7 @@ export default (err, req, res, next) => {
     try {
       reportErrorToSentry(err, {
         handler: HandlerType.EXPRESS,
-        user: req?.remoteUser,
-        extra: req && {
-          method: req.method,
-          url: req.url,
-          query: req.query,
-          body: req.body,
-          headers: req.headers,
-        },
+        req,
       });
     } catch (e) {
       // Ignore errors from Sentry reporting to make sure we keep returning a real error

--- a/test/server/lib/sentry.test.ts
+++ b/test/server/lib/sentry.test.ts
@@ -1,3 +1,4 @@
+import { BaseContext, GraphQLRequestContext } from '@apollo/server';
 import * as Sentry from '@sentry/node';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -17,50 +18,16 @@ describe('server/lib/sentry', () => {
   });
 
   describe('SentryGraphQLPlugin', () => {
-    it('should create SPANs for each resolver', () => {
-      const transaction = Sentry.startTransaction({ name: 'test' });
-      const startChildSpy = sandbox.spy(transaction, 'startChild');
-      sandbox.stub(Sentry, 'getCurrentHub').returns({
-        getScope: () => ({
-          getTransaction: () => transaction,
-        }),
-      });
-
-      const req = makeRequest();
-      req.operationName = 'test';
-      const context = SentryLib.SentryGraphQLPlugin.requestDidStart({
-        request: req,
-        forceSampling: true,
-      }).executionDidStart();
-      context.willResolveField({ info: { parentType: { name: 'Account' }, fieldName: 'name' } })?.();
-      context.willResolveField({ info: { parentType: { name: 'Expense' }, fieldName: 'description' } })?.();
-      expect(startChildSpy).to.have.been.calledTwice;
-      expect(startChildSpy.firstCall.args[0]).to.deep.equal({
-        op: 'resolver',
-        description: 'Account.name',
-      });
-      expect(startChildSpy.secondCall.args[0]).to.deep.equal({
-        op: 'resolver',
-        description: 'Expense.description',
-      });
-    });
-
-    it('should create a new transaction if not available', () => {
-      const req = makeRequest();
-      req.operationName = 'test';
-      const startTransactionSpy = sandbox.spy(Sentry, 'startTransaction');
-      SentryLib.SentryGraphQLPlugin.requestDidStart({ request: req, forceSampling: true }).executionDidStart();
-      expect(startTransactionSpy).to.have.been.calledOnce;
-    });
-
-    it('should report errors', () => {
+    it('should report errors', async () => {
       const req = makeRequest();
       req.query = 'query { test }';
       req.variables = { test: 'test' };
 
-      const context = SentryLib.SentryGraphQLPlugin.requestDidStart({ request: req, forceSampling: true });
+      const context = await SentryLib.SentryGraphQLPlugin.requestDidStart({
+        request: req,
+      } as unknown as GraphQLRequestContext<BaseContext>);
       const captureExceptionSpy = sandbox.spy(Sentry, 'captureException');
-      context.didEncounterErrors({
+      context['didEncounterErrors']({
         operation: {},
         errors: [{ message: 'Test error 1' }, { message: 'Test error 2' }],
         contextValue: {},
@@ -71,14 +38,16 @@ describe('server/lib/sentry', () => {
       expect(captureExceptionSpy.secondCall.args[0]).to.deep.equal({ message: 'Test error 2' });
     });
 
-    it('should not report errors that are ignored', () => {
+    it('should not report errors that are ignored', async () => {
       const req = makeRequest();
       req.query = 'query { test }';
       req.variables = { test: 'test' };
 
-      const context = SentryLib.SentryGraphQLPlugin.requestDidStart({ request: req, forceSampling: true });
+      const context = await SentryLib.SentryGraphQLPlugin.requestDidStart({
+        request: req,
+      } as unknown as GraphQLRequestContext<BaseContext>);
       const captureExceptionSpy = sandbox.spy(Sentry, 'captureException');
-      context.didEncounterErrors({
+      context['didEncounterErrors']({
         operation: {},
         errors: [{ extensions: { code: 'IGNORED' } }, { path: ['account'], message: 'No collective found' }],
         contextValue: {},


### PR DESCRIPTION
- Pass request data with `scope.setSDKProcessingMetadata({ request: req })` => This was taken from default Sentry's handlers to make sure the request is being treated as such (rather than being interpreted as `extra` fields).
- Sanitize query parameters (they were previously not)
- Remove all code related to Sentry tracing
- Automatically set `user` from `req`
- Type Sentry GraphQL plugin