### PR TITLE
chore(2fa): fido download error handling

### DIFF
--- a/server/lib/two-factor-authentication/fido-metadata.ts
+++ b/server/lib/two-factor-authentication/fido-metadata.ts
@@ -57,7 +57,11 @@ let cachedEntriesByAaguid: Record<string, MetadataEntry> = cachedMetadata.entrie
 export async function downloadFidoMetadata(): Promise<Metadata> {
   const fidoAlianceMetadataUrl = 'https://mds3.fidoalliance.org';
 
-  const response = await fetch(fidoAlianceMetadataUrl);
+  const response = await fetch(fidoAlianceMetadataUrl, { timeout: 15_000 });
+  if (!response.ok) {
+    throw new Error(`Failed to download FIDO metadata: ${response.statusText}`);
+  }
+
   const text = await response.text();
   const decodedMetadataJwt = jwt.decode(text, { complete: true });
   const certs = (


### PR DESCRIPTION
- Add timeouts to not block initialization if the domain is unresponsive 
- Handle rejected requests (e.g. rate limits)