### PR TITLE
Fix(host.hostApplications): Don't return applications with deleted accounts

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -349,7 +349,7 @@ export const GraphQLHost = new GraphQLObjectType({
               {
                 model: models.Collective,
                 as: 'collective',
-                ...(searchTermConditions.length && { where: { [Op.or]: searchTermConditions } }),
+                where: { deletedAt: null, ...(searchTermConditions.length && { [Op.or]: searchTermConditions }) },
               },
             ],
           });

--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -349,7 +349,8 @@ export const GraphQLHost = new GraphQLObjectType({
               {
                 model: models.Collective,
                 as: 'collective',
-                where: { deletedAt: null, ...(searchTermConditions.length && { [Op.or]: searchTermConditions }) },
+                required: true,
+                ...(searchTermConditions.length && { where: { [Op.or]: searchTermConditions } }),
               },
             ],
           });


### PR DESCRIPTION
Follow up fix for https://github.com/opencollective/opencollective-api/pull/9271.

### Description
Detected issue on staging where the hostApplications resolver was returning applications where the account was deleted  resulting in a GraphQL error violating the non-null constraint for account on host applications.

This fix makes sure to only return host applications where the collective/account is not deleted.