### PR TITLE
Filter null UserId from Expense.approvedBy

### DIFF
--- a/server/graphql/v2/object/Expense.ts
+++ b/server/graphql/v2/object/Expense.ts
@@ -203,7 +203,7 @@ const GraphQLExpense = new GraphQLObjectType<ExpenseModel, express.Request>({
               ].includes(a.type),
           ).filter(a => a.type === ActivityTypes.COLLECTIVE_EXPENSE_APPROVED);
 
-          const approvingUserIds = uniq(approvalActivitiesSinceLastUnapprovedState.map(a => a.UserId));
+          const approvingUserIds = uniq(approvalActivitiesSinceLastUnapprovedState.map(a => a.UserId)).filter(id => id);
 
           if (approvingUserIds.length === 0) {
             return [];

--- a/test/server/graphql/v2/object/Expense.test.ts
+++ b/test/server/graphql/v2/object/Expense.test.ts
@@ -27,6 +27,7 @@ describe('server/graphql/v2/object/Expense', () => {
       await fakeActivity({ ExpenseId: expense.id, UserId: user1.id, type: ActivityTypes.COLLECTIVE_EXPENSE_APPROVED });
       await fakeActivity({ ExpenseId: expense.id, UserId: user2.id, type: ActivityTypes.COLLECTIVE_EXPENSE_APPROVED });
       await fakeActivity({ ExpenseId: expense.id, UserId: user3.id, type: ActivityTypes.COLLECTIVE_EXPENSE_APPROVED });
+      await fakeActivity({ ExpenseId: expense.id, UserId: null, type: ActivityTypes.COLLECTIVE_EXPENSE_APPROVED });
 
       const result = await graphqlQueryV2(expenseQuery, { id: expense.id });
       expect(result.data.expense.approvedBy.length).to.eql(3);


### PR DESCRIPTION
When an expense is re-approved by the platform after the submitter comments on a incomplete expense, the approval activity contains a null UserId.

Reported on slack: https://opencollective.slack.com/archives/C0HSLRNVC/p1692970040254069