### PR TITLE
fix(Expense): chargeHasReceipts performance

### DIFF
--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -293,17 +293,16 @@ export const ExpensesCollectionQueryResolver = async (
   }
 
   if (!isNil(args.chargeHasReceipts)) {
-    where[Op.and].push({
-      [Op.or]: [
-        { type: { [Op.ne]: ExpenseType.CHARGE } },
-        sequelize.where(
-          sequelize.literal(`
-                 NOT EXISTS (SELECT id from "ExpenseItems" ei where ei."ExpenseId" = "Expense".id and ei.url IS NULL)`),
-          Op.eq,
-          args.chargeHasReceipts,
+    where[Op.and].push(
+      { type: ExpenseType.CHARGE },
+      sequelize.where(
+        sequelize.literal(
+          `NOT EXISTS (SELECT id from "ExpenseItems" ei WHERE ei."ExpenseId" = "Expense".id and ei.url IS NULL AND ei."deletedAt" IS NULL)`,
         ),
-      ],
-    });
+        Op.eq,
+        args.chargeHasReceipts,
+      ),
+    );
   }
 
   if (!isEmpty(args.virtualCards)) {


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/7637

The performance fix is to look at `deletedAt` to make sure the query is able to use the index. I haven't looked at the potential gain of moving that to a join (rather than a subquery) but it should at least solve the existing timeout.
