### PR TITLE
Ignore duplicate payout methods if they belong to a vendor

### DIFF
--- a/server/lib/security/expense.ts
+++ b/server/lib/security/expense.ts
@@ -2,6 +2,7 @@ import type { Request } from 'express';
 import { capitalize, compact, filter, find, first, isEqual, isNil, keyBy, max, startCase, uniq, uniqBy } from 'lodash';
 import moment from 'moment';
 
+import { CollectiveType } from '../../constants/collectives';
 import { SupportedCurrency } from '../../constants/currencies';
 import status from '../../constants/expense-status';
 import expenseType from '../../constants/expense-type';
@@ -459,7 +460,14 @@ export const checkExpensesBatch = async (
 
         // Check if this Payout Method is being used by someone other user or collective
         const similarPayoutMethods = await expense.PayoutMethod.findSimilar({
-          include: [{ model: models.Collective, attributes: ['slug'] }],
+          include: [
+            {
+              model: models.Collective,
+              where: { type: { [Op.ne]: CollectiveType.VENDOR } },
+              attributes: ['slug'],
+              required: true,
+            },
+          ],
           where: { CollectiveId: { [Op.ne]: expense.FromCollectiveId } },
         });
         if (similarPayoutMethods) {

--- a/test/server/lib/security/expense.test.ts.snap
+++ b/test/server/lib/security/expense.test.ts.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/security/expense checkExpense() and checkExpenses() ignores payout method check of VENDORs 1`] = `
+"
+| scope         | level  | message                                           |
+| ------------- | ------ | ------------------------------------------------- |
+| USER          | MEDIUM | User is not using 2FA                             |
+| USER          | MEDIUM | User has never been paid on the platform          |
+| PAYOUT_METHOD | MEDIUM | Payout Method has never been paid on the platform |"
+`;
+
+exports[`lib/security/expense checkExpense() and checkExpenses() ignores similar payout methods that belong to VENDORs 1`] = `
+"
+| scope         | level  | message                                           |
+| ------------- | ------ | ------------------------------------------------- |
+| USER          | MEDIUM | User is not using 2FA                             |
+| USER          | MEDIUM | User has never been paid on the platform          |
+| PAYOUT_METHOD | MEDIUM | Payout Method has never been paid on the platform |"
+`;
+
+exports[`lib/security/expense checkExpense() and checkExpenses() ignores similar payout methods that belongs to VENDORs 1`] = `
+"
+| scope         | level  | message                                           |
+| ------------- | ------ | ------------------------------------------------- |
+| USER          | MEDIUM | User is not using 2FA                             |
+| USER          | MEDIUM | User has never been paid on the platform          |
+| PAYOUT_METHOD | MEDIUM | Payout Method has never been paid on the platform |"
+`;
+
 exports[`lib/security/expense checkExpense() and checkExpenses() returns potential threats related to the expense payment (batch) 1`] = `
 "
 | scope         | level  | message                                                          |


### PR DESCRIPTION
Vendors are created and managed by Fiscal Hosts and it is OK to have multiple vendors pointing to the same account.