### PR TITLE
typescript: Convert payment utils

### DIFF
--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -101,6 +101,9 @@ export type TransactionData = {
   taxMigration?: string;
   taxRemovedFromMigration?: Tax;
   transfer?: Transfer;
+  transaction?: Record<string, unknown>; // This field is used by `persistVirtualCardTransaction` to store the provider's transaction data
+  id?: string; // Up to 2021-06-08, this field was used to store the external IDs of virtual card transactions
+  token?: string; // Up to 2021-11-19, this field was used to store the external IDs of privacy.com transactions
 };
 
 class Transaction extends Model<InferAttributes<Transaction>, InferCreationAttributes<Transaction>> {

--- a/server/paymentProviders/stripe/virtual-cards.ts
+++ b/server/paymentProviders/stripe/virtual-cards.ts
@@ -14,7 +14,7 @@ import { reportMessageToSentry } from '../../lib/sentry';
 import stripe, { convertToStripeAmount, StripeCustomToken } from '../../lib/stripe';
 import models from '../../models';
 import VirtualCard from '../../models/VirtualCard';
-import { getOrCreateVendor, getVirtualCardForTransaction, persistTransaction } from '../utils';
+import { getOrCreateVendor, getVirtualCardForTransaction, persistVirtualCardTransaction } from '../utils';
 
 export const assignCardToCollective = async (cardNumber, expiryDate, cvv, name, collectiveId, host, userId) => {
   const stripe = await getStripeClient(host);
@@ -285,7 +285,7 @@ export const processTransaction = async (stripeTransaction: Stripe.Issuing.Trans
   const isRefund = stripeTransaction.type === 'refund';
   const clearedAt = moment.unix(stripeTransaction.created).toDate();
 
-  return persistTransaction(virtualCard, {
+  return persistVirtualCardTransaction(virtualCard, {
     id: stripeTransaction.id,
     amount,
     currency,

--- a/server/paymentProviders/utils.ts
+++ b/server/paymentProviders/utils.ts
@@ -43,7 +43,7 @@ export const notifyCollectiveMissingReceipt = async (expense, virtualCard) => {
   );
 };
 
-export const persistTransaction = async (virtualCard, transaction) => {
+export const persistVirtualCardTransaction = async (virtualCard, transaction) => {
   // Make sure amount is an absolute value
   const amount = Math.abs(transaction.amount);
 
@@ -174,10 +174,12 @@ export const persistTransaction = async (virtualCard, transaction) => {
       });
       if (originalCreditTransaction?.amount === amount) {
         if (!originalCreditTransaction.RefundTransactionId) {
-          await createRefundTransaction(originalCreditTransaction, 0, {
-            refundTransactionId: transactionId,
-            transaction,
-          });
+          await createRefundTransaction(
+            originalCreditTransaction,
+            0,
+            { refundTransactionId: transactionId, transaction },
+            null,
+          );
         }
         return;
       }


### PR DESCRIPTION
Extracted from https://github.com/opencollective/opencollective-api/pull/10249 for cleaner diff

Side-note: it would be great if `persistVirtualCardTransaction` would use more explicit names, storing provider IDs in `data.id`, `data.token` is a bit too generic.