### PR TITLE
Webhooks: adapt formatMessage for Slack webhooks

### DIFF
--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -127,7 +127,7 @@ const doFormatMessage = (activity, format) => {
           tweetLink = linkify(format, `https://twitter.com/intent/tweet?text=${tweet}`, 'Thank that person on Twitter');
           tweetThis = ` [${tweetLink}]`;
         }
-        return `New financial contribution: ${userString} gave ${currency} ${amount} to ${collective}!${tweetThis}`;
+        return `New financial contribution: ${userString} gave ${currency} ${amount} to ${collective}${tweetThis}`;
       } else if (activity.data.transaction.ExpenseId) {
         return `New transaction for paid expense "${description}" (${currency} ${amount}) on ${collective}`;
       } else if (activity.data.transaction.isRefund) {
@@ -137,16 +137,16 @@ const doFormatMessage = (activity, format) => {
       }
 
     case activities.COLLECTIVE_EXPENSE_CREATED:
-      return `New Expense: ${userString} submitted an expense to ${collective}: ${currency} ${amount} for ${description}!`;
+      return `New Expense: ${userString} submitted an expense to ${collective}: ${currency} ${amount} for ${description}`;
 
     case activities.COLLECTIVE_EXPENSE_REJECTED:
-      return `Expense rejected: ${currency} ${amount} for ${description} in ${collective}!`;
+      return `Expense rejected: ${currency} ${amount} for ${description} in ${collective}`;
 
     case activities.COLLECTIVE_EXPENSE_RE_APPROVAL_REQUESTED:
-      return `Expense needs re-approval: ${currency} ${amount} for ${description} in ${collective}!`;
+      return `Expense needs re-approval: ${currency} ${amount} for ${description} in ${collective}`;
 
     case activities.COLLECTIVE_EXPENSE_APPROVED:
-      return `Expense approved: ${currency} ${amount} for ${description} in ${collective}!`;
+      return `Expense approved: ${currency} ${amount} for ${description} in ${collective}`;
 
     case activities.COLLECTIVE_EXPENSE_PAID:
       return `Expense paid on ${collective}: ${currency} ${amount} for '${description}'`;
@@ -161,7 +161,7 @@ const doFormatMessage = (activity, format) => {
         tweetLink = linkify(format, `https://twitter.com/intent/tweet?text=${tweet}`, 'Thank that person on Twitter');
         tweetThis = ` [${tweetLink}]`;
       }
-      return `New subscription confirmed: ${currency} ${recurringAmount} from ${userString} to ${collective}!${tweetThis}`;
+      return `New subscription confirmed: ${currency} ${recurringAmount} from ${userString} to ${collective}${tweetThis}`;
 
     case activities.COLLECTIVE_CREATED:
       return `New collective created by ${userString}: ${collective} ${hostString}`.trim();

--- a/test/server/lib/activities.test.js
+++ b/test/server/lib/activities.test.js
@@ -11,7 +11,7 @@ describe('server/lib/activities', () => {
     it(`${constants.COLLECTIVE_TRANSACTION_CREATED} donation`, () => {
       const { message } = activitiesLib.formatMessageForPublicChannel(activitiesData[10], 'slack');
       expect(message).to.equal(
-        'New financial contribution: someone gave USD 10.42 to <https://opencollective.com/pubquiz|Pub quiz>!',
+        'New financial contribution: someone gave USD 10.42 to <https://opencollective.com/pubquiz|Pub quiz>',
       );
     });
 
@@ -39,14 +39,14 @@ describe('server/lib/activities', () => {
     it(constants.SUBSCRIPTION_CONFIRMED, () => {
       const { message } = activitiesLib.formatMessageForPublicChannel(activitiesData[15], 'slack');
       expect(message).to.equal(
-        'New subscription confirmed: EUR 12.34 from someone to <https://opencollective.com/blah|Blah>!',
+        'New subscription confirmed: EUR 12.34 from someone to <https://opencollective.com/blah|Blah>',
       );
     });
 
     it(`${constants.SUBSCRIPTION_CONFIRMED} with month interval`, () => {
       const { message } = activitiesLib.formatMessageForPublicChannel(activitiesData[16], 'slack');
       expect(message).to.equal(
-        'New subscription confirmed: EUR 12.34/month from <https://twitter.com/xdamman|xdamman> to <https://opencollective.com/yeoman|Yeoman>! [<https://twitter.com/intent/tweet?text=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20contribution%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman|Thank that person on Twitter>]',
+        'New subscription confirmed: EUR 12.34/month from <https://twitter.com/xdamman|xdamman> to <https://opencollective.com/yeoman|Yeoman> [<https://twitter.com/intent/tweet?text=%40xdamman%20thanks%20for%20your%20%E2%82%AC12.34%2Fmonth%20contribution%20to%20%40yeoman%20%F0%9F%91%8D%20https%3A%2F%2Fopencollective.com%2Fyeoman|Thank that person on Twitter>]',
       );
     });
 
@@ -58,21 +58,21 @@ describe('server/lib/activities', () => {
     it(`${constants.COLLECTIVE_EXPENSE_CREATED}`, () => {
       const { message } = activitiesLib.formatMessageForPublicChannel(activitiesData[19], 'slack');
       expect(message).to.equal(
-        'New Expense: someone submitted an expense to <blah.com|Blah>: EUR 12.34 for <http://localhost:3000/blah/expenses/42|for pizza>!',
+        'New Expense: someone submitted an expense to <blah.com|Blah>: EUR 12.34 for <http://localhost:3000/blah/expenses/42|for pizza>',
       );
     });
 
     it(`${constants.COLLECTIVE_EXPENSE_REJECTED}`, () => {
       const { message } = activitiesLib.formatMessageForPublicChannel(activitiesData[20], 'slack');
       expect(message).to.equal(
-        'Expense rejected: EUR 12.34 for <http://localhost:3000/blah/expenses/42|for pizza> in <blah.com|Blah>!',
+        'Expense rejected: EUR 12.34 for <http://localhost:3000/blah/expenses/42|for pizza> in <blah.com|Blah>',
       );
     });
 
     it(`${constants.COLLECTIVE_EXPENSE_APPROVED}`, () => {
       const { message } = activitiesLib.formatMessageForPublicChannel(activitiesData[21], 'slack');
       expect(message).to.equal(
-        'Expense approved: EUR 12.34 for <http://localhost:3000/blah/expenses/42|for pizza> in <blah.com|Blah>!',
+        'Expense approved: EUR 12.34 for <http://localhost:3000/blah/expenses/42|for pizza> in <blah.com|Blah>',
       );
     });
   });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5552 by removing the `!` at the end of webhook messages.