### PR TITLE
test: Only trigger scripts usage check when ran directly

### DIFF
--- a/scripts/ledger/split-payment-processor-fees.ts
+++ b/scripts/ledger/split-payment-processor-fees.ts
@@ -6,11 +6,6 @@ import models, { Op, sequelize } from '../../server/models';
 
 const startDate = process.env.START_DATE ? new Date(process.env.START_DATE) : new Date('2024-01-01');
 
-if (process.argv.length < 3) {
-  console.error('Usage: ./scripts/ledger/split-payment-processor-fees.ts migrate|rollback|check (rollbackTimestamp)');
-  process.exit(1);
-}
-
 const getTransactionsToMigrateQuery = `
   SELECT *
   FROM "Transactions" t
@@ -219,6 +214,11 @@ export const main = async (command: Command, additionalParameters = undefined) =
 };
 
 if (!module.parent) {
+  if (process.argv.length < 3) {
+    console.error('Usage: ./scripts/ledger/split-payment-processor-fees.ts migrate|rollback|check (rollbackTimestamp)');
+    process.exit(1);
+  }
+
   main(process.argv[2] as Command, process.argv.slice(2))
     .then(() => process.exit())
     .catch(e => {

--- a/scripts/ledger/split-taxes.ts
+++ b/scripts/ledger/split-taxes.ts
@@ -7,11 +7,6 @@ import models, { Op, sequelize } from '../../server/models';
 
 const startDate = process.env.START_DATE ? new Date(process.env.START_DATE) : new Date('2024-01-01');
 
-if (process.argv.length < 3) {
-  console.error('Usage: ./scripts/ledger/split-taxes.ts migrate|rollback|check (rollbackTimestamp)');
-  process.exit(1);
-}
-
 const getTransactionsToMigrateQuery = `
   SELECT *
   FROM "Transactions" t
@@ -231,6 +226,11 @@ export const main = async (command: Command, additionalParameters = undefined) =
 };
 
 if (!module.parent) {
+  if (process.argv.length < 3) {
+    console.error('Usage: ./scripts/ledger/split-taxes.ts migrate|rollback|check (rollbackTimestamp)');
+    process.exit(1);
+  }
+
   main(process.argv[2] as Command, process.argv.slice(2))
     .then(() => process.exit())
     .catch(e => {


### PR DESCRIPTION
The `npm run test` command ran alone was not working because of this.