### PR TITLE
Fraud Prevention: get available fingerprint from paymentIntent orders

### DIFF
--- a/server/lib/security/order.ts
+++ b/server/lib/security/order.ts
@@ -24,6 +24,8 @@ const BASE_STATS_QUERY = `
     COALESCE(
       COUNT(
         DISTINCT COALESCE(
+          NULLIF(o."data"#>>'{paymentIntent,last_payment_error,payment_method,card,fingerprint}', ''),
+          NULLIF(o."data"#>>'{paymentIntent,last_payment_error,payment_method,us_bank_account,fingerprint}', ''),
           NULLIF(CONCAT(pm."name", pm."data"->>'expYear'), ''),
           pm."id"::TEXT
         )


### PR DESCRIPTION
Since the implementation of payment intent contributions, we're no longer deduplicating some failed payment methods the correct way. This aims to correct some of the issues that have been causing some assets to be suspended.