### PR TITLE
Fix(HostApplications): Only return applications where the associated account has correct HostCollectiveId

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -350,7 +350,11 @@ export const GraphQLHost = new GraphQLObjectType({
                 model: models.Collective,
                 as: 'collective',
                 required: true,
-                ...(searchTermConditions.length && { where: { [Op.or]: searchTermConditions } }),
+                where: {
+                  HostCollectiveId: host.id,
+                  ...(args.status === 'PENDING' && { approvedAt: null }),
+                  ...(searchTermConditions.length && { [Op.or]: searchTermConditions }),
+                },
               },
             ],
           });


### PR DESCRIPTION
Fix to only return applications where the associated collective also has correct HostCollectiveId. 

Also adds a check to see if approvedAt on the Collective is null when filtering on "PENDING", found two instances where there was a "PENDING" application to OSC but the Collective was already approved.