### PR TITLE
Attribute default clearedAt value on createRefundTransaction

### DIFF
--- a/server/lib/payments.js
+++ b/server/lib/payments.js
@@ -434,7 +434,7 @@ export async function createRefundTransaction(
   data,
   user,
   transactionGroupId = null,
-  clearedAt = null,
+  clearedAt,
 ) {
   /* If the transaction passed isn't the one from the collective
    * perspective, the opposite transaction is retrieved.


### PR DESCRIPTION
This should fix some expense refunds lacking clearedAt value in the DB.