### PR TITLE
Fix: Undefined PayoutMethod in Expense dashboard

### DIFF
--- a/server/graphql/v2/mutation/PayoutMethodMutations.ts
+++ b/server/graphql/v2/mutation/PayoutMethodMutations.ts
@@ -95,7 +95,7 @@ const payoutMethodMutations = {
         throw new Forbidden();
       }
 
-      if (await payoutMethod.canBeEditedOrDeleted()) {
+      if (await payoutMethod.canBeDeleted()) {
         await payoutMethod.destroy();
         return payoutMethod;
       } else {
@@ -146,7 +146,7 @@ const payoutMethodMutations = {
       // Enforce 2FA
       await twoFactorAuthLib.enforceForAccount(req, collective);
 
-      if (await payoutMethod.canBeEditedOrDeleted()) {
+      if (await payoutMethod.canBeEdited()) {
         return await payoutMethod.update({
           ...pick(args.payoutMethod, ['name', 'data', 'isSaved']),
           CollectiveId: collective.id,

--- a/server/graphql/v2/object/PayoutMethod.ts
+++ b/server/graphql/v2/object/PayoutMethod.ts
@@ -66,16 +66,31 @@ const GraphQLPayoutMethod = new GraphQLObjectType({
         }
       },
     },
-    canBeEditedOrDeleted: {
+    canBeEdited: {
       type: GraphQLBoolean,
-      description: 'Whether this payout method can be edit or deleted',
+      description: 'Whether this payout method can be edited',
       resolve: async (payoutMethod: PayoutMethod, _, req: express.Request): Promise<boolean> => {
         if (!req.remoteUser) {
           return false;
         }
         const collective = await req.loaders.Collective.byId.load(payoutMethod.CollectiveId);
         if (req.remoteUser?.isAdminOfCollective(collective)) {
-          return payoutMethod.canBeEditedOrDeleted();
+          return payoutMethod.canBeEdited();
+        } else {
+          return false;
+        }
+      },
+    },
+    canBeDeleted: {
+      type: GraphQLBoolean,
+      description: 'Whether this payout method can be deleted or only archived',
+      resolve: async (payoutMethod: PayoutMethod, _, req: express.Request): Promise<boolean> => {
+        if (!req.remoteUser) {
+          return false;
+        }
+        const collective = await req.loaders.Collective.byId.load(payoutMethod.CollectiveId);
+        if (req.remoteUser?.isAdminOfCollective(collective)) {
+          return payoutMethod.canBeDeleted();
         } else {
           return false;
         }

--- a/server/models/PayoutMethod.ts
+++ b/server/models/PayoutMethod.ts
@@ -214,7 +214,7 @@ class PayoutMethod extends Model<InferAttributes<PayoutMethod>, InferCreationAtt
     }
   }
 
-  async canBeEditedOrDeleted(): Promise<boolean> {
+  async canBeEdited(): Promise<boolean> {
     const expenses = await (sequelize.models.Expense as typeof Expense).findOne({
       where: {
         PayoutMethodId: this.id,
@@ -226,6 +226,16 @@ class PayoutMethod extends Model<InferAttributes<PayoutMethod>, InferCreationAtt
             ExpenseStatuses.REJECTED,
           ],
         },
+      },
+    });
+
+    return !expenses;
+  }
+
+  async canBeDeleted(): Promise<boolean> {
+    const expenses = await (sequelize.models.Expense as typeof Expense).findOne({
+      where: {
+        PayoutMethodId: this.id,
       },
     });
 

--- a/test/server/models/PayoutMethod.test.js
+++ b/test/server/models/PayoutMethod.test.js
@@ -157,16 +157,29 @@ describe('server/models/PayoutMethod', () => {
     });
   });
 
-  describe('canBeEditedOrDeleted', () => {
-    it(`returns false for a payout method is attached to an expense`, async () => {
+  describe('canBeEdited', () => {
+    it(`returns false for a payout method is attached to an approved or paid expense`, async () => {
       const pm = await fakePayoutMethod();
-      await fakeExpense({ CollectiveId: pm.CollectiveId, PayoutMethodId: pm.id, status: 'APPROVED' });
-      expect(await pm.canBeEditedOrDeleted()).to.be.false;
+      await fakeExpense({ CollectiveId: pm.CollectiveId, PayoutMethodId: pm.id, status: 'PAID' });
+      expect(await pm.canBeEdited()).to.be.false;
     });
 
     it('returns true for a payout method that is not attached to any expenses', async () => {
       const pm = await fakePayoutMethod();
-      expect(await pm.canBeEditedOrDeleted()).to.be.true;
+      expect(await pm.canBeEdited()).to.be.true;
+    });
+  });
+
+  describe('canBeDeleted', () => {
+    it(`returns false for a payout method is attached to any expense`, async () => {
+      const pm = await fakePayoutMethod();
+      await fakeExpense({ CollectiveId: pm.CollectiveId, PayoutMethodId: pm.id });
+      expect(await pm.canBeDeleted()).to.be.false;
+    });
+
+    it('returns true for a payout method that is not attached to any expenses', async () => {
+      const pm = await fakePayoutMethod();
+      expect(await pm.canBeDeleted()).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Requires https://github.com/opencollective/opencollective-frontend/pull/11183.

Fixes the issue with expenses missing deleted PayoutMethods in the fiscal host Expense dashboard.