### PR TITLE
Don't include PAYMENT_PROCESSOR_FEE in expense tag stats

### DIFF
--- a/server/models/Expense.ts
+++ b/server/models/Expense.ts
@@ -527,6 +527,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
         CollectiveId: { [Op.in]: collectiveIds },
         FromCollectiveId: { [Op.notIn]: collectiveIds },
         type: 'DEBIT',
+        kind: 'EXPENSE', // net=false don't include related PAYMENT_PROCESSOR_FEE
         RefundTransactionId: null,
       },
     ];
@@ -594,6 +595,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
         CollectiveId: { [Op.in]: collectiveIds },
         FromCollectiveId: { [Op.notIn]: collectiveIds },
         type: 'DEBIT',
+        kind: 'EXPENSE', // net=false don't include related PAYMENT_PROCESSOR_FEE
         RefundTransactionId: null,
       },
     ];

--- a/test/server/models/Expense.test.js
+++ b/test/server/models/Expense.test.js
@@ -137,9 +137,9 @@ describe('test/server/models/Expense', () => {
       const tags = await Expense.getCollectiveExpensesTags(collective);
 
       expect(tags).to.deep.eq([
-        { label: 'team', count: 3, amount: 1470, currency: 'USD' },
-        { label: 'office', count: 1, amount: 840, currency: 'USD' },
-        { label: 'food', count: 2, amount: 630, currency: 'USD' },
+        { label: 'team', count: 3, amount: 1400, currency: 'USD' },
+        { label: 'office', count: 1, amount: 800, currency: 'USD' },
+        { label: 'food', count: 2, amount: 600, currency: 'USD' },
       ]);
     });
 
@@ -149,8 +149,8 @@ describe('test/server/models/Expense', () => {
       });
 
       expect(tags).to.deep.eq([
-        { label: 'food', count: 2, amount: 630, currency: 'USD' },
-        { label: 'team', count: 2, amount: 630, currency: 'USD' },
+        { label: 'food', count: 2, amount: 600, currency: 'USD' },
+        { label: 'team', count: 2, amount: 600, currency: 'USD' },
       ]);
     });
 
@@ -162,42 +162,42 @@ describe('test/server/models/Expense', () => {
           date: moment.utc().subtract(1, 'days').startOf('day').toDate(),
           label: 'food',
           count: 1,
-          amount: 210,
+          amount: 200,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(1, 'days').startOf('day').toDate(),
           label: 'team',
           count: 1,
-          amount: 210,
+          amount: 200,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(2, 'days').startOf('day').toDate(),
           label: 'food',
           count: 1,
-          amount: 420,
+          amount: 400,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(2, 'days').startOf('day').toDate(),
           label: 'team',
           count: 1,
-          amount: 420,
+          amount: 400,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(3, 'days').startOf('day').toDate(),
           label: 'office',
           count: 1,
-          amount: 840,
+          amount: 800,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(3, 'days').startOf('day').toDate(),
           label: 'team',
           count: 1,
-          amount: 840,
+          amount: 800,
           currency: 'USD',
         },
       ]);
@@ -213,28 +213,28 @@ describe('test/server/models/Expense', () => {
           date: moment.utc().subtract(1, 'days').startOf('day').toDate(),
           label: 'food',
           count: 1,
-          amount: 210,
+          amount: 200,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(1, 'days').startOf('day').toDate(),
           label: 'team',
           count: 1,
-          amount: 210,
+          amount: 200,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(2, 'days').startOf('day').toDate(),
           label: 'food',
           count: 1,
-          amount: 420,
+          amount: 400,
           currency: 'USD',
         },
         {
           date: moment.utc().subtract(2, 'days').startOf('day').toDate(),
           label: 'team',
           count: 1,
-          amount: 420,
+          amount: 400,
           currency: 'USD',
         },
       ]);


### PR DESCRIPTION
It's mostly used in the new budget view and we agreed that those stats should be before fees.