### PR TITLE
Fix floatting point issues

### DIFF
--- a/server/graphql/v2/object/Expense.ts
+++ b/server/graphql/v2/object/Expense.ts
@@ -16,6 +16,7 @@ import ActivityTypes from '../../../constants/activities';
 import expenseStatus from '../../../constants/expense-status';
 import ExpenseTypes from '../../../constants/expense-type';
 import OAuthScopes from '../../../constants/oauth-scopes';
+import { floatAmountToCents } from '../../../lib/math';
 import SQLQueries from '../../../lib/queries';
 import models, { Activity, Op } from '../../../models';
 import { CommentType } from '../../../models/Comment';
@@ -577,12 +578,12 @@ export const GraphQLExpense = new GraphQLObjectType<ExpenseModel, express.Reques
             }
 
             const sourceAmount = {
-              value: quote.paymentOption.sourceAmount * 100,
+              value: floatAmountToCents(quote.paymentOption.sourceAmount),
               currency: quote.paymentOption.sourceCurrency,
             };
             const estimatedDeliveryAt = quote.paymentOption.estimatedDelivery;
             const paymentProcessorFeeAmount = {
-              value: quote.paymentOption.fee.total * 100,
+              value: floatAmountToCents(quote.paymentOption.fee.total),
               currency: quote.sourceCurrency,
             };
             return { sourceAmount, estimatedDeliveryAt, paymentProcessorFeeAmount };

--- a/server/graphql/v2/object/TransferWise.ts
+++ b/server/graphql/v2/object/TransferWise.ts
@@ -1,6 +1,7 @@
 import { GraphQLBoolean, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLJSON, GraphQLJSONObject } from 'graphql-scalars';
 
+import { floatAmountToCents } from '../../../lib/math';
 import models, { Op } from '../../../models';
 import transferwise from '../../../paymentProviders/transferwise';
 import { getIdEncodeResolver, IDENTIFIER_TYPES } from '../identifiers';
@@ -147,7 +148,7 @@ export const GraphQLTransferWise = new GraphQLObjectType({
 
         if (sourceAmount) {
           return {
-            value: sourceAmount * 100,
+            value: floatAmountToCents(sourceAmount),
             currency: scheduledExpenses[0].data.quote.sourceCurrency,
           };
         }

--- a/server/lib/stripe.ts
+++ b/server/lib/stripe.ts
@@ -70,7 +70,7 @@ export const convertToStripeAmount = (currency, amount) => {
 
 export const convertFromStripeAmount = (currency, amount) => {
   if (ZERO_DECIMAL_CURRENCIES.includes(currency?.toUpperCase())) {
-    return amount * 100;
+    return Math.round(amount * 100);
   } else {
     return amount;
   }


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/7444.

The issue is easily reproduced with expense `204029`:
- `quote.paymentOption.fee.total` = 1.13


```es6
> 1.13 * 100
112.99999999999999
```