### PR TITLE
Platform Tips support for OSC

### DIFF
--- a/server/graphql/common/orders.ts
+++ b/server/graphql/common/orders.ts
@@ -80,6 +80,9 @@ export async function addFunds(order: AddFundsInput, remoteUser: User) {
     orderData.data.tax = getOrderTaxInfoFromTaxInput(order.tax, fromCollective, collective, host);
   }
 
+  // Added Funds are not eligible to Platform Tips
+  orderData.platformTipEligible = false;
+
   const orderCreated = await models.Order.create(orderData);
 
   const hostPaymentMethod = await host.getOrCreateHostPaymentMethod();

--- a/server/graphql/v2/interface/AccountWithHost.ts
+++ b/server/graphql/v2/interface/AccountWithHost.ts
@@ -66,31 +66,29 @@ export const AccountWithHostFields = {
           possibleValues.push(parent?.hostFeePercent);
         }
         possibleValues.push(host?.data?.bankTransfersHostFeePercent);
+      } else if (args.paymentMethodType === 'collective') {
+        // Default to 0 for Collective to Collective on the same Host
+        possibleValues.push(0);
       } else if (args.paymentMethodService === 'stripe') {
-        // the setting used to be named `creditCardHostFeePercent` but it's meant to be used for Stripe generally
-        // to be removed once we don't have Hosts with `creditCardHostFeePercent`
-        possibleValues.push(account.data?.creditCardHostFeePercent);
-        possibleValues.push(parent?.data?.creditCardHostFeePercent);
-        possibleValues.push(account.data?.stripeHostFeePercent);
-        possibleValues.push(parent?.data?.stripeHostFeePercent);
+        // possibleValues.push(account.data?.stripeHostFeePercent);
+        // possibleValues.push(parent?.data?.stripeHostFeePercent);
         if (account.data?.useCustomHostFee) {
           possibleValues.push(account.hostFeePercent);
         }
         if (parent?.data?.useCustomHostFee) {
           possibleValues.push(parent?.hostFeePercent);
         }
-        possibleValues.push(host?.data?.creditCardHostFeePercent);
-        possibleValues.push(host?.data?.stripeHostFeePercent);
+        // possibleValues.push(host?.data?.stripeHostFeePercent);
       } else if (args.paymentMethodService === 'paypal') {
-        possibleValues.push(account.data?.paypalHostFeePercent);
-        possibleValues.push(parent?.data?.paypalHostFeePercent);
+        // possibleValues.push(account.data?.paypalHostFeePercent);
+        // possibleValues.push(parent?.data?.paypalHostFeePercent);
         if (account.data?.useCustomHostFee) {
           possibleValues.push(account.hostFeePercent);
         }
         if (parent?.data?.useCustomHostFee) {
           possibleValues.push(parent?.hostFeePercent);
         }
-        possibleValues.push(host?.data?.paypalHostFeePercent);
+        // possibleValues.push(host?.data?.paypalHostFeePercent);
       }
 
       possibleValues.push(account.hostFeePercent);

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -1000,6 +1000,7 @@ const orderMutations = {
         currency: args.order.amount.currency,
         description: args.order.description || models.Order.generateDescription(toAccount, undefined, undefined),
         taxAmount,
+        platformTipEligible: false, // Pending Contributions are not eligible to Platform Tips
         data: {
           fromAccountInfo: args.order.fromAccountInfo,
           expectedAt: args.order.expectedAt,

--- a/server/paymentProviders/opencollective/host.js
+++ b/server/paymentProviders/opencollective/host.js
@@ -81,6 +81,7 @@ paymentMethodProvider.processOrder = async (order, options) => {
     description: order.description,
     data: {
       // No platform tip for now here
+      platformTipEligible: false,
       isSharedRevenue,
       hostFeeSharePercent,
       tax: order.data?.tax,

--- a/test/server/models/Transaction.test.js
+++ b/test/server/models/Transaction.test.js
@@ -463,7 +463,7 @@ describe('server/models/Transaction', () => {
         data: {
           plan: {
             hostFeeSharePercent: 20,
-            creditCardHostFeeSharePercent: 0,
+            stripeHostFeeSharePercent: 0,
             paypalHostFeeSharePercent: 0,
           },
         },


### PR DESCRIPTION
Proposed configuration for OSC:

Fow now (inchanged):
- hostFeePercent: 10
- hostFeeSharePercent: 50

Later:
- hostFeePercent: 8 (or any other value)
- addedFundsHostFeePercent: 10
- bankTransfersHostFeePercent: 10
- stripeNotPlatformTipEligibleHostFeePercent: 10
- paypalNotPlatformTipEligibleHostFeePercent: 10
- hostFeeSharePercent: 50

Then no configuration, but ALWAYS hostFeeSharePercent=0 on contributions eligible to platform tips as a general rule.

Collectives with a custom host fee (like 4%), will always have their custom host fee for all transactions unless they're configured differently at the collective level.

**Again, this PR ensure there is never "Host Fee Share" on contributions eligible to platform tips as a general rule.**