### PR TITLE
Wrap multiline subjects in emails

### DIFF
--- a/templates/emails/order.new.pendingFinancialContribution.hbs
+++ b/templates/emails/order.new.pendingFinancialContribution.hbs
@@ -1,5 +1,4 @@
-Subject: New pending financial contribution of {{{currency order.totalAmount
-currency=order.currency}}} to {{collective.name}}
+Subject: New pending financial contribution of {{{currency order.totalAmount currency=order.currency}}} to {{collective.name}}
 
 <style>
   code {

--- a/templates/emails/order.payment.failed.hbs
+++ b/templates/emails/order.payment.failed.hbs
@@ -1,5 +1,4 @@
-Subject: Your {{{currency order.totalAmount
-currency=order.currency}}} {{order.type}} to {{collective.name}} failed
+Subject: Your {{{currency order.totalAmount currency=order.currency}}} {{order.type}} to {{collective.name}} failed
 
 {{> header}}
 

--- a/templates/emails/order.pending.hbs
+++ b/templates/emails/order.pending.hbs
@@ -1,5 +1,4 @@
-Subject: {{#if instructions}}ACTION REQUIRED:{{/if}} your {{{currency order.totalAmount
-currency=order.currency}}} {{order.type}} to {{collective.name}} is pending
+Subject: {{#if instructions}}ACTION REQUIRED:{{/if}} your {{{currency order.totalAmount currency=order.currency}}} {{order.type}} to {{collective.name}} is pending
 
 <style>
   code {

--- a/templates/emails/order.processing.hbs
+++ b/templates/emails/order.processing.hbs
@@ -1,5 +1,4 @@
-Subject: Your {{{currency order.totalAmount
-currency=order.currency}}} {{order.type}} to {{collective.name}} is being processed
+Subject: Your {{{currency order.totalAmount currency=order.currency}}} {{order.type}} to {{collective.name}} is being processed
 
 {{> header}}
 

--- a/templates/emails/order.reminder.pendingFinancialContribution.hbs
+++ b/templates/emails/order.reminder.pendingFinancialContribution.hbs
@@ -1,5 +1,4 @@
-Subject: Has {{{currency order.totalAmount
-currency=order.currency}}} arrived for {{collective.name}}?
+Subject: Has {{{currency order.totalAmount currency=order.currency}}} arrived for {{collective.name}}?
 
 <style>
   code {


### PR DESCRIPTION
While this was working because we're splitting in a template variable (`{{`), thus not introducing a new line, we shouldn't encourage it as splitting anywhere else would break the subject.