### PR TITLE
enhancement(Expense): only auto-approve vendor on host profile

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -2020,10 +2020,13 @@ export async function createExpense(
   }
 
   let status = statuses.PENDING;
+
+  // Auto-approve expenses for host vendor expenses if the user is admin of both the vendor and the host
   if (
     remoteUser.isAdminOfCollectiveOrHost(collective) &&
     remoteUser.isAdminOfCollective(fromCollective) &&
-    fromCollective.type === CollectiveType.VENDOR
+    fromCollective.type === CollectiveType.VENDOR &&
+    collective.isHostAccount
   ) {
     status = statuses.APPROVED;
   }


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/10797
Following feedback from https://oficonsortium.slack.com/archives/GFH4N961L/p1745829012979379

> Hi, it appears that there is an automatic approval of all expenses submitted by a fiscal host using the vendor feature?
> While it is brilliant to have an expense approved when we use vendors to submit to our fiscal host, by no means it should be automatically approved when we use vendors to submit expenses for a collective.