### PR TITLE
Wise: getToken mutex

### DIFF
--- a/server/lib/mutex.ts
+++ b/server/lib/mutex.ts
@@ -1,0 +1,39 @@
+import debugLib from 'debug';
+
+import { createRedisClient } from './redis';
+import { sleep } from './utils';
+
+const debug = debugLib('mutex');
+
+/**
+ * Cache based, service-wide mutex implementation.
+ */
+export async function lockUntilResolved<T>(
+  key: string,
+  until: () => Promise<T>,
+  { lockAcquireTimeoutMs = 15 * 1000, unlockTimeoutMs = 60 * 1000 } = {},
+): Promise<T> {
+  const redis = await createRedisClient();
+  if (!redis) {
+    return until();
+  }
+  const _key = `lock:${key}`;
+  const start = Date.now();
+  let lockAcquired = await redis.mSetNX([_key, '1']);
+  while (!lockAcquired) {
+    debug(`Waiting for lock ${_key}`);
+    await sleep(100);
+    lockAcquired = await redis.mSetNX([_key, '1']);
+    if (Date.now() - start > lockAcquireTimeoutMs) {
+      debug(`Timeouted waiting for lock ${_key}`);
+      throw new Error(`Timeout to acquire lock for key ${_key}`);
+    }
+  }
+
+  await redis.expire(_key, unlockTimeoutMs / 1000);
+  debug(`Acquired lock ${_key}`);
+  return until().finally(async () => {
+    await redis.del(_key);
+    debug(`Released lock ${_key}`);
+  });
+}

--- a/server/lib/mutex.ts
+++ b/server/lib/mutex.ts
@@ -12,7 +12,7 @@ const debug = debugLib('mutex');
 export async function lockUntilResolved<T>(
   key: string,
   until: () => Promise<T>,
-  { lockAcquireTimeoutMs = 15 * 1000, unlockTimeoutMs = 60 * 1000, retryDelayMs = 100 } = {},
+  { lockAcquireTimeoutMs = 15 * 1000, unlockTimeoutMs = 10 * 60 * 1000, retryDelayMs = 100 } = {},
 ): Promise<T> {
   const redis = await createRedisClient();
   if (!redis) {

--- a/server/lib/mutex.ts
+++ b/server/lib/mutex.ts
@@ -1,7 +1,7 @@
 import debugLib from 'debug';
 
 import logger from './logger';
-import { createRedisClient } from './redis';
+import { createRedisClient, RedisInstanceType } from './redis';
 import { sleep } from './utils';
 
 const debug = debugLib('mutex');
@@ -14,7 +14,7 @@ export async function lockUntilResolved<T>(
   until: () => Promise<T>,
   { lockAcquireTimeoutMs = 15 * 1000, unlockTimeoutMs = 10 * 60 * 1000, retryDelayMs = 100 } = {},
 ): Promise<T> {
-  const redis = await createRedisClient();
+  const redis = await createRedisClient(RedisInstanceType.SESSION);
   if (!redis) {
     logger.warn(`Redis is not available, ${key} running without a mutex lock!`);
     return until();

--- a/server/lib/mutex.ts
+++ b/server/lib/mutex.ts
@@ -1,5 +1,6 @@
 import debugLib from 'debug';
 
+import logger from './logger';
 import { createRedisClient } from './redis';
 import { sleep } from './utils';
 
@@ -15,6 +16,7 @@ export async function lockUntilResolved<T>(
 ): Promise<T> {
   const redis = await createRedisClient();
   if (!redis) {
+    logger.warn(`Redis is not available, ${key} running without a mutex lock!`);
     return until();
   }
   const _key = `lock:${key}`;

--- a/server/lib/transferwise.ts
+++ b/server/lib/transferwise.ts
@@ -32,6 +32,7 @@ import {
 
 import { FEATURE } from './allowed-features';
 import logger from './logger';
+import { lockUntilResolved } from './mutex';
 import { reportErrorToSentry } from './sentry';
 import { sleep } from './utils';
 
@@ -86,15 +87,24 @@ const parseError = (
 
 export async function getToken(connectedAccount: ConnectedAccount, refresh = false): Promise<string> {
   // OAuth token, require us to refresh every 12 hours
-  const tokenCreation = moment.utc(connectedAccount.data.created_at);
-  const diff = moment.duration(moment.utc().diff(tokenCreation)).asSeconds();
-  const isOutdated = diff > <number>connectedAccount.data.expires_in - 60;
-  if (refresh || isOutdated) {
+  const checkTokenIsExpired = connectedAccount => {
+    if (refresh) {
+      return true;
+    }
+    const tokenCreation = moment.utc(connectedAccount.data.created_at);
+    const diff = moment.duration(moment.utc().diff(tokenCreation)).asSeconds();
+    return diff > <number>connectedAccount.data.expires_in - 60 * 15;
+  };
+
+  const refreshAndUpdateToken = async connectedAccount => {
     const newToken = await getOrRefreshToken({ refreshToken: connectedAccount.refreshToken });
     if (!newToken) {
       Activity.create({
         type: ActivityTypes.CONNECTED_ACCOUNT_ERROR,
-        data: { connectedAccount: connectedAccount.activity, error: 'There was an error refreshing the Wise token' },
+        data: {
+          connectedAccount: connectedAccount.activity,
+          error: 'There was an error refreshing the Wise token',
+        },
         CollectiveId: connectedAccount.CollectiveId,
       });
       throw new Error('There was an error refreshing the Wise token');
@@ -102,8 +112,19 @@ export async function getToken(connectedAccount: ConnectedAccount, refresh = fal
     const { access_token: token, refresh_token: refreshToken, ...data } = newToken;
     await connectedAccount.update({ token, refreshToken, data: { ...connectedAccount.data, ...data } });
     return token;
-  } else {
+  };
+
+  if (!checkTokenIsExpired(connectedAccount)) {
     return connectedAccount.token;
+  } else {
+    return lockUntilResolved(`wise-token-${connectedAccount.id}`, async () => {
+      await connectedAccount.reload();
+      if (!checkTokenIsExpired(connectedAccount)) {
+        return connectedAccount.token;
+      } else {
+        return refreshAndUpdateToken(connectedAccount);
+      }
+    });
   }
 }
 

--- a/server/lib/transferwise.ts
+++ b/server/lib/transferwise.ts
@@ -117,14 +117,18 @@ export async function getToken(connectedAccount: ConnectedAccount, refresh = fal
   if (!checkTokenIsExpired(connectedAccount)) {
     return connectedAccount.token;
   } else {
-    return lockUntilResolved(`wise-token-${connectedAccount.id}`, async () => {
-      await connectedAccount.reload();
-      if (!checkTokenIsExpired(connectedAccount)) {
-        return connectedAccount.token;
-      } else {
-        return refreshAndUpdateToken(connectedAccount);
-      }
-    });
+    return lockUntilResolved(
+      `wise-token-${connectedAccount.id}`,
+      async () => {
+        await connectedAccount.reload();
+        if (!checkTokenIsExpired(connectedAccount)) {
+          return connectedAccount.token;
+        } else {
+          return refreshAndUpdateToken(connectedAccount);
+        }
+      },
+      { unlockTimeoutMs: 60 * 1000 },
+    );
   }
 }
 

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -422,7 +422,9 @@ async function payExpensesBatchGroup(host, expenses, x2faApproval?: string, remo
   try {
     if (!x2faApproval && expenses) {
       let batchGroup = await transferwise.getBatchGroup(connectedAccount, expenses[0].data.batchGroup.id);
-      if (batchGroup.status !== 'NEW') {
+      if (batchGroup.status === 'COMPLETED' && batchGroup.alreadyPaid !== false) {
+        throw new Error('Can not pay batch group, existing batch group was already paid');
+      } else if (batchGroup.status !== 'NEW') {
         throw new Error('Can not pay batch group, existing batch group was already processed');
       }
       const expenseTransferIds = expenses.map(e => e.data.transfer.id);

--- a/server/types/transferwise.ts
+++ b/server/types/transferwise.ts
@@ -427,6 +427,7 @@ export type BatchGroup = {
   status: 'NEW' | 'COMPLETED' | 'MARKED_FOR_CANCELLATION' | 'PROCESSING_CANCEL' | 'CANCELLED';
   transferIds: Array<number>;
   payInDetails?: Array<Record<string, any>>;
+  alreadyPaid?: boolean;
 };
 
 export type TransactionRequiredFieldsGroup = {

--- a/test/server/lib/mutex.test.ts
+++ b/test/server/lib/mutex.test.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai';
+import config from 'config';
+import { has } from 'lodash';
+
+import { lockUntilResolved } from '../../../server/lib/mutex';
+import { createRedisClient } from '../../../server/lib/redis';
+import { sleep } from '../../utils';
+
+describe('lockUntilResolved', () => {
+  if (has(config, 'redis.serverUrl')) {
+    const pRedis = createRedisClient();
+
+    beforeEach(async () => {
+      (await pRedis).del('lock:test');
+    });
+    after(async () => {
+      (await pRedis).del('lock:test');
+    });
+
+    it('should wait for the first lock to finish', async () => {
+      const start = Date.now();
+      let endFirst;
+      const pFirst = lockUntilResolved('test', async () => {
+        await sleep(800 - 20);
+        return 'first';
+      });
+      const second = await lockUntilResolved('test', async () => {
+        endFirst = Date.now();
+        await sleep(200 - 20);
+        return 'second';
+      });
+      const endSecond = Date.now();
+
+      assert.approximately(endFirst - start, 800, 100);
+      assert.approximately(endSecond - start, 800 + 200, 100);
+      assert.equal(await pFirst, 'first');
+      assert.equal(second, 'second');
+    });
+
+    it('releases the lock if the callback function fails', async () => {
+      const start = Date.now();
+      let endFirst;
+      const pFirst = lockUntilResolved('test', async () => {
+        await sleep(500 - 20);
+        throw new Error('first');
+      });
+      const second = await lockUntilResolved('test', async () => {
+        endFirst = Date.now();
+        await sleep(200 - 20);
+        return 'second';
+      });
+      const endSecond = Date.now();
+
+      assert.approximately(endFirst - start, 500, 100);
+      assert.approximately(endSecond - start, 500 + 200, 100);
+      assert.isRejected(pFirst, /first/);
+      assert.equal(second, 'second');
+    });
+
+    it('throws if it fails to acquire a lock', async () => {
+      lockUntilResolved('test', async () => sleep(800));
+      const pSecond = lockUntilResolved('test', async () => sleep(800), { lockAcquireTimeoutMs: 100 });
+      assert.isRejected(pSecond, /Timeout to acquire lock for key lock:test/);
+    });
+  }
+});

--- a/test/server/lib/mutex.test.ts
+++ b/test/server/lib/mutex.test.ts
@@ -21,18 +21,22 @@ describe('lockUntilResolved', () => {
       const start = Date.now();
       let endFirst;
       const pFirst = lockUntilResolved('test', async () => {
-        await sleep(800 - 20);
+        await sleep(50);
         return 'first';
       });
-      const second = await lockUntilResolved('test', async () => {
-        endFirst = Date.now();
-        await sleep(200 - 20);
-        return 'second';
-      });
+      const second = await lockUntilResolved(
+        'test',
+        async () => {
+          endFirst = Date.now();
+          await sleep(50);
+          return 'second';
+        },
+        { retryDelayMs: 1 },
+      );
       const endSecond = Date.now();
 
-      assert.approximately(endFirst - start, 800, 100);
-      assert.approximately(endSecond - start, 800 + 200, 100);
+      assert.approximately(endFirst - start, 50, 5);
+      assert.approximately(endSecond - start, 50 + 50, 5);
       assert.equal(await pFirst, 'first');
       assert.equal(second, 'second');
     });
@@ -41,25 +45,29 @@ describe('lockUntilResolved', () => {
       const start = Date.now();
       let endFirst;
       const pFirst = lockUntilResolved('test', async () => {
-        await sleep(500 - 20);
+        await sleep(50);
         throw new Error('first');
       });
-      const second = await lockUntilResolved('test', async () => {
-        endFirst = Date.now();
-        await sleep(200 - 20);
-        return 'second';
-      });
+      const second = await lockUntilResolved(
+        'test',
+        async () => {
+          endFirst = Date.now();
+          await sleep(50);
+          return 'second';
+        },
+        { retryDelayMs: 1 },
+      );
       const endSecond = Date.now();
 
-      assert.approximately(endFirst - start, 500, 100);
-      assert.approximately(endSecond - start, 500 + 200, 100);
+      assert.approximately(endFirst - start, 50, 5);
+      assert.approximately(endSecond - start, 50 + 50, 5);
       assert.isRejected(pFirst, /first/);
       assert.equal(second, 'second');
     });
 
     it('throws if it fails to acquire a lock', async () => {
-      lockUntilResolved('test', async () => sleep(800));
-      const pSecond = lockUntilResolved('test', async () => sleep(800), { lockAcquireTimeoutMs: 100 });
+      lockUntilResolved('test', async () => sleep(100));
+      const pSecond = lockUntilResolved('test', async () => sleep(100), { lockAcquireTimeoutMs: 50 });
       assert.isRejected(pSecond, /Timeout to acquire lock for key lock:test/);
     });
   }

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -447,7 +447,7 @@ describe('server/paymentProviders/transferwise/index', () => {
       const call = transferwise.payExpensesBatchGroup(host, [expense]);
       await expect(call).to.be.eventually.rejectedWith(
         Error,
-        `Can not pay batch group, existing batch group was already processed`,
+        `Can not pay batch group, existing batch group was already paid`,
       );
     });
 


### PR DESCRIPTION
I'm currently investigating a series of failed Wise authorizations related to refresh token requests.
As a first step, I'm following the recommendation on Wise documentation and making sure there's no racing condition between these calls.

Reference: https://open-collective.sentry.io/issues/3490446877/events/a97a4dd3ef204142aeabef2d45877f6d/events/?project=5199682