### PR TITLE
Prevent removing payment method from processing orders and return payment method info even if deleted

### DIFF
--- a/server/graphql/loaders/index.js
+++ b/server/graphql/loaders/index.js
@@ -710,6 +710,15 @@ export const loaders = req => {
     }).then(results => sortResults(CollectiveIds, results, 'CollectiveId', [])),
   );
 
+  context.loaders.PaymentMethod.byIdIncludeDeleted = new DataLoader(keys => {
+    return models.PaymentMethod.findAll({
+      where: {
+        id: keys,
+      },
+      paranoid: false,
+    }).then(results => sortResultsSimple(keys, results, pm => pm.id, []));
+  });
+
   /** *** Order *****/
   // Order - findByMembership
   context.loaders.Order.findByMembership = new DataLoader(combinedKeys =>

--- a/server/graphql/v1/mutations/paymentMethods.js
+++ b/server/graphql/v1/mutations/paymentMethods.js
@@ -184,12 +184,22 @@ export async function removePaymentMethod(paymentMethodId, req) {
 
   // Block the removal if the payment method has subscriptions linked
   const subscriptions = await paymentMethod.getOrders({
-    where: { status: { [Op.or]: [ORDER_STATUS.ACTIVE, ORDER_STATUS.ERROR] } },
+    where: {
+      [Op.or]: [
+        {
+          status: {
+            [Op.or]: [ORDER_STATUS.ACTIVE, ORDER_STATUS.ERROR],
+          },
+          ['$Subscription.id$']: { [Op.ne]: null },
+        },
+        { status: ORDER_STATUS.PROCESSING },
+      ],
+    },
     include: [
       {
         model: models.Subscription,
         where: { isActive: true },
-        required: true,
+        required: false,
       },
     ],
   });

--- a/server/graphql/v2/object/Order.js
+++ b/server/graphql/v2/object/Order.js
@@ -202,7 +202,7 @@ export const GraphQLOrder = new GraphQLObjectType({
         type: GraphQLPaymentMethod,
         resolve(order, _, req) {
           if (order.PaymentMethodId) {
-            return req.loaders.PaymentMethod.byId.load(order.PaymentMethodId);
+            return req.loaders.PaymentMethod.byIdIncludeDeleted.load(order.PaymentMethodId);
           }
         },
       },


### PR DESCRIPTION
An order paid with a delayed payment method (SEPA, ACH, etc)  can be processing, we prevent the payment method to be deleted in that case.

If a payment method is deleted, its info should not be missing from the order list. 