### PR TITLE
Make "status" optional in Host Applications query

### DIFF
--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -367,7 +367,7 @@ export const GraphQLHost = new GraphQLObjectType({
             order: [[args.orderBy.field, args.orderBy.direction]],
             where: {
               HostCollectiveId: host.id,
-              status: args.status,
+              ...(args.status && { status: args.status }),
             },
             limit: args.limit,
             offset: args.offset,
@@ -378,7 +378,6 @@ export const GraphQLHost = new GraphQLObjectType({
                 required: true,
                 where: {
                   HostCollectiveId: host.id,
-                  ...(args.status === 'PENDING' && { approvedAt: null }),
                   ...(searchTermConditions.length && { [Op.or]: searchTermConditions }),
                 },
               },


### PR DESCRIPTION
### Description
Fixes the host.hostApplications resolver to make sure the 'status' argument is actually optional as specified by the GraphQL schema and what is required for the new filters.