### PR TITLE
Update host-settlement minimum invoice amount pinned to USD

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -246,5 +246,8 @@
     "dashboard": {
       "redirect": "FEATURES_DASHBOARD_REDIRECT"
     }
+  },
+  "settlement": {
+    "minimumAmountInUSD": "SETTLEMENT_MINIMUM_AMOUNT_IN_USD"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -264,5 +264,8 @@
   "performance": {
     "hostsWithManyTransactions": [],
     "collectivesWithManyTransactions": []
+  },
+  "settlement": {
+    "minimumAmountInUSD": 1000
   }
 }


### PR DESCRIPTION
I notice we invoice a great amount of settlements that are either invalid (no one is settling $2,95) or ignored. Considering that invoiced transactions are no longer considered in the next invoice (they're no longer debts) I decided to:
- [x] Updates the host-settlement cron job to enforce a minimum invoiceable amount in USD
- [x] Set minimum invoiceable amount through environment variable