### PR TITLE
Set bacs debit mandate when confirming payment intent

### DIFF
--- a/server/paymentProviders/stripe/bacsdebit.ts
+++ b/server/paymentProviders/stripe/bacsdebit.ts
@@ -35,7 +35,6 @@ const processOrder = async (order: OrderModelInterface): Promise<void> => {
     },
     // eslint-disable-next-line camelcase
     payment_method: order.paymentMethod?.data?.stripePaymentMethodId,
-    mandate: order.paymentMethod?.data?.stripeMandate?.id,
     // eslint-disable-next-line camelcase
     payment_method_types: ['bacs_debit'],
   };
@@ -54,9 +53,15 @@ const processOrder = async (order: OrderModelInterface): Promise<void> => {
       data: { ...order.data, paymentIntent: { id: paymentIntent.id, status: paymentIntent.status } },
     });
 
-    paymentIntent = await stripe.paymentIntents.confirm(paymentIntent.id, {
-      stripeAccount: hostStripeAccount.username,
-    });
+    paymentIntent = await stripe.paymentIntents.confirm(
+      paymentIntent.id,
+      {
+        mandate: order.paymentMethod?.data?.stripeMandate?.id,
+      },
+      {
+        stripeAccount: hostStripeAccount.username,
+      },
+    );
 
     await order.update({
       status: OrderStatuses.PROCESSING,


### PR DESCRIPTION
https://opencollective.freshdesk.com/a/tickets/303653
https://opencollective.slack.com/archives/C0429NTTABF/p1702582604444719

> Error processing Stripe bacs_debit: The parameter `mandate` cannot be passed when creating a PaymentIntent unless `confirm` is set to true