### PR TITLE
fix(PayPal/Adaptive): crash in mark as paid

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -2117,7 +2117,14 @@ export async function deleteExpense(req: express.Request, expenseId: number): Pr
   return expense.reload({ paranoid: false });
 }
 
-async function payExpenseWithPayPalAdaptive(remoteUser, expense, host, paymentMethod, toPaypalEmail, fees = {}) {
+async function payExpenseWithPayPalAdaptive(
+  remoteUser,
+  expense,
+  host,
+  paymentMethod,
+  toPaypalEmail,
+  fees = {},
+): Promise<Expense> {
   debug('payExpenseWithPayPalAdaptive', expense.id);
 
   if (expense.currency !== expense.collective.currency) {
@@ -2235,9 +2242,9 @@ async function payExpenseWithPayPalAdaptive(remoteUser, expense, host, paymentMe
     // Adaptive does not work with multi-currency expenses, so we can safely assume that expense.currency = collective.currency
     await createTransactionsFromPaidExpense(host, expense, fees, hostCurrencyFxRate, paymentResponse);
     // Mark Expense as Paid, create activity and send notifications
-    const updatedExpense = await expense.markAsPaid({ user: remoteUser });
+    await expense.markAsPaid({ user: remoteUser });
     await paymentMethod.updateBalance();
-    return updatedExpense;
+    return expense;
   } catch (err) {
     debug('paypal> error', JSON.stringify(err, null, '  '));
     if (


### PR DESCRIPTION
Fix a crash reported by Ivan: (see [Sentry](https://open-collective.sentry.io/issues/4960290497/?project=5199682&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=3))

Introduced in https://github.com/opencollective/opencollective-api/pull/9711/files#diff-90ee3a074ce4d95ccb38d581b33cb78d00855e488561cc76ea4b0582f31f71b4R2240. This is similar to https://github.com/opencollective/opencollective-api/pull/9711/files#r1465556900, it seems that when we moved the function from `markExpenseAsPaid` to `expense.markAsPaid`, we got rid of the `return` but did not update depending code accordingly.

![image](https://github.com/opencollective/opencollective-api/assets/1556356/c3884158-97b4-48ab-b8fb-388e1dbdcb66)
