### PR TITLE
PaymentMethod: do not crash when getting balance of removed provider

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -65,16 +65,16 @@ export function isProvider(fqn, paymentMethod) {
  *  {service: 'stripe', type: 'creditcard'}.
  * @return the payment method's JS module.
  */
-export function findPaymentMethodProvider(paymentMethod) {
+export function findPaymentMethodProvider(paymentMethod, { throwIfMissing = true } = {}) {
   const provider = get(paymentMethod, 'service') || 'opencollective';
   const methodType = get(paymentMethod, 'type') || 'default';
   let paymentMethodProvider = paymentProviders[provider];
-  if (!paymentMethodProvider) {
+  if (!paymentMethodProvider && throwIfMissing) {
     throw new Error(`No payment provider found for ${provider}`);
   }
 
   paymentMethodProvider = paymentMethodProvider.types[methodType];
-  if (!paymentMethodProvider) {
+  if (!paymentMethodProvider && throwIfMissing) {
     throw new Error(`No payment provider found for ${provider}:${methodType}`);
   }
   return paymentMethodProvider;

--- a/server/models/PaymentMethod.ts
+++ b/server/models/PaymentMethod.ts
@@ -418,7 +418,11 @@ PaymentMethod.prototype.getBalanceForUser = async function (user) {
     throw new Error('Internal error at PaymentMethod.getBalanceForUser(user): user is not an instance of User');
   }
 
-  const paymentProvider = libpayments.findPaymentMethodProvider(this);
+  const paymentProvider = libpayments.findPaymentMethodProvider(this, { throwIfMissing: false });
+  if (!paymentProvider) {
+    return { amount: 0, currency: this.currency };
+  }
+
   const getBalance =
     paymentProvider && paymentProvider.getBalance ? paymentProvider.getBalance : () => Promise.resolve(maxInteger); // GraphQL doesn't like Infinity
 


### PR DESCRIPTION
Resolve [this Sentry issue](https://open-collective.sentry.io/issues/4656795162/?project=5199682&query=is%3Aunresolved+No+payment+provider+found+for+thegivingblock&referrer=issue-stream&statsPeriod=90d&stream_index=0)
Follow-up on https://github.com/opencollective/opencollective-api/pull/9495
See [Slack](https://opencollective.slack.com/archives/C0471HKNW7J/p1700833038969419)

We fetch this field from https://github.com/opencollective/opencollective-frontend/blob/f3b523ddd1ecfa3d291bf0137e9c1a2a9b819176/pages/transactions.tsx#L41. It's still unclear to me why we do so, but it seems like a good idea not to crash when getting the balance for a removed payment provider PM anyway.