### PR TITLE
Optimize ExpensePipelineOverview query

### DIFF
--- a/migrations/20240215073437-expense-pipeline-index.js
+++ b/migrations/20240215073437-expense-pipeline-index.js
@@ -35,7 +35,7 @@ module.exports = {
     `);
 
     await queryInterface.sequelize.query(`
-      DROP INDEX IF EXISTS "connected_accounts__username"
+      DROP INDEX IF EXISTS "connected_accounts__service_username"
     `);
 
     await queryInterface.sequelize.query(`

--- a/migrations/20240215073437-expense-pipeline-index.js
+++ b/migrations/20240215073437-expense-pipeline-index.js
@@ -16,8 +16,8 @@ module.exports = {
 
     // Related to security check and findRelatedUsersByConnectedAccounts
     await queryInterface.sequelize.query(`
-      CREATE INDEX CONCURRENTLY IF NOT EXISTS "connected_accounts__username"
-      ON "ConnectedAccounts"("username")
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "connected_accounts__service_username"
+      ON "ConnectedAccounts"("service", "username")
       WHERE "deletedAt" IS NULL
     `);
 

--- a/migrations/20240215073437-expense-pipeline-index.js
+++ b/migrations/20240215073437-expense-pipeline-index.js
@@ -1,0 +1,49 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "expenses__collective_id_status"
+      ON "Expenses"("CollectiveId", "status")
+      WHERE "deletedAt" IS NULL
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "collectives__host_collective_id_approved"
+      ON "Collectives"("HostCollectiveId")
+      WHERE "HostCollectiveId" IS NOT NULL AND "deletedAt" IS NULL AND "approvedAt" IS NOT NULL
+    `);
+
+    // Related to security check and findRelatedUsersByConnectedAccounts
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "connected_accounts__username"
+      ON "ConnectedAccounts"("username")
+      WHERE "deletedAt" IS NULL
+    `);
+
+    // Related to security check and PayoutMethod.findSimilar
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "payout_methods__account_number"
+      ON "PayoutMethods" USING BTREE ((data#>>'{details,accountNumber}'))
+      WHERE data#>>'{details,accountNumber}' IS NOT NULL AND "deletedAt" IS NULL
+    `);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "payout_methods__account_number"
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "connected_accounts__username"
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "collectives__host_collective_id_approved"
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "expenses__collective_id_status"
+    `);
+  },
+};

--- a/server/graphql/v2/interface/Collection.ts
+++ b/server/graphql/v2/interface/Collection.ts
@@ -62,7 +62,7 @@ export const getCollectionArgs = ({ limit = 10, offset = 0 }) => ({
 });
 
 export interface CollectionReturnType {
-  nodes: unknown[];
+  nodes: unknown[] | Promise<unknown[]> | (() => Promise<unknown[]>);
   totalCount: number | Promise<number> | (() => Promise<number>);
   limit: number;
   offset: number;

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -10,7 +10,6 @@ import { getBalances } from '../../../../lib/budget';
 import { loadFxRatesMap } from '../../../../lib/currency';
 import { buildSearchConditions } from '../../../../lib/search';
 import { expenseMightBeSubjectToTaxForm } from '../../../../lib/tax-forms';
-import { sleep } from '../../../../lib/utils';
 import { Op, sequelize } from '../../../../models';
 import Expense, { ExpenseType } from '../../../../models/Expense';
 import { PayoutMethodTypes } from '../../../../models/PayoutMethod';
@@ -378,24 +377,11 @@ export const ExpensesCollectionQueryResolver = async (
 
   const { offset, limit } = args;
 
-  let nodes;
-
   const fetchNodes = () => {
-    if (!nodes) {
-      // We don't await on purpose, we set and return the Promise
-      nodes = Expense.findAll({ include, where, order, offset, limit });
-    }
-    return nodes;
+    return Expense.findAll({ include, where, order, offset, limit });
   };
 
-  const fetchTotalCount = async () => {
-    await sleep(1); // Give time for fetchNodes to be triggered
-    if (nodes) {
-      const result = await nodes;
-      if (!offset && (!limit || result.length < limit)) {
-        return result.length;
-      }
-    }
+  const fetchTotalCount = () => {
     return Expense.count({ include, where });
   };
 

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -392,7 +392,7 @@ export const ExpensesCollectionQueryResolver = async (
     await sleep(1); // Give time for fetchNodes to be triggered
     if (nodes) {
       const result = await nodes;
-      if (!limit || result.length < limit) {
+      if (!offset && (!limit || result.length < limit)) {
         return result.length;
       }
     }

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -392,7 +392,7 @@ export const ExpensesCollectionQueryResolver = async (
     await sleep(1); // Give time for fetchNodes to be triggered
     if (nodes) {
       const result = await nodes;
-      if (result.length < limit) {
+      if (!limit || result.length < limit) {
         return result.length;
       }
     }


### PR DESCRIPTION
- add an index to fetch all approved collectives on a given host
- add an index to fetch expenses per collective and status
- add 2 indexes to make security checks faster
- make the expenses resolver async (nodes and totalCount fully on demand)