### PR TITLE
Add performance conditional to getCollectivesJoinCondition

### DIFF
--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -43,7 +43,11 @@ const getCollectivesJoinCondition = (
   limitToHostedAccounts?: Collective[],
 ): Record<string, unknown> => {
   const associationFields = { collective: 'CollectiveId', fromCollective: 'FromCollectiveId' };
-  const field = associationFields[association] || `$${association}.id$`;
+  const field =
+    // Foreign Key columns should only be used in isolation. When querying for associated data, it is more performant to also query for the associated id
+    associationFields[association] && !includeChildrenAccounts && !(includeHostedAccounts && account.isHostAccount)
+      ? associationFields[association]
+      : `$${association}.id$`;
   const limitToHostedAccountsIds = limitToHostedAccounts?.map(a => a.id) || [];
   const allTopAccountIds = uniq([account.id, ...limitToHostedAccountsIds]);
   let conditions = [{ [field]: allTopAccountIds }];


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/7871

Plan: https://explain.dalibo.com/plan/c2dfad06ca8ch5ag

The issue with this particular query was that `getCollectivesJoinCondition` would end up generating a query that would mix filtering the same information from both Order and Collective tables.
Making we're querying information from the same place makes this query much more performant, something I mistakenly addressed in the past by removing associatedFields altogether.

This is the end result we have in this particular Incomming Contributions case:
```diff
-("Order"."CollectiveId" IN (11004) OR "collective"."ParentCollectiveId" IN (11004))
+("collective"."id" IN (11004) OR "collective"."ParentCollectiveId" IN (11004))
```