### PR TITLE
Recurring contributions CRON tweaks

### DIFF
--- a/cron/hourly/00-charge-recurring-contributions.js
+++ b/cron/hourly/00-charge-recurring-contributions.js
@@ -55,6 +55,7 @@ async function run(options) {
   const { count, rows: orders } = await ordersWithPendingCharges({
     limit: options.limit,
     startDate: options.startDate,
+    limitedToOrderIds: options.orderIds,
   });
   console.log(
     `${count} recurring contributions pending charges. Charging ${orders.length} contributions right now. dryRun: ${options.dryRun}`,
@@ -179,12 +180,24 @@ function parseCommandLineArguments() {
     action: 'store_const',
     const: true,
   });
+  parser.add_argument('--orders', {
+    help: 'Comma separated list of order ids to process',
+  });
   const args = parser.parse_args();
   return {
     dryRun: args.dryrun,
     limit: args.limit,
     concurrency: args.concurrency,
     simulate: args.simulate,
+    orderIds: args.orders
+      ? args.orders.split(',').map(str => {
+          const num = Number(str);
+          if (isNaN(num)) {
+            throw new Error(`Invalid order id: ${str}`);
+          }
+          return num;
+        })
+      : undefined,
   };
 }
 /* eslint-enable camelcase */

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -28,12 +28,13 @@ export const MAX_RETRIES = 6;
  * Subscriptions are considered due if their `nextChargeDate` is
  * already past.
  */
-export async function ordersWithPendingCharges({ limit, startDate } = {}) {
+export async function ordersWithPendingCharges({ limit, startDate, limitedToOrderIds = undefined } = {}) {
   return models.Order.findAndCountAll({
     where: {
       status: { [Op.not]: status.PAUSED },
       SubscriptionId: { [Op.ne]: null },
       deletedAt: null,
+      ...(limitedToOrderIds && { id: { [Op.in]: limitedToOrderIds } }),
     },
     order: [
       ['createdAt', 'ASC'],

--- a/server/lib/recurring-contributions.js
+++ b/server/lib/recurring-contributions.js
@@ -35,6 +35,10 @@ export async function ordersWithPendingCharges({ limit, startDate } = {}) {
       SubscriptionId: { [Op.ne]: null },
       deletedAt: null,
     },
+    order: [
+      ['createdAt', 'ASC'],
+      ['id', 'ASC'],
+    ],
     limit: limit,
     include: [
       { model: models.User, as: 'createdByUser' },


### PR DESCRIPTION
- process in predictable order by sorting the orders on `createdAt`/`id`
- add the ability to limit the CRON job to some manually provided order IDs, helpful to test some limited scenarios