### PR TITLE
fix(Expenses): link user in create activity

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1856,7 +1856,10 @@ export async function submitExpenseDraft(
     UserId: options.overrideRemoteUser?.id || req.remoteUser?.id,
   });
 
-  await existingExpense.createActivity(activities.COLLECTIVE_EXPENSE_CREATED, req.remoteUser);
+  await existingExpense.createActivity(
+    activities.COLLECTIVE_EXPENSE_CREATED,
+    options.overrideRemoteUser ?? req.remoteUser,
+  );
 
   return existingExpense;
 }


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/10204

Prevents the create activity from being unassigned:
![Screenshot from 2024-07-25 14-01-57](https://github.com/user-attachments/assets/8165452e-7431-4706-acd0-f95020a03704)
