### PR TITLE
fix(Features): Update "TRANSFERWISE" feature access

### DIFF
--- a/server/graphql/common/features.ts
+++ b/server/graphql/common/features.ts
@@ -239,7 +239,6 @@ export const getFeatureStatusResolver =
         return checkIsActiveIfExistsInDB(
           `SELECT 1 FROM "ConnectedAccounts" WHERE "CollectiveId" = :CollectiveId AND "deletedAt" IS NULL AND "service" = 'transferwise'`,
           { replacements: { CollectiveId: collective.id } },
-          FEATURE_STATUS.DISABLED,
         );
       case FEATURE.EVENTS:
         return checkIsActiveIfExistsInDB(

--- a/server/lib/allowed-features.ts
+++ b/server/lib/allowed-features.ts
@@ -163,6 +163,7 @@ const FeaturesAccess: Partial<
   },
   [FEATURE.TRANSFERWISE]: {
     onlyAllowedFor: [FEATURE_ACCESS_PARTY.HOSTS, FEATURE_ACCESS_PARTY.INDEPENDENT_COLLECTIVES],
+    flagOverride: 'settings.features.transferwise',
   },
   [FEATURE.UPDATES]: {
     accountTypes: [

--- a/test/server/graphql/common/features.test.js
+++ b/test/server/graphql/common/features.test.js
@@ -68,6 +68,12 @@ describe('server/graphql/common/features', () => {
         expect(result).to.eq(FEATURE_STATUS.DISABLED);
       });
 
+      it('Returns AVAILABLE when the feature is available', async () => {
+        const collective = await fakeHost({ plan: 'start-plan-2021', settings: { features: { transferwise: true } } });
+        const result = await getFeatureStatusResolver(FEATURE.TRANSFERWISE)(collective);
+        expect(result).to.eq(FEATURE_STATUS.AVAILABLE);
+      });
+
       it("Returns ACTIVE if there's a linked transferwise account", async () => {
         const collective = await fakeHost({ plan: 'start-plan-2021', settings: { features: { transferwise: true } } });
         await fakeConnectedAccount({ CollectiveId: collective.id, service: 'transferwise' });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8186

# Description
- Removes the "DISABLED" fallback for transferwise. The `checkFeatureAccess` already checks if the feature should be disabled or unsupported depending on things like account type, plans, and flagOverride etc, at this point it should only check whether it is "ACTIVE" or "AVAILABLE".

- Also adding a flagOverride to the TRANSFERWISE feature access, so that the `settings.features.transferwise` flag specified in the tests are taken into consideration.