### PR TITLE
Add config to opt-in `collective.transaction.created` activity

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -209,7 +209,8 @@
     "daysCached": "TIMELINE_DAYS_CACHED"
   },
   "activities": {
-    "skipTransactions": "SKIP_TRANSACTION_ACTIVITIES"
+    "skipTransactions": "SKIP_TRANSACTION_ACTIVITIES",
+    "legacyTransactionsCollectiveIds": "LEGACY_TRANSACTIONS_ACTIVITY_COLLECTIVE_IDS"
   },
   "twoFactorAuthentication": {
     "enabled": "TWO_FACTOR_AUTHENTICATION_ENABLED"

--- a/config/default.json
+++ b/config/default.json
@@ -197,8 +197,7 @@
     "fetchTransactionsReceipts": false
   },
   "activities": {
-    "skipTransactions": false,
-    "skipCreationForTransactions": false
+    "skipTransactions": false
   },
   "restService": {
     "fetchCollectiveTransactionsCsv": false,

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -1,60 +1,61 @@
 # Environment Variables
 
-| Environment Variable                      | Config Name(name on the `config` file)             | Description                                                                    |
-| ----------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------ |
-| OC_ENV                                    | .env                                               | Application Environment variable                                               |
-| PG_DATABASE                               | .database.database                                 | Postgres database name                                                         |
-| PG_USERNAME                               | .database.username                                 | Postgres database username                                                     |
-| PG_PASSWORD                               | .database.password                                 | Postgres database password                                                     |
-| PG_HOST                                   | .database.options.host                             | Postgres database host                                                         |
-| PG_MIN_CONNECTIONS                        | .database.options.pool.min                         | Postgres number of min connections                                             |
-| PG_MAX_CONNECTIONS                        | .database.options.pool.max                         | Postgres number of max connections                                             |
-| API_KEY                                   | .keys.opencollective.apiKey                        | The API KEY                                                                    |
-| JWT_SECRET                                | .keys.opencollective.jwtSecret                     | JWT secret                                                                     |
-| EMAIL_UNSUBSCRIBE_SECRET                  | .keys.opencollective.emailUnsubscribeSecret        | JWT secret                                                                     |
-| STRIPE_CLIENT_ID                          | .stripe.client_id                                  | Stripe Client id                                                               |
-| STRIPE_KEY                                | .stripe.key                                        | Stripe key                                                                     |
-| STRIPE_SECRET                             | .stripe.secret                                     | Stripe secret                                                                  |
-| SENTRY_DSN                                | .sentry.dsn                                        | Sentry DSN                                                                     |
-| SENTRY_TRACES_SAMPLE_RATE                 | .sentry.tracesSampleRate                           | Percentage of collected transactions to send to Sentry (for performances)      |
-| AWS_KEY                                   | .aws.s3.key                                        | AWS key                                                                        |
-| AWS_SECRET                                | .aws.s3.secret                                     | AWS secret                                                                     |
-| AWS_S3_BUCKET                             | .aws.s3.bucket                                     | AWS s3 bucket to send files                                                    |
-| CLOUDFLARE_KEY                            | .cloudflare.key                                    | CLOUDFLARE key                                                                 |
-| CLOUDFLARE_EMAIL                          | .cloudflare.email                                  | CLOUDFLARE email                                                               |
-| CLOUDFLARE_ZONE                           | .cloudflare.zone                                   | CLOUDFLARE zone                                                                |
-| PAYPAL_USER_ID                            | .paypal.classic.userId                             | Paypal USER ID (legacy adaptive)                                               |
-| PAYPAL_APP_ID                             | .paypal.classic.appId                              | Paypal APP ID (legacy adaptive)                                                |
-| PAYPAL_PASSWORD                           | .paypal.classic.password                           | Paypal password (legacy adaptive)                                              |
-| PAYPAL_SIGNATURE                          | .paypal.classic.signature                          | Paypal signature (legacy adaptive)                                             |
-| MAILGUN_USER                              | .mailgun.user                                      | mailgun user                                                                   |
-| MAILGUN_API_KEY                           | .mailgun.apiKey                                    | mailgun password                                                               |
-| API_URL                                   | .host.api                                          | API exposed url                                                                |
-| WEBSITE_URL                               | .host.website                                      | UI URL                                                                         |
-| FRONTEND_URL                              | .host.frontend                                     | URL of the frontend service (for caching)                                      |
-| SLACK_WEBHOOK_ABUSE                       | .slack.webhooks.abuse                              | slack abuse webhook url                                                        |
-| GITHUB_CLIENT_ID                          | .github.clientId                                   | github client ID                                                               |
-| GITHUB_CLIENT_SECRET                      | .github.clientSecret                               | github client secret                                                           |
-| TWITTER_CONSUMER_KEY                      | .twitter.consumerKey                               | twitter key                                                                    |
-| TWITTER_CONSUMER_SECRET                   | .twitter.consumerSecret                            | twitter secret                                                                 |
-| TWITTER_DISABLE                           | .twitter.disable                                   | disable twitter integration                                                    |
-| FOREST_AUTH_SECRET                        |                                                    | forest auth secret                                                             |
-| FOREST_ENV_SECRET                         |                                                    | forest environment secret                                                      |
-|                                           | .stripe.redirectUri                                |                                                                                |
-| HELLO_WORKS_KEY                           | .helloworks.key                                    | HelloWorks key                                                                 |
-| HELLO_WORKS_SECRET                        | .helloworks.secret                                 | HelloWorks secret                                                              |
-| HELLO_WORKS_DOCUMENT_ENCRYPTION_KEY       | .helloworks.documentEncryptionKey                  | base64 encoded secret key for encrypting document before storage.              |
-| HELLO_WORKS_AWS_S3_BUCKET                 | .helloworks.aws.s3.bucket                          | the bucket where tax forms will be uploaded                                    |
-| GITHUB_FLOW_MIN_NB_STARS                  | .githubFlow.minNbStars                             | Minimum number of Github stars required to apply to the open source collective |
-| TRANSFERWISE_API_URL                      | .transferwise.apiUrl                               |                                                                                |
-| TRANSFERWISE_OAUTH_URL                    | .transferwise.oauthUrl                             |                                                                                |
-| TRANSFERWISE_CLIENT_KEY                   | .transferwise.clientKey                            |                                                                                |
-| TRANSFERWISE_CLIENT_ID                    | .transferwise.clientId                             |                                                                                |
-| TRANSFERWISE_CLIENT_SECRET                | .transferwise.clientSecret                         |                                                                                |
-| TRANSFERWISE_REDIRECT_URI                 | .transferwise.redirectUri                          |                                                                                |
-| TRANSFERWISE_PRIVATE_KEY                  | .transferwise.privateKey                           |                                                                                |
-| TRANSFERWISE_BLOCKED_CURRENCIES           | .transferwise.blockedCurrencies                    |                                                                                |
-| TRANSFERWISE_BLOCKED_CURRENCIES_BUSINESS  | .transferwise.blockedCurrenciesForBusinessProfiles |                                                                                |
-| TRANSFERWISE_BLOCKED_CURRENCIES_NONPROFIT | .transferwise.blockedCurrenciesForNonProfits       |                                                                                |
-| KLIPPA_API_KEY                            | .klippa.apiKey                                     | The API key for Klippa                                                         |
-| KLIPPA_ENABLED                            | .klippa.enabled                                    | Whether Klippa is enabled                                                      |
+| Environment Variable                        | Config Name(name on the `config` file)             | Description                                                                          |
+| ------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| OC_ENV                                      | .env                                               | Application Environment variable                                                     |
+| PG_DATABASE                                 | .database.database                                 | Postgres database name                                                               |
+| PG_USERNAME                                 | .database.username                                 | Postgres database username                                                           |
+| PG_PASSWORD                                 | .database.password                                 | Postgres database password                                                           |
+| PG_HOST                                     | .database.options.host                             | Postgres database host                                                               |
+| PG_MIN_CONNECTIONS                          | .database.options.pool.min                         | Postgres number of min connections                                                   |
+| PG_MAX_CONNECTIONS                          | .database.options.pool.max                         | Postgres number of max connections                                                   |
+| API_KEY                                     | .keys.opencollective.apiKey                        | The API KEY                                                                          |
+| JWT_SECRET                                  | .keys.opencollective.jwtSecret                     | JWT secret                                                                           |
+| EMAIL_UNSUBSCRIBE_SECRET                    | .keys.opencollective.emailUnsubscribeSecret        | JWT secret                                                                           |
+| STRIPE_CLIENT_ID                            | .stripe.client_id                                  | Stripe Client id                                                                     |
+| STRIPE_KEY                                  | .stripe.key                                        | Stripe key                                                                           |
+| STRIPE_SECRET                               | .stripe.secret                                     | Stripe secret                                                                        |
+| SENTRY_DSN                                  | .sentry.dsn                                        | Sentry DSN                                                                           |
+| SENTRY_TRACES_SAMPLE_RATE                   | .sentry.tracesSampleRate                           | Percentage of collected transactions to send to Sentry (for performances)            |
+| AWS_KEY                                     | .aws.s3.key                                        | AWS key                                                                              |
+| AWS_SECRET                                  | .aws.s3.secret                                     | AWS secret                                                                           |
+| AWS_S3_BUCKET                               | .aws.s3.bucket                                     | AWS s3 bucket to send files                                                          |
+| CLOUDFLARE_KEY                              | .cloudflare.key                                    | CLOUDFLARE key                                                                       |
+| CLOUDFLARE_EMAIL                            | .cloudflare.email                                  | CLOUDFLARE email                                                                     |
+| CLOUDFLARE_ZONE                             | .cloudflare.zone                                   | CLOUDFLARE zone                                                                      |
+| PAYPAL_USER_ID                              | .paypal.classic.userId                             | Paypal USER ID (legacy adaptive)                                                     |
+| PAYPAL_APP_ID                               | .paypal.classic.appId                              | Paypal APP ID (legacy adaptive)                                                      |
+| PAYPAL_PASSWORD                             | .paypal.classic.password                           | Paypal password (legacy adaptive)                                                    |
+| PAYPAL_SIGNATURE                            | .paypal.classic.signature                          | Paypal signature (legacy adaptive)                                                   |
+| MAILGUN_USER                                | .mailgun.user                                      | mailgun user                                                                         |
+| MAILGUN_API_KEY                             | .mailgun.apiKey                                    | mailgun password                                                                     |
+| API_URL                                     | .host.api                                          | API exposed url                                                                      |
+| WEBSITE_URL                                 | .host.website                                      | UI URL                                                                               |
+| FRONTEND_URL                                | .host.frontend                                     | URL of the frontend service (for caching)                                            |
+| SLACK_WEBHOOK_ABUSE                         | .slack.webhooks.abuse                              | slack abuse webhook url                                                              |
+| GITHUB_CLIENT_ID                            | .github.clientId                                   | github client ID                                                                     |
+| GITHUB_CLIENT_SECRET                        | .github.clientSecret                               | github client secret                                                                 |
+| TWITTER_CONSUMER_KEY                        | .twitter.consumerKey                               | twitter key                                                                          |
+| TWITTER_CONSUMER_SECRET                     | .twitter.consumerSecret                            | twitter secret                                                                       |
+| TWITTER_DISABLE                             | .twitter.disable                                   | disable twitter integration                                                          |
+| FOREST_AUTH_SECRET                          |                                                    | forest auth secret                                                                   |
+| FOREST_ENV_SECRET                           |                                                    | forest environment secret                                                            |
+|                                             | .stripe.redirectUri                                |                                                                                      |
+| HELLO_WORKS_KEY                             | .helloworks.key                                    | HelloWorks key                                                                       |
+| HELLO_WORKS_SECRET                          | .helloworks.secret                                 | HelloWorks secret                                                                    |
+| HELLO_WORKS_DOCUMENT_ENCRYPTION_KEY         | .helloworks.documentEncryptionKey                  | base64 encoded secret key for encrypting document before storage.                    |
+| HELLO_WORKS_AWS_S3_BUCKET                   | .helloworks.aws.s3.bucket                          | the bucket where tax forms will be uploaded                                          |
+| GITHUB_FLOW_MIN_NB_STARS                    | .githubFlow.minNbStars                             | Minimum number of Github stars required to apply to the open source collective       |
+| TRANSFERWISE_API_URL                        | .transferwise.apiUrl                               |                                                                                      |
+| TRANSFERWISE_OAUTH_URL                      | .transferwise.oauthUrl                             |                                                                                      |
+| TRANSFERWISE_CLIENT_KEY                     | .transferwise.clientKey                            |                                                                                      |
+| TRANSFERWISE_CLIENT_ID                      | .transferwise.clientId                             |                                                                                      |
+| TRANSFERWISE_CLIENT_SECRET                  | .transferwise.clientSecret                         |                                                                                      |
+| TRANSFERWISE_REDIRECT_URI                   | .transferwise.redirectUri                          |                                                                                      |
+| TRANSFERWISE_PRIVATE_KEY                    | .transferwise.privateKey                           |                                                                                      |
+| TRANSFERWISE_BLOCKED_CURRENCIES             | .transferwise.blockedCurrencies                    |                                                                                      |
+| TRANSFERWISE_BLOCKED_CURRENCIES_BUSINESS    | .transferwise.blockedCurrenciesForBusinessProfiles |                                                                                      |
+| TRANSFERWISE_BLOCKED_CURRENCIES_NONPROFIT   | .transferwise.blockedCurrenciesForNonProfits       |                                                                                      |
+| KLIPPA_API_KEY                              | .klippa.apiKey                                     | The API key for Klippa                                                               |
+| KLIPPA_ENABLED                              | .klippa.enabled                                    | Whether Klippa is enabled                                                            |
+| LEGACY_TRANSACTIONS_ACTIVITY_COLLECTIVE_IDS | .activities.legacyTransactionsCollectiveIds        | List of collective ids for which to generate legacy `transaction.created` activities |

--- a/server/lib/activities.js
+++ b/server/lib/activities.js
@@ -260,3 +260,15 @@ const getUserString = (format, userCollective, email) => {
   }
   return returnVal;
 };
+
+const LEGACY_TRANSACTION_ACTIVITY_COLLECTIVE_IDS = config.activities?.legacyTransactionsCollectiveIds
+  ? config.activities.legacyTransactionsCollectiveIds.split(',').map(Number)
+  : [];
+
+/**
+ * Returns true if a `collective.transaction.created` activity should be generated for the given collective.
+ * Implemented as a separate function to allow for easy testing.
+ */
+export const shouldGenerateTransactionActivities = collectiveId => {
+  return LEGACY_TRANSACTION_ACTIVITY_COLLECTIVE_IDS.includes(collectiveId);
+};

--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -23,6 +23,7 @@ import {
   PLATFORM_TIP_TRANSACTION_PROPERTIES,
   TransactionTypes,
 } from '../constants/transactions';
+import { shouldGenerateTransactionActivities } from '../lib/activities';
 import { getFxRate } from '../lib/currency';
 import { toNegative } from '../lib/math';
 import { calcFee, getHostFeeSharePercent, getPlatformTip } from '../lib/payments';
@@ -483,7 +484,7 @@ const Transaction: ModelStatic<TransactionInterface> & TransactionModelStaticInt
 
     hooks: {
       afterCreate: transaction => {
-        if (!config.activities?.skipCreationForTransactions) {
+        if (shouldGenerateTransactionActivities(transaction.CollectiveId)) {
           Transaction.createActivity(transaction);
         }
 

--- a/test/scripts/ledger/split-payment-processor-fees.test.ts
+++ b/test/scripts/ledger/split-payment-processor-fees.test.ts
@@ -1,6 +1,3 @@
-import config from 'config';
-import { createSandbox } from 'sinon';
-
 import { main as splitPaymentProcessorFees } from '../../../scripts/ledger/split-payment-processor-fees';
 import { refundTransaction } from '../../../server/lib/payments';
 import { fakeCollective, fakeHost, fakeTransaction, fakeUser } from '../../test-helpers/fake-data';
@@ -19,17 +16,9 @@ const SNAPSHOT_COLUMNS = [
 ];
 
 describe('scripts/ledger/split-payment-processor-fees', () => {
-  let sandbox;
-
   beforeEach('reset test database', async () => {
     await resetTestDB();
     await seedDefaultVendors();
-    sandbox = createSandbox();
-    sandbox.stub(config, 'activities').value({ ...config.activities, skipCreationForTransactions: true }); // Async activities are created async, which doesn't play well with `resetTestDb`
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('1. migrate a regular contribution with payment processor fees', async () => {

--- a/test/scripts/ledger/split-taxes.test.ts
+++ b/test/scripts/ledger/split-taxes.test.ts
@@ -1,6 +1,3 @@
-import config from 'config';
-import { createSandbox } from 'sinon';
-
 import { main as splitTaxes } from '../../../scripts/ledger/split-taxes';
 import { refundTransaction } from '../../../server/lib/payments';
 import Transaction from '../../../server/models/Transaction';
@@ -23,17 +20,9 @@ const SNAPSHOT_COLUMNS = [
 ];
 
 describe('scripts/ledger/split-taxes', () => {
-  let sandbox;
-
   beforeEach('reset test database', async () => {
     await resetTestDB();
     await seedDefaultVendors();
-    sandbox = createSandbox();
-    sandbox.stub(config, 'activities').value({ ...config.activities, skipCreationForTransactions: true }); // Async activities are created async, which doesn't play well with `resetTestDb`
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('1. migrate a regular contribution with taxes', async () => {

--- a/test/server/models/Transaction.test.js
+++ b/test/server/models/Transaction.test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
-import config from 'config';
 import { createSandbox } from 'sinon';
 
 import { TransactionKind } from '../../../server/constants/transaction-kind';
+import * as LibActivities from '../../../server/lib/activities';
 import models from '../../../server/models';
 import {
   fakeCollective,
@@ -53,7 +53,6 @@ describe('server/models/Transaction', () => {
   beforeEach(async () => {
     await utils.resetTestDB();
     sandbox = createSandbox();
-    sandbox.stub(config, 'activities').value({ ...config.activities, skipCreationForTransactions: true }); // Async activities are created async, which doesn't play well with `resetTestDb`
     user = await fakeUser({}, { name: 'User' });
     inc = await fakeHost({
       id: 8686,
@@ -204,8 +203,8 @@ describe('server/models/Transaction', () => {
     });
   });
 
-  it('createFromContributionPayload() generates a new activity', async () => {
-    sandbox.stub(config, 'activities').value({ ...config.activities, skipCreationForTransactions: false }); // Async activities are created async, which doesn't play well with `resetTestDb`
+  it('createFromContributionPayload() generates a new activity for allowed collectives', async () => {
+    sandbox.stub(LibActivities, 'shouldGenerateTransactionActivities').returns(true);
     const createActivityStub = sandbox.stub(Transaction, 'createActivity');
 
     const transaction = await Transaction.createFromContributionPayload({

--- a/test/server/paymentProviders/stripe/webhook.test.ts
+++ b/test/server/paymentProviders/stripe/webhook.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 
 import { expect } from 'chai';
-import config from 'config';
 import { set } from 'lodash';
 import { assert, createSandbox } from 'sinon';
 import Stripe from 'stripe';
@@ -33,7 +32,6 @@ describe('webhook', () => {
   beforeEach(async () => {
     await utils.resetTestDB();
     sandbox = createSandbox();
-    sandbox.stub(config, 'activities').value({ ...config.activities, skipCreationForTransactions: true }); // Async activities are created async, which doesn't play well with `resetTestDb`
   });
 
   afterEach(() => {


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/7162

This should also improve test reliability, as asynchronously created activities mess up with `resetTestDB` (deadlocks).

To get the notifications list:

```sql
SELECT array_agg(DISTINCT "CollectiveId") as "CollectiveId"
FROM "Notifications"
WHERE type = 'collective.transaction.created'
  AND active IS TRUE
```

