### PR TITLE
test: Improve stability for email checks

### DIFF
--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -55,6 +55,7 @@ import {
   seedDefaultVendors,
   snapshotTransactions,
   waitForCondition,
+  waitForEmail,
 } from '../../../../utils';
 
 const SECRET_KEY = config.dbEncryption.secretKey;
@@ -1983,11 +1984,11 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         expect(expense.data.items[0].description).to.equal('Item 1');
         expect(expense.data.payee).to.contain({ email: 'test@email.com', name: 'test' });
 
-        await waitForCondition(() => emailSendMessageSpy.callCount > 0);
-        expect(emailSendMessageSpy).calledWith(
-          'test@email.com',
-          'An expense you were invited to submit has been updated',
-        );
+        await waitForEmail(emailSendMessageSpy, [
+          { to: 'test@email.com' },
+          { subject: 'An expense you were invited to submit has been updated' },
+          { html: `/expenses/${expense.id}`, op: 'contains' },
+        ]);
       });
 
       it('invited external user can decline DRAFT expense invite', async () => {

--- a/test/server/models/TransactionSettlement.test.ts
+++ b/test/server/models/TransactionSettlement.test.ts
@@ -174,7 +174,7 @@ describe('server/models/TransactionSettlement', () => {
   it('1. getHostDebts returns all debts for host', async () => {
     const debts = await TransactionSettlement.getHostDebts(host.id);
     await utils.preloadAssociationsForTransactions(debts, SNAPSHOT_COLUMNS);
-    utils.snapshotTransactions(debts, { columns: SNAPSHOT_COLUMNS, loadAssociations: true });
+    utils.snapshotTransactions(debts, { columns: SNAPSHOT_COLUMNS });
   });
 
   it('2. updateTransactionsSettlementStatus updates statuses selectively', async () => {
@@ -186,13 +186,13 @@ describe('server/models/TransactionSettlement', () => {
 
     const updatedDebts = await TransactionSettlement.getHostDebts(host.id);
     await utils.preloadAssociationsForTransactions(updatedDebts, SNAPSHOT_COLUMNS);
-    utils.snapshotTransactions(updatedDebts, { columns: SNAPSHOT_COLUMNS, loadAssociations: true });
+    utils.snapshotTransactions(updatedDebts, { columns: SNAPSHOT_COLUMNS });
   });
 
   it('3. getHostDebts can then filter by settlement status', async () => {
     const debts = await TransactionSettlement.getHostDebts(host.id, TransactionSettlementStatus.OWED);
     await utils.preloadAssociationsForTransactions(debts, SNAPSHOT_COLUMNS);
-    utils.snapshotTransactions(debts, { columns: SNAPSHOT_COLUMNS, loadAssociations: true });
+    utils.snapshotTransactions(debts, { columns: SNAPSHOT_COLUMNS });
   });
 
   it('4. getAccountsWithOwedSettlements returns all accounts with OWED debts', async () => {


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/6564#issuecomment-2461648883

This helper should be more stable because the previous condition, `waitForCondition(() => emailSendMessageSpy.callCount > 0);` that we use in many places can be validated for other reasons: an email from a previous test being sent out late, for example.

**Usage:**

```es6
// Wait for email sent to test@opencollective.com with subject 'Hello'
await waitForEmail(emailSendMessageSpy, { to: 'test@opencollective.com', subject: 'Hello' });

// Wait for email sent to test@opencollective.com where html contains 'Hello'
await waitForEmail(emailSendMessageSpy, [
  { to: 'test@opencollective.com' },
  { html: 'Hello', op: 'contains' }
]);
```