### PR TITLE
Add new GraphQL Goal object and resolver on Account.goal

### DIFF
--- a/server/constants/goal-types.ts
+++ b/server/constants/goal-types.ts
@@ -1,0 +1,14 @@
+/**
+ * Constants for the goal type
+ *
+ */
+
+enum GoalTypes {
+  ALL_TIME = 'ALL_TIME',
+  MONTHLY_BUDGET = 'MONTHLY_BUDGET',
+  YEARLY_BUDGET = 'YEARLY_BUDGET',
+  CALENDAR_MONTH = 'CALENDAR_MONTH',
+  CALENDAR_YEAR = 'CALENDAR_YEAR',
+}
+
+export default GoalTypes;

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -991,6 +991,21 @@ interface Account {
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
 }
 
 """
@@ -3432,6 +3447,21 @@ type Host implements Account & AccountWithContributions {
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -6305,14 +6335,24 @@ enum GoalType {
   ALL_TIME
 
   """
-  Contributions per month
+  Active yearly contributions (divided by 12), active monthly contributions and one-time contributions in the past 30 days
   """
-  MONTHLY
+  MONTHLY_BUDGET
 
   """
-  Contributions per year
+  Active yearly contributions , active monthly contributions (times 12) and one-time contributions in the past 365 days
   """
-  YEARLY
+  YEARLY_BUDGET
+
+  """
+  Contributions in the current calendar month
+  """
+  CALENDAR_MONTH
+
+  """
+  Contributions in the current calendar year
+  """
+  CALENDAR_YEAR
 }
 
 """
@@ -8464,6 +8504,21 @@ type Bot implements Account {
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -9312,6 +9367,21 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -10613,6 +10683,21 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -11694,6 +11779,21 @@ type Individual implements Account {
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -12748,6 +12848,21 @@ type Organization implements Account & AccountWithContributions {
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -13693,6 +13808,21 @@ type Vendor implements Account & AccountWithContributions {
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -17270,6 +17400,21 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -18231,6 +18376,21 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
   goal: Goal
+  activeContributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+    forGoalType: GoalType
+    dateFrom: DateTime
+    dateTo: DateTime
+    includeActiveRecurringContributions: Boolean
+  ): AccountCollection
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -990,6 +990,7 @@ interface Account {
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
 }
 
 """
@@ -3430,6 +3431,7 @@ type Host implements Account & AccountWithContributions {
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -6265,6 +6267,54 @@ type TransactionsAmountGroup {
   expenseType: ExpenseType
 }
 
+type Goal {
+  """
+  The type of the goal (per month, per year or all time)
+  """
+  type: GoalType
+
+  """
+  The amount of the goal
+  """
+  amount: Amount
+
+  """
+  The progress of the goal in percentage
+  """
+  progress: Int
+  contributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int! = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int! = 0
+  ): AccountCollection
+}
+
+"""
+All supported goal types
+"""
+enum GoalType {
+  """
+  Total contributions
+  """
+  ALL_TIME
+
+  """
+  Contributions per month
+  """
+  MONTHLY
+
+  """
+  Contributions per year
+  """
+  YEARLY
+}
+
 """
 A collection of webhooks
 """
@@ -8413,6 +8463,7 @@ type Bot implements Account {
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -9260,6 +9311,7 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -10560,6 +10612,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -11640,6 +11693,7 @@ type Individual implements Account {
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -12693,6 +12747,7 @@ type Organization implements Account & AccountWithContributions {
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -13637,6 +13692,7 @@ type Vendor implements Account & AccountWithContributions {
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -17213,6 +17269,7 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -18173,6 +18230,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
   EXPERIMENTAL (this may change or be removed)
   """
   transactionReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): TransactionReports
+  goal: Goal
   webhooks(
     """
     The number of results to fetch (default 10, max 1000)
@@ -19209,6 +19267,18 @@ type Mutation {
     """
     emailConfirmationToken: String!
   ): ConfirmGuestAccountResponse!
+
+  """
+  Set a goal for your account.
+  """
+  setGoal(
+    account: AccountReferenceInput!
+
+    """
+    The goal to set for the account. Setting goal to undefined or null will remove any current goal.
+    """
+    goal: GoalInput
+  ): Goal
 
   """
   Apply to an host with a collective. Scope: "account".
@@ -21477,6 +21547,14 @@ type ConfirmGuestAccountResponse {
   A token that can be used to sign in
   """
   accessToken: String!
+}
+
+"""
+Input type for Goals
+"""
+input GoalInput {
+  type: GoalType!
+  amount: Int!
 }
 
 type ProcessHostApplicationResponse {

--- a/server/graphql/v2/enum/GoalType.ts
+++ b/server/graphql/v2/enum/GoalType.ts
@@ -1,0 +1,27 @@
+import { GraphQLEnumType } from 'graphql';
+
+import goalType from '../../../constants/goal-types';
+
+export const GraphQLGoalType = new GraphQLEnumType({
+  name: 'GoalType',
+  description: 'All supported goal types',
+  values: {
+    [goalType.ALL_TIME]: {
+      description: 'Total contributions',
+    },
+    [goalType.MONTHLY_BUDGET]: {
+      description:
+        'Active yearly contributions (divided by 12), active monthly contributions and one-time contributions in the past 30 days',
+    },
+    [goalType.YEARLY_BUDGET]: {
+      description:
+        'Active yearly contributions , active monthly contributions (times 12) and one-time contributions in the past 365 days',
+    },
+    [goalType.CALENDAR_MONTH]: {
+      description: 'Contributions in the current calendar month',
+    },
+    [goalType.CALENDAR_YEAR]: {
+      description: 'Contributions in the current calendar year',
+    },
+  },
+});

--- a/server/graphql/v2/input/GoalInput.ts
+++ b/server/graphql/v2/input/GoalInput.ts
@@ -1,0 +1,12 @@
+import { GraphQLInputObjectType, GraphQLInt, GraphQLNonNull } from 'graphql';
+
+import { GraphQLGoalType } from '../enum/GoalType';
+
+export const GraphQLGoalInput = new GraphQLInputObjectType({
+  name: 'GoalInput',
+  description: 'Input type for Goals',
+  fields: () => ({
+    type: { type: new GraphQLNonNull(GraphQLGoalType) },
+    amount: { type: new GraphQLNonNull(GraphQLInt) },
+  }),
+});

--- a/server/graphql/v2/mutation/GoalMutations.ts
+++ b/server/graphql/v2/mutation/GoalMutations.ts
@@ -1,0 +1,72 @@
+import { GraphQLNonNull } from 'graphql';
+import { cloneDeep, set } from 'lodash';
+
+import activities from '../../../constants/activities';
+import models, { sequelize } from '../../../models';
+import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
+import { Forbidden, Unauthorized } from '../../errors';
+import { fetchAccountWithReference, GraphQLAccountReferenceInput } from '../input/AccountReferenceInput';
+import { GraphQLGoalInput } from '../input/GoalInput';
+import { GraphQLGoal } from '../object/Goal';
+
+const goalMutations = {
+  setGoal: {
+    type: GraphQLGoal,
+    description: 'Set a goal for your account.',
+    args: {
+      account: {
+        type: new GraphQLNonNull(GraphQLAccountReferenceInput),
+      },
+      goal: {
+        type: GraphQLGoalInput,
+        description: 'The goal to set for the account. Setting goal to undefined or null will remove any current goal.',
+      },
+    },
+    async resolve(_: void, args: Record<string, unknown>, req: Express.Request): Promise<typeof GraphQLGoal> {
+      if (!req.remoteUser) {
+        throw new Unauthorized();
+      }
+
+      return sequelize.transaction(async transaction => {
+        const account = await fetchAccountWithReference(args.account, {
+          throwIfMissing: true,
+          lock: true,
+          dbTransaction: transaction,
+        });
+
+        if (!req.remoteUser.isAdminOfCollective(account)) {
+          throw new Forbidden();
+        }
+
+        checkRemoteUserCanUseAccount(req);
+
+        const settings = account.settings ? cloneDeep(account.settings) : {};
+        set(settings, 'goal', args.goal);
+        // Remove legacy goals
+        set(settings, 'goals', undefined);
+        const previousData = {
+          settings: { goal: account.settings?.goal, ...(account.settings?.goals && { goals: account.settings.goals }) },
+        };
+        const updatedAccount = await account.update({ settings }, { transaction });
+        await models.Activity.create(
+          {
+            type: activities.COLLECTIVE_EDITED,
+            UserId: req.remoteUser.id,
+            UserTokenId: req.userToken?.id,
+            CollectiveId: account.id,
+            FromCollectiveId: account.id,
+            HostCollectiveId: account.approvedAt ? account.HostCollectiveId : null,
+            data: {
+              previousData,
+              newData: { settings: { goal: args.goal } },
+            },
+          },
+          { transaction },
+        );
+        return updatedAccount.settings.goal;
+      });
+    },
+  },
+};
+
+export default goalMutations;

--- a/server/graphql/v2/mutation/index.js
+++ b/server/graphql/v2/mutation/index.js
@@ -15,6 +15,7 @@ import createProjectMutation from './CreateProjectMutation';
 import emojiReactionMutations from './EmojiReactionMutations';
 import expenseMutations from './ExpenseMutations';
 import guestMutations from './GuestMutations';
+import goalMutations from './GoalMutations';
 import hostApplicationMutations from './HostApplicationMutations';
 import individualMutations from './IndividualMutations';
 import { legalDocumentsMutations } from './LegalDocumentsMutations';
@@ -55,6 +56,7 @@ const mutation = {
   ...emojiReactionMutations,
   ...expenseMutations,
   ...guestMutations,
+  ...goalMutations,
   ...hostApplicationMutations,
   ...individualMutations,
   ...legalDocumentsMutations,

--- a/server/graphql/v2/object/Goal.ts
+++ b/server/graphql/v2/object/Goal.ts
@@ -1,0 +1,89 @@
+import { GraphQLInt, GraphQLObjectType } from 'graphql';
+import moment from 'moment';
+
+import models, { sequelize } from '../../../models';
+import { GraphQLAccountCollection } from '../collection/AccountCollection';
+import { GraphQLGoalType } from '../enum/GoalType';
+import { CollectionArgs } from '../interface/Collection';
+
+import { GraphQLAmount } from './Amount';
+import GoalTypes from '../../../constants/goal-types';
+
+export const GraphQLGoal = new GraphQLObjectType({
+  name: 'Goal',
+  fields: () => ({
+    type: {
+      type: GraphQLGoalType,
+      description: 'The type of the goal (per month, per year or all time)',
+    },
+    amount: {
+      type: GraphQLAmount,
+      description: 'The amount of the goal',
+    },
+    progress: {
+      type: GraphQLInt,
+      description: 'The progress of the goal in percentage',
+    },
+    contributors: {
+      type: GraphQLAccountCollection,
+      args: CollectionArgs,
+      async resolve(goal, args) {
+        const collectiveIdsResult = await sequelize.query(
+          `WITH "CollectiveDonations" AS (
+            SELECT 
+              "Orders"."FromCollectiveId",
+              SUM("Transactions".amount) AS total_donated
+            FROM "Orders"
+            JOIN "Transactions" ON "Transactions"."OrderId" = "Orders".id
+            WHERE "Orders"."CollectiveId" = :accountId
+              AND (
+                ("Orders".status = 'ACTIVE' AND "Orders".interval IN ('month', 'year'))
+                OR ("Orders".status = 'PAID' ${[GoalTypes.MONTHLY_BUDGET, GoalTypes.YEARLY_BUDGET].includes(goal.type) ? 'AND "Orders"."createdAt" >= :dateFrom' : ''})
+              )
+              AND "Transactions".type = 'CREDIT'
+              AND "Transactions"."CollectiveId" = :accountId
+              AND "Transactions"."FromCollectiveId" = "Orders"."FromCollectiveId"
+              AND "Transactions"."isRefund" = FALSE
+              AND "Transactions"."RefundTransactionId" IS NULL
+              AND "Transactions"."deletedAt" IS NULL
+              AND "Orders"."deletedAt" IS NULL
+            GROUP BY "Orders"."FromCollectiveId"
+          )
+          SELECT "Collectives".id
+          FROM "Collectives"
+          JOIN "CollectiveDonations" ON "Collectives".id = "CollectiveDonations"."FromCollectiveId"
+          WHERE "Collectives"."deletedAt" IS NULL
+          ORDER BY "CollectiveDonations".total_donated DESC;
+          `,
+          {
+            replacements: {
+              accountId: goal.accountId,
+              dateFrom: [GoalTypes.MONTHLY_BUDGET, GoalTypes.YEARLY_BUDGET].includes(goal.type)
+                ? moment().utc().subtract(1, 'year').toDate().toISOString()
+                : undefined,
+            },
+            type: sequelize.QueryTypes.SELECT,
+          },
+        );
+
+        const collectiveIds = collectiveIdsResult.map(result => result.id);
+
+        const collectives = await models.Collective.findAll({
+          where: {
+            id: collectiveIds,
+          },
+          order: [['id', 'DESC']], // To maintain the order of total donations
+          offset: args.offset,
+          limit: args.limit,
+        });
+
+        return {
+          totalCount: collectiveIdsResult.length,
+          nodes: collectives,
+          limit: args.limit,
+          offset: args.offset,
+        };
+      },
+    },
+  }),
+});

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -133,8 +133,13 @@ import VirtualCard from './VirtualCard';
 
 const debug = debugLib('models:Collective');
 
-type Goal = {
+type LegacyGoal = {
   type: string;
+  amount: number;
+};
+
+type Goal = {
+  type: 'YEARLY' | 'MONTHLY' | 'ALL_TIME';
   amount: number;
 };
 
@@ -146,7 +151,8 @@ type TaxSettings = {
 };
 
 type Settings = {
-  goals?: Array<Goal>;
+  goals?: Array<LegacyGoal>;
+  goal?: Goal;
   disablePublicExpenseSubmission?: boolean;
   isPlatformRevenueDirectlyCollected?: boolean;
   features?: {
@@ -577,7 +583,7 @@ class Collective extends Model<
    * Used for the monthly reports to backers
    */
   getNextGoal = async function (until) {
-    const goals = <Array<Goal>>get(this, 'settings.goals');
+    const goals = <Array<LegacyGoal>>get(this, 'settings.goals');
     if (!goals) {
       return null;
     }


### PR DESCRIPTION
Project: https://github.com/opencollective/opencollective/issues/7605

### Todo
- [x] Add Goal GraphQL object and resolver on `account.goal`
- [ ] Add `account.getMonthlyBudget()` to calculate monthly goal progress instead of using `yearlyBudget/12`?
- [ ] Add `setGoal` mutation