### PR TITLE
PayPal: Fix single expense payout retry bug

### DIFF
--- a/server/paymentProviders/paypal/payouts.ts
+++ b/server/paymentProviders/paypal/payouts.ts
@@ -1,8 +1,6 @@
 /* eslint-disable camelcase */
-
-import { createHash } from 'crypto';
-
 import { isNil, round, toNumber } from 'lodash';
+import { v4 as uuid } from 'uuid';
 
 import activities from '../../constants/activities';
 import status from '../../constants/expense-status';
@@ -51,11 +49,7 @@ export const payExpensesBatch = async (expenses: Expense[]): Promise<Expense[]> 
 
   // Map expense items...
   const items = expenses.map(getExpenseItem);
-
-  // Calculate unique sender_batch_id hash
-  const hash = createHash('SHA1');
-  expenses.forEach(e => hash.update(e.id.toString()));
-  const sender_batch_id = hash.digest('hex');
+  const sender_batch_id = uuid();
 
   const requestBody = {
     sender_batch_header: {

--- a/test/server/paymentProviders/paypal/payouts.test.js
+++ b/test/server/paymentProviders/paypal/payouts.test.js
@@ -1,6 +1,4 @@
 /* eslint-disable camelcase */
-import crypto from 'crypto';
-
 import { expect } from 'chai';
 import { assert, createSandbox } from 'sinon';
 
@@ -77,15 +75,6 @@ describe('server/paymentProviders/paypal/payouts.js', () => {
 
       assert.calledOnce(paypalLib.executePayouts);
       expect(expense.data).to.deep.equals({ payout_batch_id: 'fake' });
-    });
-
-    it('should generate unique sender_batch_id', async () => {
-      await paypalPayouts.payExpensesBatch([expense]);
-      const expectedHash = crypto.createHash('SHA1').update(expense.id.toString()).digest('hex');
-
-      expect(paypalLib.executePayouts.firstCall.lastArg)
-        .to.have.nested.property('sender_batch_header.sender_batch_id')
-        .equals(expectedHash);
     });
   });
 


### PR DESCRIPTION
Dropping the manually calculated hash in favor of a simpler UUID. There's no reason why this hash needs to be reproducible, we just need something to compare if we want to.