### PR TITLE
enhancement(Plaid): better handle removed/updated

### DIFF
--- a/server/constants/activities.ts
+++ b/server/constants/activities.ts
@@ -78,6 +78,7 @@ enum ActivityTypes {
   COLLECTIVE_TRANSACTION_CREATED = 'collective.transaction.created',
   // Transactions imports
   TRANSACTIONS_IMPORT_CREATED = 'transactions.import.created',
+  TRANSACTIONS_IMPORT_ROW_UPDATED = 'transactions.import.updated',
   // Updates
   COLLECTIVE_UPDATE_CREATED = 'collective.update.created',
   COLLECTIVE_UPDATE_PUBLISHED = 'collective.update.published',

--- a/server/models/TransactionsImportRow.ts
+++ b/server/models/TransactionsImportRow.ts
@@ -6,12 +6,10 @@ import type {
   InferCreationAttributes,
 } from 'sequelize';
 
-import { SupportedCurrency } from '../constants/currencies';
 import { TransactionsImportRowStatus } from '../graphql/v2/enum/TransactionsImportRowStatus';
 import sequelize, { DataTypes, Model } from '../lib/sequelize';
 
 import Collective from './Collective';
-import CustomDataTypes from './DataTypes';
 import Expense from './Expense';
 import Order from './Order';
 import TransactionsImport from './TransactionsImport';
@@ -31,8 +29,8 @@ class TransactionsImportRow extends Model<
   declare public date: Date;
   declare public amount: number;
   declare public isUnique: boolean;
-  declare public currency: SupportedCurrency;
-  declare public rawValue: Record<string, string>;
+  declare public currency: string;
+  declare public rawValue: Record<string, unknown>;
   declare public note: string | null;
   declare public createdAt: Date;
   declare public updatedAt: Date;
@@ -100,7 +98,15 @@ TransactionsImportRow.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    currency: CustomDataTypes(DataTypes).currency,
+    currency: {
+      type: DataTypes.STRING(3),
+      allowNull: false,
+      set(val) {
+        if (val && typeof val === 'string' && val.toUpperCase) {
+          this.setDataValue('currency', val.toUpperCase());
+        }
+      },
+    },
     isUnique: {
       type: DataTypes.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
Resolve https://open-collective.sentry.io/issues/6051378561
Related to https://github.com/opencollective/opencollective/issues/7740

1. Ignore any event for removed transactions that are "pending". [We don't record](https://github.com/opencollective/opencollective/issues/7617) pending transactions, and the way Plaid moves transactions from pending to non-pending is by sending to events: "remove" then "added". We already handle the "added" part, so this should be pretty safe.
2. Keep a log in our systems in case Plaid removes a transaction that is not pending. According to Plaid docs, this can happen in a few cases that we want to handle in the future, but need to make sure there's a correct UX path for it:
   - If canceled by the bank or payment processor
   - If a transaction's details (e.g., amount, description) change significantly, Plaid treats it as a new transaction—removing the old version and adding a modified one.
3. Fully handle the "modified" event by updating our local record with the new data and creating an Activity that we'll be able to surface in the interface if needed. Sourav shared feedback that transactions were sometimes missing the reference number in their description, this change will hopefully address that.