### PR TITLE
Migrate wrongly encoded S3 keys

### DIFF
--- a/scripts/fixes/s3-uploaded-files-url-encode.ts
+++ b/scripts/fixes/s3-uploaded-files-url-encode.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env ./node_modules/.bin/babel-node
+import '../../server/env';
+
+import { moveFileInS3 } from '../../server/lib/awsS3';
+import { parseToBoolean } from '../../server/lib/utils';
+import { sequelize } from '../../server/models';
+
+const IS_DRY = !process.env.DRY ? true : parseToBoolean(process.env.DRY);
+
+const migrate = async () => {
+  const files = await sequelize.query(
+    `
+    SELECT "id", "url"
+    FROM "UploadedFiles"
+    WHERE "createdAt" BETWEEN '2023-08-22 13:04:59 UTC' AND '2023-08-22 23:58:42 UTC'
+    AND TRUE = FALSE -- Uncomment to enable script, added to prevent double run, which would corrupt the URLs
+    ORDER BY id DESC
+  `,
+    {
+      type: sequelize.QueryTypes.SELECT,
+    },
+  );
+  for (const file of files) {
+    const key = file.url.replace('https://opencollective-production.s3.us-west-1.amazonaws.com/', '');
+    const keyParts = key.split('/');
+    const lastKeyPart = keyParts.pop();
+    const newKey = [...keyParts, decodeURIComponent(lastKeyPart)].join('/');
+    const corruptedKey = [...keyParts, encodeURIComponent(lastKeyPart)].join('/');
+    const currentURL = `https://opencollective-production.s3.us-west-1.amazonaws.com/${corruptedKey}`;
+    if (key !== newKey) {
+      console.log(`File: ${file.id}`);
+      console.log(`File URL: ${file.url}`);
+      console.log(`Actual URL: ${currentURL}`);
+      console.log(`Key: ${key}`);
+      console.log(`New: ${newKey}`);
+      if (!IS_DRY) {
+        await moveFileInS3(currentURL, newKey, { ACL: 'public-read' });
+        console.log(`File moved to ${file.url}`);
+      }
+      console.log('---');
+    }
+  }
+};
+
+const main = async () => {
+  return migrate();
+};
+
+main()
+  .then(() => process.exit())
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/server/lib/awsS3.ts
+++ b/server/lib/awsS3.ts
@@ -180,11 +180,12 @@ export const trashFileFromS3 = async (s3Url: string, trashType: TrashType): Prom
 
 /**
  * Restore the file from the trash folder to its original location.
+ * Remember to specify the `ACL` to `public-read` if you want the file to be public.
  */
-export const restoreFileFromS3Trash = (s3Url: string, trashType: TrashType): Promise<void> => {
+export const restoreFileFromS3Trash = (s3Url: string, trashType: TrashType, acl: string): Promise<void> => {
   const { key } = parseS3Url(s3Url);
   const originalKey = key.replace(new RegExp(`^${S3_TRASH_PREFIX}${trashType}/`), '');
-  return moveFileInS3(s3Url, originalKey, { StorageClass: 'STANDARD' });
+  return moveFileInS3(s3Url, originalKey, { StorageClass: 'STANDARD', ACL: acl });
 };
 
 export const checkS3Configured = (): boolean => Boolean(s3);


### PR DESCRIPTION
Follow up on https://github.com/opencollective/opencollective-api/pull/9274

The script already ran, do not run again or it will corrupt the files.