### PR TITLE
enhancement(search): add min_score to query

### DIFF
--- a/server/lib/elastic-search/search.ts
+++ b/server/lib/elastic-search/search.ts
@@ -214,6 +214,7 @@ export const elasticSearchGlobalSearch = async (
       body: {
         size: 0, // We don't need hits at the top level
         query,
+        min_score: 0.0001, // Ignore results that fulfill the accounts criteria but don't match the search term
         // Aggregate results by index, keeping only `limit` top hits per index
         aggs: {
           by_index: {


### PR DESCRIPTION
This is to filter out items that fulfill the account criteria but don't match the search term. These are returned with score=0.