### PR TITLE
Modify root redirect cookie

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -231,5 +231,10 @@
     "url": "STATSD_URL",
     "port": "STATSD_PORT",
     "prefix": "STATSD_PREFIX"
+  },
+  "features": {
+    "dashboard": {
+      "redirect": "FEATURES_DASHBOARD_REDIRECT"
+    }
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -254,5 +254,10 @@
     "rpName": "[Test] Open Collective",
     "rpId": "localhost",
     "expectedOrigins": ["http://localhost:3000"]
+  },
+  "features": {
+    "dashboard": {
+      "redirect": false
+    }
   }
 }

--- a/server/lib/redirect-cookie.ts
+++ b/server/lib/redirect-cookie.ts
@@ -1,0 +1,16 @@
+import config from 'config';
+
+const cookieName = 'rootRedirectDashboard';
+
+export const setRedirectCookie = res => {
+  res.cookie(cookieName, 'true', {
+    secure: true,
+    httpOnly: true,
+    sameSite: config.env === 'production' ? 'lax' : 'none',
+    maxAge: 24 * 60 * 60 * 1000 * 365,
+  });
+};
+
+export const clearRedirectCookie = res => {
+  res.clearCookie(cookieName);
+};


### PR DESCRIPTION
- Changing the name of the `rootRedirect` cookie to `rootRedirectDashboard` to signify that we're only interested in the presence of the cookie, not it's value.
- Making sure to clear the cookie if user turns off the preview feature