### PR TITLE
Allow pg_dump customization

### DIFF
--- a/scripts/smart-dump.ts
+++ b/scripts/smart-dump.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import { readJsonSync, writeJsonSync } from 'fs-extra';
 import { cloneDeepWith, compact, concat, flatten, repeat, set, uniqBy } from 'lodash';
 
+import { PG_DUMP_CMD } from '../server/lib/db';
 import { md5 } from '../server/lib/utils';
 import models, { Op, sequelize } from '../server/models';
 import { IDENTIFIABLE_DATA_FIELDS } from '../server/models/PayoutMethod';
@@ -305,7 +306,7 @@ program.command('dump [recipe] [env]').action(async (recipe, env) => {
   writeJsonSync(`dbdumps/${filename}.json`, docs, { spaces: 2 });
 
   console.log('\n>>> Dumping Schema...');
-  exec(`pg_dump -csOx $PG_URL > dbdumps/${filename}.schema.sql`);
+  exec(`${PG_DUMP_CMD} -csOx $PG_URL > dbdumps/${filename}.schema.sql`);
 
   console.log(`\n>>> Done! Dumped to dbdumps/${filename}.json`);
   sequelize.close();

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -160,3 +160,5 @@ export async function recreateDatabase(destroy = true) {
   const clientApp = await getConnectedClient(getDBUrl('database'));
   return [client, clientApp];
 }
+
+export const PG_DUMP_CMD = process.env.OC_PG_DUMP_CMD || 'pg_dump';

--- a/test/test-helpers/data-snapshot.ts
+++ b/test/test-helpers/data-snapshot.ts
@@ -11,7 +11,7 @@ import config from 'config';
 import slugify from 'limax';
 import { Context } from 'mocha';
 
-import { getDBConf } from '../../server/lib/db';
+import { getDBConf, PG_DUMP_CMD } from '../../server/lib/db';
 import logger from '../../server/lib/logger';
 import { parseToBoolean } from '../../server/lib/utils';
 import { sequelize } from '../../server/models';
@@ -25,7 +25,7 @@ const snapshotCurrentDB = (filePath: string) => {
 
   // Run pg_dump
   const { database, username, password, host, port } = getDBConf('database');
-  const cmd = `pg_dump -Fc -Z9 "postgres://${username}:${password}@${host}:${port}/${database}" > "${filePath}"`;
+  const cmd = `${PG_DUMP_CMD} -Fc -Z9 "postgres://${username}:${password}@${host}:${port}/${database}" > "${filePath}"`;
   execSync(cmd, { stdio: 'inherit' });
 };
 


### PR DESCRIPTION
This aims to provide a workaround for this issue that occurs when a dump from a recent postgres version is meant to be restored on an older Postgres (e.g. on CI):

> pg_restore: error: unsupported version (1.15) in file header.

To enable it, set the `OC_PG_DUMP_CMD`  variable in your `.env`. Some examples:

- Run an older `pg_dump` with Docker:

> OC_PG_DUMP_CMD=docker run --net host postgres:15 pg_dump

- RUn an older `pg_dump` with Docker (sudo protected): 
> OC_PG_DUMP_CMD=pkexec docker run --net host postgres:15 pg_dump 