### PR TITLE
Misc improvements for GraphQL armor

### DIFF
--- a/server/lib/sentry.ts
+++ b/server/lib/sentry.ts
@@ -264,7 +264,9 @@ export const reportMessageToSentry = (message: string, params: CaptureErrorParam
     if (checkIfSentryConfigured()) {
       Sentry.captureMessage(message, params?.severity || 'error');
     } else {
-      logger.error(`[Sentry disabled] The following message would be reported: ${message} (${JSON.stringify(params)})`);
+      const errorDetailsStr = safeJsonStringify(params);
+      const logMsg = `[Sentry fallback] ${message} (${errorDetailsStr})`;
+      params?.severity === 'warning' ? logger.warn(logMsg) : logger.error(logMsg);
     }
   });
 };


### PR DESCRIPTION
- Increase max complexity to `1250` (related to the latest changes on accounting categories in the host expenses)
- Make the request AST optional, since the library specifies it can be null
- Rename the `logRejection` function to clarify its purpose
- Better logging fallback when Sentry is disabled