### PR TITLE
feat(TransactionsImport): introduce ON_HOLD status on rows

### DIFF
--- a/migrations/20250117134847-add-status-to-transactions-import-row.ts
+++ b/migrations/20250117134847-add-status-to-transactions-import-row.ts
@@ -1,0 +1,38 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('TransactionsImportsRows', 'status', {
+      type: Sequelize.ENUM('LINKED', 'IGNORED', 'ON_HOLD', 'PENDING'),
+      defaultValue: 'PENDING',
+      allowNull: false,
+    });
+
+    await queryInterface.sequelize.query(`
+      UPDATE "TransactionsImportsRows"
+      SET "status" = 'IGNORED'
+      WHERE "isDismissed" = true
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE "TransactionsImportsRows"
+      SET "status" = 'LINKED'
+      WHERE "ExpenseId" IS NOT NULL
+      OR "OrderId" IS NOT NULL
+    `);
+
+    await queryInterface.removeColumn('TransactionsImportsRows', 'isDismissed');
+
+    await queryInterface.addIndex('TransactionsImportsRows', ['TransactionsImportId', 'status']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('TransactionsImportsRows', 'status');
+    await queryInterface.addColumn('TransactionsImportsRows', 'isDismissed', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+};

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1876,7 +1876,7 @@ export async function createExpense(req: express.Request, expenseData: ExpenseDa
     // Link to transactions import
     if (expenseData.transactionsImportRow) {
       await expenseData.transactionsImportRow.update(
-        { ExpenseId: createdExpense.id, isDismissed: false },
+        { ExpenseId: createdExpense.id, status: 'LINKED' },
         { transaction: t },
       );
     }

--- a/server/graphql/common/orders.ts
+++ b/server/graphql/common/orders.ts
@@ -142,7 +142,7 @@ export async function addFunds(order: AddFundsInput, remoteUser: User) {
   const orderCreated = await sequelize.transaction(async transaction => {
     const orderCreated = await models.Order.create(orderData, { transaction });
     if (order.transactionsImportRow) {
-      await order.transactionsImportRow.update({ OrderId: orderCreated.id, isDismissed: false }, { transaction });
+      await order.transactionsImportRow.update({ OrderId: orderCreated.id, status: 'LINKED' }, { transaction });
     }
     return orderCreated;
   });

--- a/server/graphql/loaders/transactions-import.ts
+++ b/server/graphql/loaders/transactions-import.ts
@@ -18,8 +18,10 @@ export const generateTransactionsImportStatsLoader = () => {
       SELECT
         row."TransactionsImportId",
         COUNT(row.id) AS total,
-        COUNT(row.id) FILTER (WHERE "isDismissed" IS TRUE OR "ExpenseId" IS NOT NULL OR "OrderId" IS NOT NULL) AS processed,
-        COUNT(row.id) FILTER (WHERE "isDismissed" IS TRUE) AS ignored,
+        COUNT(row.id) FILTER (WHERE "status" = 'IGNORED' OR "status" = 'LINKED') AS processed,
+        COUNT(row.id) FILTER (WHERE "status" = 'LINKED' AND "ExpenseId" IS NULL AND "OrderId" IS NULL) AS invalid,
+        COUNT(row.id) FILTER (WHERE "status" = 'IGNORED') AS ignored,
+        COUNT(row.id) FILTER (WHERE "status" = 'ON_HOLD') AS on_hold,
         COUNT(row.id) FILTER (WHERE "ExpenseId" IS NOT NULL) AS expenses,
         COUNT(row.id) FILTER (WHERE "OrderId" IS NOT NULL) AS orders
       FROM "TransactionsImportsRows" row
@@ -41,6 +43,8 @@ export const generateTransactionsImportStatsLoader = () => {
         expenses: result['expenses'] || 0,
         orders: result['orders'] || 0,
         processed: result['processed'] || 0,
+        onHold: result['on_hold'] || 0,
+        invalid: result['invalid'] || 0,
       };
     });
   });

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -4716,6 +4716,11 @@ enum LastCommentBy {
   HOST_ADMIN
 
   """
+  Not a Fiscal Host Admin
+  """
+  NON_HOST_ADMIN
+
+  """
   Collective Admin
   """
   COLLECTIVE_ADMIN
@@ -7166,7 +7171,12 @@ type TransactionsImportRow {
   """
   Whether the row has been dismissed
   """
-  isDismissed: Boolean!
+  isDismissed: Boolean! @deprecated(reason: "2025-01-17: isDismissed is deprecated, use status instead")
+
+  """
+  The status of the row
+  """
+  status: TransactionsImportRowStatus!
 
   """
   The description of the row
@@ -7200,11 +7210,6 @@ type TransactionsImportRow {
 }
 
 """
-The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSONObject
-
-"""
 The status of a row in a transactions import
 """
 enum TransactionsImportRowStatus {
@@ -7222,7 +7227,17 @@ enum TransactionsImportRowStatus {
   The row has been ignored
   """
   IGNORED
+
+  """
+  The row is on hold
+  """
+  ON_HOLD
 }
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject
 
 type TransactionsImportStats {
   """
@@ -7249,6 +7264,16 @@ type TransactionsImportStats {
   Number of rows that have been processed (either dismissed or converted to expenses or orders)
   """
   processed: Int!
+
+  """
+  Number of rows that are on hold
+  """
+  onHold: Int!
+
+  """
+  Number of rows that are invalid (e.g. linked but without an expense or order)
+  """
+  invalid: Int!
 }
 
 enum AccountingCategoryAppliesTo {
@@ -23117,6 +23142,11 @@ input TransactionsImportRowUpdateInput {
   The order associated with the row
   """
   order: OrderReferenceInput
+
+  """
+  The expense associated with the row
+  """
+  expense: ExpenseReferenceInput
 }
 
 """

--- a/server/graphql/v2/enum/TransactionsImportRowStatus.ts
+++ b/server/graphql/v2/enum/TransactionsImportRowStatus.ts
@@ -4,6 +4,7 @@ export enum TransactionsImportRowStatus {
   PENDING = 'PENDING',
   LINKED = 'LINKED',
   IGNORED = 'IGNORED',
+  ON_HOLD = 'ON_HOLD',
 }
 
 export const GraphQLTransactionsImportRowStatus = new GraphQLEnumType({
@@ -13,5 +14,6 @@ export const GraphQLTransactionsImportRowStatus = new GraphQLEnumType({
     PENDING: { value: 'PENDING', description: 'The row has not been processed yet' },
     LINKED: { value: 'LINKED', description: 'The row has been linked to an existing expense or order' },
     IGNORED: { value: 'IGNORED', description: 'The row has been ignored' },
-  },
+    ON_HOLD: { value: 'ON_HOLD', description: 'The row is on hold' },
+  } satisfies Record<TransactionsImportRowStatus, { value: `${TransactionsImportRowStatus}`; description: string }>,
 });

--- a/server/graphql/v2/input/ExpenseReferenceInput.ts
+++ b/server/graphql/v2/input/ExpenseReferenceInput.ts
@@ -7,7 +7,7 @@ import Expense from '../../../models/Expense';
 import { NotFound } from '../../errors';
 import { idDecode, IDENTIFIER_TYPES } from '../identifiers';
 
-interface ExpenseReferenceInputFields {
+export interface ExpenseReferenceInputFields {
   id?: string;
   legacyId?: number;
 }

--- a/server/graphql/v2/input/TransactionsImportRowUpdateInput.ts
+++ b/server/graphql/v2/input/TransactionsImportRowUpdateInput.ts
@@ -2,6 +2,7 @@ import { GraphQLBoolean, GraphQLInputObjectType, GraphQLNonNull, GraphQLString }
 import { GraphQLDateTime, GraphQLNonEmptyString } from 'graphql-scalars';
 
 import { AmountInputType, GraphQLAmountInput } from './AmountInput';
+import { ExpenseReferenceInputFields, GraphQLExpenseReferenceInput } from './ExpenseReferenceInput';
 import { GraphQLOrderReferenceInput, OrderReferenceInputGraphQLType } from './OrderReferenceInput';
 
 export type TransactionImportRowGraphQLType = {
@@ -12,6 +13,7 @@ export type TransactionImportRowGraphQLType = {
   amount?: AmountInputType | null;
   isDismissed?: boolean | null;
   order?: OrderReferenceInputGraphQLType | null;
+  expense: ExpenseReferenceInputFields | null;
 };
 
 export const GraphQLTransactionsImportRowUpdateInput = new GraphQLInputObjectType({
@@ -45,6 +47,10 @@ export const GraphQLTransactionsImportRowUpdateInput = new GraphQLInputObjectTyp
     order: {
       type: GraphQLOrderReferenceInput,
       description: 'The order associated with the row',
+    },
+    expense: {
+      type: GraphQLExpenseReferenceInput,
+      description: 'The expense associated with the row',
     },
   }),
 });

--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -669,7 +669,7 @@ const orderMutations = {
           await sequelize.transaction(async transaction => {
             await order.save({ transaction });
             if (transactionsImportRow) {
-              await transactionsImportRow.update({ OrderId: order.id, isDismissed: false }, { transaction });
+              await transactionsImportRow.update({ OrderId: order.id, status: 'LINKED' }, { transaction });
             }
           });
         }

--- a/server/graphql/v2/object/TransactionsImport.ts
+++ b/server/graphql/v2/object/TransactionsImport.ts
@@ -110,13 +110,7 @@ export const GraphQLTransactionsImport = new GraphQLObjectType({
 
         // Filter by status
         if (args.status) {
-          if (args.status === 'IGNORED') {
-            where[Op.and].push({ isDismissed: true });
-          } else if (args.status === 'LINKED') {
-            where[Op.and].push({ [Op.or]: [{ ExpenseId: { [Op.not]: null } }, { OrderId: { [Op.not]: null } }] });
-          } else if (args.status === 'PENDING') {
-            where[Op.and].push({ ExpenseId: null }, { OrderId: null }, { isDismissed: false });
-          }
+          where[Op.and].push({ status: args.status });
         }
 
         // Search term
@@ -170,6 +164,14 @@ export const GraphQLTransactionsImport = new GraphQLObjectType({
             type: new GraphQLNonNull(GraphQLInt),
             description:
               'Number of rows that have been processed (either dismissed or converted to expenses or orders)',
+          },
+          onHold: {
+            type: new GraphQLNonNull(GraphQLInt),
+            description: 'Number of rows that are on hold',
+          },
+          invalid: {
+            type: new GraphQLNonNull(GraphQLInt),
+            description: 'Number of rows that are invalid (e.g. linked but without an expense or order)',
           },
         },
       }),

--- a/server/graphql/v2/object/TransactionsImportRow.ts
+++ b/server/graphql/v2/object/TransactionsImportRow.ts
@@ -2,6 +2,7 @@ import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType, GraphQLString } from
 import { GraphQLDateTime, GraphQLJSONObject, GraphQLNonEmptyString } from 'graphql-scalars';
 
 import { TransactionsImportRow } from '../../../models';
+import { GraphQLTransactionsImportRowStatus } from '../enum/TransactionsImportRowStatus';
 import { getIdEncodeResolver } from '../identifiers';
 
 import { GraphQLAmount } from './Amount';
@@ -24,6 +25,12 @@ export const GraphQLTransactionsImportRow = new GraphQLObjectType({
     isDismissed: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'Whether the row has been dismissed',
+      deprecationReason: '2025-01-17: isDismissed is deprecated, use status instead',
+      resolve: (row: TransactionsImportRow) => row.status === 'IGNORED',
+    },
+    status: {
+      type: new GraphQLNonNull(GraphQLTransactionsImportRowStatus),
+      description: 'The status of the row',
     },
     description: {
       type: new GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7777

Also made `status` a 1st class citizen on the import.