### PR TITLE
Fix ability to see rejected Host Applications

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -377,7 +377,9 @@ export const GraphQLHost = new GraphQLObjectType({
                 as: 'collective',
                 required: true,
                 where: {
-                  HostCollectiveId: host.id,
+                  ...(args.status !== 'REJECTED' && {
+                    HostCollectiveId: host.id,
+                  }),
                   ...(searchTermConditions.length && { [Op.or]: searchTermConditions }),
                 },
               },


### PR DESCRIPTION
### Description
Fix for bug reported on Slack where you were not able to see rejected host applications.

In the Sequelize fetch to get the Host Applications we were only including those Host Applications where the related Collective had the correct HostCollectiveId, we should not do this for REJECTED applications since those Collectives will have cleared the HostCollectiveId when being rejected.