### PR TITLE
Remove filename from S3 meta

### DIFF
--- a/server/models/UploadedFile.ts
+++ b/server/models/UploadedFile.ts
@@ -162,7 +162,6 @@ class UploadedFile extends Model<InferAttributes<UploadedFile>, InferCreationAtt
       Metadata: {
         CreatedByUserId: `${user?.id}`,
         FileKind: kind,
-        FileName: fileName,
       },
     };
 


### PR DESCRIPTION
S3 does not like special characters in meta, so it rejects the meta: https://open-collective.sentry.io/issues/4431729154/