### PR TITLE
Implement PKCE correctly and align token responses with RFC6749

### DIFF
--- a/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
+++ b/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('OAuthAuthorizationCodes', 'codeChallenge', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('OAuthAuthorizationCodes', 'codeChallengeMethod', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallenge');
+    await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallengeMethod');
+  },
+};

--- a/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
+++ b/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
@@ -14,7 +14,7 @@ module.exports = {
     });
   },
 
-  async down(queryInterface, Sequelize) {
+  async down(queryInterface) {
     await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallenge');
     await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallengeMethod');
   },

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -8,6 +8,7 @@ import BearerTokenType from '@node-oauth/oauth2-server/lib/token-types/bearer-to
 import { assign } from 'lodash';
 
 import * as auth from '../../lib/auth';
+import logger from '../logger';
 
 import model from './model';
 
@@ -218,6 +219,7 @@ const handleResponse = function (req, res, response) {
  */
 
 const handleError = function (e, req, res, response, next) {
+  logger.error(e);
   if (this.useErrorHandler === true) {
     next(e);
   } else {

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -4,6 +4,7 @@ import OAuth2Server, { UnauthorizedRequestError } from '@node-oauth/oauth2-serve
 import InvalidArgumentError from '@node-oauth/oauth2-server/lib/errors/invalid-argument-error';
 import AuthorizeHandler from '@node-oauth/oauth2-server/lib/handlers/authorize-handler';
 import TokenHandler from '@node-oauth/oauth2-server/lib/handlers/token-handler';
+import BearerTokenType from '@node-oauth/oauth2-server/lib/token-types/bearer-token-type';
 import { assign } from 'lodash';
 
 import * as auth from '../../lib/auth';
@@ -19,20 +20,16 @@ class CustomTokenHandler extends TokenHandler {
   }
 
   getTokenType = function (model) {
-    return {
-      valueOf: () => {
-        const accessToken = model.user.jwt(
-          {
-            scope: 'oauth',
-            // eslint-disable-next-line camelcase
-            access_token: model.accessToken,
-          },
-          auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
-        );
+    const accessToken = model.user.jwt(
+      {
+        scope: 'oauth',
         // eslint-disable-next-line camelcase
-        return { access_token: accessToken };
+        access_token: model.accessToken,
       },
-    };
+      auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
+    );
+
+    return BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope);
   };
 }
 

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -29,7 +29,7 @@ class CustomTokenHandler extends TokenHandler {
       auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
     );
 
-    return BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope);
+    return new BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope);
   };
 }
 

--- a/server/lib/oauth/model.ts
+++ b/server/lib/oauth/model.ts
@@ -42,6 +42,8 @@ export const dbOAuthAuthorizationCodeToAuthorizationCode = (
   authorizationCode: authorization.code,
   expiresAt: authorization.expiresAt,
   redirectUri: authorization.redirectUri,
+  codeChallenge: authorization.codeChallenge,
+  codeChallengeMethod: authorization.codeChallengeMethod,
   client: dbApplicationToClient(authorization.application),
   user: authorization.user,
   scope: authorization.scope,
@@ -152,6 +154,8 @@ const model: OauthModel = {
       code: code.authorizationCode,
       expiresAt: code.expiresAt,
       redirectUri: code.redirectUri,
+      codeChallenge: code.codeChallenge,
+      codeChallengeMethod: code.codeChallengeMethod,
       scope,
     });
 

--- a/server/lib/oauth/model.ts
+++ b/server/lib/oauth/model.ts
@@ -49,6 +49,29 @@ export const dbOAuthAuthorizationCodeToAuthorizationCode = (
   scope: authorization.scope,
 });
 
+// For some reason `saveAuthorizationCode` and `saveToken` can receive a `scope`
+// property that is a string[], string or undefined, and in the case of a string
+// it may still be URL encoded. I wouldn't expected the framework to parse the
+// scope value appropriately and just always give a `string[]` here, but
+// apparently it does not.
+//
+// In order to handle both the previous accepted value of `read,write` and
+// scope values that much the OAuth specification such as `read write` or
+// when URL encoded `read%20write` we use the regex split.
+//
+// If there is no scope value (i.e., the application's scope's should apply),
+// then we return an empty array, since OAuth Applications in OpenCollective
+// cannot currently specify their valid scope values ahead of time.
+function parseScopes(scope: string | string[] | undefined): string[] {
+  if (Array.isArray(scope)) {
+    return scope;
+  } else if (typeof scope === 'string') {
+    return decodeURIComponent(scope).split(/,|\s/);
+  } else {
+    return [];
+  }
+}
+
 /**
  * OAuth model implementation.
  */
@@ -65,6 +88,7 @@ const model: OauthModel = {
     debug('model.saveToken', token, client, user);
     try {
       const application = await models.Application.findOne({ where: { clientId: client.id } });
+      const scope = parseScopes(token.scope);
 
       // Delete existing Tokens as we have a 1 token only policy
       await UserToken.destroy({
@@ -82,7 +106,7 @@ const model: OauthModel = {
         refreshTokenExpiresAt: token.refreshTokenExpiresAt,
         ApplicationId: application.id,
         UserId: user.id,
-        scope: Array.isArray(token.scope) ? token.scope : token.scope?.split(','),
+        scope,
         preAuthorize2FA: Boolean(application.preAuthorize2FA),
       });
       oauthToken.user = user;
@@ -146,7 +170,7 @@ const model: OauthModel = {
     debug('model.saveAuthorizationCode', code, client);
     const application = await models.Application.findOne({ where: { clientId: client.id } });
     const collective = await user.getCollective();
-    const scope = Array.isArray(code.scope) ? code.scope : code.scope?.split(',');
+    const scope = parseScopes(code.scope);
 
     const authorization = await models.OAuthAuthorizationCode.create({
       ApplicationId: application.id,
@@ -154,9 +178,9 @@ const model: OauthModel = {
       code: code.authorizationCode,
       expiresAt: code.expiresAt,
       redirectUri: code.redirectUri,
-      codeChallenge: code.codeChallenge,
-      codeChallengeMethod: code.codeChallengeMethod,
       scope,
+      codeChallenge: code.codeChallenge ?? null,
+      codeChallengeMethod: code.codeChallengeMethod ?? null,
     });
 
     // Only send the email if there is no active user token right now

--- a/server/models/OAuthAuthorizationCode.ts
+++ b/server/models/OAuthAuthorizationCode.ts
@@ -21,6 +21,8 @@ class OAuthAuthorizationCode extends Model<
   declare public ApplicationId: number;
   declare public UserId: ForeignKey<User['id']>;
   declare public scope: string[];
+  declare public codeChallenge: CreationOptional<string>;
+  declare public codeChallengeMethod: CreationOptional<string>;
 
   declare public application?: NonAttribute<Application>;
   declare public user?: NonAttribute<User>;
@@ -78,6 +80,14 @@ OAuthAuthorizationCode.init(
     },
     scope: {
       type: DataTypes.ARRAY(DataTypes.ENUM(...Object.values(oAuthScopes))),
+      allowNull: true,
+    },
+    codeChallenge: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    codeChallengeMethod: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },

--- a/test/server/routes/oauth.test.ts
+++ b/test/server/routes/oauth.test.ts
@@ -10,11 +10,11 @@ import { fakeApplication, fakeOAuthAuthorizationCode, fakeUser } from '../../tes
 import { startTestServer, stopTestServer } from '../../test-helpers/server';
 import { resetTestDB } from '../../utils';
 
-export function generatePKCECodeVerifier() {
+function generatePKCECodeVerifier() {
   return randomBytes(32).toString('base64url');
 }
 
-export async function calculatePKCECodeChallenge(codeVerifier: string): Promise<string> {
+async function calculatePKCECodeChallenge(codeVerifier: string): Promise<string> {
   return createHash('sha256').update(codeVerifier).digest().toString('base64url');
 }
 


### PR DESCRIPTION
This pull request adds the necessary properties to `OAuthAuthorizationCodes` to support PKCE, per the last paragraph in https://node-oauthoauth2-server.readthedocs.io/en/master/misc/pkce.html (essentially two nullable string columns: `codeChallenge` and `codeChallengeMethod`)

This doesn't "add" PKCE, since it already existed, this just makes it work as expected.

It also fixes the `/oauth/token` response to return a compliant Bearer token response, per [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1). The returned `accessToken` is still a JWT, it just now also returns the `token_type` property and the `scope` property based on the UserToken's actual scope value. It does not return a refresh token (it's unclear to me if these are actually generated).

Tests should all pass, I think, but I couldn't run them locally.