### PR TITLE
perf: add index for current collective transaction stats

### DIFF
--- a/migrations/20241029071652-collective-transaction-stats-fixes.js
+++ b/migrations/20241029071652-collective-transaction-stats-fixes.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * /!\ When updating `CurrentCollectiveTransactionStats`, remember to also update `CurrentCollectiveTransactionStatsIndex`.
+ */
+
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface) {

--- a/migrations/20241230092547-current-collective-transaction-stats-indexes.js
+++ b/migrations/20241230092547-current-collective-transaction-stats-indexes.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY "CurrentCollectiveTransactionStatsIndex"
+      ON "Transactions" ("CollectiveId", "createdAt")
+      WHERE "deletedAt" IS NULL
+      AND "RefundTransactionId" IS NULL
+      AND ("isRefund" IS NOT TRUE OR "kind" = 'PAYMENT_PROCESSOR_COVER')
+      AND "isInternal" IS NOT TRUE
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY "CurrentCollectiveTransactionStatsIndex"
+    `);
+  },
+};


### PR DESCRIPTION
For https://open-collective.sentry.io/issues/6182121042

Before: https://explain.dalibo.com/plan/4b1fc7g3f6g44g8d
