### PR TITLE
Add expense collection filter by types

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -582,6 +582,7 @@ interface Account {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -2157,6 +2158,7 @@ type Host implements Account & AccountWithContributions {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -6953,6 +6955,7 @@ type Bot implements Account {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -7652,6 +7655,7 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -8782,6 +8786,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -9701,6 +9706,7 @@ type Individual implements Account {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -10606,6 +10612,7 @@ type Organization implements Account & AccountWithContributions {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -11395,6 +11402,7 @@ type Vendor implements Account & AccountWithContributions {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -12076,6 +12084,7 @@ type Query {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -14581,6 +14590,7 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags
@@ -15378,6 +15388,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
     Use this field to filter expenses on their type (RECEIPT/INVOICE)
     """
     type: ExpenseType
+    types: [ExpenseType]
 
     """
     Only expenses that match these tags

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -130,6 +130,9 @@ export const ExpensesCollectionQueryArgs = {
     type: GraphQLExpenseType,
     description: 'Use this field to filter expenses on their type (RECEIPT/INVOICE)',
   },
+  types: {
+    type: new GraphQLList(GraphQLExpenseType),
+  },
   tags: {
     type: new GraphQLList(GraphQLString),
     description: 'Only expenses that match these tags',
@@ -294,7 +297,12 @@ export const ExpensesCollectionQueryResolver = async (
   // Add filters
   if (args.type) {
     where['type'] = args.type;
+  } else if (args.types && args.types.length > 0) {
+    where['type'] = {
+      [Op.in]: args.types,
+    };
   }
+
   if (args.tag || args.tags) {
     where['tags'] = { [Op.contains]: args.tag || args.tags };
   } else if (args.tag === null || args.tags === null) {


### PR DESCRIPTION
Existing filter option only allows filtering by either INVOICE **or** RECEIPT expenses.
Adding this to allow filtering by both, while excluding CHARGEs, GRANTs, etc.