### PR TITLE
fix(Collective): Prevent archiving Collectives with child balances

### DIFF
--- a/server/graphql/v1/mutations/collectives.js
+++ b/server/graphql/v1/mutations/collectives.js
@@ -551,7 +551,7 @@ export async function archiveCollective(_, args, req) {
   }
 
   if (collective.isActive) {
-    const balance = await collective.getBalance();
+    const balance = await collective.getBalance({ includeChildren: true });
     if (balance > 0) {
       throw new Error('Cannot archive collective with balance > 0');
     }

--- a/server/graphql/v2/interface/Account.ts
+++ b/server/graphql/v2/interface/Account.ts
@@ -1175,7 +1175,7 @@ export const AccountFields = {
     type: new GraphQLNonNull(GraphQLBoolean),
     description: 'Returns whether this account is archived',
     resolve(collective) {
-      return Boolean(collective.deactivatedAt);
+      return Boolean(collective.deactivatedAt && !collective.isActive);
     },
   },
   isFrozen: {


### PR DESCRIPTION
# Description
Prevents archiving Collectives with child balances. Follow up on customer issue ([Slack reference](https://oficonsortium.slack.com/archives/C06K5J91675/p1751029212273539)) where child projects ended up in a semi-archived state (`deactivatedAt` was set, but `isActive` were still true, since the mutation to archive collectives only checked the main accounts balance before setting `deactivatedAt`, but failed to set `isActive` to false due to the resetting the host in `changeHost` does check child balances.

Also updating the `account.isArchived` to also check `isActive` being false, in addition to `deactivatedAt` being set (which is the implementation of GraphQL v1).