### PR TITLE
fix(Updates): only return for acively hosted collectives

### DIFF
--- a/server/graphql/v2/query/collection/UpdatesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/UpdatesCollectionQuery.ts
@@ -54,7 +54,7 @@ const UpdatesCollectionQuery = {
       };
       if (args.host) {
         const hostCollectiveIds = await fetchAccountsIdsWithReference(args.host);
-        include.where = { ...include.where, HostCollectiveId: hostCollectiveIds };
+        include.where = { ...include.where, HostCollectiveId: hostCollectiveIds, approvedAt: { [Op.ne]: null } };
       }
       if (args.accountTag) {
         include.where = { ...include.where, tags: { [Op.overlap]: args.accountTag } };


### PR DESCRIPTION
A small fix as we're currently showing updates for not-yet approved collectives on https://discover.opencollective.com/:

![image](https://github.com/user-attachments/assets/abe1e272-daef-4236-93ce-fbd9381a4aa7)
