### PR TITLE
Update typescript to 5.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "supertest": "^6.3.3",
-        "typescript": "^5.1.3"
+        "typescript": "^5.3.2"
       },
       "engines": {
         "node": "20.x",
@@ -24299,9 +24299,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "supertest": "^6.3.3",
-    "typescript": "^5.1.3"
+    "typescript": "^5.3.2"
   },
   "scripts": {
     "build": "npm run build:clean && npm run build:updates && npm run build:server",


### PR DESCRIPTION
2 breaking errors:

- server/graphql/v2/object/AccountingCategory.ts:35:1 - error TS2303: Circular definition of import alias 'GraphQLAccountingCategory'.

`export default GraphQLAccountingCategory;`

 - server/graphql/v2/object/Expense.ts:534:10 - error TS2303: Circular definition of import alias 'GraphQLExpense'.

`export { GraphQLExpense };`
