### PR TITLE
ExpenseMutations: reset item currencies when appropriate

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1289,12 +1289,16 @@ export const prepareExpenseItemInputs = async (
             );
           }
         }
+      } else {
+        values.expenseCurrencyFxRate = 1;
+        values.expenseCurrencyFxRateSource = null;
       }
     } else if (itemInput['amount']) {
       // For backwards compatibility, we force expense currency if not provided
       values.amount = itemInput['amount'] as number;
       values.currency = expenseCurrency;
       values.expenseCurrencyFxRate = 1;
+      values.expenseCurrencyFxRateSource = null;
     }
 
     return values;


### PR DESCRIPTION
Related to https://opencollective.slack.com/archives/GFH4N961L/p1705518458933889?thread_ts=1705350277.438529&cid=GFH4N961L

This PR ensures we reset expense items' currencies when appropriate.