### PR TITLE
Transaction: default date for `getFxRate`

### DIFF
--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -1661,7 +1661,8 @@ Transaction.getFxRate = async function (fromCurrency, toCurrency, transaction) {
     }
   }
 
-  return getFxRate(fromCurrency, toCurrency, transaction.createdAt);
+  const createdAt = transaction.createdAt || new Date();
+  return getFxRate(fromCurrency, toCurrency, createdAt);
 };
 
 Transaction.updateCurrency = async function (currency: SupportedCurrency, transaction: TransactionInterface) {


### PR DESCRIPTION
Fixing the root cause for https://github.com/opencollective/opencollective/issues/7296

Since we need a date to compute the FX Rate, we were pre-setting the value in [https://github.com/opencollective/opencollective-api/pull/9829/files/d8c59a959742172359943bd9a1f6560f4d8c9ea3#diff-11d6da745887[…]9652f6e5085L81-L83](https://github.com/opencollective/opencollective-api/pull/9829/files/d8c59a959742172359943bd9a1f6560f4d8c9ea3#diff-11d6da745887c2521c0cc321680a658c6885fbdc9132feb16ba8d9652f6e5085L81-L83). Added the fix directly on `getFxRate` to have a wider coverage.