### PR TITLE
Fix daily stats for Host metrics

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -74,7 +74,11 @@ const getFilterDateRange = (startDate, endDate) => {
 };
 
 const getNumberOfDays = (startDate, endDate, host) => {
-  return Math.abs(moment(startDate || host.createdAt).diff(moment(endDate), 'days'));
+  const momentStartDate = startDate && moment(startDate);
+  const momentCreated = moment(host.createdAt);
+  const momentFrom = momentStartDate?.isAfter(momentCreated) ? momentStartDate : momentCreated; // We bound the date range to the host creation date
+  const momentTo = moment(endDate || undefined); // Defaults to Today
+  return Math.abs(momentFrom.diff(momentTo, 'days'));
 };
 
 const getTimeUnit = numberOfDays => {


### PR DESCRIPTION
Two fixes for host metrics:
- Fix number of days when the `endDate` is not set (which defaults to "today")
- Fix stats for newly created hosts, when looking at the stats for the first year (startDate < host.createdAt)