### PR TITLE
feat(Move expense): Add mutation to move expenses within the same Collective

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -100,7 +100,7 @@ import { getValueInCentsFromAmountInput } from '../v2/input/AmountInput';
 import { GraphQLCurrencyExchangeRateInputType } from '../v2/input/CurrencyExchangeRateInput';
 
 import { getContextPermission, PERMISSION_TYPE } from './context-permissions';
-import { checkRemoteUserCanRoot, checkScope } from './scope-check';
+import { checkScope } from './scope-check';
 import { hasProtectedUrlPermission } from './uploaded-file';
 
 const debug = debugLib('expenses');
@@ -3907,12 +3907,11 @@ export const getExpenseAmountInDifferentCurrency = async (expense: Expense, toCu
 };
 
 /**
+ * DANGER: This function needs pre-authorization and permissions checks
  * Move expenses to destination account
  * @param expenses the list of models.Expense, with the collective association preloaded
  */
 export const moveExpenses = async (req: express.Request, expenses: Expense[], destinationAccount: Collective) => {
-  // Root also checked in the mutation resolver, but duplicating just to be safe if someone decides to use this elsewhere
-  checkRemoteUserCanRoot(req);
   if (!expenses.length) {
     return [];
   } else if (destinationAccount.type === CollectiveType.USER) {

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -20790,6 +20790,21 @@ type Mutation {
   ): Expense!
 
   """
+  Moves an expense from one account within a Collective to another
+  """
+  moveExpense(
+    """
+    Reference of the expense to move
+    """
+    expense: ExpenseReferenceInput!
+
+    """
+    Reference of the account to move the expense to
+    """
+    destinationAccount: AccountReferenceInput!
+  ): Expense!
+
+  """
   Delete an expense. Only work if the expense is rejected - please check permissions.canDelete. Scope: "expenses".
   """
   deleteExpense(

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -25,6 +25,7 @@ import { createComment } from '../../common/comment';
 import {
   approveExpense,
   canDeleteExpense,
+  canEditPaidBy,
   canVerifyDraftExpense,
   createExpense,
   declineInvitedExpense,
@@ -35,6 +36,7 @@ import {
   markExpenseAsIncomplete,
   markExpenseAsSpam,
   markExpenseAsUnpaid,
+  moveExpenses,
   payExpense,
   prepareAttachedFiles,
   prepareExpenseItemInputs,
@@ -261,6 +263,61 @@ const expenseMutations = {
       }
     },
   },
+  moveExpense: {
+    type: new GraphQLNonNull(GraphQLExpense),
+    description: `Moves an expense from one account within a Collective to another`,
+    args: {
+      expense: {
+        type: new GraphQLNonNull(GraphQLExpenseReferenceInput),
+        description: 'Reference of the expense to move',
+      },
+      destinationAccount: {
+        type: new GraphQLNonNull(GraphQLAccountReferenceInput),
+        description: 'Reference of the account to move the expense to',
+      },
+    },
+    async resolve(_: void, args, req: express.Request): Promise<ExpenseModel> {
+      checkRemoteUserCanUseExpenses(req);
+
+      const expenseId = getDatabaseIdFromExpenseReference(args.expense);
+      const expense = await models.Expense.findByPk(expenseId, {
+        // Need to load the collective/fromCollective because canEditPaidBy checks these
+        include: [
+          { model: models.Collective, as: 'collective' },
+          { model: models.Collective, as: 'fromCollective' },
+        ],
+      });
+
+      if (!expense) {
+        throw new NotFound('Expense not found');
+
+        // Check if user has permissions to move expense and that expense can be moved
+      } else if (!(await canEditPaidBy(req, expense, { throw: true }))) {
+        throw new Unauthorized('You do not have permission to move this expense');
+      }
+
+      const destinationAccount = await fetchAccountWithReference(args.destinationAccount, {
+        loaders: req.loaders,
+        throwIfMissing: true,
+      });
+
+      if (expense.collective.id === destinationAccount.id) {
+        throw new Unauthorized('The expense is already on this account');
+      }
+
+      const currentAccountParentId = expense.collective.ParentCollectiveId ?? expense.collective.id;
+      const destinationAccountParentId = destinationAccount.ParentCollectiveId ?? destinationAccount.id;
+
+      // Check that destination account is within the same Collective
+      if (currentAccountParentId !== destinationAccountParentId) {
+        throw new Unauthorized('You can only move expenses within the same collective');
+      }
+
+      const [movedExpense] = await moveExpenses(req, [expense], destinationAccount);
+      return movedExpense;
+    },
+  },
+
   deleteExpense: {
     type: new GraphQLNonNull(GraphQLExpense),
     description: `Delete an expense. Only work if the expense is rejected - please check permissions.canDelete. Scope: "expenses".`,

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -292,7 +292,7 @@ const expenseMutations = {
         throw new NotFound('Expense not found');
 
         // Check if user has permissions to move expense and that expense can be moved
-      } else if (!(await canEditPaidBy(req, expense, { throw: true }))) {
+      } else if (!(await canEditPaidBy(req, expense))) {
         throw new Unauthorized('You do not have permission to move this expense');
       }
 

--- a/server/graphql/v2/mutation/ExpenseMutations.ts
+++ b/server/graphql/v2/mutation/ExpenseMutations.ts
@@ -283,7 +283,7 @@ const expenseMutations = {
       const expense = await models.Expense.findByPk(expenseId, {
         // Need to load the collective/fromCollective because canEditPaidBy checks these
         include: [
-          { model: models.Collective, as: 'collective' },
+          { model: models.Collective, as: 'collective', required: true },
           { model: models.Collective, as: 'fromCollective' },
         ],
       });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7980 https://github.com/opencollective/opencollective/issues/7955

Note: This PR currently targets the extended expense edit permissions branch since those are used in the resolver

### Description
Adds a `moveExpense` mutation to move an expense within a Collective.

The new mutation resolver does the permissions checks, and uses the general `moveExpenses` function to perform the operation. 

However, this means we are removing the user root check from that function, which is already handled by the `moveExpenses` root mutation resolver, but has been there as straps and braces to prevent accidental unauthorized usage of the function by developers. I'm adding a DANGER comment to note that this functions needs pre-authorization/permissions checks.