### PR TITLE
Script to generate 1099 yearly export

### DIFF
--- a/scripts/tax-forms/export-1099.ts
+++ b/scripts/tax-forms/export-1099.ts
@@ -1,0 +1,294 @@
+/**
+ * This script produces the yearly export that fiscal hosts send to their accountants.
+ * It outputs a `{year}-{host}-tax-forms.zip` file structured as follows:
+ * - `recipients.csv`: list of all recipients with their details
+ * - `files/`: directory containing all the tax forms
+ */
+
+import '../../server/env';
+
+import fs from 'fs';
+import path from 'path';
+
+import { Command } from 'commander';
+import { parse as json2CSV } from 'json2csv';
+import { get, truncate } from 'lodash';
+import markdownTable from 'markdown-table'; // eslint-disable-line node/no-unpublished-import
+
+import {
+  fetchHelloWorksInstance,
+  getFormFieldsFromHelloWorksInstance,
+  HelloWorksTaxFormInstance,
+} from '../../server/controllers/helloworks';
+import { formatCurrency } from '../../server/lib/utils';
+import models, { sequelize } from '../../server/models';
+
+const taxFormsQuery = `
+  -- Get tax forms
+  WITH tax_form_status AS (
+    SELECT
+      account.id AS "accountId",
+      account.slug,
+      account.name,
+      account."legalName",
+      account.type,
+      d."documentType" as "requiredDocument",
+      MAX(ld."createdAt") AS requested_at,
+      MAX(ld."requestStatus") as "legalDocRequestStatus",
+      MAX(ld."documentLink") AS "documentLink",
+      MAX(ld."data"::varchar) AS "data",
+      ABS(
+        SUM(t."amountInHostCurrency" * (
+          CASE
+            WHEN all_expenses."currency" = host.currency THEN 1
+            ELSE (
+              SELECT COALESCE("rate", 1)
+              FROM "CurrencyExchangeRates" er
+              WHERE er."from" = all_expenses."currency"
+              AND er."to" = host.currency
+              AND er."createdAt" < all_expenses."createdAt"
+              ORDER BY "createdAt" DESC
+              LIMIT 1
+            )
+          END
+        ))
+      ) AS total
+    FROM "Collectives" account
+    INNER JOIN "Expenses" all_expenses
+      ON all_expenses."FromCollectiveId" = account.id
+    INNER JOIN "Collectives" c
+      ON all_expenses."CollectiveId" = c.id
+    INNER JOIN "RequiredLegalDocuments" d
+      ON d."HostCollectiveId" = all_expenses."HostCollectiveId"
+      AND d."documentType" = 'US_TAX_FORM'
+    INNER JOIN "Collectives" host
+      ON all_expenses."HostCollectiveId" = host.id
+    LEFT JOIN (
+      SELECT
+        *,
+        -- Rank documents by putting RECEIVED first, then by date DESC
+        ROW_NUMBER() OVER(
+          PARTITION BY "CollectiveId"
+          ORDER BY CASE WHEN "requestStatus" = 'RECEIVED' THEN 1 ELSE 2 END ASC, "createdAt" DESC
+        ) AS rank
+      FROM "LegalDocuments"
+      WHERE "deletedAt" IS NULL
+      AND year + 3 >= :year
+      AND "documentType" = 'US_TAX_FORM'
+    ) ld ON ld."CollectiveId" = account.id AND ld.rank = 1
+    INNER JOIN "Transactions" t
+      ON t."ExpenseId" = all_expenses.id
+      AND t.type = 'DEBIT'
+      AND t.kind = 'EXPENSE'
+      AND t."RefundTransactionId" is NULL
+      AND t."deletedAt" IS NULL
+    LEFT JOIN "PayoutMethods" pm
+      ON all_expenses."PayoutMethodId" = pm.id
+    WHERE all_expenses.type NOT IN ('RECEIPT', 'CHARGE', 'SETTLEMENT', 'FUNDING_REQUEST', 'GRANT')
+    AND host.slug = :hostSlug
+    AND account.id != d."HostCollectiveId"
+    AND (account."HostCollectiveId" IS NULL OR account."HostCollectiveId" != d."HostCollectiveId")
+    AND all_expenses.status = 'PAID'
+    AND all_expenses."deletedAt" IS NULL
+    AND EXTRACT('year' FROM t."createdAt") = :year
+    AND pm."type" != 'PAYPAL' AND pm."type" != 'ACCOUNT_BALANCE'
+    GROUP BY account.id, d."documentType"
+    HAVING COALESCE(SUM(all_expenses."amount"), 0) >= 60000
+  ) SELECT
+    c.name,
+    c."legalName",
+    ('https://opencollective.com/' || c.slug) AS "profileUrl",
+    c."type",
+    c."countryISO" as country,
+    MIN(tax_form_status."requested_at") AS requested_at,
+    MAX(tax_form_status."data") AS "data",
+    coalesce(MAX(tax_form_status.total), 0) AS paid,
+    REPLACE(MAX(tax_form_status."documentLink"), 'https://opencollective-production-us-tax-forms.s3.us-west-1.amazonaws.com/', '') AS "documentPath",
+    string_agg(DISTINCT u.email, ', ') AS "adminEmails"
+  FROM tax_form_status
+  -- Add collective admins
+  INNER JOIN "Collectives" c ON tax_form_status."accountId" = c.id
+  LEFT JOIN "Members" m ON m."CollectiveId" = c.id AND m."role" = 'ADMIN'
+  INNER JOIN "Users" u ON u."CollectiveId" = c.id OR u."CollectiveId" = m."MemberCollectiveId"
+  GROUP BY c.id, tax_form_status."accountId"
+  ORDER BY c."name"
+`;
+
+/**
+ * A small helper to convert the path to the format produced by https://github.com/opencollective/encrypt_dir/blob/f038ffc8d53d679f9edbd1b1131de484be99e81f/decryptDir.js
+ * @param basePath The base path without the S3 domain
+ */
+const prepareDocumentPath = (basePath: string) => {
+  if (!basePath) {
+    return '';
+  } else if (basePath.startsWith('https://')) {
+    return basePath; // Do nothing for Drive links
+  }
+
+  if (!basePath.match(/US_TAX_FORM\/\d{4}\/.+/)) {
+    // Get year from basePath (US_TAX_FORM_2020_xxx.pdf)
+    const year = basePath.match(/US_TAX[ _]FORM_(\d{4})/i)[1];
+    const pathWithoutYear = basePath.replace(/US_TAX[ _]FORM_\d{4}_/i, '');
+    basePath = path.join('US_TAX_FORM', year, pathWithoutYear);
+  }
+
+  // Finish by running decodeURIComponent on the filename
+  const filename = decodeURIComponent(path.basename(basePath));
+  return path.join(path.dirname(basePath), filename);
+};
+
+const parseCommandLine = () => {
+  const program = new Command();
+  program.showSuggestionAfterError();
+  program.arguments('<year> <hostSlug>');
+  program.option('--files-dir <path>', 'Directory where the tax forms are stored');
+  program.option('--output-dir <path>', 'Directory where the output files will be stored');
+  program.option('--cache-dir <path>', 'Directory where the cache files (the responses from HelloWorks) are stored');
+  program.parse();
+
+  const options = program.opts();
+  if (!options.outputDir) {
+    console.warn(
+      'Output directory (--output-dir) not specified, the script will only summarize the results in the console',
+    );
+  }
+  if (!options.cacheDir) {
+    console.warn(
+      'Cache directory (--cache-dir) not specified, the script will be slower as it will have to fetch the HelloWorks responses again',
+    );
+  }
+
+  return { year: program.args[0], hostSlug: program.args[1], options };
+};
+
+const getHelloWorksInstance = async (instanceId: string, cacheDir): Promise<HelloWorksTaxFormInstance> => {
+  if (!instanceId) {
+    return null;
+  }
+
+  // Try to return from cache
+  if (cacheDir) {
+    const cachePath = path.join(cacheDir, `${instanceId}.json`);
+    if (fs.existsSync(cachePath)) {
+      return JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    }
+  }
+
+  // Otherwise fetch from HelloWorks
+  const instance = await fetchHelloWorksInstance(instanceId);
+  if (instance && cacheDir) {
+    fs.writeFileSync(path.join(cacheDir, `${instanceId}.json`), JSON.stringify(instance));
+  }
+
+  return instance;
+};
+
+const generateExport = async (
+  hostSlug: string,
+  year: number | string,
+  recipients,
+  { outputDir = null, filesDir = null, cacheDir = null },
+) => {
+  const preparedData = [];
+  for (const recipient of recipients) {
+    const data = JSON.parse(recipient.data);
+    const helloWorksInstance = await getHelloWorksInstance(get(data, 'helloWorks.instance.id'), cacheDir);
+    const formData = getFormFieldsFromHelloWorksInstance(helloWorksInstance);
+    preparedData.push({
+      "Recipient's Name": formData.participantName || recipient.legalName || recipient.name,
+      Account: recipient.profileUrl,
+      Type: formData.type,
+      Entity: formData.entityName,
+      Status: formData.status,
+      'Tax ID Type': formData.taxIdNumberType,
+      'Tax ID': formData.taxIdNumber,
+      'Recipient Address (1)': formData.address1,
+      'Recipient Address (2)': formData.address2,
+      'Recipient Country': formData.country,
+      'Recipient Email': formData.email || helloWorksInstance?.metadata?.email || recipient.adminEmails,
+      'Box 1 Nonemployee Compensation': formatCurrency(recipient.paid, 'USD'),
+      File: prepareDocumentPath(recipient.documentPath),
+      'Dropbox Form Instance': get(data, 'helloWorks.instance.id'),
+    });
+  }
+
+  const csv = json2CSV(preparedData, { header: true });
+  if (outputDir) {
+    const tmpDir = path.join(outputDir, `${hostSlug}-${year}`);
+
+    if (!fs.existsSync(tmpDir)) {
+      fs.mkdirSync(tmpDir, { recursive: true });
+    }
+
+    // Copy all PDFs
+    if (!filesDir) {
+      console.warn('Files directory (--files-dir) not specified, the script will not copy the tax forms');
+    } else {
+      for (const row of preparedData) {
+        if (!row.File || !row.File.startsWith('US_TAX_FORM/')) {
+          continue;
+        }
+
+        const filePath = path.join(filesDir, row.File);
+        if (fs.existsSync(filePath)) {
+          const outputFile = path.join(tmpDir, row.File);
+          const fileDir = path.dirname(outputFile);
+          if (!fs.existsSync(fileDir)) {
+            fs.mkdirSync(fileDir, { recursive: true });
+          }
+
+          fs.copyFileSync(filePath, outputFile);
+        } else {
+          console.warn(`File not found: ${filePath}`);
+        }
+      }
+    }
+
+    // Generate CSV
+    fs.writeFileSync(`${tmpDir}/${hostSlug}-${year}-tax-forms.csv`, csv);
+
+    console.log(`Export generated in ${tmpDir}`);
+  } else {
+    console.log(
+      markdownTable([
+        Object.keys(preparedData[0]).map(key => truncate(key, { length: 30 })),
+        ...preparedData.map(recipient =>
+          Object.entries(recipient).map(([key, value]) => {
+            if (key === 'File') {
+              return value;
+            } else {
+              return value && truncate(value.toString(), { length: 30 });
+            }
+          }),
+        ),
+      ]),
+    );
+  }
+};
+
+const main = async () => {
+  const { year, hostSlug, options } = parseCommandLine();
+  const host = await models.Collective.findBySlug(hostSlug, {
+    include: [{ model: models.RequiredLegalDocument, where: { documentType: 'US_TAX_FORM' }, required: false }],
+  });
+
+  if (!host) {
+    throw new Error(`${hostSlug} not found`);
+  } else if (!host.RequiredLegalDocuments.length) {
+    throw new Error(`${hostSlug} is not connected to the tax form system`);
+  }
+
+  const recipients = await sequelize.query(taxFormsQuery, {
+    replacements: { hostSlug, year },
+    type: sequelize.QueryTypes.SELECT,
+  });
+
+  await generateExport(hostSlug, year, recipients, options);
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/scripts/tax-forms/seed-hello-works-ids.ts
+++ b/scripts/tax-forms/seed-hello-works-ids.ts
@@ -1,0 +1,264 @@
+/**
+ * A script to seed HelloWorks IDs for existing tax forms.
+ * Pre-2022, or more precisely before https://github.com/opencollective/opencollective-api/pull/6907,
+ * we were not storing the HelloWorks instance ID in the database. This script aims to fix that
+ * as best as possible, by looking at HelloWorks CSV exports and trying to match them with existing
+ * `LegalDocument`s in the database.
+ *
+ * The CSV can be downloaded with the script below (look at Dropbox Forms for the exact curl command):
+ *
+ * ```bash
+ * start_date="2019-01-01T00:00:00.000Z"
+ * end_date="2019-05-01T23:59:59.000Z"
+ * end_loop_date="2023-01-01T00:00:00.000Z"
+ * interval="4 months"
+ * workflows="&guid[]=MfmOZErmhz1qPgMp&guid[]=qdUbX5nw8sMZzykz&guid[]=MkFBvG39RIA61OnD"
+ *
+ * # Download
+ * while [[ "$start_date" < "$end_loop_date" ]]; do
+ *   # Calculate the end date for this period
+ *   period_end_date=$(date -d "$start_date + $interval" "+%Y-%m-%dT%H:%M:%S.000Z")
+ *
+ *   # Call the curl command with the current date range
+ *   # curl "http://my-url.com?start_date=$start_date&end_date=$period_end_date"
+ *   curl --output result-$start_date-$period_end_date.zip "https://portal.helloworks.com/workflow/transactions/detail/?mode=live&$worflows&start_date=$start_date&end_date=$period_end_date"
+ *
+ *   # Update the start date for the next period
+ *   start_date=$(date -d "$period_end_date + 1 second" "+%Y-%m-%dT%H:%M:%S.000Z")
+ * done
+ *
+ * # Extract all CSV files from the zip files
+ * for f in *.zip; do unzip -B -j "$f" "*.csv"; done
+ *
+ * # Merge all CSV files into one
+ * csvstack Open*.csv* >all.csv
+ * ```
+ *
+ */
+
+import '../../server/env';
+
+import fs from 'fs';
+
+import Commander from 'commander';
+import { parse } from 'csv-parse/sync'; // eslint-disable-line
+
+import { fetchHelloWorksInstance, HelloWorksTaxFormInstance } from '../../server/controllers/helloworks';
+import models, { sequelize } from '../../server/models';
+
+const parseCommandLine = () => {
+  const program = new Commander.Command();
+  program.requiredOption('-i, --input <path>', 'Path to the CSV file exported from HelloWorks');
+  program.option('--offset <number>', 'Number of rows to skip', parseInt);
+  program.option('--email <email>', 'Email of the user to look for');
+  program.parse(process.argv);
+  return program.opts();
+};
+
+const getDocumentForYear = (documents, year, identifier) => {
+  if (year && documents.find(d => d.year === year)) {
+    if (documents.filter(d => d.year === year).length !== 1) {
+      console.log(
+        `Multiple documents found for ${identifier} at year ${year} (${documents
+          .map(d => d.year)
+          .join(', ')}). Skipping...`,
+      );
+    } else {
+      return documents.find(d => d.year === year);
+    }
+  }
+};
+
+const getYearFromMetadata = metadata => {
+  if (!metadata) {
+    return null;
+  }
+  if (metadata.year) {
+    return parseInt(metadata.year);
+  }
+
+  const yearKey = Object.keys(metadata).find(key => typeof key === 'string' && key.startsWith('year,'));
+  if (yearKey) {
+    return parseInt(yearKey.split(',')[1]);
+  }
+};
+
+const getTaxFormForCollective = async (collectiveId, getInstance) => {
+  const documents = await models.LegalDocument.findAll({
+    where: { CollectiveId: collectiveId, documentType: 'US_TAX_FORM' },
+    order: [['year', 'DESC']],
+  });
+
+  if (documents.length === 0) {
+    console.log(`No documents found for ${collectiveId}`);
+  } else if (documents.length === 1) {
+    return documents[0];
+  } else if (documents.length > 1) {
+    // If there's 1 document per year, we can try and match on the best one
+    const instance = await getInstance();
+    const year = getYearFromMetadata(instance.metadata);
+
+    if (!year && instance.status === 'completed') {
+      return documents.find(d => !d.data?.helloWorks?.instance?.id) || documents[0];
+    } else if (year && documents.find(d => d.year === year)) {
+      return getDocumentForYear(documents, year, collectiveId);
+    } else {
+      console.log(
+        `Multiple documents found for ${collectiveId} (${documents.map(d => d.year).join(', ')}). None for ${year}`,
+      );
+    }
+  }
+};
+
+const isCorruptedMetadata = metadata => {
+  return Boolean(metadata && Object.keys(metadata).some(key => typeof key === 'string' && key.startsWith('userId,')));
+};
+
+const getTaxFormForInstanceWithCorruptedMetadata = async (instance: HelloWorksTaxFormInstance) => {
+  const userKey = Object.keys(instance.metadata).find(key => typeof key === 'string' && key.startsWith('userId,'));
+  const userId = parseInt(userKey?.split(',')[1]);
+  const user = await models.User.findByPk(userId);
+  if (user) {
+    return getTaxFormForCollective(user.CollectiveId, () => Promise.resolve(instance));
+  } else {
+    console.log(`No user found for ${instance.id} (${userKey})`);
+  }
+};
+
+const findDocumentForEmail = async (email, getInstance) => {
+  let user = await models.User.findOne({ where: { email }, paranoid: false });
+  if (user) {
+    return getTaxFormForCollective(user.CollectiveId, getInstance);
+  } else {
+    // Users may have changed their emails, look in the histories table
+    const result = await sequelize.query(`SELECT DISTINCT "id" FROM "UserHistories" WHERE email = :email`, {
+      type: sequelize.QueryTypes.SELECT,
+      replacements: { email },
+    });
+
+    if (result.length === 1) {
+      user = await models.User.findByPk(result[0].id, { paranoid: false });
+      if (user) {
+        return getTaxFormForCollective(user.CollectiveId, getInstance);
+      }
+    }
+  }
+};
+
+const findLegalDocument = async (instanceId, { email, slug }) => {
+  // Try to find by instance ID
+  let ld = await models.LegalDocument.findOne({ where: { data: { helloWorks: { instance: { id: instanceId } } } } });
+  let fullInstance: HelloWorksTaxFormInstance;
+  const getInstance = async () => {
+    if (!fullInstance) {
+      fullInstance = await fetchHelloWorksInstance(instanceId);
+    }
+    return fullInstance;
+  };
+
+  // Fallback on account slug if available
+  if (!ld && slug) {
+    const documents = await models.LegalDocument.findAll({
+      include: [{ association: 'collective', where: { slug }, attributes: [], paranoid: false }],
+    });
+
+    if (documents.length > 1) {
+      const instance = await getInstance();
+      ld = getDocumentForYear(documents, parseInt(instance.metadata?.year), slug);
+    } else {
+      ld = documents[0];
+    }
+  }
+
+  // Fallback on email
+  if (!ld && email) {
+    ld = await findDocumentForEmail(email, getInstance);
+  }
+
+  // Use the instance to find the legal document
+  if (!ld && instanceId) {
+    const instance = await getInstance();
+    if (!instance) {
+      console.log('No metadata for', instanceId);
+    } else {
+      const collectiveId = instance.metadata?.accountId;
+      if (collectiveId) {
+        ld = await getTaxFormForCollective(collectiveId, getInstance);
+      } else if (isCorruptedMetadata(instance.metadata)) {
+        ld = await getTaxFormForInstanceWithCorruptedMetadata(instance);
+      } else if (instance.metadata?.userId) {
+        const user = await models.User.findByPk(instance.metadata.userId);
+        if (user) {
+          ld = await getTaxFormForCollective(user.CollectiveId, getInstance);
+        }
+      } else if (instance.metadata?.email) {
+        ld = await findDocumentForEmail(instance.metadata.email, getInstance);
+      } else {
+        console.log('No account ID for', instance.id);
+      }
+    }
+  }
+
+  return ld;
+};
+
+const main = async () => {
+  const options = parseCommandLine();
+  const rawContent = fs.readFileSync(options.input, 'utf8');
+  const parsedCsv = parse(rawContent, { delimiter: ',', columns: true });
+
+  for (const [index, row] of parsedCsv.entries()) {
+    if (options.offset && index < options.offset) {
+      continue;
+    } else if (index % 50 === 0) {
+      console.log(`Processed ${index}/${parsedCsv.length}`);
+    }
+
+    const instanceId = row['Instance ID'];
+    const email = (row['Participant - Authentication'] || row['Your Email'] || '').toLowerCase();
+    let name = row['Name'] || row['Name of Beneficial Owner'] || row['Signer name'] || row['Business name'];
+    let slug;
+    if (options.email && email !== options.email) {
+      continue;
+    }
+
+    // Extract slug from format "carolyn-ephraim (Cosmos Ray)"
+    if (row['Participant - Name']) {
+      const slugRegex = /(?<slug>[a-z0-9-]+) (\((?<name>.+)\))/i;
+      const match = row['Participant - Name'].match(slugRegex);
+      if (match) {
+        slug = match.groups.slug;
+        name = match.groups.name || name;
+      }
+    }
+
+    // All entries must have an instance ID
+    if (!instanceId) {
+      console.log(`No instance ID found for ${email} - ${name} - ${slug}`);
+      continue;
+    }
+
+    // Try to find the legal document and update it
+    const ld = await findLegalDocument(instanceId, { email, slug });
+    if (!ld) {
+      console.log(`No legal document found for ${instanceId} (${email} - ${name} - ${slug})`);
+    } else if (!ld.data?.helloWorks?.instance?.id) {
+      console.log(`Updating ${instanceId} (${email} - ${name} - ${slug})`);
+      await ld.update({ data: { ...ld.data, helloWorks: { instance: { id: instanceId } } } });
+    } else if (ld.data.helloWorks.instance.id !== instanceId) {
+      console.log(
+        `Another instance ID found for ${instanceId} (${email} - ${name} - ${slug}): ${ld.data.helloWorks?.instance.id}`,
+      );
+    }
+  }
+};
+
+main()
+  .then(() => {
+    console.log('Done');
+    process.exit(0);
+  })
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/server/controllers/helloworks.ts
+++ b/server/controllers/helloworks.ts
@@ -48,13 +48,15 @@ export type HelloWorksTaxFormInstance = {
   mode: string;
   type: string;
   data: {
-    Form_nRZrdh: {
+    // Latest version of the form
+    Form_nRZrdh?: {
       /** Name of organization that is the beneficial owner */
       field_3HxExU: string;
       /** Chapter 3 Status (entity type) */
       field_7h9cxX: string;
       field_96QX5j: string;
-      field_ENxHCd: string;
+      /** Are you US Person or Entity? */
+      field_ENxHCd: 'Yes' | 'No';
       field_FTZIWD: string;
       field_G7YfJr: string;
       field_OSOk14: string;
@@ -62,17 +64,230 @@ export type HelloWorksTaxFormInstance = {
       field_T0IdZf: string;
       /** Country of incorporation or organization */
       field_VvICe1: string;
+      /** Your_Email (Participant) */
       field_gwd8pa: string;
       /** Foreign TIN */
       field_hJkq4B: string;
+      /** Name of disregarded entity receiving the payment */
+      field_F1U7HL: string;
       field_hWAMyS: string;
       /** Name of the signer */
       field_mqVUrj: string;
       /** Mailing address */
       field_pITmtq: string;
-      field_xdp45L: string;
+      /** Are you submitting as... */
+      field_xdp45L: 'an individual person' | 'a business or entity';
+      /** Signature date */
+      field_5yf9Bp: string;
+      /** Foreign tax identifying number */
+      field_JiKEj4: string;
+      /** Certify country of residence */
+      field_SZJNur: string;
+      field_XdGK3o: string;
+      /** Signer name */
+      field_Xdy5Kk: string;
+      // -----
+      /** Signer name */
+      field_JI6gsq: string;
+      /** Enter_SSN (Participant) */
+      field_SXcrBL: string;
+      /** Address_(city,_state,_ZIP) (Participant) */
+      field_bsHU5V: string;
+      /** Tax ID number type */
+      field_m4nLix: 'SSN' | 'EIN';
+      field_oU5IRt: string;
+      field_pxvAbW: string;
+      /** Business type */
+      field_ruhFN4:
+        | 'Individual (or sole proprietor)'
+        | 'C-Corp'
+        | 'S-Corp'
+        | 'Partnership'
+        | 'Trust/Estate'
+        | 'LLC'
+        | 'Other (specify at the end of this form)';
+      /** You selected "other tax classification" — please specify: */
+      field_IYb1zy: string;
+      // ----  US person/entity fields (field_ENxHCd=true) ----
+      /** Name (Participant) */
+      field_vBxRqQ: string;
+      /** Address_(number,_street,_apt) (Participant) */
+      field_y19HZi: string;
+      /** Optional:_Exempt_payee_code_(if_any) (Participant) */
+      field_tOgTam: string;
+      /** Enter_EIN (Participant) */
+      field_nsaxM8: string;
+      /** U.S._SSN_or_ITIN_(if_required) (Participant) */
+      field_iGedCY: string;
+      // ---- W8-BEN (individuals) ----
+      /** Permanent residence address (street, apt. or suite no., or rural route) */
+      field_AdoY67: string;
+      /** Country of citizenship */
+      field_dIEvL2: string;
+      /** Name of individual who is the beneficial owner */
+      field_3IvuYi: string;
+      field_26SpJI: string;
+      field_2BzOcB: string;
+      field_2o6n1d: string;
+      /** Postal_address (Participant) */
+      field_3j4IQT: string;
+      /** Country of residence */
+      field_e2uMPk: string;
+    };
+    // Legacy version of the form
+    Form_jmV4rR?: {
+      /** Participant name */
+      field_nTuM3q: string;
+      /** Date of birth  */
+      field_5zvlrH: string;
+      /** Name of individual that is the beneficial owner */
+      field_7G0PTT: string;
+      /** Do you claim tax treaty benefits for chapter 3 purposes? */
+      field_8JIBUU: string;
+      /** Signer name */
+      field_HEJfi8: string;
+      /** Are you US Person or Entity? */
+      field_Jj5lq3: 'Yes' | 'No';
+      /** Email */
+      field_LEHARZ: string;
+      /** Foreign tax identifying number */
+      field_TDttcV: string;
+      /** Mailing address */
+      field_UXEERA: string;
+      /** Country of citizenship */
+      field_VjJblP: string;
+      /** Are you submitting as... */
+      field_W7cOxA: 'an individual person' | 'a business or entity';
+      /** Has confirmed info */
+      field_XKL6pp: 'Yes' | 'No';
+      /** Signature date */
+      field_kIEVyL: string;
+      /** Permanent residence address */
+      field_nhEGv2: string;
+      // Conditional fields
+      field_6qJvKv: string;
+      /** Signature date */
+      field_LCxCSj: string;
+      /** Tax ID number type */
+      field_GP1WVV: 'SSN' | 'EIN';
+      /** SSN */
+      field_IHousr: string;
+      /** EIN */
+      field_U1SIy7: string;
+      /** US tax ID number */
+      field_YBBuNx: string;
+      /** Foreign tax identifying number */
+      field_NwJcK9: string;
+      /** You selected "other tax classification" — please specify: */
+      field_uRwOOO: string;
+      /** Name */
+      field_Q3j60N: string;
+      field_WHuufi: string;
+      /** Permanent residence address (street, apt. or suite no., or rural route). */
+      field_Zdjn7X: string;
+      /** Certify that is not a financial institution */
+      field_fAve48: 'Yes' | 'No';
+      /** Name of organization that is the beneficial owner */
+      field_pLPdKR: string;
+      field_qXoH7X: string;
+      /** Chapter 3 status */
+      field_qgGMt1: string;
+      /** Country of incorporation or organization */
+      field_ro87Pn: string;
+      /** Address_(number,_street,_apt) (Participant) */
+      field_nSSZij: string;
+      /** Address_(city,_state,_ZIP) (Participant) */
+      field_2A7YUM: string;
+      /** Business name */
+      field_TDe8mH: string;
+      /** Business type */
+      field_TDyswI:
+        | 'Individual (or sole proprietor)'
+        | 'C-Corp'
+        | 'S-Corp'
+        | 'Partnership'
+        | 'Trust/Estate'
+        | 'LLC'
+        | 'Other (specify at the end of this form)';
     };
   };
+};
+
+export const getFormFieldsFromHelloWorksInstance = (instance: HelloWorksTaxFormInstance) => {
+  if (!instance?.data) {
+    return {};
+  } else if (instance.data.Form_nRZrdh) {
+    const data = instance.data.Form_nRZrdh;
+    const participantName = data.field_JI6gsq || data.field_mqVUrj || data.field_Xdy5Kk || data.field_3HxExU;
+    const entityName = data.field_3HxExU || data.field_vBxRqQ || data.field_3IvuYi || data.field_F1U7HL;
+    return {
+      // Participant name == signer name
+      type:
+        data.field_ENxHCd === 'Yes'
+          ? 'W9'
+          : data.field_xdp45L === 'a business or entity'
+            ? 'W8-BEN-E'
+            : data.field_xdp45L === 'an individual person'
+              ? 'W8-BEN'
+              : null,
+      participantName,
+      entityName: participantName !== entityName ? entityName : null,
+      address1: data.field_y19HZi || data.field_AdoY67 || data.field_3j4IQT || data.field_T0IdZf,
+      address2: data.field_bsHU5V,
+      taxIdNumberType: data.field_m4nLix || ((data.field_JiKEj4 || data.field_hJkq4B) && 'Foreign'),
+      taxIdNumber:
+        data.field_iGedCY || data.field_nsaxM8 || data.field_JiKEj4 || data.field_hJkq4B || data.field_SXcrBL,
+      country:
+        data.field_ENxHCd === 'Yes'
+          ? 'United States'
+          : data.field_VvICe1 || data.field_SZJNur || data.field_e2uMPk || data.field_dIEvL2,
+      email: data.field_gwd8pa,
+      status:
+        data.field_xdp45L === 'an individual person'
+          ? 'Individual (or sole proprietor)'
+          : data.field_ruhFN4 === 'Other (specify at the end of this form)'
+            ? `Other: ${data.field_IYb1zy}`
+            : data.field_ruhFN4 || data.field_xdp45L,
+    };
+  } else if (instance.data.Form_jmV4rR) {
+    const data = instance.data.Form_jmV4rR;
+    return {
+      type:
+        data.field_Jj5lq3 === 'Yes'
+          ? 'W9'
+          : data.field_W7cOxA === 'a business or entity'
+            ? 'W8-BEN-E'
+            : data.field_W7cOxA === 'an individual person'
+              ? 'W8-BEN'
+              : null,
+      participantName: data.field_nTuM3q || data.field_7G0PTT || data.field_pLPdKR || data.field_TDe8mH,
+      address1: data.field_Zdjn7X || data.field_nSSZij || data.field_nhEGv2,
+      address2: data.field_2A7YUM,
+      taxIdNumberType: data.field_GP1WVV || ((data.field_TDttcV || data.field_NwJcK9) && 'Foreign'),
+      taxIdNumber:
+        data.field_IHousr || data.field_U1SIy7 || data.field_YBBuNx || data.field_TDttcV || data.field_NwJcK9,
+      country: data.field_Jj5lq3 === 'Yes' ? 'United States' : data.field_VjJblP || data.field_ro87Pn,
+      email: data.field_LEHARZ,
+      status:
+        data.field_W7cOxA === 'an individual person'
+          ? 'Individual (or sole proprietor)'
+          : data.field_TDyswI === 'Other (specify at the end of this form)'
+            ? `Other: ${data.field_uRwOOO}`
+            : data.field_TDyswI || data.field_W7cOxA,
+    };
+  } else {
+    console.warn('Could not find form data in HelloWorks instance', instance);
+    return {};
+  }
+};
+
+const getClient = () => {
+  return new HelloWorks({ apiKeyId: HELLO_WORKS_KEY, apiKeySecret: HELLO_WORKS_SECRET });
+};
+
+export const fetchHelloWorksInstance = async (instanceId: string): Promise<HelloWorksTaxFormInstance> => {
+  const client = getClient();
+  return client.workflowInstances.getInstance({ instanceId }) as Promise<HelloWorksTaxFormInstance>;
 };
 
 function processMetadata(metadata: HelloWorksTaxFormInstance['metadata']): HelloWorksTaxFormInstance['metadata'] {
@@ -93,11 +308,7 @@ function processMetadata(metadata: HelloWorksTaxFormInstance['metadata']): Hello
 async function callback(req, res) {
   logger.info('Tax Form callback (parsed):', req.body);
 
-  const client = new HelloWorks({
-    apiKeyId: HELLO_WORKS_KEY,
-    apiKeySecret: HELLO_WORKS_SECRET,
-  });
-
+  const client = getClient();
   const body = req.body as HelloWorksTaxFormInstance;
   const { status, workflow_id: workflowId, data, id, metadata: metadataReceived } = body;
 


### PR DESCRIPTION
Pre-requisites:
- Set the `HELLO_WORKS_KEY` and `HELLO_WORKS_SECRET`
- To use the `--files-dir` option (that copies the PDFs to the export), you'll need to have a local dump of the PDF files. To generate it:
  - aws s3 sync s3://opencollective-production-us-tax-forms encrypt_dir/files_to_decrypt
  - Using [encrypt_dir](https://github.com/opencollective/encrypt_dir): KEY=XXXXXX node decryptDir.js

Usage:
> npm run script scripts/tax-forms/export-1099.ts 2023 foundation -- --files-dir ../encrypt_dir/decrypted --output-dir ~/tmp/result-tax-forms --cache-dir ~/tmp/helloworks-cache
