### PR TITLE
enhancement: permissions for adding funds and creating pending orders

### DIFF
--- a/server/graphql/v2/mutation/OrderMutations.js
+++ b/server/graphql/v2/mutation/OrderMutations.js
@@ -1113,6 +1113,15 @@ const orderMutations = {
 
       if (!req.remoteUser?.isAdminOfCollective(host)) {
         throw new Unauthorized('Only host admins can create pending orders');
+      } else if (
+        fromAccount.HostCollectiveId !== host.id &&
+        !req.remoteUser.isRoot() &&
+        !host.data?.allowAddFundsFromAllAccounts &&
+        !host.data?.isTrustedHost
+      ) {
+        throw new Error(
+          "You don't have the permission to create pending contributions from this account. Please contact support@opencollective.com if you want to enable this.",
+        );
       }
 
       // Check accounting category

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -1599,7 +1599,7 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
     before(async () => {
       hostAdmin = await fakeUser();
       collectiveAdmin = await fakeUser();
-      host = await fakeHost({ admin: hostAdmin });
+      host = await fakeActiveHost({ admin: hostAdmin, data: { isTrustedHost: true } });
       const collective = await fakeCollective({ currency: 'USD', HostCollectiveId: host.id, admin: collectiveAdmin });
       const user = await fakeUser();
       const validAccountingCategory = await fakeAccountingCategory({ CollectiveId: host.id, kind: 'CONTRIBUTION' });
@@ -1626,6 +1626,25 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
       result = await callCreatePendingOrder({ order: validOrderPrams }, collectiveAdmin);
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.equal('Only host admins can create pending orders');
+    });
+
+    it('must be a trusted host if fromCollective and collective have different hosts', async () => {
+      const host = await fakeActiveHost({ admin: hostAdmin });
+      const collective = await fakeCollective({ currency: 'USD', HostCollectiveId: host.id, admin: collectiveAdmin });
+      const result = await callCreatePendingOrder(
+        {
+          order: {
+            ...validOrderPrams,
+            fromAccount: { legacyId: (await fakeCollective({ currency: 'USD' })).id },
+            toAccount: { legacyId: collective.id },
+          },
+        },
+        hostAdmin,
+      );
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(
+        "You don't have the permission to create pending contributions from this account. Please contact support@opencollective.com if you want to enable this.",
+      );
     });
 
     it('creates a pending order', async () => {


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/3837, https://github.com/opencollective/opencollective-security/issues/68, https://github.com/opencollective/opencollective/issues/7452

Improve authorization checks for adding funds and creating pending contributions by:
- Validating host admin permissions
- Adding checks for trusted hosts and cross-account fund additions