### PR TITLE
Return exchange rate  date key with same utc date as request

### DIFF
--- a/server/lib/currency.ts
+++ b/server/lib/currency.ts
@@ -21,7 +21,7 @@ export function getDate(date: string | Date = 'latest'): string {
   if (typeof date === 'string') {
     return date;
   } else if (date.getFullYear) {
-    return moment(date).format('YYYY-MM-DD');
+    return moment(date).utc().format('YYYY-MM-DD');
   }
 }
 


### PR DESCRIPTION
Fixes an error where the exchange rate is requested in a UTC date and is returned into another UTC date by API.

![image](https://github.com/user-attachments/assets/79e25bbc-b961-4047-8394-23d07e7af89b)

![image](https://github.com/user-attachments/assets/83e28d35-ce8c-4ec7-a6de-0bdf10948b8d)
