### PR TITLE
Fix incognito profile retrieval for remote user

### DIFF
--- a/server/middleware/authentication.js
+++ b/server/middleware/authentication.js
@@ -136,7 +136,7 @@ const checkJwtScope = req => {
 const _authenticateUserByJwt = async (req, res, next) => {
   const userId = Number(req.jwtPayload.sub);
   const user = await User.findByPk(userId, {
-    include: [{ association: 'collective', required: false, attributes: ['id'] }],
+    include: [{ association: 'collective', required: false }],
   });
   if (!user) {
     logger.warn(`User id ${userId} not found`);


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6914

This `attributes` resulted in `req.remoteUser` being partially fetched, thus not resolving the `getIncognitoProfile` correctly in some cases