### PR TITLE
fix: Prevent errors due to the postgres healthcheck in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready -U postgres --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
         image: minio/minio:edge-cicd
         ports:
@@ -282,7 +282,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready -U postgres --health-interval 10s --health-timeout 5s --health-retries 5
       opensearch:
         image: opensearchproject/opensearch:3
         ports:
@@ -354,7 +354,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready -U postgres --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Checkout
@@ -396,7 +396,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready -U postgres --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,7 @@ jobs:
         ports:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready -U postgres --health-interval 10s --health-timeout 5s --health-retries 5
       minio:
         image: minio/minio:edge-cicd
         ports:


### PR DESCRIPTION
This change fixes that noise in the GitHub Action logs:

```
(Debian 12.2.0-14) 12.2.0, 64-bit
 2025-06-04 21:00:16.559 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
 2025-06-04 21:00:16.559 UTC [1] LOG:  listening on IPv6 address "::", port 5432
 2025-06-04 21:00:16.561 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
 2025-06-04 21:00:16.565 UTC [63] LOG:  database system was shut down at 2025-06-04 21:00:16 UTC
 2025-06-04 21:00:16.569 UTC [1] LOG:  database system is ready to accept connections
 2025-06-04 21:00:25.631 UTC [74] FATAL:  role "root" does not exist
 2025-06-04 21:00:35.701 UTC [82] FATAL:  role "root" does not exist
 2025-06-04 21:00:45.768 UTC [90] FATAL:  role "root" does not exist
 2025-06-04 21:00:55.837 UTC [99] FATAL:  role "root" does not exist
 2025-06-04 21:01:05.904 UTC [107] FATAL:  role "root" does not exist
```

Essentially `pg_isready` defaults to `root` but the services on github for postgresql are provisioned as `postgres` not `root` as the user, so by specifying the user explicitly we don't get those errors.

Do note though that you could be using `POSTGRES_PASSWORD` and avoiding the other big warning in those logs:
```
 WARNING: POSTGRES_HOST_AUTH_METHOD has been set to "trust". This will allow
          anyone with access to the Postgres port to access your database without
          a password, even if POSTGRES_PASSWORD is set. See PostgreSQL
          documentation about "trust":
          https://www.postgresql.org/docs/current/auth-trust.html
          In Docker's default configuration, this is effectively any other
          container on the same system.
 
          It is not recommended to use POSTGRES_HOST_AUTH_METHOD=trust. Replace
          it with "-e POSTGRES_PASSWORD=password" instead to set a password in
          "docker run".
```

But that would require inject the correct password value into the various places you use that (e.g., via environment variables)