### PR TITLE
fix(2FA): handle malformed TOTP tokens gracefully

### DIFF
--- a/server/lib/two-factor-authentication/totp.ts
+++ b/server/lib/two-factor-authentication/totp.ts
@@ -37,11 +37,16 @@ export default {
  * twoFactorAuthenticatorCode = 6-digit TOTP
  */
 function validateTOTPToken(encryptedSecret: string, token: string): boolean {
-  const decryptedTwoFactorAuthToken = crypto.decrypt(encryptedSecret);
-  return speakeasy.totp.verify({
-    secret: decryptedTwoFactorAuthToken,
-    encoding: 'base32',
-    token: token,
-    window: 2,
-  });
+  try {
+    const decryptedTwoFactorAuthToken = crypto.decrypt(encryptedSecret);
+    return speakeasy.totp.verify({
+      secret: decryptedTwoFactorAuthToken,
+      encoding: 'base32',
+      token: token,
+      window: 2,
+    });
+  } catch {
+    // An error can be thrown if the token is malformed. We simply return false in this case.
+    return false;
+  }
 }


### PR DESCRIPTION
Fix an issue on CI tests:

```
2024-12-31T08:56:20.0759259Z   "stacktrace": "Error: Malformed UTF-8 data\n    at Object.stringify (/home/runner/work/opencollective-api/opencollective-api/node_modules/crypto-js/core.js:523:24)\n    at WordArray.init.toString (/home/runner/work/opencollective-api/opencollective-api/node_modules/crypto-js/core.js:278:38)\n    at Object.decrypt (/home/runner/work/opencollective-api/opencollective-api/server/lib/encryption.ts:73:67)\n    at validateTOTPToken (/home/runner/work/opencollective-api/opencollective-api/server/lib/two-factor-authentication/totp.ts:40:46)\n    at Object.validateToken (/home/runner/work/opencollective-api/opencollective-api/server/lib/two-factor-authentication/totp.ts:24:21)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at validateRequest (/home/runner/work/opencollective-api/opencollective-api/server/lib/two-factor-authentication/lib.ts:227:3)\n    at Object.download (/home/runner/work/opencollective-api/opencollective-api/server/controllers/legal-documents.ts:91:7)\n    at Context.<anonymous> (/home/runner/work/opencollective-api/opencollective-api/test/server/controllers/legal-documents.test.ts:227:9)"
2024-12-31T08:56:20.0763741Z })
2024-12-31T09:01:28.4292244Z   1) server/controllers/legal-documents
2024-12-31T09:01:28.4292744Z        download
2024-12-31T09:01:28.4293157Z          with the right permissions
2024-12-31T09:01:28.4293673Z            should reject invalid 2FA codes:
2024-12-31T09:01:28.4294004Z 
2024-12-31T09:01:28.4294297Z       AssertionError: expected 500 to equal 401
2024-12-31T09:01:28.4294809Z       + expected - actual
2024-12-31T09:01:28.4295075Z 
2024-12-31T09:01:28.4295216Z       -500
2024-12-31T09:01:28.4295533Z       +401
2024-12-31T09:01:28.4295828Z       
2024-12-31T09:01:28.4296710Z       at Context.<anonymous> (test/server/controllers/legal-documents.test.ts:230:49)
2024-12-31T09:01:28.4297650Z       at processTicksAndRejections (node:internal/process/task_queues:95:5)
```