### PR TITLE
Invalidate all tokens when email changes

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -71,6 +71,7 @@
       "confirmToken": 15
     },
     "setPasswordPerUserPerHour": 10,
+    "confirmEmailPerIpPerHour": 10,
     "skipCleanOrdersLimitSlugs": "",
     "enabledMasks": "",
     "sendGuestConfirmPerMinutePerEmail": 1,

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -17905,6 +17905,16 @@ type Mutation {
   ): SetPasswordResponse!
 
   """
+  Confirm email for Individual. Scope: "account".
+  """
+  confirmEmail(
+    """
+    The token to confirm the email.
+    """
+    token: String!
+  ): IndividualConfirmEmailResponse!
+
+  """
   Submit a legal document
   """
   submitLegalDocument(
@@ -20002,6 +20012,18 @@ enum ProcessHostApplicationAction {
 type SetPasswordResponse {
   individual: Individual!
   token: String
+}
+
+type IndividualConfirmEmailResponse {
+  """
+  The account that was confirmed
+  """
+  individual: Individual!
+
+  """
+  A new session token to use for the account. Only returned if user is signed in already.
+  """
+  sessionToken: String
 }
 
 """

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -180,6 +180,7 @@ const mutations = {
   confirmUserEmail: {
     type: UserType,
     description: 'Confirm the new user email from confirmation token',
+    deprecationReason: '2024-07-15: Please use the mutation `confirmEmail` from GQLV2',
     args: {
       token: {
         type: new GraphQLNonNull(GraphQLString),

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -7,7 +7,7 @@ import models from '../../models';
 import { bulkCreateGiftCards, createGiftCardsForEmails } from '../../paymentProviders/opencollective/giftcard';
 import { checkCanEmitGiftCards } from '../common/features';
 import { editPublicMessage } from '../common/members';
-import { createUser } from '../common/user';
+import { confirmUserEmail, createUser } from '../common/user';
 import { NotFound, RateLimitExceeded, Unauthorized } from '../errors';
 
 import {
@@ -26,7 +26,7 @@ import { editConnectedAccount } from './mutations/connectedAccounts';
 import { createWebhook, deleteNotification, editWebhooks } from './mutations/notifications';
 import * as paymentMethodsMutation from './mutations/paymentMethods';
 import { editTier, editTiers } from './mutations/tiers';
-import { confirmUserEmail, updateUserEmail } from './mutations/users';
+import { updateUserEmail } from './mutations/users';
 import { CollectiveInterfaceType } from './CollectiveInterface';
 import {
   CollectiveInputType,

--- a/server/graphql/v1/mutations/users.js
+++ b/server/graphql/v1/mutations/users.js
@@ -6,7 +6,7 @@ import { activities } from '../../../constants';
 import cache from '../../../lib/cache';
 import emailLib from '../../../lib/email';
 import models from '../../../models';
-import { InvalidToken, RateLimitExceeded, Unauthorized, ValidationFailed } from '../../errors';
+import { RateLimitExceeded, Unauthorized, ValidationFailed } from '../../errors';
 
 const oneHourInSeconds = 60 * 60;
 
@@ -78,28 +78,4 @@ export const updateUserEmail = async (user, newEmail) => {
   cache.set(countCacheKey, existingCount + 1, oneHourInSeconds);
 
   return user;
-};
-
-/**
- * From a given token (generated in `updateUserEmail`) confirm the new email
- * and updates the user record.
- */
-export const confirmUserEmail = async emailConfirmationToken => {
-  if (!emailConfirmationToken) {
-    throw new ValidationFailed('Email confirmation token must be set');
-  }
-
-  const user = await models.User.findOne({ where: { emailConfirmationToken } });
-
-  if (!user) {
-    throw new InvalidToken('Invalid email confirmation token', 'INVALID_TOKEN', {
-      internalData: { emailConfirmationToken },
-    });
-  }
-
-  return user.update({
-    email: user.emailWaitingForValidation,
-    emailWaitingForValidation: null,
-    emailConfirmationToken: null,
-  });
 };

--- a/server/graphql/v2/mutation/IndividualMutations.ts
+++ b/server/graphql/v2/mutation/IndividualMutations.ts
@@ -3,12 +3,13 @@ import assert from 'assert';
 import bcrypt from 'bcrypt';
 import config from 'config';
 import express from 'express';
-import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from 'graphql';
+import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 
 import RateLimit, { ONE_HOUR_IN_SECONDS } from '../../../lib/rate-limit';
 import TwoFactorAuthLib from '../../../lib/two-factor-authentication';
 import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
+import { confirmUserEmail } from '../../common/user';
 import { RateLimitExceeded, Unauthorized } from '../../errors';
 import { GraphQLIndividual } from '../object/Individual';
 import { GraphQLSetPasswordResponse } from '../object/SetPasswordResponse';
@@ -89,6 +90,49 @@ const individualMutations = {
       const user = await req.remoteUser.setPassword(args.password, { userToken: req.userToken });
       const individual = await user.getCollective({ loaders: req.loaders });
 
+      let token;
+
+      // We don't want OAuth tokens to be exchanged against a session token
+      if (req.userToken?.type !== 'OAUTH') {
+        // Context: this is token generation when updating password
+        token = await user.generateSessionToken({
+          sessionId: req.jwtPayload?.sessionId,
+          createActivity: false,
+          updateLastLoginAt: false,
+        });
+      }
+
+      return { individual, token };
+    },
+  },
+  confirmEmail: {
+    description: 'Confirm email for Individual. Scope: "account".',
+    type: new GraphQLNonNull(
+      new GraphQLObjectType({
+        name: 'IndividualConfirmEmailResponse',
+        fields: {
+          individual: {
+            type: new GraphQLNonNull(GraphQLIndividual),
+            description: 'The account that was confirmed',
+          },
+          token: {
+            type: GraphQLString,
+            description: 'A new session token to use for the account. Only returned if not using OAuth.',
+          },
+        },
+      }),
+    ),
+    args: {
+      token: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: 'The token to confirm the email.',
+      },
+    },
+    resolve: async (_, { token: confirmEmailToken }, req) => {
+      const user = await confirmUserEmail(confirmEmailToken);
+      const individual = await user.getCollective({ loaders: req.loaders });
+
+      // The sign-in token
       let token;
 
       // We don't want OAuth tokens to be exchanged against a session token

--- a/server/graphql/v2/mutation/IndividualMutations.ts
+++ b/server/graphql/v2/mutation/IndividualMutations.ts
@@ -8,7 +8,7 @@ import { GraphQLDateTime } from 'graphql-scalars';
 
 import RateLimit, { ONE_HOUR_IN_SECONDS } from '../../../lib/rate-limit';
 import TwoFactorAuthLib from '../../../lib/two-factor-authentication';
-import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
+import { checkRemoteUserCanUseAccount, enforceScope } from '../../common/scope-check';
 import { confirmUserEmail } from '../../common/user';
 import { RateLimitExceeded, Unauthorized } from '../../errors';
 import { GraphQLIndividual } from '../object/Individual';
@@ -92,8 +92,8 @@ const individualMutations = {
 
       let token;
 
-      // We don't want OAuth tokens to be exchanged against a session token
-      if (req.userToken?.type !== 'OAUTH') {
+      // We don't want OAuth/Personal tokens to be exchanged against a session token
+      if (!req.userToken && !req.personalToken) {
         // Context: this is token generation when updating password
         token = await user.generateSessionToken({
           sessionId: req.jwtPayload?.sessionId,
@@ -129,6 +129,8 @@ const individualMutations = {
       },
     },
     resolve: async (_, { token: confirmEmailToken }, req) => {
+      enforceScope(req, 'account');
+
       const user = await confirmUserEmail(confirmEmailToken);
       const individual = await user.getCollective({ loaders: req.loaders });
 
@@ -136,7 +138,7 @@ const individualMutations = {
       let token;
 
       // We don't want OAuth tokens to be exchanged against a session token
-      if (req.userToken?.type !== 'OAUTH') {
+      if (req.remoteUser && !req.userToken && !req.personalToken) {
         // Context: this is token generation when updating password
         token = await user.generateSessionToken({
           sessionId: req.jwtPayload?.sessionId,

--- a/server/graphql/v2/mutation/IndividualMutations.ts
+++ b/server/graphql/v2/mutation/IndividualMutations.ts
@@ -4,11 +4,11 @@ import bcrypt from 'bcrypt';
 import config from 'config';
 import express from 'express';
 import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-scalars';
+import { GraphQLDateTime, GraphQLNonEmptyString } from 'graphql-scalars';
 
 import RateLimit, { ONE_HOUR_IN_SECONDS } from '../../../lib/rate-limit';
 import TwoFactorAuthLib from '../../../lib/two-factor-authentication';
-import { checkRemoteUserCanUseAccount, enforceScope } from '../../common/scope-check';
+import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
 import { confirmUserEmail } from '../../common/user';
 import { RateLimitExceeded, Unauthorized } from '../../errors';
 import { GraphQLIndividual } from '../object/Individual';
@@ -115,39 +115,42 @@ const individualMutations = {
             type: new GraphQLNonNull(GraphQLIndividual),
             description: 'The account that was confirmed',
           },
-          token: {
+          sessionToken: {
             type: GraphQLString,
-            description: 'A new session token to use for the account. Only returned if not using OAuth.',
+            description: 'A new session token to use for the account. Only returned if user is signed in already.',
           },
         },
       }),
     ),
     args: {
       token: {
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNull(GraphQLNonEmptyString),
         description: 'The token to confirm the email.',
       },
     },
     resolve: async (_, { token: confirmEmailToken }, req) => {
-      enforceScope(req, 'account');
+      // Forbid this route for OAuth and Personal Tokens. Remember to check the scope if you want to allow it.
+      // Also make sure to prevent exchanging OAuth/Personal tokens for session tokens.
+      if (req.userToken || req.personalToken) {
+        throw new Unauthorized('OAuth and Personal Tokens are not allowed for this route');
+      }
 
       const user = await confirmUserEmail(confirmEmailToken);
       const individual = await user.getCollective({ loaders: req.loaders });
 
       // The sign-in token
-      let token;
+      let sessionToken;
 
-      // We don't want OAuth tokens to be exchanged against a session token
-      if (req.remoteUser && !req.userToken && !req.personalToken) {
-        // Context: this is token generation when updating password
-        token = await user.generateSessionToken({
+      // Re-generate the session token if the user is already signed in
+      if (req.remoteUser && req.remoteUser.id === user.id) {
+        sessionToken = await user.generateSessionToken({
           sessionId: req.jwtPayload?.sessionId,
           createActivity: false,
           updateLastLoginAt: false,
         });
       }
 
-      return { individual, token };
+      return { individual, sessionToken };
     },
   },
 };

--- a/server/middleware/authentication.js
+++ b/server/middleware/authentication.js
@@ -150,6 +150,8 @@ const _authenticateUserByJwt = async (req, res, next) => {
     reportMessageToSentry(`User has no collective linked`, { user });
     next();
     return;
+  } else if (req.jwtPayload.email && user.email !== req.jwtPayload.email) {
+    return next(new errors.Unauthorized('This token has expired'));
   }
 
   const { earlyAccess = {} } = user.collective.settings || {};

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -80,6 +80,8 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
    */
   jwt = function (payload = undefined, expiration = undefined) {
     expiration = expiration || auth.TOKEN_EXPIRATION_LOGIN;
+    payload = payload || {};
+    payload.email = this.email; // Include email to easily invalidate all token types when email change
     return auth.createJwt(this.id, payload, expiration);
   };
 

--- a/test/server/graphql/v2/mutation/IndividualMutations.test.ts
+++ b/test/server/graphql/v2/mutation/IndividualMutations.test.ts
@@ -3,12 +3,20 @@ import { expect } from 'chai';
 import config from 'config';
 import crypto from 'crypto-js';
 import gql from 'fake-tag';
+import jwt from 'jsonwebtoken';
 import { createSandbox } from 'sinon';
 import speakeasy from 'speakeasy';
 import request from 'supertest';
 
 import { idEncode } from '../../../../../server/graphql/v2/identifiers';
-import { fakeApplication, fakeUser, fakeUserToken, randEmail } from '../../../../test-helpers/fake-data';
+import {
+  fakeApplication,
+  fakePersonalToken,
+  fakeUser,
+  fakeUserToken,
+  randEmail,
+  randStr,
+} from '../../../../test-helpers/fake-data';
 import { startTestServer, stopTestServer } from '../../../../test-helpers/server';
 import { graphqlQueryV2 } from '../../../../utils';
 
@@ -192,10 +200,10 @@ describe('server/graphql/v2/mutation/IndividualMutations', () => {
           .post('/graphql')
           .send({ query: resetPasswordMutation, variables: { password: 'newpassword' } })
           .set('Authorization', `Bearer ${token}`)
-          .expect(200);
+          .expect(401);
 
-        expect(res.body.errors).to.exist;
-        expect(res.body.errors[0].message).to.equal('This token has expired');
+        expect(res.body.error.code).to.equal(401);
+        expect(res.body.error.message).to.equal('This token has expired');
       });
     });
 
@@ -249,6 +257,95 @@ describe('server/graphql/v2/mutation/IndividualMutations', () => {
         expect(user.passwordHash).to.not.be.empty;
         expect(user.passwordUpdatedAt).to.exist;
         expect(await bcrypt.compare('newpassword', user.passwordHash)).to.be.true;
+      });
+    });
+  });
+
+  describe('confirmEmail', () => {
+    const confirmEmailMutation = gql`
+      mutation ConfirmEmail($token: NonEmptyString!) {
+        confirmEmail(token: $token) {
+          sessionToken
+          individual {
+            id
+            slug
+          }
+        }
+      }
+    `;
+
+    it('should error if the token is invalid', async () => {
+      const result = await graphqlQueryV2(confirmEmailMutation, { token: 'invalidtoken' });
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal('Invalid email confirmation token');
+    });
+
+    it('cannot be used with a OAuth or personal token', async () => {
+      const user = await fakeUser({ emailWaitingForValidation: randEmail(), emailConfirmationToken: randStr() });
+
+      const userToken = await fakeUserToken({ type: 'OAUTH', UserId: user.id });
+      const resultOauth = await graphqlQueryV2(
+        confirmEmailMutation,
+        { token: user.emailConfirmationToken },
+        user,
+        null,
+        null,
+        userToken,
+      );
+      expect(resultOauth.errors).to.exist;
+      expect(resultOauth.errors[0].message).to.equal('OAuth and Personal Tokens are not allowed for this route');
+
+      const personalToken = await fakePersonalToken({ UserId: user.id });
+      const resultPersonalToken = await graphqlQueryV2(
+        confirmEmailMutation,
+        { token: user.emailConfirmationToken },
+        user,
+        null,
+        null,
+        null,
+        personalToken,
+      );
+      expect(resultPersonalToken.errors).to.exist;
+      expect(resultPersonalToken.errors[0].message).to.equal(
+        'OAuth and Personal Tokens are not allowed for this route',
+      );
+    });
+
+    it('should confirm the new email', async () => {
+      const newEmail = randEmail();
+      const user = await fakeUser({ emailWaitingForValidation: newEmail, emailConfirmationToken: randStr() });
+      const result = await graphqlQueryV2(confirmEmailMutation, { token: user.emailConfirmationToken }); // Unauthenticated
+      expect(result.errors).to.not.exist;
+      expect(result.data.confirmEmail.sessionToken).to.not.exist; // Do not log in if not authenticated already
+      expect(result.data.confirmEmail.individual.slug).to.equal(user.collective.slug);
+
+      await user.reload();
+      expect(user.email).to.equal(newEmail);
+      expect(user.emailWaitingForValidation).to.be.null;
+      expect(user.emailConfirmationToken).to.be.null;
+    });
+
+    it('should confirm the new email and return a session token if logged in', async () => {
+      const newEmail = randEmail();
+      const user = await fakeUser({ emailWaitingForValidation: newEmail, emailConfirmationToken: randStr() });
+      const result = await graphqlQueryV2(confirmEmailMutation, { token: user.emailConfirmationToken }, user); // Authenticated
+      expect(result.errors).to.not.exist;
+      expect(result.data.confirmEmail.sessionToken).to.exist;
+      expect(result.data.confirmEmail.individual.slug).to.equal(user.collective.slug);
+
+      await user.reload();
+      expect(user.email).to.equal(newEmail);
+      expect(user.emailWaitingForValidation).to.be.null;
+      expect(user.emailConfirmationToken).to.be.null;
+
+      const decodedToken = jwt.decode(result.data.confirmEmail.sessionToken, { complete: true });
+      expect(decodedToken).to.containSubset({
+        header: { alg: 'HS256', typ: 'JWT', kid: 'HS256-2019-09-02' },
+        payload: {
+          scope: 'session',
+          email: newEmail,
+          sub: user.id.toString(),
+        },
       });
     });
   });


### PR DESCRIPTION
Goes with https://github.com/opencollective/opencollective-frontend/pull/10379

Implemented by introducing a new `confirmEmail` mutation on GraphQL V2 (rather than using the V1 mutation) to prevent breaking changes when deploying. As a result, old frontends will be logged out after successfully changing the email.
