### PR TITLE
Transferring orders when changing hosts

### DIFF
--- a/cron/daily/60-clean-orders.js
+++ b/cron/daily/60-clean-orders.js
@@ -20,6 +20,14 @@ Promise.all([
   AND "Orders"."createdAt" <  (NOW() - interval '2 month')
   `,
   ),
+  // Mark all paused Orders as EXPIRED after 1 year
+  sequelize.query(
+    `UPDATE "Orders"
+  SET "status" = 'EXPIRED', "updatedAt" = NOW()
+  WHERE "Orders"."status" = 'PAUSED'
+  AND "Orders"."updatedAt" <  (NOW() - interval '1 year')
+  `,
+  ),
 ]).then(() => {
   console.log('>>> Clean Orders: done');
   process.exit(0);

--- a/server/constants/activities.ts
+++ b/server/constants/activities.ts
@@ -83,6 +83,7 @@ enum ActivityTypes {
   CONTRIBUTION_REJECTED = 'contribution.rejected',
   SUBSCRIPTION_ACTIVATED = 'subscription.activated',
   SUBSCRIPTION_CANCELED = 'subscription.canceled',
+  SUBSCRIPTION_PAUSED = 'subscription.paused',
   TICKET_CONFIRMED = 'ticket.confirmed',
   ORDER_CANCELED_ARCHIVED_COLLECTIVE = 'order.canceled.archived.collective',
   ORDER_PENDING = 'order.pending',
@@ -239,6 +240,7 @@ export const ActivitiesPerClass: Record<ActivityClasses, ActivityTypes[]> = {
     ActivityTypes.PAYMENT_FAILED,
     ActivityTypes.SUBSCRIPTION_ACTIVATED,
     ActivityTypes.SUBSCRIPTION_CANCELED,
+    ActivityTypes.SUBSCRIPTION_PAUSED,
     ActivityTypes.SUBSCRIPTION_CONFIRMED,
   ],
   [ActivityClasses.ACTIVITIES_UPDATES]: [

--- a/server/constants/order-status.ts
+++ b/server/constants/order-status.ts
@@ -24,6 +24,7 @@ enum OrderStatuses {
   // Disputed charges from Stripe
   DISPUTED = 'DISPUTED',
   REFUNDED = 'REFUNDED',
+  PAUSED = 'PAUSED',
   // In review charges from Stripe,
   IN_REVIEW = 'IN_REVIEW',
 }

--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -733,6 +733,7 @@ enum OrderStatus {
   EXPIRED
   DISPUTED
   REFUNDED
+  PAUSED
   IN_REVIEW
 }
 

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -1194,6 +1194,7 @@ enum OrderStatus {
   EXPIRED
   DISPUTED
   REFUNDED
+  PAUSED
   IN_REVIEW
 }
 
@@ -4617,6 +4618,27 @@ type AccountStats {
     """
     frequency: ContributionFrequency! = MONTHLY
   ): Amount
+    @deprecated(reason: "2024-03-04: Use activeRecurringContributionsBreakdown while we migrate to better semantics.")
+
+  """
+  Returns some statistics about active recurring contributions, broken down by frequency
+  """
+  activeRecurringContributionsBreakdown(
+    """
+    Return only the stats for this frequency
+    """
+    frequency: ContributionFrequency
+
+    """
+    Filter contributions on whether they can be ported to another fiscal host directly
+    """
+    hasPortability: Boolean
+
+    """
+    Include contributions to children accounts (Projects and Events)
+    """
+    includeChildren: Boolean = false
+  ): [AmountStats!]!
 
   """
   Returns expense tags for collective sorted by popularity
@@ -5311,6 +5333,7 @@ enum ActivityType {
   CONTRIBUTION_REJECTED
   SUBSCRIPTION_ACTIVATED
   SUBSCRIPTION_CANCELED
+  SUBSCRIPTION_PAUSED
   TICKET_CONFIRMED
   ORDER_CANCELED_ARCHIVED_COLLECTIVE
   ORDER_PENDING
@@ -13864,6 +13887,7 @@ enum ActivityAndClassesType {
   CONTRIBUTION_REJECTED
   SUBSCRIPTION_ACTIVATED
   SUBSCRIPTION_CANCELED
+  SUBSCRIPTION_PAUSED
   TICKET_CONFIRMED
   ORDER_CANCELED_ARCHIVED_COLLECTIVE
   ORDER_PENDING
@@ -16229,7 +16253,16 @@ type Mutation {
     The account to unhost
     """
     account: AccountReferenceInput!
+
+    """
+    An optional message to explain the reason for unhosting
+    """
     message: String
+
+    """
+    If true, contributions will be paused rather than canceled
+    """
+    pauseContributions: Boolean! = true
   ): Account!
 
   """

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -522,7 +522,10 @@ export const CollectiveStatsType = new GraphQLObjectType({
       activeRecurringContributions: {
         type: GraphQLJSON,
         resolve(collective, args, req) {
-          return req.loaders.Collective.stats.activeRecurringContributions.load(collective.id);
+          const loader = req.loaders.Collective.stats.activeRecurringContributions.buildLoader({
+            currency: collective.currency,
+          });
+          return loader.load(collective.id);
         },
       },
     };

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -357,6 +357,8 @@ const orderMutations = {
         throw new Unauthorized("You don't have permission to update this order");
       } else if (!order.Subscription.isActive) {
         throw new Error('Order must be active to be updated');
+      } else if (order.status === OrderStatuses.PAUSED) {
+        throw new Error('Paused orders cannot be updated');
       } else if (args.paypalSubscriptionId && args.paymentMethod) {
         throw new Error('paypalSubscriptionId and paymentMethod are mutually exclusive');
       } else if (haveDetailsChanged && hasPaymentMethodChanged) {

--- a/server/graphql/v2/object/AmountStats.js
+++ b/server/graphql/v2/object/AmountStats.js
@@ -1,4 +1,5 @@
 import { GraphQLInt, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
+import { isNil } from 'lodash';
 
 import { GraphQLAmount } from '../object/Amount';
 
@@ -14,7 +15,7 @@ export const GraphQLAmountStats = new GraphQLObjectType({
       type: new GraphQLNonNull(GraphQLAmount),
       description: 'Total amount for this label',
       resolve(entry) {
-        if (entry.amount) {
+        if (!isNil(entry.amount)) {
           return { value: entry.amount, currency: entry.currency };
         }
       },

--- a/server/lib/emailTemplates.ts
+++ b/server/lib/emailTemplates.ts
@@ -92,6 +92,7 @@ export const templateNames = [
   'report.platform',
   'report.platform.weekly',
   'subscription.canceled',
+  'subscription.paused',
   'taxform.request',
   'ticket.confirmed',
   'ticket.confirmed.fearlesscitiesbrussels',

--- a/server/lib/notifications/email.ts
+++ b/server/lib/notifications/email.ts
@@ -239,6 +239,7 @@ export const notifyByEmail = async (activity: Activity) => {
       break;
 
     case ActivityTypes.SUBSCRIPTION_CANCELED:
+    case ActivityTypes.SUBSCRIPTION_PAUSED:
       await notify.user(activity);
       break;
 

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -43,11 +43,13 @@ const dispatch = async (activity: Activity, { onlyChannels = null, force = false
   const shouldNotifyChannel = channel => !onlyChannels || onlyChannels.includes(channel);
 
   if (shouldNotifyChannel(channels.EMAIL)) {
-    notifyByEmail(activity).catch(e => {
+    try {
+      await notifyByEmail(activity);
+    } catch (e) {
       if (!['ci', 'test', 'e2e'].includes(config.env)) {
         console.error(e);
       }
-    });
+    }
   }
 
   // process notification entries for slack, twitter, etc...

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -31,13 +31,22 @@ export const MAX_RETRIES = 6;
 export async function ordersWithPendingCharges({ limit, startDate } = {}) {
   return models.Order.findAndCountAll({
     where: {
+      status: { [Op.not]: status.PAUSED },
       SubscriptionId: { [Op.ne]: null },
       deletedAt: null,
     },
     limit: limit,
     include: [
       { model: models.User, as: 'createdByUser' },
-      { model: models.Collective, as: 'collective', required: true },
+      {
+        model: models.Collective,
+        as: 'collective',
+        required: true,
+        where: {
+          HostCollectiveId: { [Op.not]: null },
+          isActive: true,
+        },
+      },
       { model: models.Collective, as: 'fromCollective', required: true },
       { model: models.PaymentMethod, as: 'paymentMethod' },
       { model: models.Tier, as: 'Tier' },

--- a/server/lib/timeline.ts
+++ b/server/lib/timeline.ts
@@ -154,6 +154,7 @@ const makeTimelineQuery = async (
         ActivityTypes.PAYMENT_CREDITCARD_EXPIRING,
         ActivityTypes.PAYMENT_FAILED,
         ActivityTypes.SUBSCRIPTION_CANCELED,
+        ActivityTypes.SUBSCRIPTION_PAUSED,
       ],
     );
   }

--- a/server/lib/webhooks.js
+++ b/server/lib/webhooks.js
@@ -142,7 +142,7 @@ export const sanitizeActivity = activity => {
     cleanActivity.data = pick(activity.data, ['recipient.name']);
     cleanActivity.data.tier = getTierInfo(activity.data.tier);
     cleanActivity.data.order = getOrderInfo(activity.data.order);
-  } else if (type === activities.SUBSCRIPTION_CANCELED) {
+  } else if (type === activities.SUBSCRIPTION_CANCELED || type === activities.SUBSCRIPTION_PAUSED) {
     cleanActivity.data = pick(activity.data, ['subscription.id']);
     cleanActivity.data.order = getOrderInfo(activity.data.order);
     cleanActivity.data.tier = getTierInfo(activity.data.tier);

--- a/server/models/Activity.ts
+++ b/server/models/Activity.ts
@@ -105,11 +105,13 @@ Activity.init(
     sequelize,
     updatedAt: false,
     hooks: {
-      afterCreate(activity) {
+      async afterCreate(activity) {
         if (activity.data?.notify !== false) {
-          dispatch(activity); // intentionally no return statement, needs to be async
+          const dispatchPromise = dispatch(activity); // intentionally no return statement, needs to be async by default
+          if (activity.data?.awaitForDispatch) {
+            await dispatchPromise;
+          }
         }
-        return Promise.resolve();
       },
     },
   },

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -52,6 +52,7 @@ import { SupportedCurrency } from '../constants/currencies';
 import expenseStatus from '../constants/expense-status';
 import expenseTypes from '../constants/expense-type';
 import FEATURE from '../constants/feature';
+import OrderStatuses from '../constants/order-status';
 import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../constants/paymentMethods';
 import plans from '../constants/plans';
 import POLICIES, { Policies } from '../constants/policies';
@@ -2412,7 +2413,12 @@ class Collective extends Model<
       });
     }
 
-    await Order.cancelNonTransferableActiveOrdersByCollectiveId(this.id);
+    // Pause or cancel all orders that cannot be transferred
+    await Order.updateNonTransferableActiveOrdersStatusesByCollectiveId(
+      this.id,
+      options?.pauseContributions ? OrderStatuses.PAUSED : OrderStatuses.CANCELLED,
+      'Changing host',
+    );
 
     const virtualCards = await VirtualCard.findAll({ where: { CollectiveId: this.id } });
     await Promise.all(virtualCards.map(virtualCard => virtualCard.delete()));

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -2414,12 +2414,10 @@ class Collective extends Model<
     }
 
     // Pause or cancel all orders that cannot be transferred
-    await Order.updateNonTransferableActiveOrdersStatusesByCollectiveId(
-      this.id,
-      options?.pauseContributions ? OrderStatuses.PAUSED : OrderStatuses.CANCELLED,
-      'Changing host',
-    );
+    const newOrderStatus = options?.pauseContributions ? OrderStatuses.PAUSED : OrderStatuses.CANCELLED;
+    await Order.stopActiveSubscriptions(this.id, newOrderStatus, options?.messageForContributors);
 
+    // Delete all virtual cards
     const virtualCards = await VirtualCard.findAll({ where: { CollectiveId: this.id } });
     await Promise.all(virtualCards.map(virtualCard => virtualCard.delete()));
 

--- a/server/models/Order.ts
+++ b/server/models/Order.ts
@@ -1,5 +1,4 @@
 import { TaxType } from '@opencollective/taxes';
-import config from 'config';
 import debugLib from 'debug';
 import { get } from 'lodash';
 import {
@@ -42,11 +41,7 @@ interface OrderModelStaticInterface {
   generateDescription(collective, amount, interval, tier): string;
   cancelActiveOrdersByCollective(collectiveId: number): Promise<[affectedCount: number]>;
   cancelActiveOrdersByTierId(tierId: number): Promise<[affectedCount: number]>;
-  updateNonTransferableActiveOrdersStatusesByCollectiveId(
-    collectiveId: number,
-    newStatus: OrderStatus,
-    context: string,
-  ): Promise<number>;
+  stopActiveSubscriptions(collectiveId: number, newStatus: OrderStatus, context: string): Promise<void>;
   clearExpiredLocks(): Promise<[null, number]>;
 }
 
@@ -677,45 +672,30 @@ Order.cancelActiveOrdersByTierId = function (tierId: number) {
  * The only type of contributions that can be transferred are non-Stripe Connect credit card subscriptions.
  * In the future, we could add support for recurring contributions between children and parent collectives.
  *
- * Note: for externally managed subscriptions (PayPal), marking the orders as CANCELLED will trigger the
- * cancellation of the associated subscriptions on the payment provider.
- * See `cron/hourly/70-cancel-subscriptions-for-cancelled-orders.ts`.
+ * Note: the linked subscriptions will be cancelled in `cron/hourly/70-handle-batch-subscriptions-update.ts`.
  */
-Order.updateNonTransferableActiveOrdersStatusesByCollectiveId = async function (
+Order.stopActiveSubscriptions = async function (
   collectiveId: number,
-  newStatus: OrderStatus,
-  updateContext = 'Bulk update for non-transferable active orders',
-): Promise<number> {
-  const [orders] = await sequelize.query(
+  newStatus: OrderStatus.CANCELLED | OrderStatus.PAUSED,
+  messageForContributors: string,
+): Promise<void> {
+  // Update all orders
+  await sequelize.query(
     `
       UPDATE "Orders"
       SET
         status = :newStatus,
         "updatedAt" = NOW(),
-        "data" = COALESCE("data", '{}'::JSONB) || JSONB_BUILD_OBJECT('updateContext', :updateContext)
+        "data" = COALESCE("data", '{}'::JSONB) || JSONB_BUILD_OBJECT(
+          'messageForContributors', :messageForContributors,
+          'needsAsyncDeactivation', TRUE
+        )
       WHERE id IN (
         SELECT "Orders".id FROM "Orders"
         INNER JOIN "Subscriptions" ON "Subscriptions".id = "Orders"."SubscriptionId"
-        LEFT JOIN "PaymentMethods" pm ON "Orders"."PaymentMethodId" = pm.id
-        LEFT JOIN "PaymentMethods" spm ON pm."SourcePaymentMethodId" = spm.id
         WHERE "Orders"."CollectiveId" = :collectiveId
         AND "Subscriptions"."isActive" IS TRUE
-        AND CASE
-          WHEN spm.id IS NOT NULL THEN (
-            -- For gift cards, we need to check the source payment method
-            spm.service != 'stripe'
-            OR spm.type != 'creditcard'
-            OR COALESCE(spm.data#>>'{stripeAccount}', :platformStripeAccountId) != :platformStripeAccountId
-          ) WHEN pm.id IS NOT NULL THEN (
-            -- Only legacy stripe credit card contributions are transferable
-            pm.service != 'stripe'
-            OR pm.type != 'creditcard'
-            OR COALESCE(pm.data#>>'{stripeAccount}', :platformStripeAccountId) != :platformStripeAccountId
-          )
-          ELSE TRUE
-        END
       )
-      RETURNING id, "SubscriptionId"
     `,
     {
       type: QueryTypes.UPDATE,
@@ -723,31 +703,10 @@ Order.updateNonTransferableActiveOrdersStatusesByCollectiveId = async function (
       replacements: {
         collectiveId,
         newStatus,
-        updateContext,
-        platformStripeAccountId: config.stripe.accountId,
+        messageForContributors: messageForContributors || '',
       },
     },
   );
-
-  // Update related subscriptions that are managed internally. For the ones managed externally, we need to get
-  // the payment provider's confirmation before marking them as cancelled (see `cron/hourly/70-cancel-subscriptions-for-cancelled-orders.ts`).
-  if ([OrderStatus.CANCELLED, OrderStatus.PAUSED].includes(newStatus) && orders.length) {
-    await sequelize.query(
-      `
-      UPDATE "Subscriptions"
-      SET "isActive" = FALSE, "updatedAt" = NOW()
-      WHERE "id" IN (:subscriptionIds)
-      AND "isManagedExternally" = FALSE
-    `,
-      {
-        replacements: {
-          subscriptionIds: orders.map(order => order.SubscriptionId),
-        },
-      },
-    );
-  }
-
-  return orders.length;
 };
 
 Temporal(Order, sequelize);

--- a/templates/emails/collective.unhosted.hbs
+++ b/templates/emails/collective.unhosted.hbs
@@ -6,11 +6,14 @@ Subject: Important: {{{collective.name}}} has been un-hosted by {{{host.name}}}
   Hi {{collective.name}},
   <br /><br />
   You have been un-hosted by {{> linkCollective collective=host}}. This Fiscal Host will no longer manage money on behalf of your Collective. Any active recurring PayPal contributions or Virtual Cards will be cancelled.
+  {{#if pauseContributions}}
+  Once you're ready to start receiving contributions again (either with a new Fiscal Host or as an Independent Collective), we will help you reach out to your contributors to let them know how to resume their contributions.
+  {{/if}}
 </p>
 
 {{#if message}}
 <p style="font-size: 17px; padding: 0 1em;">
-  Message from {{host.name}}:
+  Message from {{#if isHostAdmin}}{{host.name}}{{else}}{{collective.name}}{{/if}}:
 </p>
   <blockquote style="padding: 1em; color: #6a737d;font-size: 16px;text-align: left;padding: 0.5em 0.75em;margin: 0 24px;border-left: 3px solid #e4e4e4;white-space: pre-line;font-style: italic;">{{message}}</blockquote>
 {{/if}}

--- a/templates/emails/subscription.paused.hbs
+++ b/templates/emails/subscription.paused.hbs
@@ -1,0 +1,24 @@
+Subject: Your contribution to {{{collective.name}}} has been paused
+
+{{> header}}
+
+<p>{{> greeting}}</p>
+
+<p>Your recurring contribution to {{collective.name}} for {{currency subscription.amount currency=subscription.currency}}/{{subscription.interval}} has been paused.</p>
+
+{{#if reason}}
+  <p>The reason given by the collective is:</p>
+  <blockquote style="color: #6a737d;font-size: 12px; font-style: italic; text-align: left;padding: 0.5em 0.75em;margin: 1em 0;border-left: 3px solid #e4e4e4;white-space: pre-line;">{{reason}}</blockquote>
+{{/if}}
+
+<p>
+  We'll inform you when your contribution is ready for reactivation. Without any further action from you, your contribution will remained paused.
+</p>
+
+<p>Warmly,</p>
+
+<p>
+  – {{collective.name}}
+</p>
+
+{{> footer}}

--- a/templates/emails/subscription.paused.hbs
+++ b/templates/emails/subscription.paused.hbs
@@ -6,13 +6,13 @@ Subject: Your contribution to {{{collective.name}}} has been paused
 
 <p>Your recurring contribution to {{collective.name}} for {{currency subscription.amount currency=subscription.currency}}/{{subscription.interval}} has been paused.</p>
 
-{{#if reason}}
-  <p>The reason given by the collective is:</p>
-  <blockquote style="color: #6a737d;font-size: 12px; font-style: italic; text-align: left;padding: 0.5em 0.75em;margin: 1em 0;border-left: 3px solid #e4e4e4;white-space: pre-line;">{{reason}}</blockquote>
+{{#if messageForContributors}}
+  <p>From {{collective.name}}:</p>
+  <blockquote style="color: #6a737d;font-size: 12px; font-style: italic; text-align: left;padding: 0.5em 0.75em;margin: 1em 0;border-left: 3px solid #e4e4e4;white-space: pre-line;">{{messageForContributors}}</blockquote>
 {{/if}}
 
 <p>
-  We'll inform you when your contribution is ready for reactivation. Without any further action from you, your contribution will remained paused.
+  We'll let you know when your contribution is ready for reactivation. Without any further action from you, your contribution will remain paused.
 </p>
 
 <p>Warmly,</p>

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -5,6 +5,7 @@ import { createSandbox } from 'sinon';
 
 import { activities, roles } from '../../../../../server/constants';
 import OrderStatuses from '../../../../../server/constants/order-status';
+import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../../../server/constants/paymentMethods';
 import { TransactionKind } from '../../../../../server/constants/transaction-kind';
 import VirtualCardProviders from '../../../../../server/constants/virtual-card-providers';
 import { GraphQLProcessHostApplicationAction } from '../../../../../server/graphql/v2/enum';
@@ -14,12 +15,14 @@ import { VirtualCardStatus } from '../../../../../server/models/VirtualCard';
 import * as stripeVirtualCardService from '../../../../../server/paymentProviders/stripe/virtual-cards';
 import { randEmail } from '../../../../stores';
 import {
+  fakeActiveHost,
   fakeCollective,
   fakeEvent,
   fakeHost,
   fakeHostApplication,
   fakeMember,
   fakeOrder,
+  fakePaymentMethod,
   fakeProject,
   fakeTier,
   fakeTransaction,
@@ -92,8 +95,8 @@ const PROCESS_HOST_APPLICATION_MUTATION = gql`
 `;
 
 const REMOVE_HOST_MUTATION = gql`
-  mutation UnhostAccount($account: AccountReferenceInput!, $message: String) {
-    removeHost(account: $account, message: $message) {
+  mutation UnhostAccount($account: AccountReferenceInput!, $message: String, $pauseContributions: Boolean) {
+    removeHost(account: $account, message: $message, pauseContributions: $pauseContributions) {
       id
       slug
       name
@@ -410,7 +413,7 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       );
     });
 
-    it('requires token with host scope', async () => {
+    it("can't remove if unauthenticated", async () => {
       const result = await graphqlQueryV2(REMOVE_HOST_MUTATION, {
         account: {
           id: 'some id',
@@ -418,6 +421,14 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       });
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal('You need to be logged in to manage hosted accounts.');
+    });
+
+    it("can't remove if not an admin", async () => {
+      const randomUser = await fakeUser();
+      const collective = await fakeCollective();
+      const result = await graphqlQueryV2(REMOVE_HOST_MUTATION, { account: { legacyId: collective.id } }, randomUser);
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal('Only the host admin or the account admin can trigger this action');
     });
 
     it('results in error if account does not exist', async () => {
@@ -475,6 +486,67 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       expect(unhostingActivity.data.host.id).to.eq(host.id);
     });
 
+    it('pauses the contributions if requested', async () => {
+      const host = await fakeActiveHost();
+      const collective = await fakeCollective({ HostCollectiveId: host.id });
+      const stripePm = await fakePaymentMethod({
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+      });
+      const transferableOrder = await fakeOrder(
+        {
+          status: OrderStatuses.ACTIVE,
+          CollectiveId: collective.id,
+          interval: 'month',
+          subscription: { isManagedExternally: false, isActive: true },
+          PaymentMethodId: stripePm.id,
+        },
+        {
+          withSubscription: true,
+        },
+      );
+
+      const nonTransferableOrder = await fakeOrder(
+        {
+          status: OrderStatuses.ACTIVE,
+          CollectiveId: collective.id,
+          interval: 'month',
+          subscription: { isManagedExternally: true, isActive: true },
+        },
+        {
+          withSubscription: true,
+        },
+      );
+
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: { legacyId: collective.id },
+          message: 'We are transitioning to a new host',
+          pauseContributions: true,
+        },
+        rootUser,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.removeHost.host).to.be.null;
+
+      const unhostingActivity = await models.Activity.findOne({
+        where: { type: activities.COLLECTIVE_UNHOSTED, CollectiveId: collective.id },
+      });
+      expect(unhostingActivity).to.exist;
+      expect(unhostingActivity.data.message).to.eq('We are transitioning to a new host');
+      expect(unhostingActivity.data.collective.id).to.eq(collective.id);
+      expect(unhostingActivity.data.host.id).to.eq(host.id);
+
+      await nonTransferableOrder.reload();
+      expect(nonTransferableOrder.status).to.eq(OrderStatuses.PAUSED);
+      expect(nonTransferableOrder.data.updateContext).to.eq('Changing host');
+
+      await transferableOrder.reload();
+      expect(transferableOrder.status).to.eq(OrderStatuses.ACTIVE);
+    });
+
     it('validates if collective does not have a parent account', async () => {
       const host = await fakeHost();
       const collective = await fakeCollective({ HostCollectiveId: host.id });
@@ -529,6 +601,30 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       expect(result.errors[0].message).to.equal('Unable to change host: you still have a balance of $24.00');
     });
 
+    it('removes the host as a collective admin', async () => {
+      const host = await fakeActiveHost();
+      const collective = await fakeCollective({ HostCollectiveId: host.id });
+      const result = await graphqlQueryV2(
+        REMOVE_HOST_MUTATION,
+        {
+          account: { legacyId: collective.id },
+          message: 'removing as collective admin',
+        },
+        rootUser,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.removeHost.host).to.be.null;
+
+      const unhostingActivity = await models.Activity.findOne({
+        where: { type: activities.COLLECTIVE_UNHOSTED, CollectiveId: collective.id },
+      });
+      expect(unhostingActivity).to.exist;
+      expect(unhostingActivity.data.message).to.eq('removing as collective admin');
+      expect(unhostingActivity.data.collective.id).to.eq(collective.id);
+      expect(unhostingActivity.data.host.id).to.eq(host.id);
+    });
+
     it('validates if user is admin of target host collective', async () => {
       const user = await fakeUser();
       await fakeCollective({ admin: user });
@@ -545,7 +641,7 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
         user,
       );
       expect(result.errors).to.exist;
-      expect(result.errors[0].message).to.equal('You need to be authenticated to perform this action');
+      expect(result.errors[0].message).to.equal('Only the host admin or the account admin can trigger this action');
     });
 
     it('removes the host from a hosted collective using host admin', async () => {
@@ -555,12 +651,25 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       const user = await fakeUser();
       const host = await fakeHost({ admin: user });
       const collective = await fakeCollective({ HostCollectiveId: host.id });
+      const stripeCreditCardPm = await fakePaymentMethod({
+        service: PAYMENT_METHOD_SERVICE.STRIPE,
+        type: PAYMENT_METHOD_TYPE.CREDITCARD,
+      });
+      const paypalPm = await fakePaymentMethod({
+        service: PAYMENT_METHOD_SERVICE.PAYPAL,
+        type: PAYMENT_METHOD_TYPE.SUBSCRIPTION,
+      });
       const orderWithExternalSubscription = await fakeOrder(
-        { CollectiveId: collective.id, status: OrderStatuses.ACTIVE, subscription: { isManagedExternally: true } },
+        {
+          CollectiveId: collective.id,
+          status: OrderStatuses.ACTIVE,
+          PaymentMethodId: paypalPm.id,
+          subscription: { isManagedExternally: true },
+        },
         { withSubscription: true },
       );
       const orderWithInternalSubscription = await fakeOrder(
-        { CollectiveId: collective.id, status: OrderStatuses.ACTIVE },
+        { CollectiveId: collective.id, status: OrderStatuses.ACTIVE, PaymentMethodId: stripeCreditCardPm.id },
         { withSubscription: true },
       );
 
@@ -592,7 +701,7 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       expect(unhostingActivity.data.host.id).to.eq(host.id);
 
       await orderWithExternalSubscription.reload();
-      expect(orderWithExternalSubscription.status).to.eq(OrderStatuses.CANCELLED);
+      expect(orderWithExternalSubscription.status).to.eq(OrderStatuses.PAUSED);
 
       await orderWithInternalSubscription.reload();
       expect(orderWithInternalSubscription.status).to.eq(OrderStatuses.ACTIVE);

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -541,10 +541,10 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
 
       await nonTransferableOrder.reload();
       expect(nonTransferableOrder.status).to.eq(OrderStatuses.PAUSED);
-      expect(nonTransferableOrder.data.updateContext).to.eq('Changing host');
+      expect(nonTransferableOrder.data.messageForContributors).to.eq('We are transitioning to a new host');
 
       await transferableOrder.reload();
-      expect(transferableOrder.status).to.eq(OrderStatuses.ACTIVE);
+      expect(transferableOrder.status).to.eq(OrderStatuses.PAUSED);
     });
 
     it('validates if collective does not have a parent account', async () => {
@@ -704,7 +704,7 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
       expect(orderWithExternalSubscription.status).to.eq(OrderStatuses.PAUSED);
 
       await orderWithInternalSubscription.reload();
-      expect(orderWithInternalSubscription.status).to.eq(OrderStatuses.ACTIVE);
+      expect(orderWithInternalSubscription.status).to.eq(OrderStatuses.PAUSED);
 
       await virtualCard.reload();
       expect(virtualCard.data.status).to.eq(VirtualCardStatus.CANCELED);

--- a/test/server/lib/recurring-contributions.test.js
+++ b/test/server/lib/recurring-contributions.test.js
@@ -18,7 +18,7 @@ import {
 } from '../../../server/lib/recurring-contributions';
 import models from '../../../server/models';
 import { randEmail } from '../../stores';
-import { fakeOrder } from '../../test-helpers/fake-data';
+import { fakeCollective, fakeOrder } from '../../test-helpers/fake-data';
 import * as utils from '../../utils';
 
 async function createOrderWithSubscription(interval, date, quantity = 1) {
@@ -472,7 +472,7 @@ describe('server/lib/recurring-contributions', () => {
     beforeEach(async () => {
       await utils.resetTestDB();
       user = await models.User.createUserWithCollective({ email: randEmail(), name: 'Test McTesterson' });
-      collective = await models.Collective.create({ name: 'Parcel' });
+      collective = await fakeCollective({ name: 'Parcel' });
       tier = await models.Tier.create({ name: 'backer', amount: 0, CollectiveId: collective.id });
     });
 


### PR DESCRIPTION
Left to do:
- [x] Add logic for Stripe elements
- [x] Cancel all contributions (incl Stripe) if `pauseContributions` if false

As a follow-up:
- Daily CRON to send emails to resume contributions
  - We look at PAUSED contributions for Collectives who are financially active (have a host or independent)
  - Based on some parameters (last contact, number of attempts), we send an email prompting contributors to update their payment method or create a new contribution.
  - We do our best to default all relevant parameters (guest flow is ok)
  - We keep track of the original order id to cancel it when new contribution is created (replaceOrderId)