### PR TITLE
fix(Activities): migration to fix UserId for collective.core.member.added

### DIFF
--- a/migrations/20250819075514-fix-collective-core-member-added-user-id.ts
+++ b/migrations/20250819075514-fix-collective-core-member-added-user-id.ts
@@ -1,0 +1,27 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE "Activities"
+      SET
+        "UserId" = (data -> 'member' ->> 'CreatedByUserId')::integer,
+        "data" = jsonb_set(data, '{migratedIn20250819}', 'true')
+      WHERE type = 'collective.core.member.added'
+      AND "UserId" IS NULL
+      AND data -> 'member' ->> 'CreatedByUserId' IS NOT NULL
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      UPDATE "Activities"
+      SET
+        "UserId" = NULL,
+        "data" = jsonb_set(data, '{migratedIn20250819}', 'false')
+      WHERE type = 'collective.core.member.added'
+      AND data -> 'migratedIn20250819' = 'true'
+    `);
+  },
+};


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/10970

Triggered by this alarming view, looking like someone hacked into the account:

<img width="1056" height="696" alt="image" src="https://github.com/user-attachments/assets/a9f977e9-60b1-4eb2-8122-597666d3339f" />
