### PR TITLE
Only find 2FAs not already deleted

### DIFF
--- a/server/models/UserTwoFactorMethod.ts
+++ b/server/models/UserTwoFactorMethod.ts
@@ -71,6 +71,7 @@ export default class UserTwoFactorMethod<
       group: 'method',
       where: {
         UserId: userId,
+        deletedAt: null,
       },
     });
 


### PR DESCRIPTION
I believe here we need to make sure we only take into account 2FAs that are not already deleted. Otherwise we will show things that are already deleted as not deleted in root actions for example. 

![image](https://github.com/opencollective/opencollective-api/assets/12435965/074d299f-9adb-4ead-88ef-7e53561e965d)
