### PR TITLE
Fix expense tags stats

### DIFF
--- a/server/models/Expense.ts
+++ b/server/models/Expense.ts
@@ -1,4 +1,5 @@
 import { get, isEmpty, pick, sumBy } from 'lodash';
+import { isMoment } from 'moment';
 import {
   BelongsToGetAssociationMixin,
   BelongsToSetAssociationMixin,
@@ -470,7 +471,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
         sequelize.where(
           sequelize.literal(`COALESCE("Transaction"."clearedAt", "Transaction"."createdAt")`),
           Op.gte,
-          dateFrom,
+          isMoment(dateFrom) ? dateFrom.toDate() : dateFrom,
         ),
       );
     }
@@ -479,7 +480,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
         sequelize.where(
           sequelize.literal(`COALESCE("Transaction"."clearedAt", "Transaction"."createdAt")`),
           Op.lte,
-          dateTo,
+          isMoment(dateTo) ? dateTo.toDate() : dateTo,
         ),
       );
     }
@@ -537,7 +538,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
         sequelize.where(
           sequelize.literal(`COALESCE("Transaction"."clearedAt", "Transaction"."createdAt")`),
           Op.gte,
-          dateFrom,
+          isMoment(dateFrom) ? dateFrom.toDate() : dateFrom,
         ),
       );
     }
@@ -546,7 +547,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
         sequelize.where(
           sequelize.literal(`COALESCE("Transaction"."clearedAt", "Transaction"."createdAt")`),
           Op.lte,
-          dateTo,
+          isMoment(dateTo) ? dateTo.toDate() : dateTo,
         ),
       );
     }


### PR DESCRIPTION
Follow up on https://github.com/opencollective/opencollective-api/pull/9873
Fix https://github.com/opencollective/opencollective/issues/7320
Fix https://open-collective.sentry.io/issues/5066370814/?environment=production&project=5199682&query=is%3Aunresolved+Invalid+value+Moment&referrer=issue-stream&statsPeriod=7d&stream_index=1
Fix https://open-collective.sentry.io/issues/5066069279/?environment=production&project=5199682&query=is%3Aunresolved+Invalid+value+Moment&referrer=issue-stream&statsPeriod=7d&stream_index=0