### PR TITLE
fix(migrations): out-of-memory issue with nested data

### DIFF
--- a/migrations/lib/helpers.ts
+++ b/migrations/lib/helpers.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, remove } from 'lodash';
+import { cloneDeep, merge, omit, remove } from 'lodash';
 import { QueryInterface } from 'sequelize';
 
 /**
@@ -165,4 +165,17 @@ export const renameInJSONB = (
     "${column}" #> '{${oldPathStr}}', -- Get old value
     ${createIfNotExist.toString()} -- Whether to create the new path if it doesn't exist
   )`;
+};
+
+/**
+ * Takes an object like { data: { data: {data: { key: 1 }}, key: 2, keyAlt: 3 }} and merges it into { data: { key: 2, keyAlt: 3 } }.
+ * Top level properties have priority over nested properties.
+ */
+export const mergeDataDeep = data => {
+  if (!data.data) {
+    return data;
+  } else {
+    const mergedNestedData = mergeDataDeep(data.data);
+    return merge(mergedNestedData, omit(data, 'data'));
+  }
 };

--- a/test/migrations/lib/helpers.test.ts
+++ b/test/migrations/lib/helpers.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { moveSection, removeSection } from '../../../migrations/lib/helpers';
+import { mergeDataDeep, moveSection, removeSection } from '../../../migrations/lib/helpers';
 
 describe('migrations/lib/helpers', () => {
   describe('moveSection', () => {
@@ -122,6 +122,157 @@ describe('migrations/lib/helpers', () => {
           ],
         },
       });
+    });
+  });
+
+  describe('mergeDataDeep', () => {
+    it('merges data deep', () => {
+      expect(
+        mergeDataDeep({
+          data: {
+            data: {
+              data: {
+                data: {
+                  data: {
+                    data: {
+                      data: {
+                        data: {
+                          data: {
+                            data: {
+                              policies: {
+                                EXPENSE_POLICIES: {
+                                  titlePolicy: '',
+                                  invoicePolicy: '',
+                                  receiptPolicy: '',
+                                },
+                                EXPENSE_CATEGORIZATION: {
+                                  requiredForCollectiveAdmins: true,
+                                  requiredForExpenseSubmitters: true,
+                                },
+                                EXPENSE_PUBLIC_VENDORS: false,
+                                REQUIRE_2FA_FOR_ADMINS: true,
+                                COLLECTIVE_MINIMUM_ADMINS: {
+                                  freeze: false,
+                                  applies: 'NEW_COLLECTIVES',
+                                  numberOfAdmins: 0,
+                                },
+                                COLLECTIVE_ADMINS_CAN_REFUND: true,
+                                EXPENSE_AUTHOR_CANNOT_APPROVE: {
+                                  enabled: false,
+                                  amountInCents: 0,
+                                  appliesToHostedCollectives: false,
+                                  appliesToSingleAdminCollectives: false,
+                                },
+                              },
+                            },
+                            policies: {
+                              EXPENSE_POLICIES: {
+                                titlePolicy: '',
+                                invoicePolicy: '',
+                                receiptPolicy: '',
+                              },
+                            },
+                          },
+                          policies: {
+                            EXPENSE_POLICIES: {
+                              titlePolicy: '',
+                              invoicePolicy: '',
+                              receiptPolicy: '',
+                            },
+                            REQUIRE_2FA_FOR_ADMINS: true,
+                          },
+                        },
+                        policies: {
+                          EXPENSE_POLICIES: {
+                            titlePolicy: '',
+                            invoicePolicy: '',
+                            receiptPolicy: '',
+                          },
+                        },
+                      },
+                      policies: {
+                        EXPENSE_POLICIES: {
+                          titlePolicy: '',
+                          invoicePolicy: '',
+                          receiptPolicy: '',
+                        },
+                      },
+                    },
+                    policies: {
+                      EXPENSE_POLICIES: {
+                        titlePolicy: '',
+                        invoicePolicy: '',
+                        receiptPolicy: '',
+                      },
+                    },
+                  },
+                  policies: {
+                    EXPENSE_POLICIES: {
+                      titlePolicy: '',
+                      invoicePolicy: '',
+                      receiptPolicy: '',
+                    },
+                  },
+                },
+                policies: {
+                  EXPENSE_POLICIES: {
+                    titlePolicy: '',
+                    invoicePolicy: '',
+                    receiptPolicy: '',
+                  },
+                },
+              },
+              policies: {
+                EXPENSE_POLICIES: {
+                  titlePolicy: '',
+                  invoicePolicy: '',
+                  receiptPolicy: '',
+                },
+              },
+            },
+            policies: {
+              EXPENSE_POLICIES: {
+                titlePolicy: '',
+                invoicePolicy: '',
+                receiptPolicy: '',
+              },
+            },
+          },
+          isTrustedHost: true,
+        }),
+      ).to.deep.eq({
+        isTrustedHost: true,
+        policies: {
+          EXPENSE_POLICIES: {
+            titlePolicy: '',
+            invoicePolicy: '',
+            receiptPolicy: '',
+          },
+          EXPENSE_CATEGORIZATION: {
+            requiredForCollectiveAdmins: true,
+            requiredForExpenseSubmitters: true,
+          },
+          EXPENSE_PUBLIC_VENDORS: false,
+          REQUIRE_2FA_FOR_ADMINS: true,
+          COLLECTIVE_MINIMUM_ADMINS: {
+            freeze: false,
+            applies: 'NEW_COLLECTIVES',
+            numberOfAdmins: 0,
+          },
+          COLLECTIVE_ADMINS_CAN_REFUND: true,
+          EXPENSE_AUTHOR_CANNOT_APPROVE: {
+            enabled: false,
+            amountInCents: 0,
+            appliesToHostedCollectives: false,
+            appliesToSingleAdminCollectives: false,
+          },
+        },
+      });
+    });
+
+    it('works ok with simple cases', () => {
+      expect(mergeDataDeep({ data: { key: 1 }, key: 2 })).to.deep.eq({ key: 2 });
+      expect(mergeDataDeep({ data: { key: 1 } })).to.deep.eq({ key: 1 });
     });
   });
 });


### PR DESCRIPTION
Got a deployment error with the previous version:

```
remote:        == 20250130072503-fix-nested-collecives-data: migrating =======
remote:        
remote:        ERROR: out of memory
remote:        ERROR DETAIL: Failed on request of size 576 in memory context "ExprContext".
```