### PR TITLE
Check payout methods not shared by the payee

### DIFF
--- a/server/lib/security/expense.ts
+++ b/server/lib/security/expense.ts
@@ -460,7 +460,7 @@ export const checkExpensesBatch = async (
         // Check if this Payout Method is being used by someone other user or collective
         const similarPayoutMethods = await expense.PayoutMethod.findSimilar({
           include: [{ model: models.Collective, attributes: ['slug'] }],
-          where: { CollectiveId: { [Op.ne]: expense.User.collective.id } },
+          where: { CollectiveId: { [Op.ne]: expense.FromCollectiveId } },
         });
         if (similarPayoutMethods) {
           addBooleanCheck(checks, similarPayoutMethods.length > 0, {


### PR DESCRIPTION
When checking for duplicated Payout Methods being potentially used by other collectives, search by ones that are not owned by the Payee instead of the User submitting the expense. This covers the cases where the user is submitting an expense on behalf of an organization.