### PR TITLE
Expire graphqlCacheKeys with the most recent key

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -295,7 +295,7 @@ export default async app => {
                 cache.get(`graphqlCacheKeys_${req.cacheSlug}`).then(keys => {
                   keys = keys || [];
                   keys.push(req.cacheKey);
-                  cache.set(`graphqlCacheKeys_${req.cacheSlug}`, keys);
+                  cache.set(`graphqlCacheKeys_${req.cacheSlug}`, keys, Number(config.graphql.cache.ttl));
                 });
               }
             },


### PR DESCRIPTION
We've been seeing a lot of "_OOM command not allowed when used memory > 'maxmemory'_" errors in our main Redis instance.
It seems this is related to Redis being incapable of freeing up memory due to our existing policy _volatile-lru_  that will only evict keys that have a TTL. This happens because we can fill our cache with non-volatile keys (keys with no expiration set) and when we need more space, the policy will not evict those keys.

After investigating this issue, I noticed that we're full of stale `graphqlCacheKeys_` keys. I'm setting a TTL to these keys equal to the last request set, so they can expire at the same time as the last cache created expires and free up space.