### PR TITLE
enhancement(UploadedFile): default filename when downloading

### DIFF
--- a/server/controllers/files.ts
+++ b/server/controllers/files.ts
@@ -72,7 +72,7 @@ export async function getFile(req: Request, res: Response) {
     } else {
       const { bucket, key } = parseS3Url(actualUrl);
       const responseContentDisposition = isDownload
-        ? `attachment; filename="${encodeURIComponent(uploadedFile.fileName)}"`
+        ? `attachment; filename="${encodeURIComponent(uploadedFile.fileName || 'file')}"`
         : null;
       redirectUrl = await getSignedGetURL(
         { Bucket: bucket, Key: key, ResponseContentDisposition: responseContentDisposition },


### PR DESCRIPTION
Some old uploaded files don't have a filename, which downloads them as `null.pdf`.