### PR TITLE
fix(TransactionsCollectionQuery): Fix clearedAt sorting when not using config.ledger.orderedTransactions

### DIFF
--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -522,7 +522,12 @@ export const TransactionsCollectionResolver = async (
         ],
       ]
     : [
-        [args.orderBy.field, args.orderBy.direction],
+        [
+          args.orderBy.field === 'clearedAt'
+            ? sequelize.literal('COALESCE("Transaction"."clearedAt", "Transaction"."createdAt")')
+            : args.orderBy.field,
+          args.orderBy.direction,
+        ],
         // Add additional sort for consistent sorting
         // (transactions in the same TransactionGroup usually have the exact same datetime)
         ['id', args.orderBy.direction],


### PR DESCRIPTION
Follow up for https://github.com/opencollective/opencollective-api/pull/10041 to use coalesced clearedAt and createdAt when ordering by clearedAt also when not using `config.ledger.orderedTransactions` (true in prod, but not set in local dev by default)


