### PR TITLE
Restore foreign-key conditional

### DIFF
--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -37,7 +37,8 @@ const getJoinCondition = (
   includeHostedAccounts = false,
   includeChildrenAccounts = false,
 ): Record<string, unknown> => {
-  const field = `$${association}.id$`;
+  const associationFields = { collective: 'CollectiveId', fromCollective: 'FromCollectiveId' };
+  const field = associationFields[association] || `$${association}.id$`;
   const conditions = [{ [field]: account.id }];
 
   // Hosted accounts


### PR DESCRIPTION
It was causing some issues when exporting Contributors csv: https://studio.apollographql.com/graph/Open-Collective-GraphQL-V2/variant/Dev/insights?insightsTab=operations&query=92e6c8febd5cac6820ec778d64a1dafd0caadf92&queryName=Contributors&tab=traces&trace=Open-Collective-GraphQL-V2~2025%3A01%3A07T08%3A57~6c2f5b0ab25dbafc735c9290b98494aee8593cb7b1457cb48bde9591d3678354&traceBucket=192