### PR TITLE
Allow null dateFrom and dateTo in TimeSeriesAmount type

### DIFF
--- a/server/graphql/v2/interface/TimeSeries.ts
+++ b/server/graphql/v2/interface/TimeSeries.ts
@@ -5,11 +5,11 @@ import { GraphQLTimeUnit } from '../enum/TimeUnit';
 
 export const getTimeSeriesFields = () => ({
   dateFrom: {
-    type: new GraphQLNonNull(GraphQLDateTime),
+    type: GraphQLDateTime,
     description: 'The start date of the time series',
   },
   dateTo: {
-    type: new GraphQLNonNull(GraphQLDateTime),
+    type: GraphQLDateTime,
     description: 'The end date of the time series',
   },
   timeUnit: {

--- a/server/graphql/v2/object/AccountStats.js
+++ b/server/graphql/v2/object/AccountStats.js
@@ -215,13 +215,16 @@ export const GraphQLAccountStats = new GraphQLObjectType({
             dateFrom = moment().subtract(args.periodInMonths, 'months').seconds(0).milliseconds(0).toDate();
             dateTo = null;
           }
+
+          const timeUnit = args.timeUnit || getTimeUnit(getNumberOfDays(dateFrom, dateTo, collective) || 1);
+
           return collective.getTotalAmountReceivedTimeSeries({
             loaders: req.loaders,
             net: args.net,
             kind,
             startDate: dateFrom,
             endDate: dateTo,
-            timeUnit: args.timeUnit,
+            timeUnit,
             includeChildren: args.includeChildren,
             currency: args.currency,
           });


### PR DESCRIPTION
## Description
When using the totalAmountReceivedTimeSeries with just a timeUnit argument like below, it currently errors out with "Cannot return null for non-nullable field TimeSeriesAmount.dateFrom.",

```graphql
{
  account (slug: "opensource") {
    stats {
      totalAmountReceivedTimeSeries (timeUnit: MONTH) {
        dateFrom
        dateTo
        nodes {
          date
          amount {
            value
          }
        }
      }
    }
  }
}
```

### Fixes
- Allow `dateFrom` and `dateTo` in the return value `TimeSeriesAmount` to be null.
- Drive-by: set timeUnit if not provided (to comply with the GraphQL description of the field: "The time unit of the time series (such as MONTH, YEAR, WEEK etc). If no value is provided this is calculated using the dateFrom and dateTo values.")