### PR TITLE
Fix implementation of OAuth PKCE and token responses

### DIFF
--- a/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
+++ b/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('OAuthAuthorizationCodes', 'codeChallenge', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('OAuthAuthorizationCodes', 'codeChallengeMethod', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallenge');
+    await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallengeMethod');
+  },
+};

--- a/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
+++ b/migrations/20250530202548-add_pkce_to_oauth_authorization_code.js
@@ -14,7 +14,7 @@ module.exports = {
     });
   },
 
-  async down(queryInterface, Sequelize) {
+  async down(queryInterface) {
     await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallenge');
     await queryInterface.removeColumn('OAuthAuthorizationCodes', 'codeChallengeMethod');
   },

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -8,6 +8,7 @@ import BearerTokenType from '@node-oauth/oauth2-server/lib/token-types/bearer-to
 import { assign } from 'lodash';
 
 import * as auth from '../../lib/auth';
+import logger from '../logger';
 
 import model from './model';
 
@@ -218,6 +219,7 @@ const handleResponse = function (req, res, response) {
  */
 
 const handleError = function (e, req, res, response, next) {
+  logger.error(e);
   if (this.useErrorHandler === true) {
     next(e);
   } else {

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -4,6 +4,7 @@ import OAuth2Server, { UnauthorizedRequestError } from '@node-oauth/oauth2-serve
 import InvalidArgumentError from '@node-oauth/oauth2-server/lib/errors/invalid-argument-error';
 import AuthorizeHandler from '@node-oauth/oauth2-server/lib/handlers/authorize-handler';
 import TokenHandler from '@node-oauth/oauth2-server/lib/handlers/token-handler';
+import BearerTokenType from '@node-oauth/oauth2-server/lib/token-types/bearer-token-type';
 import { assign } from 'lodash';
 
 import * as auth from '../../lib/auth';
@@ -19,20 +20,16 @@ class CustomTokenHandler extends TokenHandler {
   }
 
   getTokenType = function (model) {
-    return {
-      valueOf: () => {
-        const accessToken = model.user.jwt(
-          {
-            scope: 'oauth',
-            // eslint-disable-next-line camelcase
-            access_token: model.accessToken,
-          },
-          auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
-        );
+    const accessToken = model.user.jwt(
+      {
+        scope: 'oauth',
         // eslint-disable-next-line camelcase
-        return { access_token: accessToken };
+        access_token: model.accessToken,
       },
-    };
+      auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
+    );
+
+    return BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope);
   };
 }
 

--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -29,7 +29,7 @@ class CustomTokenHandler extends TokenHandler {
       auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
     );
 
-    return BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope);
+    return new BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope);
   };
 }
 

--- a/server/lib/oauth/model.ts
+++ b/server/lib/oauth/model.ts
@@ -42,6 +42,8 @@ export const dbOAuthAuthorizationCodeToAuthorizationCode = (
   authorizationCode: authorization.code,
   expiresAt: authorization.expiresAt,
   redirectUri: authorization.redirectUri,
+  codeChallenge: authorization.codeChallenge,
+  codeChallengeMethod: authorization.codeChallengeMethod,
   client: dbApplicationToClient(authorization.application),
   user: authorization.user,
   scope: authorization.scope,
@@ -152,6 +154,8 @@ const model: OauthModel = {
       code: code.authorizationCode,
       expiresAt: code.expiresAt,
       redirectUri: code.redirectUri,
+      codeChallenge: code.codeChallenge,
+      codeChallengeMethod: code.codeChallengeMethod,
       scope,
     });
 

--- a/server/lib/oauth/model.ts
+++ b/server/lib/oauth/model.ts
@@ -49,6 +49,29 @@ export const dbOAuthAuthorizationCodeToAuthorizationCode = (
   scope: authorization.scope,
 });
 
+// For some reason `saveAuthorizationCode` and `saveToken` can receive a `scope`
+// property that is a string[], string or undefined, and in the case of a string
+// it may still be URL encoded. I wouldn't expected the framework to parse the
+// scope value appropriately and just always give a `string[]` here, but
+// apparently it does not.
+//
+// In order to handle both the previous accepted value of `read,write` and
+// scope values that much the OAuth specification such as `read write` or
+// when URL encoded `read%20write` we use the regex split.
+//
+// If there is no scope value (i.e., the application's scope's should apply),
+// then we return an empty array, since OAuth Applications in OpenCollective
+// cannot currently specify their valid scope values ahead of time.
+function parseScopes(scope: string | string[] | undefined): string[] {
+  if (Array.isArray(scope)) {
+    return scope;
+  } else if (typeof scope === 'string') {
+    return decodeURIComponent(scope).split(/,|\s/);
+  } else {
+    return [];
+  }
+}
+
 /**
  * OAuth model implementation.
  */
@@ -65,6 +88,7 @@ const model: OauthModel = {
     debug('model.saveToken', token, client, user);
     try {
       const application = await models.Application.findOne({ where: { clientId: client.id } });
+      const scope = parseScopes(token.scope);
 
       // Delete existing Tokens as we have a 1 token only policy
       await UserToken.destroy({
@@ -82,7 +106,7 @@ const model: OauthModel = {
         refreshTokenExpiresAt: token.refreshTokenExpiresAt,
         ApplicationId: application.id,
         UserId: user.id,
-        scope: Array.isArray(token.scope) ? token.scope : token.scope?.split(','),
+        scope,
         preAuthorize2FA: Boolean(application.preAuthorize2FA),
       });
       oauthToken.user = user;
@@ -146,7 +170,7 @@ const model: OauthModel = {
     debug('model.saveAuthorizationCode', code, client);
     const application = await models.Application.findOne({ where: { clientId: client.id } });
     const collective = await user.getCollective();
-    const scope = Array.isArray(code.scope) ? code.scope : code.scope?.split(',');
+    const scope = parseScopes(code.scope);
 
     const authorization = await models.OAuthAuthorizationCode.create({
       ApplicationId: application.id,
@@ -154,9 +178,9 @@ const model: OauthModel = {
       code: code.authorizationCode,
       expiresAt: code.expiresAt,
       redirectUri: code.redirectUri,
-      codeChallenge: code.codeChallenge,
-      codeChallengeMethod: code.codeChallengeMethod,
       scope,
+      codeChallenge: code.codeChallenge ?? null,
+      codeChallengeMethod: code.codeChallengeMethod ?? null,
     });
 
     // Only send the email if there is no active user token right now

--- a/server/models/OAuthAuthorizationCode.ts
+++ b/server/models/OAuthAuthorizationCode.ts
@@ -21,6 +21,8 @@ class OAuthAuthorizationCode extends Model<
   declare public ApplicationId: number;
   declare public UserId: ForeignKey<User['id']>;
   declare public scope: string[];
+  declare public codeChallenge: CreationOptional<string>;
+  declare public codeChallengeMethod: CreationOptional<string>;
 
   declare public application?: NonAttribute<Application>;
   declare public user?: NonAttribute<User>;
@@ -78,6 +80,14 @@ OAuthAuthorizationCode.init(
     },
     scope: {
       type: DataTypes.ARRAY(DataTypes.ENUM(...Object.values(oAuthScopes))),
+      allowNull: true,
+    },
+    codeChallenge: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    codeChallengeMethod: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },

--- a/test/server/routes/oauth.test.ts
+++ b/test/server/routes/oauth.test.ts
@@ -10,11 +10,11 @@ import { fakeApplication, fakeOAuthAuthorizationCode, fakeUser } from '../../tes
 import { startTestServer, stopTestServer } from '../../test-helpers/server';
 import { resetTestDB } from '../../utils';
 
-export function generatePKCECodeVerifier() {
+function generatePKCECodeVerifier() {
   return randomBytes(32).toString('base64url');
 }
 
-export async function calculatePKCECodeChallenge(codeVerifier: string): Promise<string> {
+async function calculatePKCECodeChallenge(codeVerifier: string): Promise<string> {
   return createHash('sha256').update(codeVerifier).digest().toString('base64url');
 }
 


### PR DESCRIPTION
This fixes https://github.com/opencollective/opencollective/issues/7996
Supersedes #10912 to ensure all CI Actions run correctly.

## Token Responses

Changes the token response to return a correct `BearerTokenType` response, this automatically includes the `token_type` and access token's scopes (even though the JWT just uses the `oauth` scope)

The response changes from:
```json
{
  "access_token": "<JWT>"
}
```
To
```json
{
  "access_token": "<JWT>",
  "token_type": "Bearer",
  "expires_in": 7776000,
  "scope": ["email", "profile"]
}
```

The value `7776000` is 90 days, which matches the expiry of the JWT.

## PKCE

- Added the `codeChallenge` and `codeChallengeMethod` fields to the database model
- Correctly propagated those values through the OAuth "model"

## Scope Parsing

It turns out that the OAuth2Server library doesn't return a parsed `scope` value, and the value that gets passed into the OAuth "model"'s `saveAuthorizationCode` and `saveToken` methods can pretty much be anything, I would have expected the library to be parsing the scope parameter and passing it through correctly, but apparently that's a bug in that library, so I've added a workaround.

Future versions may fix this bug, but the [changelog](https://github.com/node-oauth/node-oauth2-server/blob/master/CHANGELOG.md) is missing a tonne of information on the change history, i.e., goes from 4.2.0 to 5.0.0, even though we're on 4.3.3

The workaround code handles the comma-separate scopes originally accepted, but also handles the spec-compliant `scope` parameter which is a space separated string.

>  The value of the scope parameter is expressed as a list of space-
>   delimited, case-sensitive strings.  The strings are defined by the
>   authorization server.  If the value contains multiple space-delimited
>   strings, their order does not matter, and each string adds an
>   additional access range to the requested scope.
>
>     scope       = scope-token *( SP scope-token )
>     scope-token = 1*( %x21 / %x23-5B / %x5D-7E )

## Frontend Changes

To make this fully work, some frontend changes are required, you can find these in:
https://github.com/opencollective/opencollective-frontend/pull/11263

I also have a fix that correctly redirects back to the application upon cancelling the OAuth request, which allows OAuth clients to correctly handle that scenario:
https://github.com/opencollective/opencollective-frontend/pull/11264

---

You could consider this a community contribution, but it did take time away from me working on open-source software (which is why people [donate to me](https://support.thisismissem.social))