### PR TITLE
fix(Search): add support for restoring missing/undeleted entries

### DIFF
--- a/scripts/search.ts
+++ b/scripts/search.ts
@@ -10,6 +10,7 @@ import {
   createElasticSearchIndex,
   deleteElasticSearchIndex,
   getAvailableElasticSearchIndexes,
+  restoreUndeletedEntries,
   syncElasticSearchIndex,
 } from '../server/lib/elastic-search/sync';
 import logger from '../server/lib/logger';
@@ -105,6 +106,23 @@ program
       }
       logger.info('Re-index completed!');
     }
+  });
+
+// Restore undeleted entries
+program
+  .command('restore')
+  .description('Restore undeleted entries')
+  .argument('[indexes...]', 'Only sync specific indexes')
+  .action(async indexesInput => {
+    checkElasticSearchAvailable();
+
+    const indexes = parseIndexesFromInput(indexesInput);
+    for (const indexName of indexes) {
+      logger.info(`Restoring undeleted entries for index ${indexName}`);
+      await restoreUndeletedEntries(indexName as ElasticSearchIndexName, { log: true });
+    }
+
+    logger.info('Restore completed!');
   });
 
 // Sync command

--- a/server/lib/elastic-search/adapters/ElasticSearchCollectivesAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchCollectivesAdapter.ts
@@ -31,19 +31,24 @@ export class ElasticSearchCollectivesAdapter implements ElasticSearchModelAdapte
   } as const;
 
   public async findEntriesToIndex(
-    offset: number,
-    limit: number,
-    options: { fromDate: Date; firstReturnedId: number },
+    options: {
+      offset?: number;
+      limit?: number;
+      fromDate?: Date;
+      maxId?: number;
+      ids?: number[];
+    } = {},
   ): Promise<Array<InstanceType<typeof models.Collective>>> {
     return models.Collective.findAll({
       attributes: Object.keys(this.mappings.properties),
       order: [['id', 'DESC']],
-      limit,
-      offset,
+      limit: options.limit,
+      offset: options.offset,
       raw: true,
       where: {
         ...(options.fromDate ? { updatedAt: options.fromDate } : null),
-        ...(options.firstReturnedId ? { id: { [Op.lte]: options.firstReturnedId } } : null),
+        ...(options.maxId ? { id: { [Op.lte]: options.maxId } } : null),
+        ...(options.ids?.length ? { id: { [Op.in]: options.ids } } : null),
       },
     });
   }

--- a/server/lib/elastic-search/adapters/ElasticSearchExpensesAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchExpensesAdapter.ts
@@ -33,15 +33,24 @@ export class ElasticSearchExpensesAdapter implements ElasticSearchModelAdapter {
     },
   } as const;
 
-  public findEntriesToIndex(offset: number, limit: number, options: { fromDate: Date; firstReturnedId: number }) {
+  public findEntriesToIndex(
+    options: {
+      offset?: number;
+      limit?: number;
+      fromDate?: Date;
+      maxId?: number;
+      ids?: number[];
+    } = {},
+  ) {
     return models.Expense.findAll({
       attributes: omit(Object.keys(this.mappings.properties), ['ParentCollectiveId']),
       order: [['id', 'DESC']],
-      offset,
-      limit,
+      limit: options.limit,
+      offset: options.offset,
       where: {
         ...(options.fromDate ? { updatedAt: options.fromDate } : null),
-        ...(options.firstReturnedId ? { id: { [Op.lte]: options.firstReturnedId } } : null),
+        ...(options.maxId ? { id: { [Op.lte]: options.maxId } } : null),
+        ...(options.ids?.length ? { id: { [Op.in]: options.ids } } : null),
       },
       include: [
         {

--- a/server/lib/elastic-search/adapters/ElasticSearchHostApplicationsAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchHostApplicationsAdapter.ts
@@ -24,15 +24,24 @@ export class ElasticSearchHostApplicationsAdapter implements ElasticSearchModelA
     },
   } as const;
 
-  public findEntriesToIndex(offset: number, limit: number, options: { fromDate: Date; firstReturnedId: number }) {
+  public findEntriesToIndex(
+    options: {
+      offset?: number;
+      limit?: number;
+      fromDate?: Date;
+      maxId?: number;
+      ids?: number[];
+    } = {},
+  ) {
     return models.HostApplication.findAll({
       attributes: omit(Object.keys(this.mappings.properties), ['ParentCollectiveId']),
       order: [['id', 'DESC']],
-      offset,
-      limit,
+      limit: options.limit,
+      offset: options.offset,
       where: {
         ...(options.fromDate ? { updatedAt: options.fromDate } : null),
-        ...(options.firstReturnedId ? { id: { [Op.lte]: options.firstReturnedId } } : null),
+        ...(options.maxId ? { id: { [Op.lte]: options.maxId } } : null),
+        ...(options.ids?.length ? { id: { [Op.in]: options.ids } } : null),
       },
       include: [
         {

--- a/server/lib/elastic-search/adapters/ElasticSearchModelAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchModelAdapter.ts
@@ -19,11 +19,13 @@ export interface ElasticSearchModelAdapter {
   readonly settings?: IndicesIndexSettings;
 
   /** Returns the attributes that `mapModelInstanceToDocument` needs to build the document */
-  findEntriesToIndex(
-    offset: number,
-    limit: number,
-    options: { fromDate: Date; firstReturnedId: number },
-  ): Promise<Array<InstanceType<ModelType>>>;
+  findEntriesToIndex(options?: {
+    offset?: number;
+    limit?: number;
+    fromDate?: Date;
+    maxId?: number;
+    ids?: number[];
+  }): Promise<Array<InstanceType<ModelType>>>;
 
   /** Maps a model instance to an ElasticSearch document */
   mapModelInstanceToDocument(

--- a/server/lib/elastic-search/adapters/ElasticSearchOrdersAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchOrdersAdapter.ts
@@ -24,15 +24,24 @@ export class ElasticSearchOrdersAdapter implements ElasticSearchModelAdapter {
     },
   } as const;
 
-  public findEntriesToIndex(offset: number, limit: number, options: { fromDate: Date; firstReturnedId: number }) {
+  public findEntriesToIndex(
+    options: {
+      offset?: number;
+      limit?: number;
+      fromDate?: Date;
+      maxId?: number;
+      ids?: number[];
+    } = {},
+  ) {
     return models.Order.findAll({
       attributes: omit(Object.keys(this.mappings.properties), ['HostCollectiveId', 'ParentCollectiveId']),
       order: [['id', 'DESC']],
-      offset,
-      limit,
+      limit: options.limit,
+      offset: options.offset,
       where: {
         ...(options.fromDate ? { updatedAt: options.fromDate } : null),
-        ...(options.firstReturnedId ? { id: { [Op.lte]: options.firstReturnedId } } : null),
+        ...(options.maxId ? { id: { [Op.lte]: options.maxId } } : null),
+        ...(options.ids?.length ? { id: { [Op.in]: options.ids } } : null),
       },
       include: [
         {

--- a/server/lib/elastic-search/adapters/ElasticSearchTiersAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchTiersAdapter.ts
@@ -28,15 +28,24 @@ export class ElasticSearchTiersAdapter implements ElasticSearchModelAdapter {
     },
   } as const;
 
-  public findEntriesToIndex(offset: number, limit: number, options: { fromDate: Date; firstReturnedId: number }) {
+  public findEntriesToIndex(
+    options: {
+      offset?: number;
+      limit?: number;
+      fromDate?: Date;
+      maxId?: number;
+      ids?: number[];
+    } = {},
+  ) {
     return models.Tier.findAll({
       attributes: omit(Object.keys(this.mappings.properties), ['HostCollectiveId', 'ParentCollectiveId']),
       order: [['id', 'DESC']],
-      offset,
-      limit,
+      limit: options.limit,
+      offset: options.offset,
       where: {
         ...(options.fromDate ? { updatedAt: options.fromDate } : null),
-        ...(options.firstReturnedId ? { id: { [Op.lte]: options.firstReturnedId } } : null),
+        ...(options.maxId ? { id: { [Op.lte]: options.maxId } } : null),
+        ...(options.ids?.length ? { id: { [Op.in]: options.ids } } : null),
       },
       include: [
         {

--- a/server/lib/elastic-search/adapters/ElasticSearchTransactionsAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchTransactionsAdapter.ts
@@ -28,15 +28,24 @@ export class ElasticSearchTransactionsAdapter implements ElasticSearchModelAdapt
     },
   } as const;
 
-  public findEntriesToIndex(offset: number, limit: number, options: { fromDate: Date; firstReturnedId: number }) {
+  public findEntriesToIndex(
+    options: {
+      offset?: number;
+      limit?: number;
+      fromDate?: Date;
+      maxId?: number;
+      ids?: number[];
+    } = {},
+  ) {
     return models.Transaction.findAll({
       attributes: omit(Object.keys(this.mappings.properties), ['merchantId']),
       order: [['id', 'DESC']],
-      offset,
-      limit,
+      limit: options.limit,
+      offset: options.offset,
       where: {
         ...(options.fromDate ? { updatedAt: options.fromDate } : null),
-        ...(options.firstReturnedId ? { id: { [Op.lte]: options.firstReturnedId } } : null),
+        ...(options.maxId ? { id: { [Op.lte]: options.maxId } } : null),
+        ...(options.ids?.length ? { id: { [Op.in]: options.ids } } : null),
       },
     });
   }

--- a/server/lib/elastic-search/adapters/ElasticSearchUpdatesAdapter.ts
+++ b/server/lib/elastic-search/adapters/ElasticSearchUpdatesAdapter.ts
@@ -29,15 +29,24 @@ export class ElasticSearchUpdatesAdapter implements ElasticSearchModelAdapter {
     },
   } as const;
 
-  public findEntriesToIndex(offset: number, limit: number, options: { fromDate: Date; firstReturnedId: number }) {
+  public findEntriesToIndex(
+    options: {
+      offset?: number;
+      limit?: number;
+      fromDate?: Date;
+      maxId?: number;
+      ids?: number[];
+    } = {},
+  ) {
     return models.Update.findAll({
       attributes: omit(Object.keys(this.mappings.properties), ['HostCollectiveId', 'ParentCollectiveId']),
       order: [['id', 'DESC']],
-      offset,
-      limit,
+      limit: options.limit,
+      offset: options.offset,
       where: {
         ...(options.fromDate ? { updatedAt: options.fromDate } : null),
-        ...(options.firstReturnedId ? { id: { [Op.lte]: options.firstReturnedId } } : null),
+        ...(options.maxId ? { id: { [Op.lte]: options.maxId } } : null),
+        ...(options.ids?.length ? { id: { [Op.in]: options.ids } } : null),
       },
       include: [
         {

--- a/server/models/Comment.ts
+++ b/server/models/Comment.ts
@@ -41,6 +41,8 @@ class Comment extends Model<InferAttributes<Comment>, InferCreationAttributes<Co
 
   declare public fromCollective?: NonAttribute<Collective>;
   declare public collective?: NonAttribute<Collective>;
+  declare public expense?: NonAttribute<Expense>;
+  declare public hostApplication?: NonAttribute<HostApplication>;
 
   // Returns the User model of the User that created this Update
   getUser = function () {

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -165,6 +165,8 @@ Comment.belongsTo(Collective, { foreignKey: 'FromCollectiveId', as: 'fromCollect
 Comment.belongsTo(Expense, { foreignKey: 'ExpenseId', as: 'expense' });
 Comment.belongsTo(HostApplication, { foreignKey: 'HostApplicationId', as: 'hostApplication' });
 Comment.belongsTo(Update, { foreignKey: 'UpdateId', as: 'update' });
+Comment.belongsTo(Order, { foreignKey: 'OrderId', as: 'order' });
+Comment.belongsTo(Conversation, { foreignKey: 'ConversationId', as: 'conversation' });
 Comment.belongsTo(User, { foreignKey: 'CreatedByUserId', as: 'user' });
 
 // ConnectedAccount


### PR DESCRIPTION
Adds the `npm run script scripts/search.ts restore <indexName>` command to look for entries that are missing from ElasticSearch. This could happen for two reasons:
1. Because we previously missed it in synchronization jobs
2. Because `deletedAt` was manually set to `NULL` directly in the DB

Also made some improvements to the options names.