### PR TITLE
Use collective.currency to enable Wise ott flag

### DIFF
--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -764,6 +764,7 @@ const oauth = {
       if (
         (collective.countryISO &&
           (isMemberOfTheEuropeanUnion(collective.countryISO) || ['AU', 'GB'].includes(collective.countryISO))) ||
+        ['AUD', 'DKK', 'EUR', 'GBP', 'SEK', 'USD'].includes(collective.currency) ||
         config.env === 'development'
       ) {
         const settings = collective.settings ? cloneDeep(collective.settings) : {};


### PR DESCRIPTION
This should cover the cases where new hosts do not assign a location before connecting to Wise.