### PR TITLE
fix(Checks): length check on errors

### DIFF
--- a/checks/model/payment-methods.ts
+++ b/checks/model/payment-methods.ts
@@ -27,7 +27,7 @@ async function checkCollectivePaymentMethodsCurrencies({ fix = false } = {}) {
     { type: sequelize.QueryTypes.SELECT, raw: true },
   );
 
-  if (results[0].count > 0) {
+  if (results.length > 0) {
     if (!fix) {
       throw new Error(message);
     }


### PR DESCRIPTION
I've used the same condition as in the other checks, but here we must simplify since we're using `{ type: sequelize.QueryTypes.SELECT, raw: true },`.