### PR TITLE
Transaction collection async + cache

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -261,5 +261,8 @@
     "dashboard": {
       "redirect": false
     }
+  },
+  "performance": {
+    "hostsWithManyTransactions": []
   }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -68,5 +68,15 @@
     "rpName": "Open Collective",
     "rpId": "opencollective.com",
     "expectedOrigins": ["https://opencollective.com"]
+  },
+  "performance": {
+    "hostsWithManyTransactions": [
+      11004, // OSC
+      8686, // OC
+      11049, // OCF
+      98478, // SCN
+      9807, // OCE
+      73495 // AFC
+    ]
   }
 }

--- a/server/graphql/v2/collection/TransactionCollection.ts
+++ b/server/graphql/v2/collection/TransactionCollection.ts
@@ -1,5 +1,6 @@
 import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
 
+import { PAYMENT_METHOD_TYPE } from '../../../constants/paymentMethods';
 import { TransactionKind } from '../../../constants/transaction-kind';
 import { TransactionInterface } from '../../../models/Transaction';
 import { GraphQLPaymentMethodType } from '../enum/PaymentMethodType';
@@ -27,12 +28,16 @@ export const GraphQLTransactionCollection = new GraphQLObjectType({
 });
 
 type AnyTransactionKind = TransactionKind | `${TransactionKind}`;
+type AnyPaymentMethodType = PAYMENT_METHOD_TYPE | `${PAYMENT_METHOD_TYPE}`;
 
 export interface GraphQLTransactionsCollectionReturnType {
-  nodes: TransactionInterface[];
-  totalCount: number;
+  nodes: TransactionInterface[] | Promise<TransactionInterface[]> | (() => Promise<TransactionInterface[]>);
+  totalCount: number | Promise<number> | (() => Promise<number>);
   limit: number;
   offset: number;
   kinds?: AnyTransactionKind[] | (() => AnyTransactionKind[]) | (() => Promise<AnyTransactionKind[]>);
-  paymentMethodTypes?: string[] | (() => string[]) | (() => Promise<string[]>);
+  paymentMethodTypes?:
+    | AnyPaymentMethodType[]
+    | (() => AnyPaymentMethodType[])
+    | (() => Promise<AnyPaymentMethodType[]>);
 }


### PR DESCRIPTION
Add some caching to the transaction collection.

count, kinds and paymentMethodTypes can be super slow on big hosts.

Lessons to apply elsewhere:
- Collection resolver should be fully on demand and async
- Fetch and Count should be always dissociated (sequelize postgres end up with 2 SQL queries anyway)