### PR TITLE
Set root redirect cookie to be secure and httpOnly

### DIFF
--- a/server/middleware/authentication.js
+++ b/server/middleware/authentication.js
@@ -155,6 +155,7 @@ const _authenticateUserByJwt = async (req, res, next) => {
     res.cookie('rootRedirect', 'dashboard', {
       secure: true,
       httpOnly: true,
+      sameSite: 'strict',
       maxAge: 24 * 60 * 60 * 1000 * 365,
     });
   }

--- a/server/middleware/authentication.js
+++ b/server/middleware/authentication.js
@@ -152,7 +152,11 @@ const _authenticateUserByJwt = async (req, res, next) => {
 
   const { earlyAccess = {} } = user.collective.settings;
   if (earlyAccess.dashboard) {
-    res.cookie('rootRedirect', 'dashboard', { maxAge: 24 * 60 * 60 * 1000 * 365 });
+    res.cookie('rootRedirect', 'dashboard', {
+      secure: true,
+      httpOnly: true,
+      maxAge: 24 * 60 * 60 * 1000 * 365,
+    });
   }
 
   // Make tokens expire on password update


### PR DESCRIPTION
Follow up for https://github.com/opencollective/opencollective-api/pull/9377

The cookie's value is not set properly in staging (the cookie shows up, but has an empty value), unclear why. Trying to set the httpOnly and secure properties to true should not hurt (also works in development)