### PR TITLE
Update `account.feed` for Collectives

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -5195,6 +5195,11 @@ type Activity {
   update: Update
 
   """
+  The conversation related to this activity, if any
+  """
+  conversation: Conversation
+
+  """
   The transaction related to this activity, if any
   """
   transaction: Transaction

--- a/server/graphql/v2/mutation/TransactionMutations.ts
+++ b/server/graphql/v2/mutation/TransactionMutations.ts
@@ -120,6 +120,7 @@ const transactionMutations = {
         FromCollectiveId: orderToUpdate.FromCollectiveId,
         CollectiveId: orderToUpdate.CollectiveId,
         HostCollectiveId: toAccount.approvedAt ? toAccount.HostCollectiveId : null,
+        UserId: req.remoteUser.id,
         data: {
           rejectionReason,
           collective: toAccount.info,

--- a/server/graphql/v2/object/Activity.ts
+++ b/server/graphql/v2/object/Activity.ts
@@ -10,6 +10,7 @@ import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';
 import { GraphQLAccount } from '../interface/Account';
 import { GraphQLTransaction } from '../interface/Transaction';
 
+import GraphQLConversation from './Conversation';
 import { GraphQLExpense } from './Expense';
 import { GraphQLHost } from './Host';
 import { GraphQLIndividual } from './Individual';
@@ -111,9 +112,19 @@ export const GraphQLActivity = new GraphQLObjectType({
       type: GraphQLUpdate,
       description: 'The update related to this activity, if any',
       resolve: async (activity, _, req: express.Request): Promise<Record<string, unknown>> => {
-        const updateId = activity.data.update?.id;
+        const updateId = activity.data.UpdateId || activity.data.update?.id;
         if (updateId) {
           return req.loaders.Update.byId.load(updateId);
+        }
+      },
+    },
+    conversation: {
+      type: GraphQLConversation,
+      description: 'The conversation related to this activity, if any',
+      resolve: async (activity, _, req: express.Request): Promise<Record<string, unknown>> => {
+        const conversationId = activity.data.ConversationId || activity.data.conversation?.id;
+        if (conversationId) {
+          return req.loaders.Conversation.byId.load(conversationId);
         }
       },
     },
@@ -194,7 +205,6 @@ export const GraphQLActivity = new GraphQLObjectType({
             toPick.push('newData');
           }
         }
-
         return pick(activity.data, toPick);
       },
     },

--- a/server/lib/timeline.ts
+++ b/server/lib/timeline.ts
@@ -104,9 +104,74 @@ const makeTimelineQuery = async (
       }
     }
     return { [Op.or]: conditionals };
-  } else {
-    return { [Op.or]: [{ CollectiveId: collective.id }, { FromCollectiveId: collective.id }] };
   }
+
+  const types = [];
+  if (classes.includes(ActivityClasses.EXPENSES)) {
+    types.push(
+      ...[
+        ActivityTypes.COLLECTIVE_EXPENSE_APPROVED,
+        ActivityTypes.COLLECTIVE_EXPENSE_CREATED,
+        ActivityTypes.COLLECTIVE_EXPENSE_DELETED,
+        ActivityTypes.COLLECTIVE_EXPENSE_INVITE_DRAFTED,
+        ActivityTypes.COLLECTIVE_EXPENSE_MARKED_AS_INCOMPLETE,
+        ActivityTypes.COLLECTIVE_EXPENSE_MARKED_AS_SPAM,
+        ActivityTypes.COLLECTIVE_EXPENSE_MARKED_AS_UNPAID,
+        ActivityTypes.COLLECTIVE_EXPENSE_PAID,
+        ActivityTypes.COLLECTIVE_EXPENSE_RECURRING_DRAFTED,
+        ActivityTypes.COLLECTIVE_EXPENSE_REJECTED,
+        ActivityTypes.COLLECTIVE_EXPENSE_UNAPPROVED,
+        ActivityTypes.COLLECTIVE_EXPENSE_RE_APPROVAL_REQUESTED,
+        ActivityTypes.COLLECTIVE_EXPENSE_UPDATED,
+        ActivityTypes.EXPENSE_COMMENT_CREATED,
+        ActivityTypes.TAXFORM_REQUEST,
+      ],
+    );
+  }
+  if (classes.includes(ActivityClasses.VIRTUAL_CARDS)) {
+    types.push(
+      ...[
+        ActivityTypes.COLLECTIVE_VIRTUAL_CARD_ADDED,
+        ActivityTypes.COLLECTIVE_VIRTUAL_CARD_SUSPENDED,
+        ActivityTypes.COLLECTIVE_VIRTUAL_CARD_REQUEST_APPROVED,
+        ActivityTypes.COLLECTIVE_VIRTUAL_CARD_REQUEST_REJECTED,
+        ActivityTypes.VIRTUAL_CARD_REQUESTED,
+        ActivityTypes.VIRTUAL_CARD_PURCHASE,
+      ],
+    );
+  }
+  if (classes.includes(ActivityClasses.CONTRIBUTIONS)) {
+    types.push(
+      ...[
+        ActivityTypes.COLLECTIVE_MEMBER_CREATED,
+        ActivityTypes.CONTRIBUTION_REJECTED,
+        ActivityTypes.ORDER_PAYMENT_FAILED,
+        ActivityTypes.ORDER_PENDING_CONTRIBUTION_NEW,
+        ActivityTypes.ORDER_PENDING_CONTRIBUTION_REMINDER,
+        ActivityTypes.ORDER_THANKYOU,
+        ActivityTypes.ORDERS_SUSPICIOUS,
+        ActivityTypes.PAYMENT_CREDITCARD_CONFIRMATION,
+        ActivityTypes.PAYMENT_CREDITCARD_EXPIRING,
+        ActivityTypes.PAYMENT_FAILED,
+        ActivityTypes.SUBSCRIPTION_CANCELED,
+      ],
+    );
+  }
+  if (classes.includes(ActivityClasses.ACTIVITIES_UPDATES)) {
+    types.push(
+      ...[
+        ActivityTypes.HOST_APPLICATION_CONTACT,
+        ActivityTypes.COLLECTIVE_CONVERSATION_CREATED,
+        ActivityTypes.COLLECTIVE_UPDATE_PUBLISHED,
+        ActivityTypes.CONVERSATION_COMMENT_CREATED,
+        ActivityTypes.UPDATE_COMMENT_CREATED,
+      ],
+    );
+  }
+  return {
+    type: { [Op.in]: types },
+    [Op.or]: [{ CollectiveId: collective.id }, { FromCollectiveId: collective.id }],
+  };
 };
 
 type SerializedActivity = { id: number; type: ActivityTypes };


### PR DESCRIPTION
- adding a selection of activity types to `account.feed` for Collectives
- adding `conversation` resolver to graphql Activity object, to enable linking to and showing summaries of conversations in timeline
- adding UserId to `CONTRIBUTION_REJECTED` activity, to enable better timeline messages
