### PR TITLE
Perf: Collective page indexes

### DIFF
--- a/migrations/20250102080100-anual-budget-index.js
+++ b/migrations/20250102080100-anual-budget-index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY transactions__unrefunded_credits
+      ON "Transactions"("CollectiveId", kind, "createdAt")
+      WHERE "deletedAt" IS NULL
+      AND "type" = 'CREDIT'
+      AND "RefundTransactionId" IS NULL;
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY transactions__unrefunded_credits;
+    `);
+  },
+};

--- a/migrations/20250102080100-index-collective-page.js
+++ b/migrations/20250102080100-index-collective-page.js
@@ -10,11 +10,21 @@ module.exports = {
       AND "type" = 'CREDIT'
       AND "RefundTransactionId" IS NULL;
     `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY transactions__non_debt
+      ON "Transactions"("HostCollectiveId", "CollectiveId", kind)
+      WHERE "deletedAt" IS NULL AND "isDebt" = false;
+    `);
   },
 
   async down(queryInterface, Sequelize) {
     await queryInterface.sequelize.query(`
       DROP INDEX CONCURRENTLY transactions__unrefunded_credits;
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY transactions__non_debt;
     `);
   },
 };

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -440,7 +440,7 @@ export const TransactionsCollectionResolver = async (
     where.push({ OrderId: { [args.hasOrder ? Op.ne : Op.eq]: null } });
   }
   if (!args.includeDebts) {
-    where.push({ isDebt: { [Op.not]: true } });
+    where.push({ isDebt: false });
   }
   if (args.kind) {
     where.push({ kind: args.kind });


### PR DESCRIPTION
Addresses one of the worst performing resolvers in `query CollectivePage` and should help with collective page first-load performance.
