### PR TITLE
enhancement(Expense): tolerate small diffs in exchange rate

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1392,9 +1392,9 @@ export const prepareExpenseItemInputs = async (
                 values.currency
               } to ${expenseCurrency}) for ${getDateKeyForItem(itemInput)}.`,
             );
-          } else if (internalFxRate && values.expenseCurrencyFxRate !== internalFxRate) {
+          } else if (Math.abs(values.expenseCurrencyFxRate - internalFxRate) / internalFxRate > 0.01) {
             throw new ValidationFailed(
-              `Invalid exchange rate: Expected ${internalFxRate} but got ${values.expenseCurrencyFxRate}.`,
+              `Invalid exchange rate: Expected ~${internalFxRate} but got ${values.expenseCurrencyFxRate}.`,
             );
           }
         } else if (values.expenseCurrencyFxRateSource === 'USER' && internalFxRate) {

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -662,7 +662,7 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
           const mutationParams = { expense: expenseData, account: { legacyId: usdCollective.id } };
           const result = await graphqlQueryV2(createExpenseMutation, mutationParams, user);
           expect(result.errors).to.exist;
-          expect(result.errors[0].message).to.eq(`Invalid exchange rate: Expected 0.37 but got 1.5.`);
+          expect(result.errors[0].message).to.eq(`Invalid exchange rate: Expected ~0.37 but got 1.5.`);
         });
 
         it('submits with type=OPENCOLLECTIVE, providing a valid value', async () => {


### PR DESCRIPTION
Due to fluctuation, there can be small differences between the rate we get for `latest` and the one stored in the cache. Tolerating a small difference should resolve this.