### PR TITLE
Expense: Edit submit-on-behalf Draft

### DIFF
--- a/server/models/RecurringExpense.ts
+++ b/server/models/RecurringExpense.ts
@@ -71,6 +71,8 @@ export class RecurringExpense extends Model<RecurringExpenseAttributes, Recurrin
 
     const draftKey = process.env.OC_ENV === 'e2e' || process.env.OC_ENV === 'ci' ? 'draft-key' : uuid();
     const expenseFields = [
+      'amount',
+      'currency',
       'description',
       'longDescription',
       'tags',
@@ -90,8 +92,6 @@ export class RecurringExpense extends Model<RecurringExpenseAttributes, Recurrin
       CollectiveId: this.CollectiveId,
       lastEditedById: expense.UserId,
       incurredAt,
-      amount: expense.amount,
-      currency: expense.currency,
       data: {
         items: expense.items?.map(item => ({ ...pick(item, ['amount', 'description', 'url']), incurredAt })),
         payee: { id: expense.FromCollectiveId },

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -705,86 +705,133 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
       expect(result.data.editExpense.payeeLocation).to.deep.equal(updatedExpenseData.payeeLocation);
     });
 
-    it('lets another user edit and submit a draft if the right key is provided', async () => {
-      const collective = await fakeCollective({ currency: 'EUR', settings: { VAT: { type: 'OWN' } } });
-      const expense = await fakeExpense({
-        status: expenseStatus.DRAFT,
-        type: ExpenseTypes.INVOICE,
-        currency: 'USD',
-        CollectiveId: collective.id,
-        data: {
-          draftKey: 'fake-key',
-          customData: { customField: 'customValue' },
-          taxes: [{ type: 'VAT', rate: 0.055 }],
-        },
-      });
-      const anotherUser = await fakeUser();
-
-      const updatedExpenseData = {
-        id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
-        description: 'This is a test.',
-        payee: {
-          legacyId: anotherUser.id,
-        },
-      };
-
-      const { errors } = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, anotherUser);
-      expect(errors).to.exist;
-      expect(errors[0]).to.have.nested.property('extensions.code', 'Unauthorized');
-
-      const result = await graphqlQueryV2(
-        editExpenseMutation,
-        {
-          expense: updatedExpenseData,
-          draftKey: 'fake-key',
-        },
-        anotherUser,
-      );
-      result.errors && console.error(result.errors);
-      expect(result.errors).to.not.exist;
-      expect(result.data.editExpense.description).to.equal(updatedExpenseData.description);
-      expect(result.data.editExpense.payee.legacyId).to.equal(anotherUser.id);
-      expect(result.data.editExpense.customData).to.deep.equal(expense.data.customData);
-      expect(result.data.editExpense.taxes).to.deep.equal([{ id: 'VAT', type: 'VAT', rate: 0.055 }]);
-    });
-
-    it('creates new user and organization if draft payee does not exist', async () => {
-      const expense = await fakeExpense({ data: { draftKey: 'fake-key' }, status: expenseStatus.DRAFT });
-      const anotherUser = await fakeUser();
-
-      const updatedExpenseData = {
-        id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
-        description: 'This is a test.',
-        payee: {
-          name: 'New Folk',
-          email: randEmail(),
-          organization: {
-            name: 'Folk Ventures',
-            slug: randStr('folk-'),
+    describe('DRAFT', () => {
+      it('lets another user edit and submit a draft if the right key is provided', async () => {
+        const collective = await fakeCollective({ currency: 'EUR', settings: { VAT: { type: 'OWN' } } });
+        const expense = await fakeExpense({
+          status: expenseStatus.DRAFT,
+          type: ExpenseTypes.INVOICE,
+          currency: 'USD',
+          CollectiveId: collective.id,
+          data: {
+            draftKey: 'fake-key',
+            customData: { customField: 'customValue' },
+            taxes: [{ type: 'VAT', rate: 0.055 }],
           },
-        },
-      };
+        });
+        const anotherUser = await fakeUser();
 
-      const { errors } = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData });
-      expect(errors).to.exist;
-      expect(errors[0]).to.have.nested.property('extensions.code', 'Unauthorized');
+        const updatedExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          description: 'This is a test.',
+          payee: {
+            legacyId: anotherUser.id,
+          },
+        };
 
-      const result = await graphqlQueryV2(
-        editExpenseMutation,
-        {
-          expense: updatedExpenseData,
-          draftKey: 'fake-key',
-        },
-        anotherUser,
-      );
-      result.errors && console.error(result.errors);
-      expect(result.errors).to.not.exist;
+        const { errors } = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, anotherUser);
+        expect(errors).to.exist;
+        expect(errors[0]).to.have.nested.property('extensions.code', 'Unauthorized');
 
-      expect(result.data.editExpense.description).to.equal(updatedExpenseData.description);
-      expect(result.data.editExpense.payee.slug).to.equal(updatedExpenseData.payee.organization.slug);
+        const result = await graphqlQueryV2(
+          editExpenseMutation,
+          {
+            expense: updatedExpenseData,
+            draftKey: 'fake-key',
+          },
+          anotherUser,
+        );
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        expect(result.data.editExpense.description).to.equal(updatedExpenseData.description);
+        expect(result.data.editExpense.payee.legacyId).to.equal(anotherUser.id);
+        expect(result.data.editExpense.customData).to.deep.equal(expense.data.customData);
+        expect(result.data.editExpense.taxes).to.deep.equal([{ id: 'VAT', type: 'VAT', rate: 0.055 }]);
+      });
 
-      const user = await models.User.findOne({ where: { email: updatedExpenseData.payee.email } });
-      expect(user).to.exist;
+      it('creates new user and organization if draft payee does not exist', async () => {
+        const expense = await fakeExpense({ data: { draftKey: 'fake-key' }, status: expenseStatus.DRAFT });
+        const anotherUser = await fakeUser();
+
+        const updatedExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          description: 'This is a test.',
+          payee: {
+            name: 'New Folk',
+            email: randEmail(),
+            organization: {
+              name: 'Folk Ventures',
+              slug: randStr('folk-'),
+            },
+          },
+        };
+
+        const { errors } = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData });
+        expect(errors).to.exist;
+        expect(errors[0]).to.have.nested.property('extensions.code', 'Unauthorized');
+
+        const result = await graphqlQueryV2(
+          editExpenseMutation,
+          {
+            expense: updatedExpenseData,
+            draftKey: 'fake-key',
+          },
+          anotherUser,
+        );
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+
+        expect(result.data.editExpense.description).to.equal(updatedExpenseData.description);
+        expect(result.data.editExpense.payee.slug).to.equal(updatedExpenseData.payee.organization.slug);
+
+        const user = await models.User.findOne({ where: { email: updatedExpenseData.payee.email } });
+        expect(user).to.exist;
+      });
+
+      it('can be edited by fiscal-host admin and/or original author', async () => {
+        const collective = await fakeCollective({ currency: 'EUR', settings: { VAT: { type: 'OWN' } } });
+        const draftAuthor = await fakeUser();
+        const payee = await fakeUser();
+        const expense = await fakeExpense({
+          status: expenseStatus.DRAFT,
+          type: ExpenseTypes.INVOICE,
+          currency: 'USD',
+          CollectiveId: collective.id,
+          UserId: draftAuthor.id,
+          invoiceInfo: 'old info',
+          data: {
+            draftKey: 'fake-key',
+            customData: { customField: 'customValue' },
+            taxes: [{ type: 'VAT', rate: 0.055 }],
+            payee: payee.collective.minimal,
+          },
+        });
+
+        const updatedExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          description: 'This is a test.',
+          invoiceInfo: 'This is an invoice',
+          tags: ['newtag'],
+          items: [
+            {
+              amount: 10000,
+              incurredAt: '2023-09-26T00:00:00.000Z',
+              description: 'Item 1',
+            },
+          ],
+        };
+
+        const result = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, draftAuthor);
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        await expense.reload();
+        expect(expense.status).to.equal(expenseStatus.DRAFT);
+        expect(expense.description).to.equal(updatedExpenseData.description);
+        expect(expense.invoiceInfo).to.equal(updatedExpenseData.invoiceInfo);
+        expect(expense.tags).to.deep.equal(updatedExpenseData.tags);
+        expect(expense.data.items).to.deep.equal(updatedExpenseData.items);
+        expect(expense.data.payee).to.contain({ id: payee.collective.id });
+      });
     });
 
     it('resets paid card charge expense missing details status', async () => {


### PR DESCRIPTION
Backend logic for allowing the expense draft author to edit its draft before the payee submits the expense.