### PR TITLE
Expenses Submit on Behalf: Attribute email to existing user

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1728,7 +1728,12 @@ export async function editExpenseDraft(req: express.Request, expenseData: Expens
   };
 
   if (args.expense.payee && isDifferentInvitedPayee(existingExpense, args.expense.payee)) {
-    const payee = args.expense.payee as { email: string; name?: string };
+    let payee = args.expense.payee as { id?: number; email?: string };
+    const existingUser = payee.email && (await models.User.findByEmail(payee.email));
+    const existingUserCollective = existingUser && (await existingUser.getCollective());
+    if (existingUserCollective) {
+      payee = existingUserCollective.minimal;
+    }
     newExpenseValues.data['payee'] = payee;
     newExpenseValues.data['draftKey'] =
       process.env.OC_ENV === 'e2e' || process.env.OC_ENV === 'ci' ? 'draft-key' : uuid();

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -457,9 +457,14 @@ const expenseMutations = {
 
       const fromCollective = await remoteUser.getCollective({ loaders: req.loaders });
       const payeeLegacyId = expenseData.payee?.legacyId || expenseData.payee?.id;
-      const payee = payeeLegacyId
+      let payee = payeeLegacyId
         ? (await fetchAccountWithReference({ legacyId: payeeLegacyId }, { throwIfMissing: true }))?.minimal
         : expenseData.payee;
+      const existingUser = payee.email && (await models.User.findByEmail(payee.email));
+      const existingUserCollective = existingUser && (await existingUser.getCollective());
+      if (existingUserCollective) {
+        payee = existingUserCollective.minimal;
+      }
       const currency = expenseData.currency || collective.currency;
       const items = await prepareExpenseItemInputs(currency, expenseData.items);
       const expense = await models.Expense.create({

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -460,6 +460,9 @@ const expenseMutations = {
       let payee = payeeLegacyId
         ? (await fetchAccountWithReference({ legacyId: payeeLegacyId }, { throwIfMissing: true }))?.minimal
         : expenseData.payee;
+      if (!payee) {
+        throw new ValidationFailed('Payee not found');
+      }
       const existingUser = payee.email && (await models.User.findByEmail(payee.email));
       const existingUserCollective = existingUser && (await existingUser.getCollective());
       if (existingUserCollective) {


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/7095

Considering that the user is:
- Logged out;
- Has access to the email that received the expense draft being submitted;
- Is using/guessing an email that already was used on the platform;
- The submitted draft still needs to be verified through the following user authentication on the platform;

It should be safe to allow an expense draft to be submitted by the logged-out user instead of throwing a "User already exists" error.