### PR TITLE
2FA support for OAuth & personal tokens

### DIFF
--- a/migrations/20231024083706-add-2fa-for-applications-and-personal-tokens.js
+++ b/migrations/20231024083706-add-2fa-for-applications-and-personal-tokens.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Applications', 'preAuthorize2FA', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    });
+    await queryInterface.addColumn('UserTokens', 'preAuthorize2FA', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    });
+    await queryInterface.addColumn('PersonalTokens', 'preAuthorize2FA', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Applications', 'preAuthorize2FA');
+    await queryInterface.removeColumn('UserTokens', 'preAuthorize2FA');
+    await queryInterface.removeColumn('PersonalTokens', 'preAuthorize2FA');
+  },
+};

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -19,6 +19,11 @@ type Application {
   redirectUri: URL
   account: Account!
   oAuthAuthorization: OAuthAuthorization
+
+  """
+  Whether this application is allowed to directly use operations that would normally require 2FA
+  """
+  preAuthorize2FA: Boolean!
 }
 
 """
@@ -66,6 +71,11 @@ type OAuthAuthorization {
   The attached scopes.
   """
   scope: [OAuthScope]
+
+  """
+  Whether this OAuth token is allowed to directly use operations that would normally require 2FA
+  """
+  preAuthorize2FA: Boolean!
 }
 
 """
@@ -8577,6 +8587,11 @@ type PersonalToken {
   The date on which the personal token was last updated
   """
   updatedAt: DateTime
+
+  """
+  Whether this token is allowed to directly use operations that would normally require 2FA
+  """
+  preAuthorize2FA: Boolean!
 }
 
 """
@@ -15052,8 +15067,8 @@ type Mutation {
   Delete a tier.
   """
   deleteTier(tier: TierReferenceInput!, stopRecurringContributions: Boolean! = false): Tier!
-  createPersonalToken(personalToken: PersonalTokenCreateInput!): PersonalToken
-  updatePersonalToken(personalToken: PersonalTokenUpdateInput!): PersonalToken
+  createPersonalToken(personalToken: PersonalTokenCreateInput!): PersonalToken!
+  updatePersonalToken(personalToken: PersonalTokenUpdateInput!): PersonalToken!
   deletePersonalToken(personalToken: PersonalTokenReferenceInput!): PersonalToken
 
   """
@@ -16997,6 +17012,11 @@ input PersonalTokenCreateInput {
   expiresAt: String
 
   """
+  Whether this token is allowed to directly use operations that would normally require 2FA
+  """
+  preAuthorize2FA: Boolean = false
+
+  """
   The account to use as the owner of the application. Defaults to currently logged in user.
   """
   account: AccountReferenceInput
@@ -17018,6 +17038,11 @@ input PersonalTokenUpdateInput {
   name: String
   scope: [OAuthScope]
   expiresAt: String
+
+  """
+  Whether this token is allowed to directly use operations that would normally require 2FA
+  """
+  preAuthorize2FA: Boolean
 }
 
 input PersonalTokenReferenceInput {

--- a/server/graphql/v2/input/PersonalTokenCreateInput.ts
+++ b/server/graphql/v2/input/PersonalTokenCreateInput.ts
@@ -1,4 +1,4 @@
-import { GraphQLInputObjectType, GraphQLList, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLInputObjectType, GraphQLList, GraphQLString } from 'graphql';
 
 import { GraphQLOAuthScope } from '../enum/OAuthScope';
 
@@ -11,6 +11,11 @@ export const GraphQLPersonalTokenCreateInput = new GraphQLInputObjectType({
     name: { type: GraphQLString },
     scope: { type: new GraphQLList(GraphQLOAuthScope) },
     expiresAt: { type: GraphQLString },
+    preAuthorize2FA: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+      description: 'Whether this token is allowed to directly use operations that would normally require 2FA',
+    },
     account: {
       type: GraphQLAccountReferenceInput,
       description: 'The account to use as the owner of the application. Defaults to currently logged in user.',

--- a/server/graphql/v2/input/PersonalTokenUpdateInput.ts
+++ b/server/graphql/v2/input/PersonalTokenUpdateInput.ts
@@ -1,4 +1,4 @@
-import { GraphQLInputObjectType, GraphQLList, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLInputObjectType, GraphQLList, GraphQLString } from 'graphql';
 
 import { GraphQLOAuthScope } from '../enum/OAuthScope';
 
@@ -12,5 +12,9 @@ export const GraphQLPersonalTokenUpdateInput = new GraphQLInputObjectType({
     name: { type: GraphQLString },
     scope: { type: new GraphQLList(GraphQLOAuthScope) },
     expiresAt: { type: GraphQLString },
+    preAuthorize2FA: {
+      type: GraphQLBoolean,
+      description: 'Whether this token is allowed to directly use operations that would normally require 2FA',
+    },
   }),
 });

--- a/server/graphql/v2/mutation/PersonalTokenMutations.ts
+++ b/server/graphql/v2/mutation/PersonalTokenMutations.ts
@@ -84,6 +84,8 @@ const updatePersonalToken = {
       );
     }
 
+    const hasCriticalChanges = ['scope', 'expiresAt'].some(field => !isUndefined(args.personalToken[field]));
+    await twoFactorAuthLib.enforceForAccount(req, personalToken.collective, { alwaysAskForToken: hasCriticalChanges });
     const updateParams = pick(args.personalToken, ['name', 'scope', 'expiresAt', 'preAuthorize2FA']);
     return personalToken.update(updateParams);
   },
@@ -109,6 +111,7 @@ const deletePersonalToken = {
       throw new Forbidden('Authenticated user is not the personal token owner.');
     }
 
+    await twoFactorAuthLib.enforceForAccount(req, personalToken.collective);
     return personalToken.destroy();
   },
 };

--- a/server/graphql/v2/mutation/PersonalTokenMutations.ts
+++ b/server/graphql/v2/mutation/PersonalTokenMutations.ts
@@ -18,7 +18,7 @@ import { GraphQLPersonalTokenUpdateInput } from '../input/PersonalTokenUpdateInp
 import { GraphQLPersonalToken } from '../object/PersonalToken';
 
 const createPersonalToken = {
-  type: GraphQLPersonalToken,
+  type: new GraphQLNonNull(GraphQLPersonalToken),
   args: {
     personalToken: {
       type: new GraphQLNonNull(GraphQLPersonalTokenCreateInput),
@@ -46,7 +46,7 @@ const createPersonalToken = {
     }
 
     const createParams = {
-      ...pick(args.personalToken, ['name', 'scope', 'expiresAt']),
+      ...pick(args.personalToken, ['name', 'scope', 'expiresAt', 'preAuthorize2FA']),
       CollectiveId: collective.id,
       UserId: req.remoteUser.id,
       token: models.PersonalToken.generateToken(),
@@ -57,7 +57,7 @@ const createPersonalToken = {
 };
 
 const updatePersonalToken = {
-  type: GraphQLPersonalToken,
+  type: new GraphQLNonNull(GraphQLPersonalToken),
   args: {
     personalToken: {
       type: new GraphQLNonNull(GraphQLPersonalTokenUpdateInput),
@@ -76,7 +76,7 @@ const updatePersonalToken = {
       throw new Forbidden('Authenticated user is not the token owner.');
     }
 
-    const updateParams = pick(args.personalToken, ['name', 'scope', 'expiresAt']);
+    const updateParams = pick(args.personalToken, ['name', 'scope', 'expiresAt', 'preAuthorize2FA']);
     return personalToken.update(updateParams);
   },
 };

--- a/server/graphql/v2/mutation/PersonalTokenMutations.ts
+++ b/server/graphql/v2/mutation/PersonalTokenMutations.ts
@@ -1,7 +1,7 @@
 import config from 'config';
 import express from 'express';
 import { GraphQLNonNull } from 'graphql';
-import { pick } from 'lodash';
+import { isUndefined, pick } from 'lodash';
 
 import twoFactorAuthLib from '../../../lib/two-factor-authentication';
 import models from '../../../models';
@@ -74,6 +74,14 @@ const updatePersonalToken = {
       throw new NotFound(`Personal token not found`);
     } else if (!req.remoteUser.isAdminOfCollective(personalToken.collective)) {
       throw new Forbidden('Authenticated user is not the token owner.');
+    } else if (
+      !isUndefined(args.personalToken.preAuthorize2FA) &&
+      args.personalToken.preAuthorize2FA !== personalToken.preAuthorize2FA &&
+      req.personalToken
+    ) {
+      throw new Error(
+        'You cannot change the preAuthorize2FA value of the token you are using. Please use the interface to change it.',
+      );
     }
 
     const updateParams = pick(args.personalToken, ['name', 'scope', 'expiresAt', 'preAuthorize2FA']);

--- a/server/graphql/v2/object/Application.js
+++ b/server/graphql/v2/object/Application.js
@@ -1,4 +1,4 @@
-import { GraphQLInt, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLInt, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 
 import models from '../../../models';
 import { checkScope } from '../../common/scope-check';
@@ -102,6 +102,10 @@ export const GraphQLApplication = new GraphQLObjectType({
           };
         }
       },
+    },
+    preAuthorize2FA: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether this application is allowed to directly use operations that would normally require 2FA',
     },
   }),
 });

--- a/server/graphql/v2/object/Individual.js
+++ b/server/graphql/v2/object/Individual.js
@@ -172,6 +172,7 @@ export const GraphQLIndividual = new GraphQLObjectType({
               expiresAt: row.accessTokenExpiresAt,
               createdAt: row.createdAt,
               updatedAt: row.updatedAt,
+              preAuthorize2FA: row.preAuthorize2FA,
               scope: row.scope,
               user,
             };

--- a/server/graphql/v2/object/OAuthAuthorization.js
+++ b/server/graphql/v2/object/OAuthAuthorization.js
@@ -1,4 +1,4 @@
-import { GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 
 import models from '../../../models';
@@ -59,6 +59,10 @@ export const GraphQLOAuthAuthorization = new GraphQLObjectType({
     scope: {
       type: new GraphQLList(GraphQLOAuthScope),
       description: 'The attached scopes.',
+    },
+    preAuthorize2FA: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether this OAuth token is allowed to directly use operations that would normally require 2FA',
     },
   }),
 });

--- a/server/graphql/v2/object/PersonalToken.ts
+++ b/server/graphql/v2/object/PersonalToken.ts
@@ -1,4 +1,4 @@
-import { GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 
 import { GraphQLOAuthScope } from '../enum/OAuthScope';
@@ -45,6 +45,10 @@ export const GraphQLPersonalToken = new GraphQLObjectType({
     updatedAt: {
       type: GraphQLDateTime,
       description: 'The date on which the personal token was last updated',
+    },
+    preAuthorize2FA: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether this token is allowed to directly use operations that would normally require 2FA',
     },
   }),
 });

--- a/server/lib/oauth/model.ts
+++ b/server/lib/oauth/model.ts
@@ -84,6 +84,7 @@ const model: OauthModel = {
         ApplicationId: application.id,
         UserId: user.id,
         scope: Array.isArray(token.scope) ? token.scope : token.scope?.split(','),
+        preAuthorize2FA: Boolean(application.preAuthorize2FA),
       });
       oauthToken.user = user;
       oauthToken.client = client;

--- a/server/models/Application.ts
+++ b/server/models/Application.ts
@@ -22,6 +22,7 @@ class Application extends Model<InferAttributes<Application>, InferCreationAttri
   public declare name: string;
   public declare description: string;
   public declare disabled: boolean;
+  public declare preAuthorize2FA: CreationOptional<boolean>;
   public declare createdAt: CreationOptional<Date>;
   public declare updatedAt: CreationOptional<Date>;
   public declare deletedAt: CreationOptional<Date>;
@@ -110,6 +111,11 @@ Application.init(
     disabled: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
+    },
+    preAuthorize2FA: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
     },
     createdAt: {
       type: DataTypes.DATE,

--- a/server/models/PersonalToken.ts
+++ b/server/models/PersonalToken.ts
@@ -21,6 +21,7 @@ class PersonalToken extends Model<InferAttributes<PersonalToken>, InferCreationA
   public declare UserId: ForeignKey<User['id']>;
   public declare scope: oAuthScopes[];
   public declare name: string;
+  public declare preAuthorize2FA: CreationOptional<boolean>;
 
   public declare application?: NonAttribute<typeof models.Application>;
   public declare user?: NonAttribute<typeof models.User>;
@@ -71,6 +72,11 @@ PersonalToken.init(
     scope: {
       type: DataTypes.ARRAY(DataTypes.ENUM(...Object.values(oAuthScopes))),
       allowNull: true,
+    },
+    preAuthorize2FA: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
     },
     data: {
       type: DataTypes.JSONB,

--- a/server/models/UserToken.ts
+++ b/server/models/UserToken.ts
@@ -21,6 +21,7 @@ class UserToken extends Model<InferAttributes<UserToken>, InferCreationAttribute
   public declare UserId: ForeignKey<User['id']>;
   public declare data: Record<string, unknown>;
   public declare scope: string[];
+  public declare preAuthorize2FA: boolean;
   public declare createdAt: CreationOptional<Date>;
   public declare updatedAt: CreationOptional<Date>;
   public declare deletedAt: CreationOptional<Date>;
@@ -83,6 +84,11 @@ UserToken.init(
     scope: {
       type: DataTypes.ARRAY(DataTypes.ENUM(...Object.values(oAuthScopes))),
       allowNull: true,
+    },
+    preAuthorize2FA: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
     },
     // Standard temporal fields
     createdAt: {


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/6088

- [x] Add a special flag on Applications and personal tokens to allow 2FA bypass
- [x] Bypass 2FA check when this flag is set
- [x] Add a warning (or error) when using a 2FA code with OAuth (apart from the 1kproject script)
