### PR TITLE
Validate collective currency

### DIFF
--- a/server/models/DataTypes.ts
+++ b/server/models/DataTypes.ts
@@ -1,3 +1,5 @@
+import { SUPPORTED_CURRENCIES } from '../constants/currencies';
+
 export default function (DataTypes) {
   return {
     // 3 letter international code (in uppercase) of the currency (e.g. USD, EUR, MXN, GBP, ...)
@@ -6,6 +8,10 @@ export default function (DataTypes) {
       defaultValue: 'USD',
       validate: {
         len: [3, 3] as [number, number],
+        isIn: {
+          args: [SUPPORTED_CURRENCIES],
+          msg: 'Currency not supported',
+        },
       },
       allowNull: false,
       set(val) {

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -151,11 +151,11 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
         admin: collectiveAdmin,
         isActive: false,
         approvedAt: null,
-        currency: 'ZWL',
+        currency: 'VUV',
       });
       children = await Promise.all([
-        fakeProject({ ParentCollectiveId: collective.id, currency: 'ZWL' }),
-        fakeEvent({ ParentCollectiveId: collective.id, currency: 'ZWL' }),
+        fakeProject({ ParentCollectiveId: collective.id, currency: 'VUV' }),
+        fakeEvent({ ParentCollectiveId: collective.id, currency: 'VUV' }),
       ]);
       application = await fakeHostApplication({
         CollectiveId: collective.id,
@@ -163,8 +163,8 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
         status: 'PENDING',
       });
       tiersInDifferentCurrency = await Promise.all([
-        fakeTier({ CollectiveId: collective.id, currency: 'ZWL' }),
-        ...children.map(child => fakeTier({ CollectiveId: child.id, currency: 'ZWL' })),
+        fakeTier({ CollectiveId: collective.id, currency: 'VUV' }),
+        ...children.map(child => fakeTier({ CollectiveId: child.id, currency: 'VUV' })),
       ]);
     });
 

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -207,6 +207,13 @@ describe('server/models/Collective', () => {
     await expect(models.Collective.create({ name: 'جهاد', slug: randStr() })).to.be.eventually.fulfilled;
   });
 
+  it('validates currency', async () => {
+    await expect(fakeCollective({ currency: 'XXX' })).to.be.rejectedWith(
+      Error,
+      'Validation error: Currency not supported',
+    );
+  });
+
   it('trims name', async () => {
     const collective = await models.Collective.create({ name: '   Frank   Zappa    ', slug: randStr() });
     expect(collective.name).to.eq('Frank Zappa');

--- a/test/server/paymentProviders/opencollective/manual.test.js
+++ b/test/server/paymentProviders/opencollective/manual.test.js
@@ -84,19 +84,19 @@ describe('server/paymentProviders/opencollective/manual', () => {
     it("throws if Collective currency doesn't match Host currency unless CROSS_CURRENCY_MANUAL_TRANSACTIONS is enabled", async () => {
       const otherCollective = await models.Collective.create({
         name: 'collective4',
-        currency: 'FKA',
+        currency: 'EUR',
         HostCollectiveId: host.id,
         isActive: true,
         hostFeePercent,
       });
 
-      const order = await createOrder(50, otherCollective, { currency: 'FKA' });
+      const order = await createOrder(50, otherCollective, { currency: 'EUR' });
       await expect(ManualPaymentMethod.processOrder(order)).to.be.eventually.rejectedWith(Error);
 
       await host.update({ settings: { features: { crossCurrencyManualTransactions: true } } });
 
       const transaction = await ManualPaymentMethod.processOrder(order);
-      expect(transaction.currency).to.equal('FKA');
+      expect(transaction.currency).to.equal('EUR');
     });
   });
 


### PR DESCRIPTION
Goes with https://github.com/opencollective/opencollective-frontend/pull/9925

This will prevent issues like https://open-collective.sentry.io/issues/4887589122/?project=5199682, where some pages were crashing because a collective set its currency to one that is not supported by the GraphQL enum.

Validated against production with:

```sql
select * from "Collectives" where currency NOT IN (
  'USD','AED','AFN','ALL','AMD','ANG','AOA','ARS','AUD','AWG','AZN','BAM','BBD','BDT','BGN','BIF','BMD','BND','BOB','BRL','BSD','BWP','BYN','BZD','CAD','CDF','CHF','CLP','CNY','COP','CRC','CVE','CZK','DJF','DKK','DOP','DZD','EGP','ETB','EUR','FJD','FKP','GBP','GEL','GIP','GMD','GNF','GTQ','GYD','HKD','HNL','HRK','HTG','HUF','IDR','ILS','INR','ISK','JMD','JPY','KES','KGS','KHR','KMF','KRW','KYD','KZT','LAK','LBP','LKR','LRD','LSL','MAD','MDL','MGA','MKD','MMK','MNT','MOP','MRO','MUR','MVR','MWK','MXN','MYR','MZN','NAD','NGN','NIO','NOK','NPR','NZD','PAB','PEN','PGK','PHP','PKR','PLN','PYG','QAR','RON','RSD','RUB','RWF','SAR','SBD','SCR','SEK','SGD','SHP','SLL','SOS','SRD','STD','SZL','THB','TJS','TOP','TRY','TTD','TWD','TZS','UAH','UGX','UYU','UZS','VND','VUV','WST','XAF','XCD','XOF','XPF','YER','ZAR','ZMW'
)
```