### PR TITLE
SanitizeHTML: add nofollow on redirected links

### DIFF
--- a/server/lib/sanitize-html.ts
+++ b/server/lib/sanitize-html.ts
@@ -59,6 +59,7 @@ export const buildSanitizerOptions = (allowedContent: AllowedContentType = {}): 
         attribs: {
           ...attribs,
           href: formatLinkHref(attribs.href),
+          rel: 'noopener noreferrer nofollow',
         },
       };
     },


### PR DESCRIPTION
It's unlikely that the redirect could still cause SEO issues, but since this contains user-submitted links, we want to ensure we don't index them.