### PR TITLE
Host transactions report resolver

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -2437,6 +2437,7 @@ type Host implements Account & AccountWithContributions {
   isOpenToApplications: Boolean
   termsUrl: URL
   plan: HostPlan!
+  transactionsReport(dateFrom: DateTime, dateTo: DateTime): [TransactionSum]
   hostMetrics(
     """
     A collection of accounts for which the metrics should be returned.
@@ -5491,6 +5492,19 @@ type HostPlan {
   Ability to collect Platform Tips.
   """
   platformTips: Boolean
+}
+
+"""
+Transaction amounts grouped by type, kind, primary kind, isRefund, isHost, expenseType
+"""
+type TransactionSum {
+  amount: Amount
+  type: TransactionType
+  kind: TransactionKind
+  primaryKind: TransactionKind
+  isRefund: Boolean
+  isHost: Boolean
+  expenseType: ExpenseType
 }
 
 """


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/7215

Adding API resolver `host.transactionsReport` that returns transaction amounts grouped by type, type, kind, primary kind, isRefund, isHost, expense type.

