### PR TITLE
Sentry: log errors in console if not configured

### DIFF
--- a/test/server/lib/sentry.test.ts
+++ b/test/server/lib/sentry.test.ts
@@ -1,6 +1,7 @@
 import { BaseContext, GraphQLRequestContext } from '@apollo/server';
 import * as Sentry from '@sentry/node';
 import { expect } from 'chai';
+import config from 'config';
 import sinon from 'sinon';
 
 import * as SentryLib from '../../../server/lib/sentry';
@@ -11,6 +12,7 @@ describe('server/lib/sentry', () => {
 
   before(() => {
     sandbox = sinon.createSandbox();
+    sandbox.stub(config, 'sentry').value({ dsn: 'https://sentry.io/123' });
   });
 
   afterEach(() => {


### PR DESCRIPTION
In many places, we now use Sentry as the default error-logging mechanism. It's still interesting to see those in the console if Sentry is not configured (mostly, in development). This will also help developers to make sure they properly format Sentry errors.