### PR TITLE
Fix: remove VENDORs from v1 children resolver

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -907,7 +907,7 @@ const CollectiveFields = () => {
     children: {
       type: new GraphQLNonNull(new GraphQLList(CollectiveInterfaceType)),
       resolve(collective) {
-        return collective.getChildren();
+        return collective.getChildren({ where: { type: { [Op.ne]: CollectiveTypeEnum.VENDOR } } });
       },
     },
     type: {


### PR DESCRIPTION
Omits Vendors from the dashboard account switcher.
![image](https://github.com/opencollective/opencollective-api/assets/2119706/918bdf3c-eb6c-4d1a-98a9-ac7fb666eb77)
