### PR TITLE
fix(Transactions): refund contributions with tips

### DIFF
--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -821,28 +821,30 @@ Transaction.createDoubleEntry = async (transaction: TransactionCreationAttribute
   transaction.hostCurrencyFxRate = transaction.hostCurrencyFxRate || 1;
 
   // Create Platform Tip transaction
-  if (transaction.data?.platformTip) {
-    // Separate donation transaction and remove platformTip from the main transaction
-    const result = await Transaction.createPlatformTipTransactions(transaction);
-    // Transaction was modified by createPlatformTipTransactions, we get it from the result
-    if (result && result.transaction) {
-      transaction = result.transaction;
-    }
-  }
-
-  // Create Host Fee Transaction
-  if (transaction.hostFeeInHostCurrency) {
-    const result = await Transaction.createHostFeeTransactions(transaction);
-    if (result) {
-      if (result.hostFeeTransaction) {
-        await Transaction.createHostFeeShareTransactions({
-          transaction: result.transaction,
-          hostFeeTransaction: result.hostFeeTransaction,
-        });
-      }
-      // Transaction was modified by createHostFeeTransaction, we get it from the result
-      if (result.transaction) {
+  if (!transaction.isRefund) {
+    if (transaction.data?.platformTip) {
+      // Separate donation transaction and remove platformTip from the main transaction
+      const result = await Transaction.createPlatformTipTransactions(transaction);
+      // Transaction was modified by createPlatformTipTransactions, we get it from the result
+      if (result && result.transaction) {
         transaction = result.transaction;
+      }
+    }
+
+    // Create Host Fee Transaction
+    if (transaction.hostFeeInHostCurrency) {
+      const result = await Transaction.createHostFeeTransactions(transaction);
+      if (result) {
+        if (result.hostFeeTransaction) {
+          await Transaction.createHostFeeShareTransactions({
+            transaction: result.transaction,
+            hostFeeTransaction: result.hostFeeTransaction,
+          });
+        }
+        // Transaction was modified by createHostFeeTransaction, we get it from the result
+        if (result.transaction) {
+          transaction = result.transaction;
+        }
       }
     }
   }


### PR DESCRIPTION
Moving these two from `createFromContributionPayload` in https://github.com/opencollective/opencollective-api/pull/9896/files#diff-517b6b387d3fb789d7bda4d342aa30454e69c46c68db511a7d342acf7b8e30e0R823 crashed the record of refunds with platform tips attached:

```
ValidationError [SequelizeValidationError]: Validation error: Only refund transactions can have null user.
  errors: [
    ValidationErrorItem {
      message: 'Only refund transactions can have null user.',
      type: 'Validation error',
      path: 'CreatedByUserId',
      value: null,
      origin: 'FUNCTION',
      instance: [Transaction],
      validatorKey: 'isValid',
      validatorName: null,
      validatorArgs: [],
      original: Error: Only refund transactions can have null user.
    }
  ]
}
```

We'll need to understand why unit tests missed these.