### PR TITLE
Dont call fixer api on e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ env:
   E2E_TEST: 1
   PGHOST: localhost
   PGUSER: opencollective
+  CYPRESS_COVERAGE: false
   CYPRESS_RECORD: false
   CYPRESS_VIDEO: false
   CYPRESS_VIDEO_UPLOAD_ON_PASSES: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,9 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+      # man-db trigger on apt install is taking some time
+      - name: Disable man-db update
+        run: sudo rm -f /var/lib/man-db/auto-update
       - name: Update apt
         run: sudo apt-get update || exit 0
 

--- a/server/lib/currency.ts
+++ b/server/lib/currency.ts
@@ -124,7 +124,7 @@ export async function fetchFxRates(
   date = getDate(date);
 
   const isFutureDate = date !== 'latest' && moment(date).isAfter(moment(), 'day'); // Fixer API is not able to fetch future rates. Ideally, this function should return null when requesting a future date.
-  const useFixerApi = Boolean(get(config, 'fixer.accessKey')) && !isFutureDate;
+  const useFixerApi = Boolean(get(config, 'fixer.accessKey')) && !isFutureDate && !process.env.E2E_TEST;
   const isLiveEnv = ['staging', 'production'].includes(config.env);
   const useMockRate = !isLiveEnv && !parseToBoolean(get(config, 'fixer.disableMock'));
 


### PR DESCRIPTION
Small optimizations to e2e runtime. 

- Fixer API is being queried with an invalid api key on e2e:

  > error: [Sentry fallback] FX Rate query issue: You have not supplied a valid API Access Key. [Technical Support: support@apilayer.com] (access_key=UNDEFINED_FIXER_ACCESS_KEY&base=BRL&symbols=USD) (undefined)

  Disabled by checking e2e environment flag, as e2e is currently executing using OC_ENV=ci and the unit/graphql tests do use the fixer client.

- man-db apt trigger is taking about a minute or so and its unnecessary 