### PR TITLE
OrdersCollectionQuery: dynamically fetch nodes/count

### DIFF
--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -270,10 +270,9 @@ export const OrdersCollectionResolver = async (args, req: express.Request) => {
 
   const order: Order = [[args.orderBy.field, args.orderBy.direction]];
   const { offset, limit } = args;
-  const result = await models.Order.findAndCountAll({ include, where, order, offset, limit });
   return {
-    nodes: result.rows,
-    totalCount: result.count,
+    nodes: () => models.Order.findAll({ include, where, order, offset, limit }),
+    totalCount: () => models.Order.count({ include, where }),
     limit: args.limit,
     offset: args.offset,
   };


### PR DESCRIPTION
This should prevent at least 4 expensive SQL queries when opening "Dashboard > Contributions", were we're fetching multiple counts based on the status: https://github.com/opencollective/opencollective-frontend/blob/d5771f3cb5028cfc9b79f1740bcdba0076c32d81/components/dashboard/sections/contributions/Contributions.tsx#L64-L75