### PR TITLE
Narrow permissions for emailWaitingForValidation

### DIFF
--- a/server/graphql/v1/types.js
+++ b/server/graphql/v1/types.js
@@ -171,7 +171,7 @@ export const UserType = new GraphQLObjectType({
           if (
             req.remoteUser &&
             user.CollectiveId && // We sometimes pass an empty object as `user`
-            (await req.loaders.Collective.canSeePrivateInfo.load(user.CollectiveId))
+            req.remoteUser.isAdmin(user.CollectiveId)
           ) {
             return user.emailWaitingForValidation;
           }


### PR DESCRIPTION
This doesn't have any real impact, but hosts don't need that information.