### PR TITLE
Fix duplicate contributors by fx.rate bug

### DIFF
--- a/server/lib/contributors.ts
+++ b/server/lib/contributors.ts
@@ -136,7 +136,7 @@ const contributorsQuery = `
     AND c."deletedAt" IS NULL
     AND (transactions."ExpenseId" IS NULL OR e."type" != 'SETTLEMENT')
   GROUP BY
-    c.id, fx.rate
+    c.id
   ORDER BY
     "totalAmountDonatedInHostCurrency" DESC,
     MIN(m."since") ASC


### PR DESCRIPTION
Remove unused group by argument.

Fixes this
![image](https://github.com/opencollective/opencollective-api/assets/2119706/77ca0040-bd76-45f8-b7cb-955071a83ce6)
