### PR TITLE
Add graceful failure when OCR times out

### DIFF
--- a/migrations/20230901113059-fix-ocr-exection-time.js
+++ b/migrations/20230901113059-fix-ocr-exection-time.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // Divide executionTime by 1000 x 1000 as it was wrongly multiplied by 1000 instead of divided
+    await queryInterface.sequelize.query(`
+      UPDATE "UploadedFiles"
+      SET "data" = JSONB_SET(
+        "data",
+        '{ocrData,executionTime}',
+        (("data"->'ocrData'->>'executionTime')::float / 1000 / 1000)::text::jsonb
+      )
+      WHERE "data"->'ocrData'->'executionTime' IS NOT NULL
+    `);
+  },
+
+  async down(queryInterface) {
+    // Multiply executionTime by 1000 x 1000 as it was wrongly divided by 1000 instead of multiplied
+    await queryInterface.sequelize.query(`
+      UPDATE "UploadedFiles"
+      SET "data" = JSONB_SET(
+        "data",
+        '{ocrData,executionTime}',
+        (("data"->'ocrData'->>'executionTime')::float * 1000 * 1000)::text::jsonb
+      )
+      WHERE "data"->'ocrData'->'executionTime' IS NOT NULL
+    `);
+  },
+};

--- a/server/graphql/v2/mutation/UploadedFileMutations.ts
+++ b/server/graphql/v2/mutation/UploadedFileMutations.ts
@@ -70,8 +70,8 @@ const uploadedFileMutations = {
           const result: UploadFileResult = { file: null, parsingResult: null };
           result.file = await models.UploadedFile.uploadGraphQl(await file, kind, req.remoteUser);
           const uploadDuration = (performance.now() - uploadStart) / 1000.0;
-          const timeLeftForParsing = 25e3 - uploadDuration; // GraphQL queries timeout after 25s.
-          if (parseDocument && timeLeftForParsing > 2000e3) {
+          const timeLeftForParsing = 25e3 - uploadDuration; // GraphQL queries timeout after 25s
+          if (parseDocument && timeLeftForParsing > 2e3) {
             result.parsingResult = await runOCRForExpenseFile(parser, result.file, { timeoutInMs: timeLeftForParsing });
           }
 

--- a/server/graphql/v2/mutation/UploadedFileMutations.ts
+++ b/server/graphql/v2/mutation/UploadedFileMutations.ts
@@ -66,10 +66,13 @@ const uploadedFileMutations = {
       const parser = useOCR ? getExpenseOCRParser(req.remoteUser) : null;
       return Promise.all(
         args.files.map(async ({ file, kind, parseDocument }) => {
+          const uploadStart = performance.now();
           const result: UploadFileResult = { file: null, parsingResult: null };
           result.file = await models.UploadedFile.uploadGraphQl(await file, kind, req.remoteUser);
-          if (parseDocument) {
-            result.parsingResult = await runOCRForExpenseFile(parser, result.file);
+          const uploadDuration = (performance.now() - uploadStart) / 1000.0;
+          const timeLeftForParsing = 25e3 - uploadDuration; // GraphQL queries timeout after 25s.
+          if (parseDocument && timeLeftForParsing > 2000e3) {
+            result.parsingResult = await runOCRForExpenseFile(parser, result.file, { timeoutInMs: timeLeftForParsing });
           }
 
           return result;

--- a/server/lib/ocr/index.ts
+++ b/server/lib/ocr/index.ts
@@ -33,7 +33,7 @@ const processFile = async (parser: ExpenseOCRService, uploadedFile: UploadedFile
         parser: parser.PARSER_ID,
         type: 'Expense',
         result,
-        executionTime: (end - start) * 1000,
+        executionTime: (end - start) / 1000, // Convert MS to seconds
       },
     },
   });

--- a/test/server/graphql/v2/mutation/UploadedFileMutations.test.ts
+++ b/test/server/graphql/v2/mutation/UploadedFileMutations.test.ts
@@ -125,8 +125,9 @@ describe('server/graphql/v2/mutation/UploadedFileMutations', () => {
         const user = await fakeUser();
         const args = { files: [{ kind: 'EXPENSE_ITEM', file: getMockFileUpload(), parseDocument: true }] };
         const result = await graphqlQueryV2(uploadFileMutation, args, user);
-        expect(uploadToS3Stub.callCount).to.eq(1);
+        result.errors && console.error(result.errors);
         expect(result.errors).to.not.exist;
+        expect(uploadToS3Stub.callCount).to.eq(1);
         expect(result.data.uploadFile[0].parsingResult).to.deep.eq({
           success: false,
           message: 'Could not parse document: OCR parsing failed on purpose for test',
@@ -140,6 +141,7 @@ describe('server/graphql/v2/mutation/UploadedFileMutations', () => {
           const user = await fakeUser();
           const args = { files: [{ kind: 'EXPENSE_ITEM', file: getMockFileUpload(), parseDocument: true }] };
           const result = await graphqlQueryV2(uploadFileMutation, args, user);
+          result.errors && console.error(result.errors);
           expect(result.errors).to.not.exist;
           expect(uploadToS3Stub.callCount).to.eq(1);
           expect(result.data.uploadFile[0].parsingResult).to.not.be.null;

--- a/test/server/lib/ocr/index.test.ts
+++ b/test/server/lib/ocr/index.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+
+import { runOCRForExpenseFile } from '../../../../server/lib/ocr';
+import { ExpenseOCRService } from '../../../../server/lib/ocr/ExpenseOCRService';
+import { fakeUploadedFile } from '../../../test-helpers/fake-data';
+
+describe('server/lib/ocr/index.ts', () => {
+  describe('runOCRForExpenseFile', () => {
+    it('gracefully fails if there is a timeout', async () => {
+      const parser = { processUrl: () => new Promise(() => {}) } as unknown as ExpenseOCRService; // A promise that will never resolve
+      const file = await fakeUploadedFile();
+      const result = await runOCRForExpenseFile(parser, file, { timeoutInMs: 1 });
+      expect(result).to.containSubset({
+        success: false,
+        message: 'OCR parsing timed out',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/6865

This will ensure the upload mutation doesn't fail while also making sure we continue to store the result in DB.