### PR TITLE
Balance time series

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -1530,6 +1530,7 @@ type Expense {
   The payout method to use for this expense
   """
   payoutMethod: PayoutMethod
+  paymentMethod: PaymentMethod
 
   """
   The virtual card used to pay for this charge
@@ -3010,6 +3011,9 @@ enum PaymentMethodType {
   bacs_debit @deprecated(reason: "Please use uppercase values")
   bancontact @deprecated(reason: "Please use uppercase values")
   link @deprecated(reason: "Please use uppercase values")
+  bank_transfer @deprecated(reason: "Please use uppercase values")
+  payout @deprecated(reason: "Please use uppercase values")
+  virtual_card @deprecated(reason: "Please use uppercase values")
   ALIPAY
   CREDITCARD
   PREPAID
@@ -3027,6 +3031,9 @@ enum PaymentMethodType {
   BACS_DEBIT
   BANCONTACT
   LINK
+  BANK_TRANSFER
+  PAYOUT
+  VIRTUAL_CARD
 }
 
 input ExpenseReferenceInput {
@@ -4144,6 +4151,7 @@ enum PaymentMethodService {
   OPENCOLLECTIVE
   PREPAID
   THEGIVINGBLOCK
+  WISE
 }
 
 enum PaymentMethodLegacyType {
@@ -4438,6 +4446,51 @@ type AccountStats {
   ): TimeSeriesAmount!
 
   """
+  Balance time series
+  """
+  balanceTimeSeries(
+    """
+    The start date of the time series
+    """
+    dateFrom: DateTime
+
+    """
+    The end date of the time series
+    """
+    dateTo: DateTime
+
+    """
+    The time unit of the time series (such as MONTH, YEAR, WEEK etc). If no value is provided this is calculated using the dateFrom and dateTo values.
+    """
+    timeUnit: TimeUnit
+
+    """
+    Return the net amount (with payment processor fees removed)
+    """
+    net: Boolean = false
+
+    """
+    Filter by kind
+    """
+    kind: [TransactionKind]
+
+    """
+    Calculate amount for the last x months. Cannot be used with startDate/endDate
+    """
+    periodInMonths: Int
+
+    """
+    Include transactions from children (Projects and Events)
+    """
+    includeChildren: Boolean = false
+
+    """
+    An optional currency. If not provided, will use the collective currency.
+    """
+    currency: Currency
+  ): TimeSeriesAmount!
+
+  """
   Total of paid expenses to the account, filter per expense type
   """
   totalPaidExpenses(
@@ -4676,12 +4729,12 @@ type TimeSeriesAmount implements TimeSeries {
   """
   The start date of the time series
   """
-  dateFrom: DateTime!
+  dateFrom: DateTime
 
   """
   The end date of the time series
   """
-  dateTo: DateTime!
+  dateTo: DateTime
 
   """
   The interval between two data points
@@ -4698,12 +4751,12 @@ interface TimeSeries {
   """
   The start date of the time series
   """
-  dateFrom: DateTime!
+  dateFrom: DateTime
 
   """
   The end date of the time series
   """
-  dateTo: DateTime!
+  dateTo: DateTime
 
   """
   The interval between two data points
@@ -5471,12 +5524,12 @@ type HostMetricsTimeSeries {
   """
   The start date of the time series
   """
-  dateFrom: DateTime!
+  dateFrom: DateTime
 
   """
   The end date of the time series
   """
-  dateTo: DateTime!
+  dateTo: DateTime
 
   """
   The interval between two data points
@@ -5521,12 +5574,12 @@ type TimeSeriesAmountWithSettlement implements TimeSeries {
   """
   The start date of the time series
   """
-  dateFrom: DateTime!
+  dateFrom: DateTime
 
   """
   The end date of the time series
   """
-  dateTo: DateTime!
+  dateTo: DateTime
 
   """
   The interval between two data points
@@ -5558,12 +5611,12 @@ type TimeSeriesAmountWithKind implements TimeSeries {
   """
   The start date of the time series
   """
-  dateFrom: DateTime!
+  dateFrom: DateTime
 
   """
   The end date of the time series
   """
-  dateTo: DateTime!
+  dateTo: DateTime
 
   """
   The interval between two data points
@@ -17842,6 +17895,11 @@ input ProcessExpensePaymentParams {
   Transfer details for fulfilling the expense
   """
   transfer: ProcessExpenseTransferParams
+
+  """
+  Payment method using for paying the expense
+  """
+  paymentMethodService: PaymentMethodService
 }
 
 enum MarkAsUnPaidExpenseStatus {

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -59,6 +59,7 @@ import roles, { MemberRoleLabels } from '../constants/roles';
 import { hasOptedOutOfFeature, isFeatureAllowedForCollectiveType } from '../lib/allowed-features';
 import {
   getBalanceAmount,
+  getBalanceTimeSeries,
   getContributionsAndContributorsCount,
   getTotalAmountPaidExpenses,
   getTotalAmountReceivedAmount,
@@ -2792,6 +2793,10 @@ class Collective extends Model<
 
   getTotalAmountReceivedTimeSeries = function (options) {
     return getTotalAmountReceivedTimeSeries(this, options);
+  };
+
+  getBalanceTimeSeries = function (options) {
+    return getBalanceTimeSeries(this, options);
   };
 
   getContributionsAndContributorsCount = function (options) {


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/7265

### Description

Adding the `account.stats.balanceTimeSeries` resolver to provide a way to get the balance as a time series.

This version is not using the TransactionBalances materialized view as described in the issue as a potential way to get performant data, since there are cases of Collectives that are not covered by this view, so we need a general strategy as a fallback either way. Using TransactionBalances could be a potential follow up to improve performance.