### PR TITLE
debt: Delete 'collective.transaction.created' activities

### DIFF
--- a/migrations/20241115090522-delete-transactions-created-activities.js
+++ b/migrations/20241115090522-delete-transactions-created-activities.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DELETE FROM "Activities"
+      WHERE "type" = 'collective.transaction.created'
+    `);
+  },
+
+  async down() {
+    console.log('This migration is irreversible, but a backup has been made.');
+  },
+};


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/7162
This should be safe to do after the changes made in https://github.com/opencollective/opencollective-api/pull/9825.

To do before release:
- [x] Make a backup of prod data
- [x] Check performance against a real dump


Backup queries:

```sql
-- Batch 1: 0 to 1,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 0
AND id <= 1000000;

-- Batch 2: 1,000,001 to 2,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 1000001
AND id <= 2000000;

-- Batch 3: 2,000,001 to 3,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 2000001
AND id <= 3000000;

-- Batch 4: 3,000,001 to 4,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 3000001
AND id <= 4000000;

-- Batch 5: 4,000,001 to 5,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 4000001
AND id <= 5000000;

-- Batch 6: 5,000,001 to 6,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 5000001
AND id <= 6000000;

-- Batch 7: 6,000,001 to 7,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 6000001
AND id <= 7000000;

-- Batch 8: 7,000,001 to 8,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 7000001
AND id <= 8000000;

-- Batch 9: 8,000,001 to 9,000,000
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 8000001
AND id <= 9000000;

-- Final Batch: 9,000,001 onwards
SELECT *
FROM "Activities"
WHERE type = 'collective.transaction.created'
AND id >= 9000001
```