### PR TITLE
Enforce order for `childrenAccounts`

### DIFF
--- a/server/graphql/v2/interface/Account.ts
+++ b/server/graphql/v2/interface/Account.ts
@@ -667,6 +667,10 @@ const accountFieldsDefinition = () => ({
         where,
         limit: args.limit,
         offset: args.offset,
+        order: [
+          ['createdAt', 'DESC'],
+          ['id', 'DESC'],
+        ] as Order,
       });
 
       return {


### PR DESCRIPTION
Having a predictable order is important for consistency and tests.