### PR TITLE
Add correct host application id index and use it in query

### DIFF
--- a/migrations/20240923080750-fix-index-to-comments-hostapplications.js
+++ b/migrations/20240923080750-fix-index-to-comments-hostapplications.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('Comments', ['HostApplicationId']);
+    await queryInterface.addIndex('Comments', ['HostApplicationId', 'createdAt'], {
+      concurrently: true,
+      where: {
+        HostApplicationId: { [Sequelize.Op.ne]: null },
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('Comments', ['HostApplicationId', 'createdAt']);
+    await queryInterface.addIndex('Comments', ['HostApplicationId'], {
+      concurrently: true,
+      where: {
+        HostApplicationId: { [Sequelize.Op.ne]: null },
+      },
+    });
+  },
+};

--- a/server/graphql/v2/object/Host.js
+++ b/server/graphql/v2/object/Host.js
@@ -696,7 +696,7 @@ export const GraphQLHost = new GraphQLObjectType({
             if (CollectiveIds.length) {
               conditions.push(
                 sequelize.literal(
-                  `(SELECT "FromCollectiveId" FROM "Comments" WHERE "Comments"."HostApplicationId" = "HostApplication"."id" ORDER BY "id" DESC LIMIT 1)
+                  `(SELECT "FromCollectiveId" FROM "Comments" WHERE "Comments"."HostApplicationId" = "HostApplication"."id" ORDER BY "Comments"."createdAt" DESC LIMIT 1)
                     IN (
                       SELECT "MemberCollectiveId" FROM "Members" WHERE
                       "role" = 'ADMIN' AND "deletedAt" IS NULL AND


### PR DESCRIPTION
The select subquery was sorting on the wrong field + it should be explicit order on createdAt.

Before
```
                                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=169541.62..169541.63 rows=11 width=2257)
   ->  Sort  (cost=169541.62..169541.63 rows=11 width=2257)
         Sort Key: "HostApplication"."createdAt" DESC
         ->  Hash Join  (cost=4683.86..169541.58 rows=11 width=2257)
               Hash Cond: ("HostApplication"."CollectiveId" = collective.id)
               ->  Index Scan using host_applications__host_collective_id on "HostApplications" "HostApplication"  (cost=0.06..164855.91 rows=3546 width=588)
                     Index Cond: ("HostCollectiveId" = 11004)
                     Filter: (("deletedAt" IS NULL) AND (SubPlan 2))
                     SubPlan 1tive.id",
                       ->  Limit  (cost=0.06..15.42 rows=1 width=8)
                             ->  Index Scan Backward using "Comments_pkey" on "Comments"  (cost=0.06..9049.42 rows=589 width=8)
                                   Filter: ("HostApplicationId" = "HostApplication".id)
                     SubPlan 2"collective.legalName",
                       ->  Index Scan using members__collective_id_role on "Members"  (cost=0.08..14.37 rows=7 width=4)
                             Index Cond: (("CollectiveId" = "HostApplication"."CollectiveId") AND ((role)::text = 'ADMIN'::text))
               ->  Hash  (cost=4674.30..4674.30 rows=2717 width=1669)",
                     ->  Bitmap Heap Scan on "Collectives" collective  (cost=14.30..4674.30 rows=2717 width=1669)
                           Recheck Cond: (("HostCollectiveId" = 11004) AND ("deletedAt" IS NULL))
                           ->  Bitmap Index Scan on collectives__host_collective_id  (cost=0.00..14.16 rows=2717 width=0)
                                 Index Cond: ("HostCollectiveId" = 11004)
```

After
```
                                                                      QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=18.01..18.01 rows=1 width=2257)
   ->  Sort  (cost=18.01..18.01 rows=1 width=2257)
         Sort Key: "HostApplication"."createdAt" DESC
         ->  Nested Loop  (cost=0.14..18.00 rows=1 width=2257)
               ->  Index Scan using host_applications__host_collective_id on "HostApplications" "HostApplication"  (cost=0.06..13.25 rows=1 width=588)
                     Index Cond: ("HostCollectiveId" = 8686)
                     Filter: (("deletedAt" IS NULL) AND (SubPlan 2))
                     SubPlan 1
                       ->  Limit  (cost=0.03..1.95 rows=1 width=12)
                             ->  Index Scan Backward using comments__host_application_id_test on "Comments"  (cost=0.03..1135.80 rows=589 width=12)
                                   Index Cond: ("HostApplicationId" = "HostApplication".id)
                     SubPlan 2
                       ->  Index Scan using members__collective_id_role on "Members"  (cost=0.08..14.37 rows=7 width=4)
                             Index Cond: (("CollectiveId" = "HostApplication"."CollectiveId") AND ((role)::text = 'ADMIN'::text))
               ->  Index Scan using "Groups_pkey" on "Collectives" collective  (cost=0.08..4.09 rows=1 width=1669)
                     Index Cond: (id = "HostApplication"."CollectiveId")
                     Filter: (("deletedAt" IS NULL) AND ("HostCollectiveId" = 8686))
```