### PR TITLE
Automatically verify expenses submitted with a draft-key

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1820,7 +1820,7 @@ export async function submitExpenseDraft(
   }
 
   const userIsOriginalPayee: boolean = Boolean(originalPayee) && req.remoteUser?.isAdminOfCollective(originalPayee);
-  const userIsAuthor = Boolean(req.remoteUser) && req.remoteUser?.id === existingExpense.UserId;
+  const userIsAuthor = Boolean(req.remoteUser) && req.remoteUser.id === existingExpense.UserId;
   if (existingExpense.data?.draftKey !== args.draftKey && !userIsOriginalPayee && !userIsAuthor) {
     throw new Unauthorized('You need to submit the right draft key to edit this expense');
   }


### PR DESCRIPTION
If the invited user is submitting the expense with the correct key and the same email the creator of the draft used to invite the payee, therefore we can consider the access to the email was already verified and the expense can move straight to the PENDING status.