### PR TITLE
Wise cron: Get host from expense HostCollectiveId if possible

### DIFF
--- a/cron/daily/91-check-pending-transferwise-transactions.ts
+++ b/cron/daily/91-check-pending-transferwise-transactions.ts
@@ -15,7 +15,7 @@ import { TransferStateChangeEvent } from '../../server/types/transferwise';
 
 async function processExpense(expense) {
   logger.info(`Processing expense #${expense.id}...`);
-  const host = await expense.collective.getHostCollective();
+  const host = expense.host || (await expense.collective.getHostCollective());
   if (!host) {
     throw new Error(`Could not find the host embursing the expense #${expense.id}.`);
   }
@@ -59,6 +59,7 @@ export async function run() {
     },
     include: [
       { model: models.Collective, as: 'collective' },
+      { model: models.Collective, as: 'host' },
       {
         model: models.PayoutMethod,
         as: 'PayoutMethod',


### PR DESCRIPTION
Related to https://open-collective.sentry.io/issues/4654544805/?project=5199682&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=9

This should cover the case where any paid expense from a former collective bounces back.