### PR TITLE
Only fiscal-host created pending orders should be editable

### DIFF
--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -1068,6 +1068,9 @@ const orderMutations = {
         throw new Unauthorized('Only host admins can edit pending orders');
       }
 
+      if (order.data?.isPendingContribution !== true) {
+        throw new ValidationFailed(`Only pending contributions created by fiscal-host admins can be editted`);
+      }
       if (!(await canEdit(req, order))) {
         throw new ValidationFailed(`Only pending orders can be edited, this one is ${order.status}`);
       }

--- a/server/graphql/v2/object/OrderPermissions.ts
+++ b/server/graphql/v2/object/OrderPermissions.ts
@@ -23,7 +23,7 @@ export const canMarkAsExpired = async (req: express.Request, order): Promise<boo
 };
 
 export const canEdit = async (req: express.Request, order): Promise<boolean> => {
-  return order.status === ORDER_STATUS.PENDING && isHostAdmin(req, order);
+  return order.status === ORDER_STATUS.PENDING && isHostAdmin(req, order) && order.data?.isPendingContribution;
 };
 
 export const canSeeOrderPrivateActivities = async (req: express.Request, order): Promise<boolean> => {

--- a/server/graphql/v2/object/OrderPermissions.ts
+++ b/server/graphql/v2/object/OrderPermissions.ts
@@ -23,7 +23,7 @@ export const canMarkAsExpired = async (req: express.Request, order): Promise<boo
 };
 
 export const canEdit = async (req: express.Request, order): Promise<boolean> => {
-  return order.status === ORDER_STATUS.PENDING && isHostAdmin(req, order) && order.data?.isPendingContribution;
+  return order.status === ORDER_STATUS.PENDING && order.data?.isPendingContribution && (await isHostAdmin(req, order));
 };
 
 export const canSeeOrderPrivateActivities = async (req: express.Request, order): Promise<boolean> => {


### PR DESCRIPTION
Fiscal Host admins shouldn't use this flow to temper with user-created manual contributions.