### PR TITLE
Support multiple files in `uploadFile` mutation

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -14605,20 +14605,10 @@ type Mutation {
   deleteUpdate(id: String!): Update!
   uploadFile(
     """
-    The file to upload
+    The files to upload
     """
-    file: Upload!
-
-    """
-    The kind of file to uploaded
-    """
-    kind: UploadedFileKind!
-
-    """
-    Whether to run OCR on the document. Note that this feature is only available to selected accounts.
-    """
-    parseDocument: Boolean! = false
-  ): UploadFileResult!
+    files: [UploadFileInput!]!
+  ): [UploadFileResult!]!
 
   """
   Assign Virtual Card information to existing hosted collective. Scope: "virtualCards".
@@ -16515,6 +16505,23 @@ type ExpenseParsedFileInfo {
 A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
 """
 scalar Date
+
+input UploadFileInput {
+  """
+  The file to upload
+  """
+  file: Upload!
+
+  """
+  The kind of file to uploaded
+  """
+  kind: UploadedFileKind!
+
+  """
+  Whether to run OCR on the document. Note that this feature is only available to selected accounts.
+  """
+  parseDocument: Boolean! = false
+}
 
 """
 The `Upload` scalar type represents a file upload.

--- a/server/graphql/v2/input/UploadFileInput.ts
+++ b/server/graphql/v2/input/UploadFileInput.ts
@@ -1,0 +1,23 @@
+import { GraphQLBoolean, GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
+import GraphQLUpload from 'graphql-upload/GraphQLUpload.js';
+
+import { GraphQLUploadedFileKind } from '../enum';
+
+export const GraphQLUploadFileInput = new GraphQLInputObjectType({
+  name: 'UploadFileInput',
+  fields: () => ({
+    file: {
+      type: new GraphQLNonNull(GraphQLUpload),
+      description: 'The file to upload',
+    },
+    kind: {
+      type: new GraphQLNonNull(GraphQLUploadedFileKind),
+      description: 'The kind of file to uploaded',
+    },
+    parseDocument: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether to run OCR on the document. Note that this feature is only available to selected accounts.',
+      defaultValue: false,
+    },
+  }),
+});


### PR DESCRIPTION
Related: https://github.com/opencollective/opencollective/issues/5105

I may refactor this later given that Klippa seems to support sending multiple files at once, just trying to make the GraphQL API right for now.