### PR TITLE
Twitter: Change strategy for legacy accounts

### DIFF
--- a/migrations/20230831084917-twitter-archied-accounts-strategy.js
+++ b/migrations/20230831084917-twitter-archied-accounts-strategy.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE
+        "ConnectedAccounts"
+      SET
+        "deletedAt" = NULL,
+        "settings" = JSONB_SET("data", '{needsReconnect}', 'true')
+      WHERE
+        "service" = 'twitter'
+        AND "deletedAt" IS NOT NULL
+        AND "data"->>'isArchivedLegacyTwitterOAuth' = 'true'
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE
+        "ConnectedAccounts"
+      SET
+        "deletedAt" = NOW(),
+        "settings" = JSONB_SET("data", '{needsReconnect}', 'false')
+      WHERE
+        "service" = 'twitter'
+        AND "deletedAt" IS NULL
+        AND "settings"->>'isArchivedLegacyTwitterOAuth' = 'true'
+    `);
+  },
+};

--- a/server/lib/twitter.ts
+++ b/server/lib/twitter.ts
@@ -91,18 +91,7 @@ const tweetActivity = async activity => {
 type TweetParams = Partial<Parameters<TwitterApi['v2']['tweet']>[0]>;
 
 const getClientFromConnectedAccount = (twitterAccount): TwitterApi => {
-  return new TwitterApi(
-    twitterAccount.clientId
-      ? // OAuth V1
-        {
-          appKey: get(config, 'twitter.consumerKey'),
-          appSecret: get(config, 'twitter.consumerSecret'),
-          accessToken: twitterAccount.clientId,
-          accessSecret: twitterAccount.token,
-        }
-      : // OAuth V2
-        twitterAccount.token,
-  );
+  return new TwitterApi(twitterAccount.token);
 };
 
 const tweetStatus = async (
@@ -124,7 +113,7 @@ const tweetStatus = async (
   debug('tweeting status: ', status, 'with options:', options);
 
   if (twitterAccount.clientId) {
-    logger.info(`Tweet not sent for ${twitterAccount.username}: Using legacy OAuth1.0 credentials`);
+    logger.debug(`Tweet not sent for ${twitterAccount.username}: Using legacy OAuth1.0 credentials`);
   } else if (!get(config, 'twitter.disable')) {
     try {
       const client = getClientFromConnectedAccount(twitterAccount);


### PR DESCRIPTION
Rather than deleting, we're going to pass a flag in the frontend that will let us show a warning in the frontend while making sure that settings are preserved for the connected account.