### PR TITLE
Fix double-refund bug of host fees and platform tips

### DIFF
--- a/server/lib/payments.ts
+++ b/server/lib/payments.ts
@@ -374,7 +374,7 @@ export async function refundHostFee(
   transactionGroup: string,
   clearedAt?: Date,
 ): Promise<void> {
-  const hostFeeTransaction = await transaction.getHostFeeTransaction();
+  const hostFeeTransaction = await transaction.getHostFeeTransaction({ type: CREDIT });
   const buildRefund = transaction => {
     return {
       ...buildRefundForTransaction(transaction, user, null, refundedPaymentProcessorFee),
@@ -383,7 +383,7 @@ export async function refundHostFee(
     };
   };
 
-  if (hostFeeTransaction) {
+  if (hostFeeTransaction && hostFeeTransaction.id !== transaction.id) {
     const hostFeeRefund = buildRefund(hostFeeTransaction);
     const hostFeeRefundTransaction = await Transaction.createDoubleEntry(hostFeeRefund);
     await associateTransactionRefundId(hostFeeTransaction, hostFeeRefundTransaction);
@@ -502,8 +502,8 @@ export async function createRefundTransaction(
   };
 
   // Refund Platform Tip
-  const platformTipTransaction = await transaction.getPlatformTipTransaction();
-  if (platformTipTransaction) {
+  const platformTipTransaction = await transaction.getPlatformTipTransaction({ type: CREDIT });
+  if (platformTipTransaction && platformTipTransaction.id !== transaction.id) {
     const platformTipRefund = buildRefund(platformTipTransaction);
     const platformTipRefundTransaction = await Transaction.createDoubleEntry(platformTipRefund);
     await associateTransactionRefundId(platformTipTransaction, platformTipRefundTransaction, data);

--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -174,9 +174,9 @@ class Transaction extends Model<InferAttributes<Transaction>, InferCreationAttri
   declare getOppositeTransaction: () => Promise<Transaction | null>;
   declare getPaymentProcessorFeeTransaction: () => Promise<Transaction | null>;
   declare getTaxTransaction: () => Promise<Transaction | null>;
-  declare getPlatformTipTransaction: () => Promise<Transaction | null>;
+  declare getPlatformTipTransaction: (options?: Pick<Transaction, 'type'>) => Promise<Transaction | null>;
   declare getPlatformTipDebtTransaction: () => Promise<Transaction | null>;
-  declare getHostFeeTransaction: () => Promise<Transaction | null>;
+  declare getHostFeeTransaction: (options?: Pick<Transaction, 'type'>) => Promise<Transaction | null>;
   declare getHostFeeShareTransaction: () => Promise<Transaction | null>;
   declare getHostFeeShareDebtTransaction: () => Promise<Transaction | null>;
   declare getRefundTransaction: () => Promise<Transaction | null>;
@@ -1753,16 +1753,16 @@ Transaction.prototype.getTaxTransaction = function () {
   return this.getRelatedTransaction({ kind: TransactionKind.TAX });
 };
 
-Transaction.prototype.getPlatformTipTransaction = function () {
-  return this.getRelatedTransaction({ kind: TransactionKind.PLATFORM_TIP });
+Transaction.prototype.getPlatformTipTransaction = function (options?: Pick<Transaction, 'type'>) {
+  return this.getRelatedTransaction({ ...options, kind: TransactionKind.PLATFORM_TIP });
 };
 
 Transaction.prototype.getPlatformTipDebtTransaction = function () {
   return this.getRelatedTransaction({ kind: TransactionKind.PLATFORM_TIP_DEBT, isDebt: true });
 };
 
-Transaction.prototype.getHostFeeTransaction = function () {
-  return this.getRelatedTransaction({ kind: TransactionKind.HOST_FEE });
+Transaction.prototype.getHostFeeTransaction = function (options?: Pick<Transaction, 'type'>) {
+  return this.getRelatedTransaction({ ...options, kind: TransactionKind.HOST_FEE });
 };
 
 Transaction.prototype.getHostFeeShareTransaction = function () {

--- a/test/server/lib/payments.test.js.snap
+++ b/test/server/lib/payments.test.js.snap
@@ -22,6 +22,30 @@ exports[`server/lib/payments createRefundTransaction should allow collective to 
 | CONTRIBUTION            | CREDIT | true     | false  | Scouts d'Arlon | Xavier Damman  | NULL | 4750   | USD      | 250         | 0          |            | Refund of \\"Monthly subscription to Webpack\\" |"
 `;
 
+exports[`server/lib/payments createRefundTransaction should be able to refund only the host fee 1`] = `
+"
+| kind         | type   | isRefund | isDebt | From       | To         | Host | amount | currency | platformFee | paymentFee | Settlement | description                |
+| ------------ | ------ | -------- | ------ | ---------- | ---------- | ---- | ------ | -------- | ----------- | ---------- | ---------- | -------------------------- |
+| HOST_FEE     | DEBIT  | false    | false  | Host       | Collective | Host | -500   | USD      | 0           | 0          |            | Host Fee                   |
+| HOST_FEE     | CREDIT | false    | false  | Collective | Host       | Host | 500    | USD      | 0           | 0          |            | Host Fee                   |
+| CONTRIBUTION | DEBIT  | false    | false  | Collective | User       | NULL | -5000  | USD      | 0           | 0          |            | Contribution to Collective |
+| CONTRIBUTION | CREDIT | false    | false  | User       | Collective | Host | 5000   | USD      | 0           | 0          |            | Contribution to Collective |
+| HOST_FEE     | DEBIT  | true     | false  | Collective | Host       | Host | -500   | USD      | 0           | 0          |            | Refund of \\"Host Fee\\"       |
+| HOST_FEE     | CREDIT | true     | false  | Host       | Collective | Host | 500    | USD      | 0           | 0          |            | Refund of \\"Host Fee\\"       |"
+`;
+
+exports[`server/lib/payments createRefundTransaction should be able to refund only the platform tip 1`] = `
+"
+| kind         | type   | isRefund | isDebt | From            | To              | Host            | amount | currency | platformFee | paymentFee | Settlement | description                                           |
+| ------------ | ------ | -------- | ------ | --------------- | --------------- | --------------- | ------ | -------- | ----------- | ---------- | ---------- | ----------------------------------------------------- |
+| PLATFORM_TIP | DEBIT  | false    | false  | Open Collective | User            | NULL            | -500   | USD      | 0           | 0          |            | Financial contribution to Open Collective             |
+| PLATFORM_TIP | CREDIT | false    | false  | User            | Open Collective | Open Collective | 500    | USD      | 0           | 0          |            | Financial contribution to Open Collective             |
+| CONTRIBUTION | DEBIT  | false    | false  | Collective      | User            | NULL            | -5000  | USD      | 0           | 0          |            | Contribution to Collective                            |
+| CONTRIBUTION | CREDIT | false    | false  | User            | Collective      | Host            | 5000   | USD      | 0           | 0          |            | Contribution to Collective                            |
+| PLATFORM_TIP | DEBIT  | true     | false  | User            | Open Collective | Open Collective | -500   | USD      | 0           | 0          |            | Refund of \\"Financial contribution to Open Collective\\" |
+| PLATFORM_TIP | CREDIT | true     | false  | Open Collective | User            | NULL            | 500    | USD      | 0           | 0          |            | Refund of \\"Financial contribution to Open Collective\\" |"
+`;
+
 exports[`server/lib/payments createRefundTransaction should not create payment processor fee cover for contribution to the host itself 1`] = `
 "
 | kind                  | type   | isRefund | isDebt | From                    | To                      | Host | amount | currency | platformFee | paymentFee | Settlement | description                                   |


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/7482

I was reviewing the refund flow and noticed that, whenever a fiscal-host admin tries to refund a HOST_FEE transaction directly, we end up refunding it twice. The same is true for platform tips.