### PR TITLE
DX: Remove annoying logs

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -223,7 +223,8 @@
     "dsn": "SENTRY_DSN",
     "tracesSampleRate": "SENTRY_TRACES_SAMPLE_RATE",
     "profilesSampleRate": "SENTRY_PROFILES_SAMPLE_RATE",
-    "minExecutionTimeToSample": "SENTRY_MIN_EXECUTION_TIME_TO_SAMPLE"
+    "minExecutionTimeToSample": "SENTRY_MIN_EXECUTION_TIME_TO_SAMPLE",
+    "logToConsole": "SENTRY_LOG_TO_CONSOLE"
   },
   "ledger": {
     "fastBalance": "LEDGER_FAST_BALANCE",

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -16,6 +16,7 @@ import { reportErrorToSentry } from './sentry';
 import { isEmailInternal, md5, sha512 } from './utils';
 
 const debug = debugLib('email');
+const isDev = config.env === 'development';
 
 type SendMessageOptions = Pick<
   nodemailer.SendMailOptions,
@@ -217,6 +218,9 @@ const sendMessage = (
             transactionName: 'emailLib.sendMessage',
             extra: { recipients, subject, html, options },
           });
+          if (isDev && err.message.includes('ECONNREFUSED')) {
+            return resolve();
+          }
           return reject(err);
         } else {
           debug('>>> mailer.sendMail success', info);

--- a/server/lib/sentry/index.ts
+++ b/server/lib/sentry/index.ts
@@ -180,7 +180,7 @@ export const reportErrorToSentry = (err: Error, params: CaptureErrorParams = {})
 
     if (checkIfSentryConfigured()) {
       Sentry.captureException(err);
-    } else {
+    } else if (config.sentry?.logToConsole) {
       logger.error(
         `[Sentry disabled] The following error would be reported: ${err.message} (${safeJsonStringify(
           {


### PR DESCRIPTION
- [x] The lack of a mailing service shouldn't break API
- [x] If you want to check Sentry logs use `SENTRY_LOG_TO_CONSOLE`