### PR TITLE
Fix processExpense comment to not trigger any state change

### DIFF
--- a/server/graphql/common/comment.ts
+++ b/server/graphql/common/comment.ts
@@ -87,7 +87,7 @@ async function deleteComment(id: number, req): Promise<void> {
   return comment.destroy();
 }
 
-async function createComment(commentData, req): Promise<Comment> {
+async function createComment(commentData, req, options?: { triggerStatusChange?: boolean }): Promise<Comment> {
   const { remoteUser } = req;
   mustBeLoggedInTo(remoteUser, 'create a comment');
 
@@ -165,7 +165,11 @@ async function createComment(commentData, req): Promise<Comment> {
 
   if (ExpenseId) {
     const expense = commentedEntity as Expense;
-    if (remoteUser.isAdmin(expense.FromCollectiveId) && expense?.status === ExpenseStatus.INCOMPLETE) {
+    if (
+      options?.triggerStatusChange !== false &&
+      remoteUser.isAdmin(expense.FromCollectiveId) &&
+      expense?.status === ExpenseStatus.INCOMPLETE
+    ) {
       await expense.update({ status: ExpenseStatus.APPROVED });
       await expense.createActivity(ActivityTypes.COLLECTIVE_EXPENSE_APPROVED);
     }

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -354,6 +354,7 @@ const expenseMutations = {
             type: ['HOLD', 'RELEASE'].includes(args.action) ? CommentType.PRIVATE_NOTE : CommentType.COMMENT,
           },
           req,
+          { triggerStatusChange: false },
         );
       }
 

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -274,6 +274,7 @@ models.Expense.belongsTo(models.RecurringExpense, {
 });
 models.Expense.hasMany(models.ExpenseAttachedFile, { as: 'attachedFiles' });
 models.Expense.hasMany(models.ExpenseItem, { as: 'items' });
+models.Expense.hasMany(models.Comment, { as: 'comments' });
 models.Expense.hasMany(models.Transaction);
 models.Expense.hasMany(models.Activity, { as: 'activities' });
 models.Transaction.belongsTo(models.Expense);


### PR DESCRIPTION
Fix known edge-case bug where the collective admin can not mark an expense as incomplete.