### PR TITLE
Add Contact Form Link to Contact Host

### DIFF
--- a/templates/emails/collective.apply.foundation.hbs
+++ b/templates/emails/collective.apply.foundation.hbs
@@ -10,7 +10,7 @@ Subject: Thanks for applying to {{{host.name}}}
 In the meantime, <a href="https://docs.opencollective.foundation"> our documentation</a> 
 has answers to many common questions.</p>
 
-<p>Feel free to respond to this email if you need to ask us anything.</p>
+<p>Feel free to <a href="https://opencollective.com/{{host.slug}}/contact">contact</a> if you need to ask us anything.</p>
 
 <p>– {{host.name}}</p>
 


### PR DESCRIPTION
Relate to the freshdesk ticket; https://opencollective.freshdesk.com/a/tickets/228742

This email `from` address is a no-reply and hence the user would not be able to contact. This fix makes sure we forward the user to the OCF contact form. 