### PR TITLE
Immediately create order members after transactions are created

### DIFF
--- a/server/models/Order.ts
+++ b/server/models/Order.ts
@@ -447,6 +447,13 @@ Order.prototype.validatePaymentMethod = function (paymentMethod) {
 Order.prototype.getOrCreateMembers = async function () {
   // Preload data
   this.collective = this.collective || (await this.getCollective());
+  this.fromCollective = this.fromCollective || (await this.getFromCollective());
+
+  // Ignore if the order is from a children collective
+  if (this.fromCollective?.ParentCollectiveId === this.collective.id) {
+    return;
+  }
+
   let tier;
   if (this.TierId) {
     tier = await this.getTier();

--- a/server/paymentProviders/paypal/webhook.ts
+++ b/server/paymentProviders/paypal/webhook.ts
@@ -210,11 +210,12 @@ async function handleCaptureCompleted(req: Request): Promise<void> {
     await order.update({ processedAt: new Date(), status: OrderStatus.PAID });
   });
 
-  // Send thankyou email
-  await sendThankYouEmail(order, transaction);
-
-  // Register user as a member, since the transaction is not created in `processOrder`
-  await order.getOrCreateMembers();
+  await Promise.all([
+    // Register user as a member, since the transaction is not created in `processOrder`
+    order.getOrCreateMembers(),
+    // Send thankyou email
+    sendThankYouEmail(order, transaction),
+  ]);
 }
 
 async function handleCaptureRefunded(req: Request): Promise<void> {


### PR DESCRIPTION
Relates to https://github.com/opencollective/opencollective/issues/7075

Moving above `await sendThankYouEmail(order, transaction);` should solve the issue and should also explain why it always happens with PayPal and not with Stripe.

Either way, I'm executing the side effects in parallel immediately after transactions are created and making it consistent across PayPal and Stripe.
