### PR TITLE
Add `status` argument to account.virtualCards resolver

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -622,7 +622,8 @@ interface Account {
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -1916,7 +1917,8 @@ type Host implements Account & AccountWithContributions {
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -4473,6 +4475,15 @@ type VirtualCardCollection implements Collection {
   nodes: [VirtualCard]
 }
 
+"""
+The status of a virtual card
+"""
+enum VirtualCardStatus {
+  ACTIVE
+  INACTIVE
+  CANCELED
+}
+
 type Policies {
   id: String
   EXPENSE_AUTHOR_CANNOT_APPROVE: EXPENSE_AUTHOR_CANNOT_APPROVE
@@ -5117,15 +5128,6 @@ enum HostApplicationStatus {
   APPROVED
   REJECTED
   EXPIRED
-}
-
-"""
-The status of a virtual card
-"""
-enum VirtualCardStatus {
-  ACTIVE
-  INACTIVE
-  CANCELED
 }
 
 """
@@ -6249,7 +6251,8 @@ type Bot implements Account {
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -6784,7 +6787,8 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -7688,7 +7692,8 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -8441,7 +8446,8 @@ type Individual implements Account {
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -9182,7 +9188,8 @@ type Organization implements Account & AccountWithContributions {
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -9840,7 +9847,8 @@ type Vendor implements Account & AccountWithContributions {
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -12839,7 +12847,8 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """
@@ -13484,7 +13493,8 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
   virtualCards(
     limit: Int! = 100
     offset: Int! = 0
-    state: String = null
+    state: String = null @deprecated(reason: "2023-11-06: Please use status.")
+    status: [VirtualCardStatus]
     merchantAccount: AccountReferenceInput = null
 
     """

--- a/server/graphql/v2/interface/Account.ts
+++ b/server/graphql/v2/interface/Account.ts
@@ -34,6 +34,7 @@ import { GraphQLActivityClassType } from '../enum/ActivityType';
 import { GraphQLExpenseType } from '../enum/ExpenseType';
 import { GraphQLPaymentMethodService } from '../enum/PaymentMethodService';
 import { GraphQLPaymentMethodType } from '../enum/PaymentMethodType';
+import { GraphQLVirtualCardStatusEnum } from '../enum/VirtualCardStatus';
 import { idEncode } from '../identifiers';
 import { fetchAccountWithReference, GraphQLAccountReferenceInput } from '../input/AccountReferenceInput';
 import { GraphQLChronologicalOrderInput } from '../input/ChronologicalOrderInput';
@@ -486,7 +487,8 @@ const accountFieldsDefinition = () => ({
     args: {
       limit: { type: new GraphQLNonNull(GraphQLInt), defaultValue: 100 },
       offset: { type: new GraphQLNonNull(GraphQLInt), defaultValue: 0 },
-      state: { type: GraphQLString, defaultValue: null },
+      state: { type: GraphQLString, defaultValue: null, deprecationReason: '2023-11-06: Please use status.' },
+      status: { type: new GraphQLList(GraphQLVirtualCardStatusEnum) },
       merchantAccount: { type: GraphQLAccountReferenceInput, defaultValue: null },
       dateFrom: {
         type: GraphQLDateTime,
@@ -532,6 +534,15 @@ const accountFieldsDefinition = () => ({
 
       if (args.state) {
         query.where['data'] = { state: args.state };
+      }
+
+      if (args.status) {
+        if (!query.where['data']) {
+          query.where['data'] = {};
+        }
+        query.where['data'].status = {
+          [Op.in]: args.status,
+        };
       }
 
       if (merchantId) {


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/7033

### Description
Add `status` argument of type `VirtualCardStatus` to account.virtualCards resolver and deprecate "state" argument, similar to the hostedVirtualCards resolver.