### PR TITLE
GraphqlV2: return hosts as Host and not as Organization

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -1625,7 +1625,7 @@ type AccountingCategory {
 """
 This represents an Host account
 """
-type Host implements Account & AccountWithContributions {
+type Host implements Account & AccountWithHost & AccountWithContributions {
   id: String!
   legacyId: Int!
 
@@ -1684,9 +1684,9 @@ type Host implements Account & AccountWithContributions {
   isFrozen: Boolean!
 
   """
-  Returns whether the account accepts financial contributions.
+  Returns whether it's active: can accept financial contributions and pay expenses.
   """
-  isActive: Boolean
+  isActive: Boolean!
 
   """
   Returns whether the account is setup to Host collectives.
@@ -2276,6 +2276,51 @@ type Host implements Account & AccountWithContributions {
   ): WebhookCollection!
 
   """
+  Returns the Fiscal Host
+  """
+  host: Host
+
+  """
+  Describe how the host charges the collective
+  """
+  hostFeesStructure: HostFeeStructure
+
+  """
+  Fees percentage that the host takes for this collective
+  """
+  hostFeePercent(paymentMethodService: PaymentMethodService, paymentMethodType: PaymentMethodType): Float
+
+  """
+  How much platform fees are charged for this account
+  """
+  platformFeePercent: Float!
+
+  """
+  Date of approval by the Fiscal Host.
+  """
+  approvedAt: DateTime
+
+  """
+  Returns whether it's approved by the Fiscal Host
+  """
+  isApproved: Boolean!
+
+  """
+  Returns agreements this account has with its host, or null if not enough permissions.
+  """
+  hostAgreements(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 30
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+  ): AgreementCollection
+
+  """
   Number of unique financial contributors.
   """
   totalFinancialContributors(
@@ -2313,11 +2358,6 @@ type Host implements Account & AccountWithContributions {
   ): ContributorCollection!
 
   """
-  How much platform fees are charged for this account
-  """
-  platformFeePercent: Float!
-
-  """
   Returns true if a custom contribution to Open Collective can be submitted for contributions made to this account
   """
   platformContributionAvailable: Boolean!
@@ -2327,7 +2367,6 @@ type Host implements Account & AccountWithContributions {
   List of accounting categories for this host
   """
   accountingCategories: AccountingCategoryCollection!
-  hostFeePercent: Float
   totalHostedCollectives: Int @deprecated(reason: "2023-03-20: Renamed to totalHostedAccounts")
   totalHostedAccounts: Int
   isOpenToApplications: Boolean
@@ -2617,6 +2656,159 @@ type Host implements Account & AccountWithContributions {
 }
 
 """
+An account that can be hosted by a Host
+"""
+interface AccountWithHost {
+  """
+  Returns the Fiscal Host
+  """
+  host: Host
+
+  """
+  Describe how the host charges the collective
+  """
+  hostFeesStructure: HostFeeStructure
+
+  """
+  Fees percentage that the host takes for this collective
+  """
+  hostFeePercent(paymentMethodService: PaymentMethodService, paymentMethodType: PaymentMethodType): Float
+
+  """
+  Fees percentage that the platform takes for this collective
+  """
+  platformFeePercent: Float
+
+  """
+  Date of approval by the Fiscal Host.
+  """
+  approvedAt: DateTime
+
+  """
+  Returns whether it's approved by the Fiscal Host
+  """
+  isApproved: Boolean!
+
+  """
+  Returns whether it's active: can accept financial contributions and pay expenses.
+  """
+  isActive: Boolean!
+
+  """
+  Returns agreements this account has with its host, or null if not enough permissions.
+  """
+  hostAgreements(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 30
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+  ): AgreementCollection
+}
+
+"""
+All supported expense types
+"""
+enum HostFeeStructure {
+  """
+  Use global host fees
+  """
+  DEFAULT
+
+  """
+  Custom fee for this Collective only
+  """
+  CUSTOM_FEE
+
+  """
+  Set a monthly retainer for this Collective
+  """
+  MONTHLY_RETAINER
+}
+
+enum PaymentMethodService {
+  PAYPAL
+  STRIPE
+  OPENCOLLECTIVE
+  PREPAID
+  THEGIVINGBLOCK
+}
+
+enum PaymentMethodType {
+  alipay @deprecated(reason: "Please use uppercase values")
+  creditcard @deprecated(reason: "Please use uppercase values")
+  prepaid @deprecated(reason: "Please use uppercase values")
+  payment @deprecated(reason: "Please use uppercase values")
+  subscription @deprecated(reason: "Please use uppercase values")
+  collective @deprecated(reason: "Please use uppercase values")
+  host @deprecated(reason: "Please use uppercase values")
+  adaptive @deprecated(reason: "Please use uppercase values")
+  giftcard @deprecated(reason: "Please use uppercase values")
+  manual @deprecated(reason: "Please use uppercase values")
+  crypto @deprecated(reason: "Please use uppercase values")
+  paymentintent @deprecated(reason: "Please use uppercase values")
+  us_bank_account @deprecated(reason: "Please use uppercase values")
+  sepa_debit @deprecated(reason: "Please use uppercase values")
+  bacs_debit @deprecated(reason: "Please use uppercase values")
+  bancontact @deprecated(reason: "Please use uppercase values")
+  link @deprecated(reason: "Please use uppercase values")
+  ALIPAY
+  CREDITCARD
+  PREPAID
+  PAYMENT
+  SUBSCRIPTION
+  COLLECTIVE
+  HOST
+  ADAPTIVE
+  GIFTCARD
+  MANUAL
+  CRYPTO
+  PAYMENT_INTENT
+  US_BANK_ACCOUNT
+  SEPA_DEBIT
+  BACS_DEBIT
+  BANCONTACT
+  LINK
+}
+
+"""
+A collection of "Agreement"
+"""
+type AgreementCollection implements Collection {
+  offset: Int
+  limit: Int
+  totalCount: Int
+  nodes: [Agreement!]
+}
+
+"""
+An agreement
+"""
+type Agreement {
+  id: String
+  title: String!
+
+  """
+  Additional notes about the agreement for the host admins
+  """
+  notes: String
+
+  """
+  The time of creation of this agreement
+  """
+  createdAt: DateTime!
+  createdBy: Account
+  account: Account!
+  host: Host!
+  expiresAt: DateTime
+  attachment: FileInfo
+}
+
+"""
 An account that can receive financial contributions
 """
 interface AccountWithContributions {
@@ -2799,26 +2991,6 @@ type MemberOfCollectionRoles {
 }
 
 """
-All supported expense types
-"""
-enum HostFeeStructure {
-  """
-  Use global host fees
-  """
-  DEFAULT
-
-  """
-  Custom fee for this Collective only
-  """
-  CUSTOM_FEE
-
-  """
-  Set a monthly retainer for this Collective
-  """
-  MONTHLY_RETAINER
-}
-
-"""
 Input to order results
 """
 input OrderByInput {
@@ -2862,43 +3034,6 @@ type TransactionCollection implements Collection {
   The types of payment methods used in this collection, regardless of the pagination
   """
   paymentMethodTypes: [PaymentMethodType]!
-}
-
-enum PaymentMethodType {
-  alipay @deprecated(reason: "Please use uppercase values")
-  creditcard @deprecated(reason: "Please use uppercase values")
-  prepaid @deprecated(reason: "Please use uppercase values")
-  payment @deprecated(reason: "Please use uppercase values")
-  subscription @deprecated(reason: "Please use uppercase values")
-  collective @deprecated(reason: "Please use uppercase values")
-  host @deprecated(reason: "Please use uppercase values")
-  adaptive @deprecated(reason: "Please use uppercase values")
-  giftcard @deprecated(reason: "Please use uppercase values")
-  manual @deprecated(reason: "Please use uppercase values")
-  crypto @deprecated(reason: "Please use uppercase values")
-  paymentintent @deprecated(reason: "Please use uppercase values")
-  us_bank_account @deprecated(reason: "Please use uppercase values")
-  sepa_debit @deprecated(reason: "Please use uppercase values")
-  bacs_debit @deprecated(reason: "Please use uppercase values")
-  bancontact @deprecated(reason: "Please use uppercase values")
-  link @deprecated(reason: "Please use uppercase values")
-  ALIPAY
-  CREDITCARD
-  PREPAID
-  PAYMENT
-  SUBSCRIPTION
-  COLLECTIVE
-  HOST
-  ADAPTIVE
-  GIFTCARD
-  MANUAL
-  CRYPTO
-  PAYMENT_INTENT
-  US_BANK_ACCOUNT
-  SEPA_DEBIT
-  BACS_DEBIT
-  BANCONTACT
-  LINK
 }
 
 input VirtualCardReferenceInput {
@@ -3984,14 +4119,6 @@ type PaymentMethod {
     """
     onlyActiveSubscriptions: Boolean
   ): OrderCollection
-}
-
-enum PaymentMethodService {
-  PAYPAL
-  STRIPE
-  OPENCOLLECTIVE
-  PREPAID
-  THEGIVINGBLOCK
 }
 
 enum PaymentMethodLegacyType {
@@ -5538,39 +5665,6 @@ type ExpenseStats {
   Number of grants
   """
   grantsCount: Int!
-}
-
-"""
-A collection of "Agreement"
-"""
-type AgreementCollection implements Collection {
-  offset: Int
-  limit: Int
-  totalCount: Int
-  nodes: [Agreement!]
-}
-
-"""
-An agreement
-"""
-type Agreement {
-  id: String
-  title: String!
-
-  """
-  Additional notes about the agreement for the host admins
-  """
-  notes: String
-
-  """
-  The time of creation of this agreement
-  """
-  createdAt: DateTime!
-  createdBy: Account
-  account: Account!
-  host: Host!
-  expiresAt: DateTime
-  attachment: FileInfo
 }
 
 """
@@ -7510,61 +7604,6 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   """
   platformContributionAvailable: Boolean!
   contributionPolicy: String
-}
-
-"""
-An account that can be hosted by a Host
-"""
-interface AccountWithHost {
-  """
-  Returns the Fiscal Host
-  """
-  host: Host
-
-  """
-  Describe how the host charges the collective
-  """
-  hostFeesStructure: HostFeeStructure
-
-  """
-  Fees percentage that the host takes for this collective
-  """
-  hostFeePercent(paymentMethodService: PaymentMethodService, paymentMethodType: PaymentMethodType): Float
-
-  """
-  Fees percentage that the platform takes for this collective
-  """
-  platformFeePercent: Float
-
-  """
-  Date of approval by the Fiscal Host.
-  """
-  approvedAt: DateTime
-
-  """
-  Returns whether it's approved by the Fiscal Host
-  """
-  isApproved: Boolean!
-
-  """
-  Returns whether it's active: can accept financial contributions and pay expenses.
-  """
-  isActive: Boolean!
-
-  """
-  Returns agreements this account has with its host, or null if not enough permissions.
-  """
-  hostAgreements(
-    """
-    The number of results to fetch (default 10, max 1000)
-    """
-    limit: Int! = 30
-
-    """
-    The offset to use to fetch
-    """
-    offset: Int! = 0
-  ): AgreementCollection
 }
 
 """

--- a/server/graphql/v2/interface/AccountWithHost.ts
+++ b/server/graphql/v2/interface/AccountWithHost.ts
@@ -15,7 +15,7 @@ import { GraphQLHost } from '../object/Host';
 
 import { getCollectionArgs } from './Collection';
 
-export const AccountWithHostFields = {
+export const AccountWithHostFields = () => ({
   host: {
     description: 'Returns the Fiscal Host',
     type: GraphQLHost,
@@ -163,10 +163,10 @@ export const AccountWithHostFields = {
       };
     },
   },
-};
+});
 
 export const GraphQLAccountWithHost = new GraphQLInterfaceType({
   name: 'AccountWithHost',
   description: 'An account that can be hosted by a Host',
-  fields: () => AccountWithHostFields,
+  fields: () => AccountWithHostFields(),
 });

--- a/server/graphql/v2/object/Collective.js
+++ b/server/graphql/v2/object/Collective.js
@@ -13,7 +13,7 @@ export const GraphQLCollective = new GraphQLObjectType({
   fields: () => {
     return {
       ...AccountFields,
-      ...AccountWithHostFields,
+      ...AccountWithHostFields(),
       ...AccountWithContributionsFields,
     };
   },

--- a/server/graphql/v2/object/Event.js
+++ b/server/graphql/v2/object/Event.js
@@ -14,7 +14,7 @@ export const GraphQLEvent = new GraphQLObjectType({
   fields: () => {
     return {
       ...AccountFields,
-      ...AccountWithHostFields,
+      ...AccountWithHostFields(),
       ...AccountWithContributionsFields,
       ...AccountWithParentFields,
       isApproved: {

--- a/server/graphql/v2/object/Fund.js
+++ b/server/graphql/v2/object/Fund.js
@@ -12,7 +12,7 @@ export const GraphQLFund = new GraphQLObjectType({
   fields: () => {
     return {
       ...AccountFields,
-      ...AccountWithHostFields,
+      ...AccountWithHostFields(),
       ...AccountWithContributionsFields,
     };
   },

--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -1,12 +1,4 @@
-import {
-  GraphQLBoolean,
-  GraphQLFloat,
-  GraphQLInt,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLString,
-} from 'graphql';
+import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 import { find, get, isEmpty, isNil, keyBy, mapValues, uniq } from 'lodash';
 import moment from 'moment';
@@ -53,6 +45,7 @@ import {
 } from '../input/ChronologicalOrderInput';
 import { AccountFields, GraphQLAccount } from '../interface/Account';
 import { AccountWithContributionsFields, GraphQLAccountWithContributions } from '../interface/AccountWithContributions';
+import { AccountWithHostFields, GraphQLAccountWithHost } from '../interface/AccountWithHost';
 import { CollectionArgs, getCollectionArgs } from '../interface/Collection';
 import URL from '../scalar/URL';
 
@@ -100,12 +93,12 @@ const getTimeUnit = numberOfDays => {
 export const GraphQLHost = new GraphQLObjectType({
   name: 'Host',
   description: 'This represents an Host account',
-  interfaces: () => [GraphQLAccount, GraphQLAccountWithContributions],
-  // Due to overlap between our Organization and Host types, we cannot use isTypeOf here
-  // isTypeOf: account => account.isHostAccount,
+  interfaces: () => [GraphQLAccount, GraphQLAccountWithHost, GraphQLAccountWithContributions],
+  isTypeOf: collective => collective.type === 'ORGANIZATION' && collective.isHostAccount,
   fields: () => {
     return {
       ...AccountFields,
+      ...AccountWithHostFields(),
       ...AccountWithContributionsFields,
       accountingCategories: {
         type: new GraphQLNonNull(GraphQLAccountingCategoryCollection),
@@ -121,12 +114,6 @@ export const GraphQLHost = new GraphQLObjectType({
             limit: categories.length,
             offset: 0,
           };
-        },
-      },
-      hostFeePercent: {
-        type: GraphQLFloat,
-        resolve(collective) {
-          return collective.hostFeePercent;
         },
       },
       totalHostedCollectives: {

--- a/server/graphql/v2/object/Organization.js
+++ b/server/graphql/v2/object/Organization.js
@@ -11,7 +11,7 @@ export const GraphQLOrganization = new GraphQLObjectType({
   name: 'Organization',
   description: 'This represents an Organization account',
   interfaces: () => [GraphQLAccount, GraphQLAccountWithContributions],
-  isTypeOf: collective => collective.type === 'ORGANIZATION',
+  isTypeOf: collective => collective.type === 'ORGANIZATION' && !collective.isHostAccount,
   fields: () => {
     return {
       ...AccountFields,

--- a/server/graphql/v2/object/Project.js
+++ b/server/graphql/v2/object/Project.js
@@ -13,7 +13,7 @@ export const GraphQLProject = new GraphQLObjectType({
   fields: () => {
     return {
       ...AccountFields,
-      ...AccountWithHostFields,
+      ...AccountWithHostFields(),
       ...AccountWithContributionsFields,
       ...AccountWithParentFields,
       isApproved: {

--- a/test/server/graphql/v2/mutation/AccountingCategoriesMutations.test.ts
+++ b/test/server/graphql/v2/mutation/AccountingCategoriesMutations.test.ts
@@ -27,18 +27,16 @@ describe('server/graphql/v2/mutation/AccountingCategoriesMutations', () => {
     const editAccountingCategoriesMutation = gqlV2/* GraphQL */ `
       mutation EditAccountingCategories($account: AccountReferenceInput!, $categories: [AccountingCategoryInput!]!) {
         editAccountingCategories(account: $account, categories: $categories) {
-          ... on Organization {
-            host {
-              id
-              accountingCategories {
-                totalCount
-                nodes {
-                  id
-                  code
-                  name
-                  friendlyName
-                  expensesTypes
-                }
+          ... on Host {
+            id
+            accountingCategories {
+              totalCount
+              nodes {
+                id
+                code
+                name
+                friendlyName
+                expensesTypes
               }
             }
           }
@@ -196,7 +194,7 @@ describe('server/graphql/v2/mutation/AccountingCategoriesMutations', () => {
     it('edits accounting categories successfully', async () => {
       const admin = await fakeUser();
       const host = await fakeActiveHost({ admin });
-      const getNodesFromResult = result => get(result, 'data.editAccountingCategories.host.accountingCategories.nodes');
+      const getNodesFromResult = result => get(result, 'data.editAccountingCategories.accountingCategories.nodes');
 
       // Host starts with no accounting categories
       expect(await host.getAccountingCategories()).to.have.length(0);


### PR DESCRIPTION
- Make Hosts returned as Host instead of Organization

Replace (BREAKING CHANGE):

```graphql
... on Organization {
  host {
    id
    hostFeePercent
  }
}
```

with simpler:

```graphql
... on Host {
  id
  hostFeePercent
}
```

or:

```graphql
... on Host {
  host {
    id
    hostFeePercent
  }
}
```

- Make Hosts be an AccountWithHost to simplify things on the frontend side

Idea is to avoid such weird code:

```graphql
... on AccountWithHost {
  host {
    id
    slug
    paypalClientId
    supportedPaymentMethods
  }
}
... on Organization {
  host {
    id
    slug
    paypalClientId
    supportedPaymentMethods
  }
}
```

And replace with just:

```graphql
... on AccountWithHost {
  host {
    id
    slug
    paypalClientId
    supportedPaymentMethods
  }
}
```