### PR TITLE
Fix broken link in Host Application email

### DIFF
--- a/templates/emails/collective.apply.for.host.hbs
+++ b/templates/emails/collective.apply.for.host.hbs
@@ -98,7 +98,7 @@ Dear admin of {{host.name}},
 <center>
   <a
     class="btn blue"
-    href="{{config.host.website}}/{{host.slug}}/admin/host-applications?accountSlug={{collective.slug}}"
+    href="{{config.host.website}}/{{host.slug}}/admin/host-applications?application={{collective.id}}"
   >
     <div style="font-size: 15px;">View application</div>
   </a>

--- a/templates/emails/collective.apply.for.host.hbs
+++ b/templates/emails/collective.apply.for.host.hbs
@@ -98,7 +98,7 @@ Dear admin of {{host.name}},
 <center>
   <a
     class="btn blue"
-    href="{{config.host.website}}/{{host.slug}}/admin/pending-applications#application-{{collective.id}}"
+    href="{{config.host.website}}/{{host.slug}}/admin/host-applications?accountSlug={{collective.slug}}"
   >
     <div style="font-size: 15px;">View application</div>
   </a>


### PR DESCRIPTION
Broken link reported on Slack.

Depends on https://github.com/opencollective/opencollective-frontend/pull/9402

Updates the link in `collective.apply.for.host` email template.