### PR TITLE
Fix paidBy resolver edge-case

### DIFF
--- a/server/graphql/v2/object/Expense.ts
+++ b/server/graphql/v2/object/Expense.ts
@@ -253,7 +253,7 @@ export const GraphQLExpense = new GraphQLObjectType<ExpenseModel, express.Reques
           const activities: Activity[] = await req.loaders.Expense.activities.load(expense.id);
           const paidActivity = findLast(activities, a => a.type === ActivityTypes.COLLECTIVE_EXPENSE_PAID);
 
-          if (paidActivity) {
+          if (paidActivity?.UserId) {
             return req.loaders.Collective.byUserId.load(paidActivity.UserId);
           }
         },


### PR DESCRIPTION
Solves the issue with `GraphQL error: The loader.load() function must be called with a value, but got: null.`.