### PR TITLE
debt(Activities): rename old "group.*" types

### DIFF
--- a/migrations/20241219102146-legacy-activity-types-migrate.ts
+++ b/migrations/20241219102146-legacy-activity-types-migrate.ts
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * As of 2024-12-19, the database holds 24840 activities like:
+ * - group.created
+ * - group.expense.approved
+ * - group.expense.created
+ * - group.expense.paid
+ * - group.expense.rejected
+ * - group.expense.updated
+ * - group.transaction.created
+ * - group.transaction.paid
+ * - group.user.added
+ *
+ * These types were renamed in migrations/archives/201707140000-GroupToCollective.js for Notifications, but
+ * the activities were not migrated.
+ *
+ * @type {import('sequelize-cli').Migration}
+ */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE "Activities"
+      SET
+        type = REPLACE(type, 'group.', 'collective.'),
+        data = jsonb_set(COALESCE(data, '{}'), '{migratedFrom20241219102146}', '"true"')
+      WHERE type like 'group.%'
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE "Activities"
+      SET type = REPLACE(type, 'collective.', 'group.')
+      WHERE type like 'collective.%'
+      AND data->>'migratedFrom20241219102146' = 'true'
+    `);
+  },
+};


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/920.

The database holds 24840 activities like:
- group.created
- group.expense.approved
- group.expense.created
- group.expense.paid
- group.expense.rejected
- group.expense.updated
- group.transaction.created
- group.transaction.paid
- group.user.added

These types were renamed in https://github.com/opencollective/opencollective-api/pull/920/files#diff-7320b55f7e6f679dc9b16ffcd19cddce2712200ce73d96453a8b5184427b41b1 for Notifications, but
the activities have not been migrated.