### PR TITLE
Fix Stripe Dispute logic

### DIFF
--- a/server/graphql/common/transactions.ts
+++ b/server/graphql/common/transactions.ts
@@ -128,7 +128,12 @@ const remoteUserMeetsOneCondition = async (req, transaction, conditions): Promis
 
 /** Checks if the user can refund this transaction */
 export const canRefund = async (transaction: Transaction, _: void, req: express.Request): Promise<boolean> => {
-  if (transaction.type !== TransactionTypes.CREDIT || transaction.OrderId === null || transaction.isRefund === true) {
+  if (
+    transaction.type !== TransactionTypes.CREDIT ||
+    transaction.OrderId === null ||
+    transaction.isRefund === true ||
+    transaction.isDisputed === true
+  ) {
     return false;
   }
   if (transaction.OrderId) {

--- a/test/mocks/stripe.ts
+++ b/test/mocks/stripe.ts
@@ -506,7 +506,21 @@ export default {
         object: 'dispute',
         amount: 1000,
         balance_transaction: 'txn_1LpcvGJKGTeo5jKpPYuPf6tC',
-        balance_transactions: [],
+        balance_transactions: [
+          {
+            type: 'adjustment',
+            reporting_category: 'dispute',
+            fee_details: [
+              {
+                amount: 1500,
+                application: null,
+                currency: 'usd',
+                description: 'Dispute fee',
+                type: 'stripe_fee',
+              },
+            ],
+          } as Stripe.BalanceTransaction,
+        ],
         charge: 'ch_3LpDOFJKGTeo5jKp0PfknYNd',
         created: 1664996786,
         currency: 'eur',

--- a/test/stories/ledger-legacy.test.ts
+++ b/test/stories/ledger-legacy.test.ts
@@ -34,7 +34,7 @@ import {
   fakePayoutMethod,
   fakeUser,
 } from '../test-helpers/fake-data';
-import { nockFixerRates, resetTestDB, snapshotLedger } from '../utils';
+import { nockFixerRates, resetTestDB, seedDefaultVendors, snapshotLedger } from '../utils';
 
 const SNAPSHOT_COLUMNS = [
   'kind',
@@ -74,6 +74,7 @@ const setupTestData = async (
 ) => {
   // TODO: The setup should ideally insert other hosts and transactions to make sure the balance queries are filtering correctly
   await resetTestDB();
+  await seedDefaultVendors();
   const hostAdmin = await fakeUser();
   const host = await fakeHost({
     name: 'OSC',

--- a/test/stories/ledger-legacy.test.ts.snap
+++ b/test/stories/ledger-legacy.test.ts.snap
@@ -246,7 +246,8 @@ exports[`test/stories/ledger Level 6: Disputed Transactions 2. Dispute is create
 "
 | kind                          | type   | amount | paymentFee | To     | From   | Host   | Settlement | isRefund | isDisputed |
 | ----------------------------- | ------ | ------ | ---------- | ------ | ------ | ------ | ---------- | -------- | ---------- |
-| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | 0          | OSC    | OSC    | OSC    |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | CREDIT | 1500   | 0          | Stripe | OSC    | NULL   |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | 0          | OSC    | Stripe | OSC    |            | false    | false      |
 | CONTRIBUTION                  | CREDIT | 10000  | 0          | Ben    | ESLint | NULL   |            | true     | false      |
 | CONTRIBUTION                  | DEBIT  | -10000 | 0          | ESLint | Ben    | OSC    |            | true     | false      |
 | HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OC Inc | OSC    | OC Inc | SETTLED    | true     | false      |
@@ -255,26 +256,28 @@ exports[`test/stories/ledger Level 6: Disputed Transactions 2. Dispute is create
 | HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC    |            | true     | false      |
 | HOST_FEE                      | CREDIT | 500    | 0          | ESLint | OSC    | OSC    |            | true     | false      |
 | HOST_FEE                      | DEBIT  | -500   | 0          | OSC    | ESLint | OSC    |            | true     | false      |
-| CONTRIBUTION                  | CREDIT | 10000  | 0          | ESLint | Ben    | OSC    |            | false    | true       |
-| CONTRIBUTION                  | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC    |            | false    | true       |
-| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OSC    | OC Inc | OSC    | SETTLED    | false    | true       |
-| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC    | SETTLED    | false    | true       |
-| HOST_FEE_SHARE                | CREDIT | 75     | 0          | OC Inc | OSC    | OSC    |            | false    | true       |
-| HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC    |            | false    | true       |
-| HOST_FEE                      | CREDIT | 500    | 0          | OSC    | ESLint | OSC    |            | false    | true       |
-| HOST_FEE                      | DEBIT  | -500   | 0          | ESLint | OSC    | OSC    |            | false    | true       |"
+| CONTRIBUTION                  | CREDIT | 10000  | 0          | ESLint | Ben    | OSC    |            | false    | false      |
+| CONTRIBUTION                  | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC    |            | false    | false      |
+| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OSC    | OC Inc | OSC    | SETTLED    | false    | false      |
+| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC    | SETTLED    | false    | false      |
+| HOST_FEE_SHARE                | CREDIT | 75     | 0          | OC Inc | OSC    | OSC    |            | false    | false      |
+| HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC    |            | false    | false      |
+| HOST_FEE                      | CREDIT | 500    | 0          | OSC    | ESLint | OSC    |            | false    | false      |
+| HOST_FEE                      | DEBIT  | -500   | 0          | ESLint | OSC    | OSC    |            | false    | false      |"
 `;
 
 exports[`test/stories/ledger Level 6: Disputed Transactions 3. Dispute is created and then closed as won 1`] = `
 "
-| kind                | type   | amount | paymentFee | To     | From   | Host | Settlement | isRefund | isDisputed |
-| ------------------- | ------ | ------ | ---------- | ------ | ------ | ---- | ---------- | -------- | ---------- |
-| CONTRIBUTION        | CREDIT | 10000  | 0          | ESLint | Ben    | OSC  |            | false    | false      |
-| CONTRIBUTION        | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC  |            | false    | false      |
-| HOST_FEE_SHARE_DEBT | CREDIT | 75     | 0          | OSC    | OC Inc | OSC  | OWED       | false    | false      |
-| HOST_FEE_SHARE_DEBT | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC  | OWED       | false    | false      |
-| HOST_FEE_SHARE      | CREDIT | 75     | 0          | OC Inc | OSC    | OSC  |            | false    | false      |
-| HOST_FEE_SHARE      | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC  |            | false    | false      |
-| HOST_FEE            | CREDIT | 500    | 0          | OSC    | ESLint | OSC  |            | false    | false      |
-| HOST_FEE            | DEBIT  | -500   | 0          | ESLint | OSC    | OSC  |            | false    | false      |"
+| kind                          | type   | amount | paymentFee | To     | From   | Host | Settlement | isRefund | isDisputed |
+| ----------------------------- | ------ | ------ | ---------- | ------ | ------ | ---- | ---------- | -------- | ---------- |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | CREDIT | 1500   | 0          | Stripe | OSC    | NULL |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | 0          | OSC    | Stripe | OSC  |            | false    | false      |
+| CONTRIBUTION                  | CREDIT | 10000  | 0          | ESLint | Ben    | OSC  |            | false    | false      |
+| CONTRIBUTION                  | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC  |            | false    | false      |
+| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OSC    | OC Inc | OSC  | OWED       | false    | false      |
+| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC  | OWED       | false    | false      |
+| HOST_FEE_SHARE                | CREDIT | 75     | 0          | OC Inc | OSC    | OSC  |            | false    | false      |
+| HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC  |            | false    | false      |
+| HOST_FEE                      | CREDIT | 500    | 0          | OSC    | ESLint | OSC  |            | false    | false      |
+| HOST_FEE                      | DEBIT  | -500   | 0          | ESLint | OSC    | OSC  |            | false    | false      |"
 `;

--- a/test/stories/ledger.test.ts.snap
+++ b/test/stories/ledger.test.ts.snap
@@ -218,42 +218,6 @@ exports[`test/stories/ledger Level 4: Refund added funds️ Refund added funds w
 | ADDED_FUNDS | CREDIT | 10000  | 0          | ESLint | ESLint | OSC  |            | false    | false      |"
 `;
 
-exports[`test/stories/ledger Level 5: Refund Expenses️ Refund an expense that had feesPayer=PAYEE 1`] = `
-"
-| kind                | type   | amount | paymentFee | To       | From     | Host   | Settlement | isRefund | isDisputed |
-| ------------------- | ------ | ------ | ---------- | -------- | -------- | ------ | ---------- | -------- | ---------- |
-| EXPENSE             | CREDIT | 1000   | 0          | ESLint   | JHipster | OSC    |            | true     | false      |
-| EXPENSE             | DEBIT  | -1000  | 0          | JHipster | ESLint   | OSC    |            | true     | false      |
-| EXPENSE             | CREDIT | 1000   | 0          | JHipster | ESLint   | OSC    |            | false    | false      |
-| EXPENSE             | DEBIT  | -1000  | 0          | ESLint   | JHipster | OSC    |            | false    | false      |
-| CONTRIBUTION        | CREDIT | 10000  | 0          | ESLint   | Ben      | OSC    |            | false    | false      |
-| CONTRIBUTION        | DEBIT  | -10000 | 0          | Ben      | ESLint   | NULL   |            | false    | false      |
-| HOST_FEE_SHARE_DEBT | CREDIT | 75     | 0          | OSC      | OC Inc   | OSC    | OWED       | false    | false      |
-| HOST_FEE_SHARE_DEBT | DEBIT  | -75    | 0          | OC Inc   | OSC      | OC Inc | OWED       | false    | false      |
-| HOST_FEE_SHARE      | CREDIT | 75     | 0          | OC Inc   | OSC      | OC Inc |            | false    | false      |
-| HOST_FEE_SHARE      | DEBIT  | -75    | 0          | OSC      | OC Inc   | OSC    |            | false    | false      |
-| HOST_FEE            | CREDIT | 500    | 0          | OSC      | ESLint   | OSC    |            | false    | false      |
-| HOST_FEE            | DEBIT  | -500   | 0          | ESLint   | OSC      | OSC    |            | false    | false      |"
-`;
-
-exports[`test/stories/ledger Level 5: Refund Expenses️ Refund an expense that had feesPayer=PAYEE 2`] = `
-"
-| kind                | type   | amount | currency | amountInHostCurrency | hostCurrency | paymentFee | To       | From     | Host   | Settlement | isRefund | isDisputed |
-| ------------------- | ------ | ------ | -------- | -------------------- | ------------ | ---------- | -------- | -------- | ------ | ---------- | -------- | ---------- |
-| EXPENSE             | CREDIT | 1000   | USD      | 1000                 | USD          | 0          | ESLint   | JHipster | OSC    |            | true     | false      |
-| EXPENSE             | DEBIT  | -1000  | USD      | -1000                | USD          | 0          | JHipster | ESLint   | OSC    |            | true     | false      |
-| EXPENSE             | CREDIT | 1000   | USD      | 1000                 | USD          | 0          | JHipster | ESLint   | OSC    |            | false    | false      |
-| EXPENSE             | DEBIT  | -1000  | USD      | -1000                | USD          | 0          | ESLint   | JHipster | OSC    |            | false    | false      |
-| CONTRIBUTION        | CREDIT | 10000  | USD      | 10000                | USD          | 0          | ESLint   | Ben      | OSC    |            | false    | false      |
-| CONTRIBUTION        | DEBIT  | -10000 | USD      | -10000               | USD          | 0          | Ben      | ESLint   | NULL   |            | false    | false      |
-| HOST_FEE_SHARE_DEBT | CREDIT | 75     | USD      | 75                   | USD          | 0          | OSC      | OC Inc   | OSC    | OWED       | false    | false      |
-| HOST_FEE_SHARE_DEBT | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OC Inc   | OSC      | OC Inc | OWED       | false    | false      |
-| HOST_FEE_SHARE      | CREDIT | 75     | USD      | 75                   | USD          | 0          | OC Inc   | OSC      | OC Inc |            | false    | false      |
-| HOST_FEE_SHARE      | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OSC      | OC Inc   | OSC    |            | false    | false      |
-| HOST_FEE            | CREDIT | 500    | USD      | 500                  | USD          | 0          | OSC      | ESLint   | OSC    |            | false    | false      |
-| HOST_FEE            | DEBIT  | -500   | USD      | -500                 | USD          | 0          | ESLint   | OSC      | OSC    |            | false    | false      |"
-`;
-
 exports[`test/stories/ledger Level 5: Refund Expenses️ Refund expense with different collectives 1`] = `
 "
 | kind                | type   | amount | paymentFee | To       | From     | Host   | Settlement | isRefund | isDisputed |
@@ -354,7 +318,8 @@ exports[`test/stories/ledger Level 6: Disputed Transactions 2. Dispute is create
 "
 | kind                          | type   | amount | paymentFee | To     | From   | Host   | Settlement | isRefund | isDisputed |
 | ----------------------------- | ------ | ------ | ---------- | ------ | ------ | ------ | ---------- | -------- | ---------- |
-| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | 0          | OSC    | OSC    | OSC    |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | CREDIT | 1500   | 0          | Stripe | OSC    | NULL   |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | 0          | OSC    | Stripe | OSC    |            | false    | false      |
 | CONTRIBUTION                  | CREDIT | 10000  | 0          | Ben    | ESLint | NULL   |            | true     | false      |
 | CONTRIBUTION                  | DEBIT  | -10000 | 0          | ESLint | Ben    | OSC    |            | true     | false      |
 | HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OC Inc | OSC    | OC Inc | SETTLED    | true     | false      |
@@ -363,21 +328,22 @@ exports[`test/stories/ledger Level 6: Disputed Transactions 2. Dispute is create
 | HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC    |            | true     | false      |
 | HOST_FEE                      | CREDIT | 500    | 0          | ESLint | OSC    | OSC    |            | true     | false      |
 | HOST_FEE                      | DEBIT  | -500   | 0          | OSC    | ESLint | OSC    |            | true     | false      |
-| CONTRIBUTION                  | CREDIT | 10000  | 0          | ESLint | Ben    | OSC    |            | false    | true       |
-| CONTRIBUTION                  | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC    |            | false    | true       |
-| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OSC    | OC Inc | OSC    | SETTLED    | false    | true       |
-| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC    | SETTLED    | false    | true       |
-| HOST_FEE_SHARE                | CREDIT | 75     | 0          | OC Inc | OSC    | OSC    |            | false    | true       |
-| HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC    |            | false    | true       |
-| HOST_FEE                      | CREDIT | 500    | 0          | OSC    | ESLint | OSC    |            | false    | true       |
-| HOST_FEE                      | DEBIT  | -500   | 0          | ESLint | OSC    | OSC    |            | false    | true       |"
+| CONTRIBUTION                  | CREDIT | 10000  | 0          | ESLint | Ben    | OSC    |            | false    | false      |
+| CONTRIBUTION                  | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC    |            | false    | false      |
+| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OSC    | OC Inc | OSC    | SETTLED    | false    | false      |
+| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC    | SETTLED    | false    | false      |
+| HOST_FEE_SHARE                | CREDIT | 75     | 0          | OC Inc | OSC    | OSC    |            | false    | false      |
+| HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC    |            | false    | false      |
+| HOST_FEE                      | CREDIT | 500    | 0          | OSC    | ESLint | OSC    |            | false    | false      |
+| HOST_FEE                      | DEBIT  | -500   | 0          | ESLint | OSC    | OSC    |            | false    | false      |"
 `;
 
 exports[`test/stories/ledger Level 6: Disputed Transactions 2. Dispute is created and then closed as lost 2`] = `
 "
 | kind                          | type   | amount | currency | amountInHostCurrency | hostCurrency | paymentFee | To     | From   | Host   | Settlement | isRefund | isDisputed |
 | ----------------------------- | ------ | ------ | -------- | -------------------- | ------------ | ---------- | ------ | ------ | ------ | ---------- | -------- | ---------- |
-| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | USD      | -1500                | USD          | 0          | OSC    | OSC    | OSC    |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | CREDIT | 1500   | USD      | 1500                 | USD          | 0          | Stripe | OSC    | NULL   |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | USD      | -1500                | USD          | 0          | OSC    | Stripe | OSC    |            | false    | false      |
 | CONTRIBUTION                  | CREDIT | 10000  | USD      | 10000                | USD          | 0          | Ben    | ESLint | NULL   |            | true     | false      |
 | CONTRIBUTION                  | DEBIT  | -10000 | USD      | -10000               | USD          | 0          | ESLint | Ben    | OSC    |            | true     | false      |
 | HOST_FEE_SHARE_DEBT           | CREDIT | 75     | USD      | 75                   | USD          | 0          | OC Inc | OSC    | OC Inc | SETTLED    | true     | false      |
@@ -386,40 +352,44 @@ exports[`test/stories/ledger Level 6: Disputed Transactions 2. Dispute is create
 | HOST_FEE_SHARE                | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OC Inc | OSC    | OSC    |            | true     | false      |
 | HOST_FEE                      | CREDIT | 500    | USD      | 500                  | USD          | 0          | ESLint | OSC    | OSC    |            | true     | false      |
 | HOST_FEE                      | DEBIT  | -500   | USD      | -500                 | USD          | 0          | OSC    | ESLint | OSC    |            | true     | false      |
-| CONTRIBUTION                  | CREDIT | 10000  | USD      | 10000                | USD          | 0          | ESLint | Ben    | OSC    |            | false    | true       |
-| CONTRIBUTION                  | DEBIT  | -10000 | USD      | -10000               | USD          | 0          | Ben    | ESLint | OSC    |            | false    | true       |
-| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | USD      | 75                   | USD          | 0          | OSC    | OC Inc | OSC    | SETTLED    | false    | true       |
-| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OC Inc | OSC    | OSC    | SETTLED    | false    | true       |
-| HOST_FEE_SHARE                | CREDIT | 75     | USD      | 75                   | USD          | 0          | OC Inc | OSC    | OSC    |            | false    | true       |
-| HOST_FEE_SHARE                | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OSC    | OC Inc | OSC    |            | false    | true       |
-| HOST_FEE                      | CREDIT | 500    | USD      | 500                  | USD          | 0          | OSC    | ESLint | OSC    |            | false    | true       |
-| HOST_FEE                      | DEBIT  | -500   | USD      | -500                 | USD          | 0          | ESLint | OSC    | OSC    |            | false    | true       |"
+| CONTRIBUTION                  | CREDIT | 10000  | USD      | 10000                | USD          | 0          | ESLint | Ben    | OSC    |            | false    | false      |
+| CONTRIBUTION                  | DEBIT  | -10000 | USD      | -10000               | USD          | 0          | Ben    | ESLint | OSC    |            | false    | false      |
+| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | USD      | 75                   | USD          | 0          | OSC    | OC Inc | OSC    | SETTLED    | false    | false      |
+| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OC Inc | OSC    | OSC    | SETTLED    | false    | false      |
+| HOST_FEE_SHARE                | CREDIT | 75     | USD      | 75                   | USD          | 0          | OC Inc | OSC    | OSC    |            | false    | false      |
+| HOST_FEE_SHARE                | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OSC    | OC Inc | OSC    |            | false    | false      |
+| HOST_FEE                      | CREDIT | 500    | USD      | 500                  | USD          | 0          | OSC    | ESLint | OSC    |            | false    | false      |
+| HOST_FEE                      | DEBIT  | -500   | USD      | -500                 | USD          | 0          | ESLint | OSC    | OSC    |            | false    | false      |"
 `;
 
 exports[`test/stories/ledger Level 6: Disputed Transactions 3. Dispute is created and then closed as won 1`] = `
 "
-| kind                | type   | amount | paymentFee | To     | From   | Host | Settlement | isRefund | isDisputed |
-| ------------------- | ------ | ------ | ---------- | ------ | ------ | ---- | ---------- | -------- | ---------- |
-| CONTRIBUTION        | CREDIT | 10000  | 0          | ESLint | Ben    | OSC  |            | false    | false      |
-| CONTRIBUTION        | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC  |            | false    | false      |
-| HOST_FEE_SHARE_DEBT | CREDIT | 75     | 0          | OSC    | OC Inc | OSC  | OWED       | false    | false      |
-| HOST_FEE_SHARE_DEBT | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC  | OWED       | false    | false      |
-| HOST_FEE_SHARE      | CREDIT | 75     | 0          | OC Inc | OSC    | OSC  |            | false    | false      |
-| HOST_FEE_SHARE      | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC  |            | false    | false      |
-| HOST_FEE            | CREDIT | 500    | 0          | OSC    | ESLint | OSC  |            | false    | false      |
-| HOST_FEE            | DEBIT  | -500   | 0          | ESLint | OSC    | OSC  |            | false    | false      |"
+| kind                          | type   | amount | paymentFee | To     | From   | Host | Settlement | isRefund | isDisputed |
+| ----------------------------- | ------ | ------ | ---------- | ------ | ------ | ---- | ---------- | -------- | ---------- |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | CREDIT | 1500   | 0          | Stripe | OSC    | NULL |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | 0          | OSC    | Stripe | OSC  |            | false    | false      |
+| CONTRIBUTION                  | CREDIT | 10000  | 0          | ESLint | Ben    | OSC  |            | false    | false      |
+| CONTRIBUTION                  | DEBIT  | -10000 | 0          | Ben    | ESLint | OSC  |            | false    | false      |
+| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | 0          | OSC    | OC Inc | OSC  | OWED       | false    | false      |
+| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | 0          | OC Inc | OSC    | OSC  | OWED       | false    | false      |
+| HOST_FEE_SHARE                | CREDIT | 75     | 0          | OC Inc | OSC    | OSC  |            | false    | false      |
+| HOST_FEE_SHARE                | DEBIT  | -75    | 0          | OSC    | OC Inc | OSC  |            | false    | false      |
+| HOST_FEE                      | CREDIT | 500    | 0          | OSC    | ESLint | OSC  |            | false    | false      |
+| HOST_FEE                      | DEBIT  | -500   | 0          | ESLint | OSC    | OSC  |            | false    | false      |"
 `;
 
 exports[`test/stories/ledger Level 6: Disputed Transactions 3. Dispute is created and then closed as won 2`] = `
 "
-| kind                | type   | amount | currency | amountInHostCurrency | hostCurrency | paymentFee | To     | From   | Host | Settlement | isRefund | isDisputed |
-| ------------------- | ------ | ------ | -------- | -------------------- | ------------ | ---------- | ------ | ------ | ---- | ---------- | -------- | ---------- |
-| CONTRIBUTION        | CREDIT | 10000  | USD      | 10000                | USD          | 0          | ESLint | Ben    | OSC  |            | false    | false      |
-| CONTRIBUTION        | DEBIT  | -10000 | USD      | -10000               | USD          | 0          | Ben    | ESLint | OSC  |            | false    | false      |
-| HOST_FEE_SHARE_DEBT | CREDIT | 75     | USD      | 75                   | USD          | 0          | OSC    | OC Inc | OSC  | OWED       | false    | false      |
-| HOST_FEE_SHARE_DEBT | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OC Inc | OSC    | OSC  | OWED       | false    | false      |
-| HOST_FEE_SHARE      | CREDIT | 75     | USD      | 75                   | USD          | 0          | OC Inc | OSC    | OSC  |            | false    | false      |
-| HOST_FEE_SHARE      | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OSC    | OC Inc | OSC  |            | false    | false      |
-| HOST_FEE            | CREDIT | 500    | USD      | 500                  | USD          | 0          | OSC    | ESLint | OSC  |            | false    | false      |
-| HOST_FEE            | DEBIT  | -500   | USD      | -500                 | USD          | 0          | ESLint | OSC    | OSC  |            | false    | false      |"
+| kind                          | type   | amount | currency | amountInHostCurrency | hostCurrency | paymentFee | To     | From   | Host | Settlement | isRefund | isDisputed |
+| ----------------------------- | ------ | ------ | -------- | -------------------- | ------------ | ---------- | ------ | ------ | ---- | ---------- | -------- | ---------- |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | CREDIT | 1500   | USD      | 1500                 | USD          | 0          | Stripe | OSC    | NULL |            | false    | false      |
+| PAYMENT_PROCESSOR_DISPUTE_FEE | DEBIT  | -1500  | USD      | -1500                | USD          | 0          | OSC    | Stripe | OSC  |            | false    | false      |
+| CONTRIBUTION                  | CREDIT | 10000  | USD      | 10000                | USD          | 0          | ESLint | Ben    | OSC  |            | false    | false      |
+| CONTRIBUTION                  | DEBIT  | -10000 | USD      | -10000               | USD          | 0          | Ben    | ESLint | OSC  |            | false    | false      |
+| HOST_FEE_SHARE_DEBT           | CREDIT | 75     | USD      | 75                   | USD          | 0          | OSC    | OC Inc | OSC  | OWED       | false    | false      |
+| HOST_FEE_SHARE_DEBT           | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OC Inc | OSC    | OSC  | OWED       | false    | false      |
+| HOST_FEE_SHARE                | CREDIT | 75     | USD      | 75                   | USD          | 0          | OC Inc | OSC    | OSC  |            | false    | false      |
+| HOST_FEE_SHARE                | DEBIT  | -75    | USD      | -75                  | USD          | 0          | OSC    | OC Inc | OSC  |            | false    | false      |
+| HOST_FEE                      | CREDIT | 500    | USD      | 500                  | USD          | 0          | OSC    | ESLint | OSC  |            | false    | false      |
+| HOST_FEE                      | DEBIT  | -500   | USD      | -500                 | USD          | 0          | ESLint | OSC    | OSC  |            | false    | false      |"
 `;


### PR DESCRIPTION
- [x] Disable refund for orders in dispute;
- [x] Use double transaction with Strip vendor to track DISPUTE_FEES;
- [x] Track DISPUTE_FEES even for `won` conditions;