### PR TITLE
Fix: OAuth errors

### DIFF
--- a/server/lib/oauth/index.ts
+++ b/server/lib/oauth/index.ts
@@ -30,7 +30,7 @@ class CustomTokenHandler extends TokenHandler {
       auth.TOKEN_EXPIRATION_SESSION_OAUTH, // 90 days,
     );
 
-    return new BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope);
+    return new BearerTokenType(accessToken, auth.TOKEN_EXPIRATION_SESSION_OAUTH, null, model.scope.join(' '));
   };
 }
 

--- a/server/models/Application.ts
+++ b/server/models/Application.ts
@@ -1,7 +1,15 @@
 import { randomBytes } from 'crypto';
 
 import { isNil, merge } from 'lodash';
-import type { CreationOptional, ForeignKey, InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
+import type {
+  Association,
+  BelongsToGetAssociationMixin,
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 
 import { crypto } from '../lib/encryption';
 import sequelize, { DataTypes, Model } from '../lib/sequelize';
@@ -27,6 +35,13 @@ class Application extends Model<InferAttributes<Application>, InferCreationAttri
   declare public updatedAt: CreationOptional<Date>;
   declare public deletedAt: CreationOptional<Date>;
   declare public data: JSON;
+
+  declare public createdByUser: NonAttribute<User>;
+  declare getCreatedByUser: BelongsToGetAssociationMixin<User>;
+
+  declare static associations: {
+    createdByUser: Association<Application, User>;
+  };
 
   get info(): NonAttribute<Partial<Application>> {
     return {

--- a/test/server/routes/oauth.test.ts
+++ b/test/server/routes/oauth.test.ts
@@ -82,7 +82,8 @@ describe('server/routes/oauth', () => {
     expect(oauthToken.access_token).to.be.a('string');
     expect(oauthToken.token_type).to.eq('Bearer');
     expect(oauthToken.expires_in).to.eq(7776000);
-    expect(oauthToken.scope).to.have.members(['email', 'account']);
+    // scope should be a string of scopes:
+    expect(oauthToken.scope).to.eq('email account');
 
     const decodedToken = jwt.verify(oauthToken.access_token, config.keys.opencollective.jwtSecret) as jwt.JwtPayload;
     expect(decodedToken.sub).to.eq(application.CreatedByUserId.toString());

--- a/test/server/routes/oauth.test.ts
+++ b/test/server/routes/oauth.test.ts
@@ -46,7 +46,6 @@ describe('server/routes/oauth', () => {
     const authorizeParams = new URLSearchParams({
       response_type: 'code',
       client_id: application.clientId,
-      client_secret: application.clientSecret,
       redirect_uri: application.callbackUrl,
       scope: 'email account',
     });
@@ -111,6 +110,7 @@ describe('server/routes/oauth', () => {
     it('must provide a client_id', async () => {
       const response = await request(expressApp).post('/oauth/authorize?response_type=code').expect(400);
       const body = response.body;
+      expect(body).to.be.an('object');
       expect(body.error).to.eq('invalid_request');
       expect(body.error_description).to.eq('Missing parameter: `client_id`');
     });
@@ -123,6 +123,7 @@ describe('server/routes/oauth', () => {
         .expect(400);
 
       const body = response.body;
+      expect(body).to.be.an('object');
       expect(body.error).to.eq('invalid_client');
       expect(body.error_description).to.eq('Invalid client');
     });
@@ -156,6 +157,55 @@ describe('server/routes/oauth', () => {
       // include an error code or other error information.""
       expect(response.body).to.be.empty;
       expect(response.get('www-authenticate')).to.eq('Bearer realm="service"');
+    });
+
+    it('correctly handles invalid response type', async () => {
+      const application = await fakeApplication({ type: 'oAuth' });
+      // Get authorization code
+      const authorizeParams = new URLSearchParams({
+        response_type: 'invalid',
+        client_id: application.clientId,
+      });
+
+      const authorizeResponse = await request(expressApp)
+        .post(`/oauth/authorize?${authorizeParams.toString()}`)
+        .set('Content-Type', `application/x-www-form-urlencoded`)
+        .set('Authorization', `Bearer ${application.createdByUser.jwt()}`)
+        .expect(400);
+
+      const body = authorizeResponse.body;
+      expect(body).to.be.an('object');
+      expect(body.error).to.eq('unsupported_response_type');
+    });
+
+    it('correctly handles denial of the authorization request', async () => {
+      const application = await fakeApplication({ type: 'oAuth' });
+      // Get authorization code
+      const authorizeParams = new URLSearchParams({
+        response_type: 'code',
+        client_id: application.clientId,
+        redirect_uri: application.callbackUrl,
+        scope: 'email account',
+        allowed: 'false',
+      });
+
+      const expectedRedirect = new URL(application.callbackUrl);
+      expectedRedirect.searchParams.set('error', 'access_denied');
+      expectedRedirect.searchParams.set('error_description', 'Access denied: user denied access to application');
+
+      // For some reason the error_description is encoded differently by URL
+      // SearchParams, but the result is effectively the same:
+      const expectedRedirectUrl = expectedRedirect.href.replaceAll('+', '%20');
+
+      const authorizeResponse = await request(expressApp)
+        .post(`/oauth/authorize?${authorizeParams.toString()}`)
+        .set('Content-Type', `application/x-www-form-urlencoded`)
+        .set('Authorization', `Bearer ${application.createdByUser.jwt()}`)
+        .expect(200);
+
+      const authorizeBody = authorizeResponse.body;
+      expect(authorizeBody).to.be.an('object');
+      expect(authorizeBody.redirect_uri).to.eq(expectedRedirectUrl);
     });
   });
 

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -1081,7 +1081,7 @@ export const fakePaypalPlan = async (data: Record<string, unknown> = {}) => {
   });
 };
 
-export const fakeApplication = async (data: Record<string, unknown> = {}): Promise<any> => {
+export const fakeApplication = async (data: Record<string, unknown> = {}) => {
   let CollectiveId;
   let CreatedByUserId;
   if (data.user) {


### PR DESCRIPTION
Following the merge of #10917, upon testing I discovered that:

1. The "cancel" button click did not actually work as expected, as the API didn't correctly return the redirect URI like I thought it would (we likely need integration test coverage on the frontend too, but for now I've explicitly added tests for this code path)
2. The `scope` property of the token response was an array of strings, when it should've been a string of space separated scope values. (this caused oauth4webapi to crash)

<img width="693" alt="Screenshot 2025-07-03 at 20 15 00" src="https://github.com/user-attachments/assets/b75e95ed-b479-4b1d-bad3-820a2312b8dd" />

### Cancel button handling:

I'd misread this error handling code in `@node-oauth/oauth-server`: https://github.com/node-oauth/node-oauth2-server/blob/master/lib/handlers/authorize-handler.js#L126-L129

I expected it to gracefully handle the AccessDeniedError and return it to the frontend, but it actually bubbles up to the `handleError` method in `server/lib/oauth/index.ts` instead as the error is rethrow, so in there I'm explicitly checking for `AccessDeniedError`. We could arguably do a try/catch on line 70 instead, and handle the error there.

### Incorrect scope property error

<img width="740" alt="Screenshot 2025-07-03 at 21 01 48" src="https://github.com/user-attachments/assets/c58e876d-d373-450b-ab06-27183fce2ba8" />

The above shows the issue with the `scope` property on bearer token response, where [OAuth4WebAPI](https://github.com/panva/oauth4webapi) throws an error because it expects the `scope` value to be a string (the specification does imply this)