### PR TITLE
Fix(Activites): Save UserId for COLLECTIVE_CORE_MEMBER_ADDED activity

### DIFF
--- a/server/models/MemberInvitation.ts
+++ b/server/models/MemberInvitation.ts
@@ -270,6 +270,7 @@ MemberInvitation.prototype.accept = async function () {
     const memberCollective = await Collective.findByPk(this.MemberCollectiveId);
     await Activity.create({
       type: ActivityTypes.COLLECTIVE_CORE_MEMBER_ADDED,
+      UserId: this.CreatedByUserId,
       CollectiveId: this.CollectiveId,
       FromCollectiveId: this.MemberCollectiveId,
       HostCollectiveId: collective.approvedAt ? collective.HostCollectiveId : null,


### PR DESCRIPTION
Project: https://github.com/opencollective/opencollective/issues/8019

# Description
- Save UserId for COLLECTIVE_CORE_MEMBER_ADDED activity, so that we can show who added a member in the timeline