### PR TITLE
fix(TransactionsStats): update CollectiveTransactionStats

### DIFF
--- a/migrations/20240710084241-current-collective-views-update.js
+++ b/migrations/20240710084241-current-collective-views-update.js
@@ -1,6 +1,10 @@
 'use strict';
 
-/** @type {import('sequelize-cli').Migration} */
+/**
+ * /!\ THIS MIGRATION WAS INCOMPLETE, DO NOT USE IT AS A REFERENCE. See `migrations/20240712081151-current-collective-views-update.js` instead.
+ *
+ * @type {import('sequelize-cli').Migration}
+ */
 module.exports = {
   async up(queryInterface) {
     await queryInterface.sequelize.query(`

--- a/migrations/20240712081151-current-collective-views-update.js
+++ b/migrations/20240712081151-current-collective-views-update.js
@@ -42,8 +42,8 @@ module.exports = {
             COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
           )
             FILTER (
-              -- Get all credits related to orders
-              WHERE (t.type = 'CREDIT' AND t."OrderId" IS NOT NULL)
+              -- Get all credits except PAYMENT_PROCESSOR_COVER from expenses
+              WHERE (t.type = 'CREDIT' AND NOT (t.kind = 'PAYMENT_PROCESSOR_COVER' AND t."OrderId" IS NULL))
               -- Deduct host fees and payment processor fees that are related to orders
               OR (t.type = 'DEBIT' AND t.kind IN ('HOST_FEE', 'PAYMENT_PROCESSOR_FEE') AND t."OrderId" IS NOT NULL)
             )
@@ -109,8 +109,8 @@ module.exports = {
             COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
           )
             FILTER (
-              -- Get all credits related to orders
-              WHERE (t.type = 'CREDIT' AND t."OrderId" IS NOT NULL)
+              -- Get all credits except PAYMENT_PROCESSOR_COVER from expenses
+              WHERE (t.type = 'CREDIT' AND NOT (t.kind = 'PAYMENT_PROCESSOR_COVER' AND t."OrderId" IS NULL))
               -- Deduct host fees and payment processor fees that are related to orders
               OR (t.type = 'DEBIT' AND t.kind IN ('HOST_FEE', 'PAYMENT_PROCESSOR_FEE') AND t."OrderId" IS NOT NULL)
             )

--- a/migrations/20240712081151-current-collective-views-update.js
+++ b/migrations/20240712081151-current-collective-views-update.js
@@ -1,0 +1,278 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`DROP VIEW IF EXISTS "CurrentCollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "CollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
+
+        WITH "ActiveCollectives" AS (
+          SELECT c."id" as "CollectiveId"
+          FROM "Transactions" t
+          LEFT JOIN "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL
+          WHERE t."deletedAt" IS NULL
+            AND t."hostCurrency" IS NOT NULL
+            AND c."deactivatedAt" IS NULL
+            -- TODO: not sure why we have those conditions omn guest/incognito, too many accounts?
+            AND (c."data" ->> 'isGuest')::boolean IS NOT TRUE
+            AND c.name != 'incognito'
+            AND c.name != 'anonymous'
+            AND c."isIncognito" = FALSE
+          GROUP BY c."id"
+          HAVING COUNT(DISTINCT t."hostCurrency") = 1 -- no hostCurrency mismatch please!
+        )
+        SELECT
+          ac."CollectiveId" as "id",
+          MAX(t."createdAt") as "LatestTransactionCreatedAt",
+          COUNT(DISTINCT t.id) AS "count",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT' AND t."kind" NOT IN ('PAYMENT_PROCESSOR_COVER'))
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (
+              -- Get all credits related to orders
+              WHERE (t.type = 'CREDIT' AND t."OrderId" IS NOT NULL)
+              -- Deduct host fees and payment processor fees that are related to orders
+              OR (t.type = 'DEBIT' AND t.kind IN ('HOST_FEE', 'PAYMENT_PROCESSOR_FEE') AND t."OrderId" IS NOT NULL)
+            )
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE' AND t.kind != 'PAYMENT_PROCESSOR_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE (t.type = 'DEBIT' AND t.kind != 'HOST_FEE') OR (t.type = 'CREDIT' AND t.kind = 'PAYMENT_PROCESSOR_COVER'))
+            AS "totalNetAmountSpentInHostCurrency",
+
+          MAX(t."hostCurrency") as "hostCurrency"
+
+        FROM "ActiveCollectives" ac
+
+        INNER JOIN "Transactions" t ON t."CollectiveId" = ac."CollectiveId"
+          AND t."deletedAt" IS NULL
+          AND t."RefundTransactionId" IS NULL
+          AND (t."isRefund" IS NOT TRUE OR t."kind" = 'PAYMENT_PROCESSOR_COVER')
+          AND t."isInternal" IS NOT TRUE
+
+        GROUP BY ac."CollectiveId";
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW "CurrentCollectiveTransactionStats" as (
+        SELECT
+          cts."id" as "CollectiveId",
+
+          COALESCE(cts."totalAmountReceivedInHostCurrency", 0) + COALESCE(t."totalAmountReceivedInHostCurrency", 0)
+            AS "totalAmountReceivedInHostCurrency",
+          COALESCE(cts."totalNetAmountReceivedInHostCurrency", 0) + COALESCE(t."totalNetAmountReceivedInHostCurrency", 0)
+            AS "totalNetAmountReceivedInHostCurrency",
+          COALESCE(cts."totalAmountSpentInHostCurrency", 0) + COALESCE(t."totalAmountSpentInHostCurrency", 0)
+            AS "totalAmountSpentInHostCurrency",
+          COALESCE(cts."totalNetAmountSpentInHostCurrency", 0) + COALESCE(t."totalNetAmountSpentInHostCurrency", 0)
+            AS "totalNetAmountSpentInHostCurrency",
+
+          cts."hostCurrency"
+
+        FROM "CollectiveTransactionStats" cts
+
+        LEFT JOIN LATERAL (
+          SELECT
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT' AND t."kind" NOT IN ('PAYMENT_PROCESSOR_COVER'))
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (
+              -- Get all credits related to orders
+              WHERE (t.type = 'CREDIT' AND t."OrderId" IS NOT NULL)
+              -- Deduct host fees and payment processor fees that are related to orders
+              OR (t.type = 'DEBIT' AND t.kind IN ('HOST_FEE', 'PAYMENT_PROCESSOR_FEE') AND t."OrderId" IS NOT NULL)
+            )
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE' AND t.kind != 'PAYMENT_PROCESSOR_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE (t.type = 'DEBIT' AND t.kind != 'HOST_FEE') OR (t.type = 'CREDIT' AND t.kind = 'PAYMENT_PROCESSOR_COVER'))
+            AS "totalNetAmountSpentInHostCurrency"
+
+          FROM "Transactions" t
+          WHERE t."CollectiveId" = cts."id"
+            AND ROUND(EXTRACT(epoch FROM t."createdAt" AT TIME ZONE 'UTC') / 10) > ROUND(EXTRACT(epoch FROM cts."LatestTransactionCreatedAt" AT TIME ZONE 'UTC') / 10)
+            AND t."deletedAt" is null
+            AND t."RefundTransactionId" IS NULL
+            AND (t."isRefund" IS NOT TRUE OR t."kind" = 'PAYMENT_PROCESSOR_COVER')
+            AND t."isInternal" IS NOT TRUE
+
+          GROUP by t."CollectiveId"
+        ) as t ON TRUE
+      );
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`DROP VIEW IF EXISTS "CurrentCollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "CollectiveTransactionStats"`);
+
+    await queryInterface.sequelize.query(`
+      CREATE MATERIALIZED VIEW "CollectiveTransactionStats" AS
+
+        WITH "ActiveCollectives" AS (
+          SELECT c."id" as "CollectiveId"
+          FROM "Transactions" t
+          LEFT JOIN "Collectives" c ON c."id" = t."CollectiveId" AND c."deletedAt" IS NULL
+          WHERE t."deletedAt" IS NULL
+            AND t."hostCurrency" IS NOT NULL
+            AND c."deactivatedAt" IS NULL
+            -- TODO: not sure why we have those conditions omn guest/incognito, too many accounts?
+            AND (c."data" ->> 'isGuest')::boolean IS NOT TRUE
+            AND c.name != 'incognito'
+            AND c.name != 'anonymous'
+            AND c."isIncognito" = FALSE
+          GROUP BY c."id"
+          HAVING COUNT(DISTINCT t."hostCurrency") = 1 -- no hostCurrency mismatch please!
+        )
+        SELECT
+          ac."CollectiveId" as "id",
+          MAX(t."createdAt") as "LatestTransactionCreatedAt",
+          COUNT(DISTINCT t.id) AS "count",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT' AND t."kind" NOT IN ('PAYMENT_PROCESSOR_COVER'))
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind IN ('HOST_FEE', 'PAYMENT_PROCESSOR_FEE')))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE' AND t.kind != 'PAYMENT_PROCESSOR_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE (t.type = 'DEBIT' AND t.kind != 'HOST_FEE') OR (t.type = 'CREDIT' AND t.kind = 'PAYMENT_PROCESSOR_COVER'))
+            AS "totalNetAmountSpentInHostCurrency",
+
+          MAX(t."hostCurrency") as "hostCurrency"
+
+        FROM "ActiveCollectives" ac
+
+        INNER JOIN "Transactions" t ON t."CollectiveId" = ac."CollectiveId"
+          AND t."deletedAt" IS NULL
+          AND t."RefundTransactionId" IS NULL
+          AND (t."isRefund" IS NOT TRUE OR t."kind" = 'PAYMENT_PROCESSOR_COVER')
+          AND t."isInternal" IS NOT TRUE
+
+        GROUP BY ac."CollectiveId";
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW "CurrentCollectiveTransactionStats" as (
+        SELECT
+          cts."id" as "CollectiveId",
+
+          COALESCE(cts."totalAmountReceivedInHostCurrency", 0) + COALESCE(t."totalAmountReceivedInHostCurrency", 0)
+            AS "totalAmountReceivedInHostCurrency",
+          COALESCE(cts."totalNetAmountReceivedInHostCurrency", 0) + COALESCE(t."totalNetAmountReceivedInHostCurrency", 0)
+            AS "totalNetAmountReceivedInHostCurrency",
+          COALESCE(cts."totalAmountSpentInHostCurrency", 0) + COALESCE(t."totalAmountSpentInHostCurrency", 0)
+            AS "totalAmountSpentInHostCurrency",
+          COALESCE(cts."totalNetAmountSpentInHostCurrency", 0) + COALESCE(t."totalNetAmountSpentInHostCurrency", 0)
+            AS "totalNetAmountSpentInHostCurrency",
+
+          cts."hostCurrency"
+
+        FROM "CollectiveTransactionStats" cts
+
+        LEFT JOIN LATERAL (
+          SELECT
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'CREDIT' AND t."kind" NOT IN ('PAYMENT_PROCESSOR_COVER'))
+            AS "totalAmountReceivedInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE t.type = 'CREDIT' OR (t.type = 'DEBIT' AND t.kind IN ('HOST_FEE', 'PAYMENT_PROCESSOR_FEE')))
+            AS "totalNetAmountReceivedInHostCurrency",
+
+          SUM(t."amountInHostCurrency")
+            FILTER (WHERE t.type = 'DEBIT' AND t.kind != 'HOST_FEE' AND t.kind != 'PAYMENT_PROCESSOR_FEE')
+            AS "totalAmountSpentInHostCurrency",
+
+          SUM(
+            COALESCE(t."amountInHostCurrency", 0) +
+            COALESCE(t."platformFeeInHostCurrency", 0) +
+            COALESCE(t."hostFeeInHostCurrency", 0) +
+            COALESCE(t."paymentProcessorFeeInHostCurrency", 0) +
+            COALESCE(t."taxAmount" * t."hostCurrencyFxRate", 0)
+          )
+            FILTER (WHERE (t.type = 'DEBIT' AND t.kind != 'HOST_FEE') OR (t.type = 'CREDIT' AND t.kind = 'PAYMENT_PROCESSOR_COVER'))
+            AS "totalNetAmountSpentInHostCurrency"
+
+          FROM "Transactions" t
+          WHERE t."CollectiveId" = cts."id"
+            AND ROUND(EXTRACT(epoch FROM t."createdAt" AT TIME ZONE 'UTC') / 10) > ROUND(EXTRACT(epoch FROM cts."LatestTransactionCreatedAt" AT TIME ZONE 'UTC') / 10)
+            AND t."deletedAt" is null
+            AND t."RefundTransactionId" IS NULL
+            AND (t."isRefund" IS NOT TRUE OR t."kind" = 'PAYMENT_PROCESSOR_COVER')
+            AND t."isInternal" IS NOT TRUE
+
+          GROUP by t."CollectiveId"
+        ) as t ON TRUE
+      );
+    `);
+  },
+};

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -646,7 +646,7 @@ export async function sumCollectivesTransactions(
       where = {
         ...where,
         [Op.or]: [
-          { type: CREDIT },
+          { type: CREDIT, OrderId: { [Op.not]: null } },
           { type: DEBIT, kind: ['HOST_FEE', 'PAYMENT_PROCESSOR_FEE'], OrderId: { [Op.not]: null } },
         ],
       };

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -646,7 +646,9 @@ export async function sumCollectivesTransactions(
       where = {
         ...where,
         [Op.or]: [
-          { type: CREDIT, OrderId: { [Op.not]: null } },
+          // Get all credits except PAYMENT_PROCESSOR_COVER from expenses
+          { type: CREDIT, [Op.not]: { kind: 'PAYMENT_PROCESSOR_COVER', OrderId: null } },
+          // Deduct host fees and payment processor fees that are related to orders
           { type: DEBIT, kind: ['HOST_FEE', 'PAYMENT_PROCESSOR_FEE'], OrderId: { [Op.not]: null } },
         ],
       };

--- a/test/stories/ledger.test.ts
+++ b/test/stories/ledger.test.ts
@@ -387,9 +387,11 @@ describe('test/stories/ledger', () => {
 
       await sequelize.query(`REFRESH MATERIALIZED VIEW "CollectiveTransactionStats"`);
       for (const useMaterializedView of [false, true]) {
-        expect(await collective.getBalance({ useMaterializedView })).to.eq(150000 - 100000 - 500);
-        expect(await collective.getTotalAmountSpent({ useMaterializedView })).to.eq(100000);
-        expect(await collective.getTotalAmountSpent({ useMaterializedView, net: true })).to.eq(100000 + 500);
+        expect(await collective.getBalance({ useMaterializedView })).to.eq(150000 - 100000 - 500); // $1500 (contribution) - $1000 (expense) - $5 (expense processor fee) = $495
+        expect(await collective.getTotalAmountReceived({ useMaterializedView })).to.eq(150000); // $1500 (contribution)
+        expect(await collective.getTotalAmountReceived({ useMaterializedView, net: true })).to.eq(150000); // $1500 (contribution)
+        expect(await collective.getTotalAmountSpent({ useMaterializedView })).to.eq(100000); // $1000 (expense)
+        expect(await collective.getTotalAmountSpent({ useMaterializedView, net: true })).to.eq(100000 + 500); // $1000 (expense) + $5 (expense processor fee)
       }
 
       await markExpenseAsUnpaid({ remoteUser: hostAdmin } as any, expense.id, false);
@@ -397,11 +399,11 @@ describe('test/stories/ledger', () => {
 
       await sequelize.query(`REFRESH MATERIALIZED VIEW "CollectiveTransactionStats"`);
       for (const useMaterializedView of [false, true]) {
-        expect(await collective.getBalance({ useMaterializedView })).to.eq(150000);
-        expect(await collective.getTotalAmountReceived({ useMaterializedView })).to.eq(150000);
-        expect(await collective.getTotalAmountReceived({ useMaterializedView, net: true })).to.eq(150000);
-        expect(await collective.getTotalAmountSpent({ useMaterializedView })).to.eq(0);
-        expect(await collective.getTotalAmountSpent({ useMaterializedView, net: true })).to.eq(0);
+        expect(await collective.getBalance({ useMaterializedView })).to.eq(150000); // $1500 (contribution)
+        expect(await collective.getTotalAmountReceived({ useMaterializedView })).to.eq(150000); // $1500 (contribution)
+        expect(await collective.getTotalAmountReceived({ useMaterializedView, net: true })).to.eq(150000); // $1500 (contribution)
+        expect(await collective.getTotalAmountSpent({ useMaterializedView })).to.eq(0); // Expense refunded => no amount spent
+        expect(await collective.getTotalAmountSpent({ useMaterializedView, net: true })).to.eq(0); // Expense refunded => no amount spent
 
         expect(await host.getTotalMoneyManaged({ useMaterializedView })).to.eq(150000 - 500);
         expect(await host.getBalance({ useMaterializedView })).to.eq(-500);


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/10194

The previous fix works for the JS version. However, fast balances are still affected by the bug because the change was only made on `CurrentCollectiveTransactionStats`, without being propagated to `CollectiveTransactionStats`.