### PR TITLE
Add unique index to CollectiveOrderStats materialized view

### DIFF
--- a/migrations/20230823105600-fix-collective-order-stats-materialized-view-index.js
+++ b/migrations/20230823105600-fix-collective-order-stats-materialized-view-index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`DROP INDEX CONCURRENTLY IF EXISTS "collective_order_stats__collectiveid";`);
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX "collective_order_stats__collectiveid" ON "CollectiveOrderStats"("CollectiveId");
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`DROP INDEX CONCURRENTLY IF EXISTS "collective_order_stats__collectiveid";`);
+    await queryInterface.sequelize.query(`
+      CREATE INDEX "collective_order_stats__collectiveid" ON "CollectiveOrderStats"("CollectiveId");
+    `);
+  },
+};


### PR DESCRIPTION
Should be enough to fix the refresh script error:
![image](https://github.com/opencollective/opencollective-api/assets/2119706/e76fcb18-d872-43c3-b753-0c4c82bd249e)
