### PR TITLE
enhancement(Stripe): handle low amount error message

### DIFF
--- a/server/paymentProviders/stripe/creditcard.ts
+++ b/server/paymentProviders/stripe/creditcard.ts
@@ -194,9 +194,14 @@ export default {
         'Invalid amount.',
         'Payment Intent require action',
         'Invalid account.',
+        /^Amount must convert to at least 50 cents\./,
       ];
 
-      if (knownErrors.includes(error.message)) {
+      if (
+        knownErrors.some(knownError =>
+          typeof knownError === 'string' ? knownError === error.message : knownError.test(error.message),
+        )
+      ) {
         logger.error(
           `Stripe Error (handled): ${error.type}, Message: ${error.message}, Decline Code: ${error.decline_code}, Code: ${error.code}`,
         );


### PR DESCRIPTION
Handle stripe responses like:
> Amount must convert to at least 50 cents. ¥5 converts to approximately $0.03.