### PR TITLE
Add script to import expense's accounting categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "cors": "2.8.5",
         "crypto-js": "4.2.0",
         "crypto-random-string": "3.3.1",
+        "csv-parse": "5.5.2",
         "dataloader": "2.2.2",
         "dataloader-sequelize": "2.3.3",
         "debug": "4.3.4",
@@ -11912,6 +11913,11 @@
       "version": "0.3.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.2.tgz",
+      "integrity": "sha512-YRVtvdtUNXZCMyK5zd5Wty1W6dNTpGKdqQd4EQ8tl/c6KW1aMBB1Kg1ppky5FONKmEqGJ/8WjLlTNLPne4ioVA=="
     },
     "node_modules/cz-conventional-changelog": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "cors": "2.8.5",
     "crypto-js": "4.2.0",
     "crypto-random-string": "3.3.1",
+    "csv-parse": "5.5.2",
     "dataloader": "2.2.2",
     "dataloader-sequelize": "2.3.3",
     "debug": "4.3.4",

--- a/scripts/accounting/seed-expense-categories-from-csv.ts
+++ b/scripts/accounting/seed-expense-categories-from-csv.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import '../../server/env';
+
+import fs from 'fs';
+
+import axios from 'axios';
+import { program } from 'commander';
+import { parse } from 'csv-parse/sync'; // eslint-disable-line
+
+import models, { Op, sequelize } from '../../server/models';
+
+const DRY_RUN = process.env.DRY_RUN !== 'false';
+
+const loadFileContents = async (filePathOrUrl: string): Promise<string> => {
+  if (filePathOrUrl.match(/^https?:\/\//)) {
+    const response = await axios.get(filePathOrUrl);
+    return response.data;
+  } else {
+    const content = await fs.promises.readFile(filePathOrUrl, 'utf8');
+    return content;
+  }
+};
+
+type RunOptions = {
+  verbose: boolean;
+};
+
+const run = async (hostSlug: string, csvPath: string, options: RunOptions) => {
+  // Load host
+  const host = await models.Collective.findOne({
+    where: { slug: hostSlug },
+    include: [{ association: 'accountingCategories', required: false }],
+  });
+
+  if (!host) {
+    throw new Error(`Host ${hostSlug} not found`);
+  }
+
+  // Load CSV content
+  const rawContent = await loadFileContents(csvPath);
+  const parsedContent = parse(rawContent, {
+    delimiter: ',',
+    columns: true,
+    skip_empty_lines: true, // eslint-disable-line camelcase
+  });
+
+  // Iterate over rows
+  for (const row of parsedContent) {
+    const shortTransactionGroup = row['Short Group ID'];
+    const expenseAccountingCategoryCode = row['EXP CODE'];
+    if (!shortTransactionGroup || !expenseAccountingCategoryCode) {
+      if (options.verbose) {
+        console.error(`Missing data for row ${JSON.stringify(row)}`);
+      }
+      continue;
+    }
+
+    const expense = await models.Expense.findOne({
+      include: [
+        {
+          model: models.Transaction,
+          attributes: [],
+          required: true,
+          where: {
+            type: 'DEBIT',
+            kind: 'EXPENSE',
+            HostCollectiveId: host.id,
+            [Op.and]: [
+              sequelize.where(sequelize.cast(sequelize.col('TransactionGroup'), 'text'), {
+                [Op.startsWith]: shortTransactionGroup,
+              }),
+            ],
+          },
+        },
+        {
+          association: 'accountingCategory',
+          required: false,
+        },
+      ],
+    });
+
+    if (!expense) {
+      console.error(`Expense not found for short transaction group ${shortTransactionGroup}`);
+    } else if (expense.HostCollectiveId && expense.HostCollectiveId !== host.id) {
+      console.error(`Expense ${expense.id} is not associated with host ${hostSlug}`);
+    } else if (expenseAccountingCategoryCode === expense.accountingCategory?.code) {
+      if (options.verbose) {
+        console.log(`Expense ${expense.id} already has the correct accounting category`);
+      }
+    } else {
+      const newCategory = host.accountingCategories.find(({ code }) => code === expenseAccountingCategoryCode);
+      console.log(`Update Expense #${expense.id} with category ${newCategory.code} - ${newCategory.name}`);
+      if (!DRY_RUN) {
+        await expense.update({ AccountingCategoryId: newCategory.id });
+      }
+    }
+  }
+};
+
+const main = async () => {
+  program
+    .showHelpAfterError()
+    .description('Seed expense categories from a CSV file')
+    .argument('<hostSlug>', 'The host slug associated with the expenses')
+    .argument('<filePath>', 'The path to the CSV file containing the expenses')
+    .option('-v, --verbose', 'Verbose mode')
+    .action(async (hostSlug: string, filePath: string) => {
+      try {
+        await run(hostSlug, filePath, program.opts());
+      } catch (error) {
+        console.error(error);
+        process.exit(1);
+      }
+    });
+
+  program.parseAsync();
+};
+
+main();

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -268,6 +268,7 @@ class Collective extends Model<
 
   public declare legalDocuments?: NonAttribute<LegalDocumentModelInterface[]>;
 
+  public declare accountingCategories?: NonAttribute<Array<typeof models.AccountingCategory>>;
   public declare getAccountingCategories: HasManyGetAssociationsMixin<typeof models.AccountingCategory>;
 
   public declare getConnectedAccounts: HasManyGetAssociationsMixin<ConnectedAccount>;


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/7088

>  $ npm run script scripts/accounting/seed-expense-categories-from-csv.ts foundation ~/Downloads/OCF-\ Receipts\ \(final\).csv
> 
> Update Expense #59888 with category 7333 - Online Subscriptions
> Update Expense #59846 with category 7312 - Program Food & Groceries
> Update Expense #59535 with category 7311 - Materials & Supplies
> Update Expense #58759 with category 7312 - Program Food & Groceries
> Update Expense #59959 with category 7332 - Membership Dues
> Update Expense #59958 with category 7334 - Design Fees & Marketing
> Update Expense #60093 with category 7311 - Materials & Supplies
> Update Expense #60092 with category 7311 - Materials & Supplies
> Update Expense #59738 with category 7311 - Materials & Supplies
> ...