### PR TITLE
feat(GraphQL): Add HostStats object to Host

### DIFF
--- a/server/graphql/schemaV1.graphql
+++ b/server/graphql/schemaV1.graphql
@@ -4403,6 +4403,11 @@ type Vendor implements CollectiveInterface {
   Returns whether this account has any payout methods saved
   """
   hasPayoutMethod: Boolean
+
+  """
+  The accounts where this vendor is visible, if empty or null applies to all collectives under the vendor host
+  """
+  visibleToAccounts: [CollectiveInterface]
 }
 
 """
@@ -4519,6 +4524,11 @@ type Query {
     Included vendors for specific host ID
     """
     includeVendorsForHostId: Int
+
+    """
+    Only return vendors visible to given account ids
+    """
+    vendorVisibleToAccountIds: [Int]
 
     """
     Whether to skip recent accounts (48h)

--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -3820,6 +3820,7 @@ type Host implements Account & AccountWithContributions {
   EXPERIMENTAL (this may change or be removed)
   """
   hostTransactionsReports(timeUnit: TimeUnit = MONTH, dateFrom: DateTime, dateTo: DateTime): HostTransactionReports
+  hostStats(hostContext: HostContext = ALL): HostStats!
   hostMetrics(
     """
     A collection of accounts for which the metrics should be returned.
@@ -3835,7 +3836,7 @@ type Host implements Account & AccountWithContributions {
     The end date of the time series
     """
     dateTo: DateTime
-  ): HostMetrics!
+  ): HostMetrics! @deprecated(reason: "2025-06-24: Low performance query, see if `hostStats` is sufficient")
   hostMetricsTimeSeries(
     """
     A collection of accounts for which the metrics should be returned.
@@ -4090,6 +4091,11 @@ type Host implements Account & AccountWithContributions {
     Rank vendors based on their relationship with this account
     """
     forAccount: AccountReferenceInput
+
+    """
+    Only returns vendors that are visible to the given accounts
+    """
+    visibleToAccounts: [AccountReferenceInput]
 
     """
     Filter on archived vendors
@@ -4542,7 +4548,7 @@ type LegalDocument {
   """
   Whether this legal document is expired
   """
-  isExpired: Boolean!
+  isExpired: Boolean! @deprecated(reason: "2025-05-27: Use \"status\" = \"EXPIRED\" instead")
 
   """
   The date and time the request for this legal document was created
@@ -7010,6 +7016,69 @@ type HostTransactionReportNode {
   operationalFunds: TransactionReport!
 }
 
+type HostStats {
+  balance(
+    """
+    Calculate amount before this date
+    """
+    dateTo: DateTime
+  ): Amount
+  totalAmountSpent(
+    """
+    Calculate amount before this date
+    """
+    dateTo: DateTime
+
+    """
+    Calculate amount after this date
+    """
+    dateFrom: DateTime
+
+    """
+    Return the net amount (with payment processor fees removed)
+    """
+    net: Boolean = false
+
+    """
+    Include transactions using Gift Cards
+    """
+    includeGiftCards: Boolean = false
+  ): Amount
+  totalAmountReceived(
+    """
+    Calculate amount before this date
+    """
+    dateTo: DateTime
+
+    """
+    Calculate amount after this date
+    """
+    dateFrom: DateTime
+
+    """
+    Return the net amount (with payment processor fees removed)
+    """
+    net: Boolean = false
+  ): Amount
+}
+
+enum HostContext {
+  """
+  Both the Host Organizations internal accounts and Hosted Collectives
+  """
+  ALL
+
+  """
+  Only the Host Organization (including its projects/events)
+  """
+  INTERNAL
+
+  """
+  Only Hosted Collectives (including their projects/events)
+  """
+  HOSTED
+}
+
 """
 Host metrics related to collected and pending fees/tips.
 """
@@ -7736,6 +7805,11 @@ type ExpenseValuesByRole {
   The values provided by the host admin(s)
   """
   hostAdmin: ExpenseValuesRoleDetails
+
+  """
+  The values provided by the prediction service
+  """
+  prediction: ExpenseValuesRoleDetails
 }
 
 type ExpenseValuesRoleDetails {
@@ -15257,6 +15331,11 @@ type Vendor implements Account & AccountWithContributions {
   The account who created this order
   """
   createdByAccount: Account
+
+  """
+  The accounts where this vendor is visible, if empty or null applies to all collectives under the vendor host
+  """
+  visibleToAccounts: [Account]!
 }
 
 """
@@ -24719,6 +24798,7 @@ input VendorCreateInput {
   imageUrl: String @deprecated(reason: "2024-11-26: Please use image + backgroundImage fields")
   vendorInfo: VendorInfoInput
   payoutMethod: PayoutMethodInput
+  visibleToAccounts: [AccountReferenceInput]
 
   """
   The profile avatar image
@@ -24773,6 +24853,7 @@ input VendorEditInput {
   imageUrl: String @deprecated(reason: "2024-11-26: Please use image + backgroundImage fields")
   vendorInfo: VendorInfoInput
   payoutMethod: PayoutMethodInput
+  visibleToAccounts: [AccountReferenceInput]
 
   """
   The profile avatar image

--- a/server/graphql/v2/enum/HostContext.ts
+++ b/server/graphql/v2/enum/HostContext.ts
@@ -1,0 +1,18 @@
+import { GraphQLEnumType } from 'graphql';
+
+const GraphQLHostContext = new GraphQLEnumType({
+  name: 'HostContext',
+  values: {
+    ALL: {
+      description: 'Both the Host Organizations internal accounts and Hosted Collectives',
+    },
+    INTERNAL: {
+      description: 'Only the Host Organization (including its projects/events)',
+    },
+    HOSTED: {
+      description: 'Only Hosted Collectives (including their projects/events)',
+    },
+  },
+});
+
+export default GraphQLHostContext;

--- a/server/graphql/v2/object/HostStats.ts
+++ b/server/graphql/v2/object/HostStats.ts
@@ -1,0 +1,84 @@
+import { GraphQLBoolean, GraphQLObjectType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+import { pick } from 'lodash';
+
+import {
+  getSumCollectivesAmountReceived,
+  getSumCollectivesAmountSpent,
+  sumTransactionsInCurrency,
+} from '../../../lib/budget';
+
+import { GraphQLAmount } from './Amount';
+
+const HostStatsArgs = {
+  net: {
+    type: GraphQLBoolean,
+    description: 'Return the net amount (with payment processor fees removed)',
+    defaultValue: false,
+  },
+  dateFrom: {
+    type: GraphQLDateTime,
+    description: 'Calculate amount after this date',
+  },
+  dateTo: {
+    type: GraphQLDateTime,
+    description: 'Calculate amount before this date',
+  },
+  includeGiftCards: {
+    type: GraphQLBoolean,
+    description: 'Include transactions using Gift Cards',
+    defaultValue: false,
+  },
+};
+
+export const GraphQLHostStats = new GraphQLObjectType({
+  name: 'HostStats',
+  fields: () => ({
+    balance: {
+      type: GraphQLAmount,
+      args: pick(HostStatsArgs, ['dateTo']),
+      resolve: async ({ host, collectiveIds }, args, req) => {
+        const totalMoneyManaged = await host.getTotalMoneyManaged({
+          endDate: args.dateTo,
+          collectiveIds,
+          loaders: req.loaders,
+        });
+
+        return { value: totalMoneyManaged, currency: host.currency };
+      },
+    },
+    totalAmountSpent: {
+      type: GraphQLAmount,
+      args: pick(HostStatsArgs, ['dateTo', 'dateFrom', 'net', 'includeGiftCards']),
+
+      resolve: async ({ host, collectiveIds }, args, req) => {
+        const results = await getSumCollectivesAmountSpent(collectiveIds, {
+          net: args.net,
+          startDate: args.dateFrom,
+          endDate: args.dateTo,
+          includeGiftCards: args.includeGiftCards,
+          loaders: req.loaders,
+        });
+        const totalAmountSpent = await sumTransactionsInCurrency(results, host.currency);
+
+        return { value: totalAmountSpent, currency: host.currency };
+      },
+    },
+    totalAmountReceived: {
+      type: GraphQLAmount,
+      args: pick(HostStatsArgs, ['dateTo', 'dateFrom', 'net']),
+
+      resolve: async ({ host, collectiveIds }, args, req) => {
+        const results = await getSumCollectivesAmountReceived(collectiveIds, {
+          net: args.net,
+          startDate: args.dateFrom,
+          endDate: args.dateTo,
+          loaders: req.loaders,
+        });
+        const totalAmountReceieved = await sumTransactionsInCurrency(results, host.currency);
+
+        return { value: totalAmountReceieved, currency: host.currency };
+      },
+    },
+  }),
+});

--- a/server/lib/budget.js
+++ b/server/lib/budget.js
@@ -16,7 +16,7 @@ const DEFAULT_BUDGET_VERSION = 'v2';
 
 const FAST_BALANCE = parseToBoolean(config.ledger.fastBalance);
 
-async function sumTransactionsInCurrency(results, currency) {
+export async function sumTransactionsInCurrency(results, currency) {
   let total = 0;
 
   for (const result of Object.values(results)) {


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/8036
Project: https://github.com/opencollective/opencollective/issues/8019

## Description
Adds a new `hostStats` object, deprecating the previously used `hostMetrics` (not used anywhere except currently the new Host Overview prototype), with `balance`, `totalAmountSpent` and `totalAmountReceived` resolvers, more closely resembling the `account.stats` fields, and with better performance than `hostMetrics` which fetched all stats for the individual resolvers at once.

The HostStats object takes a `hostContext` argument (ALL, INTERNAL, HOSTED), to provide a way to easily switch between the different contexts.