### PR TITLE
fix(AccountingCategory): soften validation when not changing

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1733,11 +1733,10 @@ export const DRAFT_EXPENSE_FIELDS = [
  * /!\ We have no 1-to-1 field mapping between `Expense` and `ExpenseData`, but since we used to only
  * check `isNil` this won't introduce any regression. Ideally, this helper should do a mapping between the two.
  */
-const isValueChanging = (expense: Expense, expenseData: ExpenseData, key: string): boolean => {
-  const nullableFields = ['accountingCategory'];
+const isValueChanging = (expense: Expense, expenseData: Partial<ExpenseData>, key: string): boolean => {
   const value = expenseData[key];
-  if (nullableFields.includes(key)) {
-    return !isUndefined(value) && !isEqual(value, expense[key]);
+  if (key === 'accountingCategory') {
+    return !isUndefined(value) && (value?.id ?? null) !== expense.AccountingCategoryId;
   } else {
     return !isNil(value) && !isEqual(value, expense[key]);
   }
@@ -1841,7 +1840,7 @@ const editOnlyTagsAndAccountingCategory = async (
   }
 
   // Accounting category
-  if (!isUndefined(expenseData.accountingCategory)) {
+  if (isValueChanging(expense, expenseData, 'accountingCategory')) {
     if (!(await canEditExpenseAccountingCategory(req, expense))) {
       throw new Unauthorized("You don't have permission to edit the accounting category for this expense");
     }

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -1443,6 +1443,48 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         result.errors && console.error(result.errors);
         expect(result.data.editExpense.accountingCategory.id).to.deep.equal(updatedExpenseData.accountingCategory.id);
       });
+
+      it('cannot change the accounting category of a paid expense', async () => {
+        const expense = await fakeExpense({ type: 'INVOICE', status: 'PAID' });
+        const accountingCategory = await fakeAccountingCategory({
+          kind: 'EXPENSE',
+          CollectiveId: expense.collective.HostCollectiveId,
+        });
+        const updatedExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          accountingCategory: { id: idEncode(accountingCategory.id, 'accounting-category') },
+        };
+        const result = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.eq(
+          "You don't have permission to edit the accounting category for this expense",
+        );
+      });
+
+      it('does not trigger any message if not changing the accounting category', async () => {
+        const collective = await fakeCollective();
+        const accountingCategory = await fakeAccountingCategory({
+          kind: 'EXPENSE',
+          CollectiveId: collective.HostCollectiveId,
+        });
+        const expense = await fakeExpense({
+          type: 'INVOICE',
+          status: 'APPROVED',
+          AccountingCategoryId: accountingCategory.id,
+          CollectiveId: collective.id,
+        });
+        const updatedExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          tags: ['new', 'tags'],
+          accountingCategory: { id: idEncode(accountingCategory.id, 'accounting-category') },
+        };
+
+        const result = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        expect(result.data.editExpense.tags).to.deep.equal(updatedExpenseData.tags);
+        expect(result.data.editExpense.accountingCategory.id).to.equal(updatedExpenseData.accountingCategory.id);
+      });
     });
 
     it('updates the location', async () => {


### PR DESCRIPTION
For https://opencollective.slack.com/archives/C0429NTTABF/p1719948680108089 / https://opencollective.freshdesk.com/a/tickets/356513

We were throwing because the frontend sends an accounting category (aka. it is not undefined), but if not changing it we don't need to throw.
