### PR TITLE
feat(Reports): Adding transactions report for regular accounts

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -878,6 +878,11 @@ interface Account {
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
 }
 
 """
@@ -2479,6 +2484,11 @@ type Host implements Account & AccountWithContributions {
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -2565,8 +2575,11 @@ type Host implements Account & AccountWithContributions {
   isOpenToApplications: Boolean
   termsUrl: URL
   plan: HostPlan!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
   hostTransactionsReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): HostTransactionReports
-  transactionsReport(dateFrom: DateTime, dateTo: DateTime): [TransactionSum]
   hostMetrics(
     """
     A collection of accounts for which the metrics should be returned.
@@ -5626,6 +5639,55 @@ enum ActivityClassType {
 }
 
 """
+EXPERIMENTAL (this may change or be deleted): Host transaction report
+"""
+type TransactionReports {
+  """
+  The start date of the time series
+  """
+  dateFrom: DateTime
+
+  """
+  The end date of the time series
+  """
+  dateTo: DateTime
+
+  """
+  The interval between two data points
+  """
+  timeUnit: TimeUnit!
+  nodes: [TransactionReport!]
+}
+
+"""
+EXPERIMENTAL (this may change or be deleted)
+"""
+type TransactionReport {
+  date: DateTime
+  startingBalance: Amount!
+  endingBalance: Amount!
+  totalChange: Amount!
+  groups: [TransactionsAmountGroup]!
+}
+
+"""
+EXPERIMENTAL (this may change or be deleted): Transaction amounts grouped by type, kind, isRefund, isHost, expenseType
+"""
+type TransactionsAmountGroup {
+  netAmount: Amount
+  amount: Amount
+  platformFee: Amount
+  paymentProcessorFee: Amount
+  hostFee: Amount
+  taxAmount: Amount
+  type: TransactionType
+  kind: TransactionKind
+  isRefund: Boolean
+  isHost: Boolean
+  expenseType: ExpenseType
+}
+
+"""
 A collection of webhooks
 """
 type WebhookCollection implements Collection {
@@ -5769,47 +5831,8 @@ type HostTransactionReports {
 
 type HostTransactionReportNode {
   date: DateTime!
-  managedFunds: TransactionsReport!
-  operationalFunds: TransactionsReport!
-}
-
-"""
-Transactions report
-"""
-type TransactionsReport {
-  startingBalance: Amount!
-  endingBalance: Amount!
-  totalChange: Amount!
-  groups: [TransactionsAmountGroup]!
-}
-
-"""
-EXPERIMENTAL (this may change or be deleted): Transaction amounts grouped by type, kind, isRefund, isHost, expenseType
-"""
-type TransactionsAmountGroup {
-  netAmount: Amount
-  amount: Amount
-  platformFee: Amount
-  paymentProcessorFee: Amount
-  hostFee: Amount
-  taxAmount: Amount
-  type: TransactionType
-  kind: TransactionKind
-  isRefund: Boolean
-  isHost: Boolean
-  expenseType: ExpenseType
-}
-
-"""
-EXPERIMENTAL (this may change or be deleted): Transaction amounts grouped by type, kind, isRefund, isHost, expenseType
-"""
-type TransactionSum {
-  amount: Amount
-  type: TransactionType
-  kind: TransactionKind
-  isRefund: Boolean
-  isHost: Boolean
-  expenseType: ExpenseType
+  managedFunds: TransactionReport!
+  operationalFunds: TransactionReport!
 }
 
 """
@@ -7487,6 +7510,11 @@ type Bot implements Account {
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -8222,6 +8250,11 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -9398,6 +9431,11 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -10361,6 +10399,11 @@ type Individual implements Account {
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -11302,6 +11345,11 @@ type Organization implements Account & AccountWithContributions {
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -12139,6 +12187,11 @@ type Vendor implements Account & AccountWithContributions {
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -15420,6 +15473,11 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -16263,6 +16321,11 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
   If this account was duplicated, the accounts that were created from it
   """
   duplicatedAccounts(limit: Int! = 100, offset: Int! = 0): AccountCollection!
+
+  """
+  EXPERIMENTAL (this may change or be removed)
+  """
+  transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)

--- a/server/graphql/v2/interface/Account.ts
+++ b/server/graphql/v2/interface/Account.ts
@@ -1,14 +1,16 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
 import { GraphQLDateTime, GraphQLJSON } from 'graphql-scalars';
 import { assign, get, invert, isEmpty, isNil, isNull, merge, omit, omitBy } from 'lodash';
+import moment from 'moment';
 import { Order } from 'sequelize';
 
 import { CollectiveType } from '../../../constants/collectives';
 import FEATURE from '../../../constants/feature';
 import { buildSearchConditions } from '../../../lib/search';
 import { getCollectiveFeed } from '../../../lib/timeline';
+import { getAccountReportNodesFromQueryResult } from '../../../lib/transaction-reports';
 import { canSeeLegalName } from '../../../lib/user-permissions';
-import models, { Op } from '../../../models';
+import models, { Op, sequelize } from '../../../models';
 import Application from '../../../models/Application';
 import { PayoutMethodTypes } from '../../../models/PayoutMethod';
 import { GraphQLCollectiveFeatures } from '../../common/CollectiveFeatures';
@@ -37,6 +39,7 @@ import { GraphQLExpenseType } from '../enum/ExpenseType';
 import { GraphQLLegalDocumentType } from '../enum/LegalDocumentType';
 import { GraphQLPaymentMethodService } from '../enum/PaymentMethodService';
 import { GraphQLPaymentMethodType } from '../enum/PaymentMethodType';
+import { GraphQLTimeUnit } from '../enum/TimeUnit';
 import { GraphQLVirtualCardStatusEnum } from '../enum/VirtualCardStatus';
 import { idEncode } from '../identifiers';
 import { fetchAccountWithReference, GraphQLAccountReferenceInput } from '../input/AccountReferenceInput';
@@ -59,6 +62,7 @@ import GraphQLPayoutMethod from '../object/PayoutMethod';
 import { GraphQLPolicies } from '../object/Policies';
 import { GraphQLSocialLink } from '../object/SocialLink';
 import { GraphQLTagStats } from '../object/TagStats';
+import { GraphQLTransactionReports } from '../object/TransactionReports';
 import { GraphQLTransferWise } from '../object/TransferWise';
 import {
   ExpensesCollectionQueryArgs,
@@ -818,6 +822,115 @@ const accountFieldsDefinition = () => ({
           offset,
         };
       }
+    },
+  },
+  transactionReports: {
+    type: GraphQLTransactionReports,
+    description: 'EXPERIMENTAL (this may change or be removed)',
+    args: {
+      timeUnit: {
+        type: GraphQLTimeUnit,
+        defaultValue: 'MONTH',
+      },
+      dateFrom: {
+        type: GraphQLDateTime,
+      },
+      dateTo: {
+        type: GraphQLDateTime,
+      },
+    },
+    resolve: async (collective, args) => {
+      if (args.timeUnit !== 'MONTH' && args.timeUnit !== 'QUARTER' && args.timeUnit !== 'YEAR') {
+        throw new Error('Only monthly, quarterly and yearly reports are supported.');
+      }
+
+      const query = `
+        WITH
+            CollectiveIds AS (
+                SELECT "id"
+                FROM "Collectives"
+                WHERE "id" = :collectiveId OR ("ParentCollectiveId" = :collectiveId AND "type" != 'VENDOR')
+            )
+                SELECT
+                    DATE_TRUNC(:timeUnit, t."createdAt") AS "date",
+                    t."HostCollectiveId",
+                    SUM(t."amountInHostCurrency") AS "amountInHostCurrency",
+                    SUM(COALESCE(t."platformFeeInHostCurrency", 0)) AS "platformFeeInHostCurrency",
+                    SUM(COALESCE(t."hostFeeInHostCurrency", 0)) AS "hostFeeInHostCurrency",
+                    SUM(
+                        COALESCE(t."paymentProcessorFeeInHostCurrency", 0)
+                    ) AS "paymentProcessorFeeInHostCurrency",
+                    SUM(
+                        COALESCE(
+                            t."taxAmount" * COALESCE(t."hostCurrencyFxRate", 1),
+                            0
+                        )
+                    ) AS "taxAmountInHostCurrency",
+                    COALESCE(
+                        SUM(COALESCE(t."amountInHostCurrency", 0)) + SUM(COALESCE(t."platformFeeInHostCurrency", 0)) + SUM(COALESCE(t."hostFeeInHostCurrency", 0)) + SUM(
+                            COALESCE(t."paymentProcessorFeeInHostCurrency", 0)
+                        ) + SUM(
+                            COALESCE(
+                                t."taxAmount" * COALESCE(t."hostCurrencyFxRate", 1),
+                                0
+                            )
+                        ),
+                        0
+                    ) AS "netAmountInHostCurrency",
+                    t."kind",
+                    t."isRefund",
+                    t."hostCurrency",
+                    t."type",
+                    e."type" AS "expenseType"
+                FROM
+                    "Transactions" t
+                    LEFT JOIN LATERAL (
+                        SELECT
+                            e2."type"
+                        FROM
+                            "Expenses" e2
+                        WHERE
+                            e2.id = t."ExpenseId"
+                    ) AS e ON t."ExpenseId" IS NOT NULL
+                WHERE
+                    t."deletedAt" IS NULL
+                    AND t."CollectiveId" IN (SELECT * FROM CollectiveIds)
+                    ${args.dateTo ? 'AND t."createdAt" <= :dateTo' : ''}
+
+                GROUP BY
+                    DATE_TRUNC(:timeUnit, t."createdAt"),
+                    t."HostCollectiveId",
+                    t."kind",
+                    t."hostCurrency",
+                    t."isRefund",
+                    t."type",
+                    "expenseType";
+      `;
+
+      const queryResult = await sequelize.query(query, {
+        replacements: {
+          collectiveId: collective.id,
+          timeUnit: args.timeUnit,
+          dateTo: moment(args.dateTo).utc().toISOString(),
+        },
+        type: sequelize.QueryTypes.SELECT,
+        raw: true,
+      });
+
+      const nodes = await getAccountReportNodesFromQueryResult({
+        queryResult,
+        dateFrom: args.dateFrom,
+        dateTo: args.dateTo,
+        timeUnit: args.timeUnit,
+        currency: collective.currency,
+      });
+
+      return {
+        timeUnit: args.timeUnit,
+        dateFrom: args.dateFrom,
+        dateTo: args.dateTo,
+        nodes,
+      };
     },
   },
 });

--- a/server/graphql/v2/object/HostTransactionReports.ts
+++ b/server/graphql/v2/object/HostTransactionReports.ts
@@ -1,60 +1,19 @@
-import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
 import { GraphQLDateTime } from 'graphql-scalars';
 
-import { GraphQLExpenseType } from '../enum/ExpenseType';
-import { GraphQLTransactionKind } from '../enum/TransactionKind';
-import { GraphQLTransactionType } from '../enum/TransactionType';
 import { getTimeSeriesFields } from '../interface/TimeSeries';
 
-import { GraphQLAmount } from './Amount';
-
-const GraphQLTransactionsAmountGroup = new GraphQLObjectType({
-  name: 'TransactionsAmountGroup',
-  description:
-    'EXPERIMENTAL (this may change or be deleted): Transaction amounts grouped by type, kind, isRefund, isHost, expenseType',
-  fields: () => ({
-    netAmount: { type: GraphQLAmount },
-    amount: { type: GraphQLAmount },
-    platformFee: { type: GraphQLAmount },
-    paymentProcessorFee: { type: GraphQLAmount },
-    hostFee: { type: GraphQLAmount },
-    taxAmount: { type: GraphQLAmount },
-    type: { type: GraphQLTransactionType },
-    kind: { type: GraphQLTransactionKind },
-    isRefund: { type: GraphQLBoolean },
-    isHost: { type: GraphQLBoolean },
-    expenseType: { type: GraphQLExpenseType },
-  }),
-});
-
-const GraphQLTransactionsReport = new GraphQLObjectType({
-  name: 'TransactionsReport',
-  description: 'Transactions report',
-  fields: () => ({
-    startingBalance: {
-      type: new GraphQLNonNull(GraphQLAmount),
-    },
-    endingBalance: {
-      type: new GraphQLNonNull(GraphQLAmount),
-    },
-    totalChange: {
-      type: new GraphQLNonNull(GraphQLAmount),
-    },
-    groups: {
-      type: new GraphQLNonNull(new GraphQLList(GraphQLTransactionsAmountGroup)),
-    },
-  }),
-});
+import { GraphQLTransactionReport } from './TransactionReport';
 
 const GraphQLHostTransactionReportNodes = new GraphQLObjectType({
   name: 'HostTransactionReportNode',
   fields: () => ({
     date: { type: new GraphQLNonNull(GraphQLDateTime) },
     managedFunds: {
-      type: new GraphQLNonNull(GraphQLTransactionsReport),
+      type: new GraphQLNonNull(GraphQLTransactionReport),
     },
     operationalFunds: {
-      type: new GraphQLNonNull(GraphQLTransactionsReport),
+      type: new GraphQLNonNull(GraphQLTransactionReport),
     },
   }),
 });

--- a/server/graphql/v2/object/TransactionReport.ts
+++ b/server/graphql/v2/object/TransactionReport.ts
@@ -1,0 +1,47 @@
+import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+
+import { GraphQLExpenseType } from '../enum/ExpenseType';
+import { GraphQLTransactionKind } from '../enum/TransactionKind';
+import { GraphQLTransactionType } from '../enum/TransactionType';
+
+import { GraphQLAmount } from './Amount';
+
+const GraphQLTransactionsAmountGroup = new GraphQLObjectType({
+  name: 'TransactionsAmountGroup',
+  description:
+    'EXPERIMENTAL (this may change or be deleted): Transaction amounts grouped by type, kind, isRefund, isHost, expenseType',
+  fields: () => ({
+    netAmount: { type: GraphQLAmount },
+    amount: { type: GraphQLAmount },
+    platformFee: { type: GraphQLAmount },
+    paymentProcessorFee: { type: GraphQLAmount },
+    hostFee: { type: GraphQLAmount },
+    taxAmount: { type: GraphQLAmount },
+    type: { type: GraphQLTransactionType },
+    kind: { type: GraphQLTransactionKind },
+    isRefund: { type: GraphQLBoolean },
+    isHost: { type: GraphQLBoolean },
+    expenseType: { type: GraphQLExpenseType },
+  }),
+});
+
+export const GraphQLTransactionReport = new GraphQLObjectType({
+  name: 'TransactionReport',
+  description: 'EXPERIMENTAL (this may change or be deleted)',
+  fields: () => ({
+    date: { type: GraphQLDateTime },
+    startingBalance: {
+      type: new GraphQLNonNull(GraphQLAmount),
+    },
+    endingBalance: {
+      type: new GraphQLNonNull(GraphQLAmount),
+    },
+    totalChange: {
+      type: new GraphQLNonNull(GraphQLAmount),
+    },
+    groups: {
+      type: new GraphQLNonNull(new GraphQLList(GraphQLTransactionsAmountGroup)),
+    },
+  }),
+});

--- a/server/graphql/v2/object/TransactionReports.ts
+++ b/server/graphql/v2/object/TransactionReports.ts
@@ -1,0 +1,16 @@
+import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+
+import { getTimeSeriesFields } from '../interface/TimeSeries';
+
+import { GraphQLTransactionReport } from './TransactionReport';
+
+export const GraphQLTransactionReports = new GraphQLObjectType({
+  name: 'TransactionReports',
+  description: 'EXPERIMENTAL (this may change or be deleted): Host transaction report',
+  fields: () => ({
+    ...getTimeSeriesFields(),
+    nodes: {
+      type: new GraphQLList(new GraphQLNonNull(GraphQLTransactionReport)),
+    },
+  }),
+});


### PR DESCRIPTION
Project: https://github.com/opencollective/opencollective/issues/7344

# Description

Adding experimental `account.transactionReports` to enable a similar transaction reports for regular Accounts like what is available for Fiscal hosts.