### PR TITLE
Improve developer experience for checks

### DIFF
--- a/checks/model/_utils.ts
+++ b/checks/model/_utils.ts
@@ -1,0 +1,26 @@
+import { parseArgs } from 'node:util';
+
+export const parseOptions = () => {
+  const { values } = parseArgs({
+    options: {
+      fix: {
+        type: 'boolean',
+        default: false,
+      },
+    },
+  });
+
+  return values;
+};
+
+type CheckFn = (options: { fix: boolean }) => Promise<void>;
+
+export const runCheckThenExit = async (check: CheckFn): Promise<void> => {
+  const options = parseOptions();
+  return check(options)
+    .then(() => process.exit(0))
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });
+};

--- a/checks/model/collectives.js
+++ b/checks/model/collectives.js
@@ -2,6 +2,8 @@ import '../../server/env';
 
 import { sequelize } from '../../server/models';
 
+import { runCheckThenExit } from './_utils';
+
 async function checkDeletedUsers() {
   const message = 'No USER Collective without a matching User (no auto fix)';
 
@@ -28,5 +30,5 @@ export async function checkCollectives() {
 }
 
 if (!module.parent) {
-  checkCollectives();
+  runCheckThenExit(checkCollectives);
 }

--- a/checks/model/hosted-collectives.js
+++ b/checks/model/hosted-collectives.js
@@ -3,6 +3,8 @@ import '../../server/env';
 import logger from '../../server/lib/logger';
 import { sequelize } from '../../server/models';
 
+import { runCheckThenExit } from './_utils';
+
 async function checkHostFeePercent({ fix = false } = {}) {
   const message = 'Hosted Collectives without hostFeePercent';
 
@@ -85,5 +87,5 @@ export async function checkHostedCollectives({ fix = false } = {}) {
 }
 
 if (!module.parent) {
-  checkHostedCollectives();
+  runCheckThenExit(checkHostedCollectives);
 }

--- a/checks/model/hosts.js
+++ b/checks/model/hosts.js
@@ -3,6 +3,8 @@ import '../../server/env';
 import logger from '../../server/lib/logger';
 import { sequelize } from '../../server/models';
 
+import { runCheckThenExit } from './_utils';
+
 async function checkHostFeePercent({ fix = false } = {}) {
   const message = 'Host without hostFeePercent';
 
@@ -39,5 +41,5 @@ export async function checkHosts({ fix = false } = {}) {
 }
 
 if (!module.parent) {
-  checkHosts();
+  runCheckThenExit(checkHosts);
 }

--- a/checks/model/independent-collectives.js
+++ b/checks/model/independent-collectives.js
@@ -3,6 +3,8 @@ import '../../server/env';
 import logger from '../../server/lib/logger';
 import { sequelize } from '../../server/models';
 
+import { runCheckThenExit } from './_utils';
+
 async function checkIsActive({ fix = false } = {}) {
   const message = 'Independent Collectives without isActive=TRUE';
 
@@ -166,7 +168,7 @@ async function checkHostFeePercent({ fix = false } = {}) {
   }
 }
 
-export async function checkIndepedentCollectives({ fix = false } = {}) {
+export async function checkIndependentCollectives({ fix = false } = {}) {
   await checkIsActive({ fix });
   await checkHasHostCollectiveId({ fix });
   await checkApprovedAt({ fix });
@@ -175,5 +177,5 @@ export async function checkIndepedentCollectives({ fix = false } = {}) {
 }
 
 if (!module.parent) {
-  checkIndepedentCollectives();
+  runCheckThenExit(checkIndependentCollectives);
 }

--- a/checks/model/index.js
+++ b/checks/model/index.js
@@ -1,14 +1,13 @@
 import '../../server/env';
 
-import { parseArgs } from 'node:util';
-
 import logger from '../../server/lib/logger';
 import { sequelize } from '../../server/models';
 
+import { runCheckThenExit } from './_utils';
 import { checkCollectives } from './collectives';
 import { checkHostedCollectives } from './hosted-collectives';
 import { checkHosts } from './hosts';
-import { checkIndepedentCollectives } from './independent-collectives';
+import { checkIndependentCollectives } from './independent-collectives';
 import { checkMembers } from './members';
 import { checkTransactions } from './transactions';
 import { checkUsers } from './users';
@@ -17,7 +16,7 @@ const allModelChecks = [
   checkCollectives,
   checkHosts,
   checkHostedCollectives,
-  checkIndepedentCollectives,
+  checkIndependentCollectives,
   checkMembers,
   checkTransactions,
   checkUsers,
@@ -40,23 +39,6 @@ export async function checkAllModels({ fix = false } = {}) {
   return { errors };
 }
 
-async function run() {
-  const options = {
-    fix: {
-      type: 'boolean',
-      default: false,
-    },
-  };
-
-  const {
-    values: { fix },
-  } = parseArgs({ options });
-
-  await checkAllModels({ fix });
-
-  process.exit();
-}
-
 if (!module.parent) {
-  run();
+  runCheckThenExit(checkAllModels);
 }

--- a/checks/model/members.js
+++ b/checks/model/members.js
@@ -6,6 +6,8 @@ import logger from '../../server/lib/logger';
 import { MigrationLog, sequelize } from '../../server/models';
 import { MigrationLogType } from '../../server/models/MigrationLog';
 
+import { runCheckThenExit } from './_utils';
+
 async function checkDeletedMembers({ fix = false } = {}) {
   const message = 'No non-deleted Members without a matching non-deleted Collective';
 
@@ -115,5 +117,5 @@ export async function checkMembers({ fix = false } = {}) {
 }
 
 if (!module.parent) {
-  checkMembers();
+  runCheckThenExit(checkMembers);
 }

--- a/checks/model/transactions.js
+++ b/checks/model/transactions.js
@@ -3,6 +3,8 @@ import '../../server/env';
 import logger from '../../server/lib/logger';
 import { sequelize } from '../../server/models';
 
+import { runCheckThenExit } from './_utils';
+
 async function checkDeletedCollectives({ fix = false } = {}) {
   const message = 'No Transactions without a matching Collective';
 
@@ -69,5 +71,5 @@ export async function checkTransactions({ fix = false } = {}) {
 }
 
 if (!module.parent) {
-  checkTransactions();
+  runCheckThenExit(checkTransactions);
 }

--- a/checks/model/users.js
+++ b/checks/model/users.js
@@ -2,6 +2,8 @@ import '../../server/env';
 
 import { sequelize } from '../../server/models';
 
+import { runCheckThenExit } from './_utils';
+
 async function checkDeletedCollectives() {
   const message = 'No Users without a matching Collective (no auto fix)';
 
@@ -46,5 +48,5 @@ export async function checkUsers() {
 }
 
 if (!module.parent) {
-  checkUsers();
+  runCheckThenExit(checkUsers);
 }


### PR DESCRIPTION
- Always call `process.exit` to make sure the scripts don't hang at the end
- Parse options (`--fix`) in individual scripts, which makes sure they can be run individually