### PR TITLE
enhancement(Collectives): handle images misuse

### DIFF
--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -21,7 +21,7 @@ import { md5 } from './utils';
 
 const { USER } = CollectiveType;
 
-type AvatarUrlOpts = {
+type ImageUrlOpts = {
   height?: boolean;
   format?: string;
 };
@@ -39,7 +39,7 @@ export const getCollectiveAvatarUrl = (
   collectiveSlug: string,
   collectiveType: CollectiveType,
   image: string,
-  args: AvatarUrlOpts,
+  args: ImageUrlOpts = {},
 ): string => {
   const sections = [config.host.images, collectiveSlug];
 
@@ -54,6 +54,37 @@ export const getCollectiveAvatarUrl = (
   }
 
   return `${sections.join('/')}.${args.format || 'png'}`;
+};
+
+export const getCollectiveBackgroundImageUrl = (
+  backgroundImage: string,
+  collectiveSlug: string,
+  args: ImageUrlOpts = {},
+) => {
+  if (!backgroundImage) {
+    return null;
+  }
+
+  const sections = [config.host.images, collectiveSlug];
+
+  sections.push(md5(backgroundImage).substring(0, 7));
+
+  sections.push('background');
+
+  if (args.height) {
+    sections.push(args.height);
+  }
+
+  // Re-use original image format if supported, default to png otherwise
+  let format = args.format;
+  if (!format) {
+    format = backgroundImage.split('.').pop();
+    if (!['jpg', 'png'].includes(format)) {
+      format = 'png';
+    }
+  }
+
+  return `${sections.join('/')}.${format}`;
 };
 
 export const COLLECTIVE_SETTINGS_KEYS_LIST = [

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import config from 'config';
 import { repeat } from 'lodash';
 import moment from 'moment';
 import { createSandbox } from 'sinon';
@@ -326,6 +327,35 @@ describe('server/models/Collective', () => {
         const collective = await fakeCollective({ image: invalidImage }, { validate: false });
         await collective.update({ image: invalidImage, name: 'New Name' });
       });
+
+      it('tolerates passing an URL from the image service if it is the same as the current one', async () => {
+        const collective = await fakeCollective({ image: validImage });
+        const imageUrl = collective.getImageUrl();
+        expect(imageUrl).to.not.equal(validImage);
+        expect(imageUrl).to.satisfy(url => url.startsWith(config.host.images));
+        await collective.update({ image: imageUrl });
+        expect(collective.image).to.equal(validImage); // Not updated
+      });
+
+      it('tolerates passing an URL from the image service if only the extension differs', async () => {
+        const collective = await fakeCollective({ image: validImage });
+        const imageUrl = collective.getImageUrl();
+        const newImageUrl = imageUrl.replace(/\.png$/, '.jpg');
+        expect(newImageUrl).to.not.equal(imageUrl);
+        await collective.update({ image: newImageUrl });
+        expect(collective.image).to.equal(validImage); // Not updated
+      });
+
+      it('throws if passing an URL from the image service if it is different from the current one', async () => {
+        const collective = await fakeCollective({ image: validImage });
+        const imageUrl = collective.getImageUrl(); // Looks like https://images-staging.opencollective.com/collective-e948b928/3a3b411/logo.png
+        const newImageUrlSplit = imageUrl.split('/');
+        newImageUrlSplit[newImageUrlSplit.length - 2] = 'different-hash';
+        await expect(collective.update({ image: newImageUrlSplit.join('/') })).to.be.rejectedWith(
+          Error,
+          'Validation error: The image URL is not valid',
+        );
+      });
     });
 
     describe('backgroundImage', () => {
@@ -365,6 +395,35 @@ describe('server/models/Collective', () => {
       it('does not re-validate the URL if it has not changed', async () => {
         const collective = await fakeCollective({ backgroundImage: invalidImage }, { validate: false });
         await collective.update({ backgroundImage: invalidImage, name: 'New Name' });
+      });
+
+      it('tolerates passing an URL from the image service if it is the same as the current one', async () => {
+        const collective = await fakeCollective({ backgroundImage: validImage });
+        const backgroundImageUrl = collective.getBackgroundImageUrl();
+        expect(backgroundImageUrl).to.not.equal(validImage);
+        expect(backgroundImageUrl).to.satisfy(url => url.startsWith(config.host.images));
+        await collective.update({ backgroundImage: backgroundImageUrl });
+        expect(collective.backgroundImage).to.equal(validImage); // Not updated
+      });
+
+      it('tolerates passing an URL from the image service if only the extension differs', async () => {
+        const collective = await fakeCollective({ backgroundImage: validImage });
+        const backgroundImageUrl = collective.getBackgroundImageUrl();
+        const newBackgroundImageUrl = backgroundImageUrl.replace(/\.jpg$/, '.png');
+        expect(newBackgroundImageUrl).to.not.equal(backgroundImageUrl);
+        await collective.update({ backgroundImage: newBackgroundImageUrl });
+        expect(collective.backgroundImage).to.equal(validImage); // Not updated
+      });
+
+      it('throws if passing an URL from the image service if it is different from the current one', async () => {
+        const collective = await fakeCollective({ backgroundImage: validImage });
+        const backgroundImageUrl = collective.getBackgroundImageUrl(); // Looks like https://images-staging.opencollective.com/collective-e948b928/3a3b411/logo.png
+        const newBackgroundImageUrlSplit = backgroundImageUrl.split('/');
+        newBackgroundImageUrlSplit[newBackgroundImageUrlSplit.length - 2] = 'different-hash';
+        await expect(collective.update({ backgroundImage: newBackgroundImageUrlSplit.join('/') })).to.be.rejectedWith(
+          Error,
+          'Validation error: The background image URL is not valid',
+        );
       });
     });
   });


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/7545 by ignoring the input when the frontend does something like this:

```ts
// We're trying to update `image`, but `imageUrl` contains the image service proxy URL,
// not the image URL itself.
updateVendorMutation({
  variables: { id: vendor.id, image: vendor.imageUrl },
})
```