### PR TITLE
Add canHostAccounts Collective setting

### DIFF
--- a/server/graphql/v2/input/OrganizationCreateInput.ts
+++ b/server/graphql/v2/input/OrganizationCreateInput.ts
@@ -1,6 +1,8 @@
 import { GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from 'graphql';
 import { GraphQLJSON } from 'graphql-scalars';
 
+import { GraphQLCurrency } from '../enum';
+
 import { AccountImagesInputFields } from './AccountCreateInputImageFields';
 
 export const GraphQLOrganizationCreateInput = new GraphQLInputObjectType({
@@ -13,6 +15,7 @@ export const GraphQLOrganizationCreateInput = new GraphQLInputObjectType({
     website: { type: GraphQLString, deprecationReason: '2024-11-12: Please use socialLinks' },
     settings: { type: GraphQLJSON },
     countryISO: { type: GraphQLString, description: 'Two-letters country code following ISO31661' },
+    currency: { type: GraphQLCurrency },
     ...AccountImagesInputFields,
   }),
 });

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -136,7 +136,7 @@ const accountMutations = {
           throwIfMissing: true,
         });
 
-        const isKeyEditableByHostAdmins = ['expenseTypes'].includes(args.key);
+        const isKeyEditableByHostAdmins = ['expenseTypes', 'canHostAccounts'].includes(args.key);
         const permissionMethod = isKeyEditableByHostAdmins ? 'isAdminOfCollectiveOrHost' : 'isAdminOfCollective';
         if (!req.remoteUser[permissionMethod](account)) {
           throw new Forbidden();

--- a/server/graphql/v2/mutation/OrganizationMutations.ts
+++ b/server/graphql/v2/mutation/OrganizationMutations.ts
@@ -145,6 +145,9 @@ export default {
       }
       await organization.save();
 
+      if (args.organization.currency) {
+        await organization.setCurrency(args.organization.currency);
+      }
       if (args.activateBudget) {
         await organization.becomeHost(user);
         await organization.reload();

--- a/server/lib/collectivelib.ts
+++ b/server/lib/collectivelib.ts
@@ -171,6 +171,7 @@ export const COLLECTIVE_SETTINGS_KEYS_LIST = [
   'exportedTransactionsFieldSets',
   'exportedHostedCollectivesFieldSets',
   'showSetupGuide',
+  'canHostAccounts', // Whether this account can host other accounts
 ];
 
 /**

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -157,6 +157,7 @@ type Settings = {
   };
   disablePublicExpenseSubmission?: boolean;
   isPlatformRevenueDirectlyCollected?: boolean;
+  canHostAccounts?: boolean;
   // @deprecated Use `data.features` instead
   features?: {
     contactForm?: boolean;
@@ -1033,6 +1034,10 @@ class Collective extends Model<
 
     await this.activateBudget();
 
+    const settings = this.settings ? cloneDeep(this.settings) : {};
+    set(settings, 'canHostAccounts', true);
+    await this.update({ settings });
+
     return this;
   };
 
@@ -1110,7 +1115,8 @@ class Collective extends Model<
 
     await this.deactivateBudget();
 
-    const settings = { ...this.settings };
+    const settings = this.settings ? cloneDeep(this.settings) : {};
+    set(settings, 'canHostAccounts', false);
     unset(settings, 'paymentMethods.manual');
 
     await this.update({ isHostAccount: false, plan: null, settings });


### PR DESCRIPTION
This can be used by Organizations to disable collective hosting oriented features while keeping access to fund management features.

Relates to https://github.com/opencollective/opencollective/issues/8067