### PR TITLE
Email: add more headers

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -383,7 +383,8 @@ export default async app => {
   /**
    * External services
    */
-  app.get('/services/email/unsubscribe/:email/:slug/:type/:token', email.unsubscribe);
+  app.get('/services/email/unsubscribe/:email/:slug/:type/:token', email.unsubscribe); // When users click on the unsubscribe link in the email
+  app.post('/services/email/unsubscribe/:email/:slug/:type/:token', email.unsubscribe); // For compatibility with the `List-Unsubscribe-Post` header
 
   /**
    * Github API - fetch all repositories using the user's access_token

--- a/test/server/lib/email.test.js
+++ b/test/server/lib/email.test.js
@@ -86,6 +86,14 @@ describe('server/lib/email', () => {
 
       expect(nm.sendMail.lastCall.args[0].html).to.matchSnapshot();
       expect(nm.sendMail.lastCall.args[0].text).to.matchSnapshot();
+
+      expect(nm.sendMail.lastCall.args[0].headers).to.containSubset({
+        'X-OpenCollective-Account': 'enmarchebe',
+        'List-ID': 'enmarchebe::order.thankyou',
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+        'List-Unsubscribe':
+          '<http://localhost:3000/email/unsubscribe/user1%40opencollective.com/enmarchebe/order.thankyou/54349853da7f4493e08265f3a6d600a9b705aec3bea42cb8ce23688c3060c3837d04a6285263edfdcdc83cfd7a7f95692f274a1c4d7f40f4c0db031e638589e9>',
+      });
     });
 
     it('sends the thankyou.wwcode email template', async () => {
@@ -117,6 +125,14 @@ describe('server/lib/email', () => {
       expect(nm.sendMail.lastCall.args[0].subject).to.contain(
         `Thank you for your ${amountStr}/month donation to WWCode Austin`,
       );
+
+      expect(nm.sendMail.lastCall.args[0].headers).to.containSubset({
+        'X-OpenCollective-Account': 'wwcodeaustin',
+        'List-ID': 'wwcodeaustin::order.thankyou',
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+        'List-Unsubscribe':
+          '<http://localhost:3000/email/unsubscribe/user1%40opencollective.com/wwcodeaustin/order.thankyou/d33986f22d66bf7254173f354874ba1557b094f96ac12ebb0afbabfd9a3fe76ed1fc5c30662d7ecc318ff6a0a47f9b09b9e71797b72627423b9694710fd0c80e>',
+      });
     });
   });
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7173

This PR adds:
- A `List-Unsubscribe` header (see [this](https://www.postmastery.com/list-unsubscribe-header-critical-for-sustained-email-delivery/))
- A `List-Unsubscribe-Post` header (see [this](https://www.postmastery.com/list-unsubscribe-header-critical-for-sustained-email-delivery/))
- An `X-OpenCollective-Account` header
- The ability to unsubscribe to "New host application"

## Examples

### New comment on update

![image](https://github.com/opencollective/opencollective-api/assets/1556356/487da021-437f-4b17-9729-64e4e0f72251)

### Sign in

![image](https://github.com/opencollective/opencollective-api/assets/1556356/d0781096-2c89-4d9e-a84d-681b01101950)

### Collective created

![image](https://github.com/opencollective/opencollective-api/assets/1556356/7f368963-4f70-4081-aa2f-6781f101c952)

### Host application (collective perspective)

![image](https://github.com/opencollective/opencollective-api/assets/1556356/48089d4e-fe7e-45f9-8f9c-a1ac36cfb84b)


### Host application (host perspective)

### Host application approved

![image](https://github.com/opencollective/opencollective-api/assets/1556356/d632b6cb-16d5-44ec-bbce-1124ad2d4fc0)

### Thank you email

Note: it is not currently possible to unsubscribe from the Thank You email.

This one is not ideal, we would like the OC account to be set on `order.toAccount`, not `order.fromAccount`.

![image](https://github.com/opencollective/opencollective-api/assets/1556356/bc6409a6-bcec-4544-b082-df4d14dc5896)


### Team member invited

![image](https://github.com/opencollective/opencollective-api/assets/1556356/28c80938-1f2a-4a36-871f-e9e38837e90f)
