### PR TITLE
Performance: Contributions Dashboard

### DIFF
--- a/migrations/20241129153622-index-order-created-at.js
+++ b/migrations/20241129153622-index-order-created-at.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS orders_created_at ON "Orders" ("createdAt" DESC) WHERE ("deletedAt" IS NULL);
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "orders_created_at";
+    `);
+  },
+};


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/7696

It turns out, we can optimize the Contributions Dashboard query by adding an index for the order clause.
Before index: https://www.pgexplain.dev/plan/3413977b-7d8f-4fcc-bd7d-de64a4dcd25b
After index: https://www.pgexplain.dev/plan/9fb3d821-1a7e-4a20-845b-c180f5bc1ff4