### PR TITLE
Fix v1 collective.payoutMethods resolver

### DIFF
--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1621,7 +1621,7 @@ const CollectiveFields = () => {
         if (!req.remoteUser || !req.remoteUser.isAdminOfCollective(collective)) {
           return null;
         } else {
-          const payoutMethods = req.loaders.PayoutMethod.byCollectiveId.load(collective.id);
+          const payoutMethods = await req.loaders.PayoutMethod.byCollectiveId.load(collective.id);
           return payoutMethods.filter(pm => {
             if (pm.type === PayoutMethodTypes.STRIPE && collective.id !== PlatformConstants.OfitechCollectiveId) {
               return false;


### PR DESCRIPTION
This is responsible for the failed vendor search queries in the legacy expense flow.