### PR TITLE
Allow admins to see invited member email

### DIFF
--- a/server/graphql/loaders/collective.ts
+++ b/server/graphql/loaders/collective.ts
@@ -95,25 +95,35 @@ export default {
       if (otherAccountsCollectiveIds.length) {
         await remoteUser.populateRoles();
         const adminOfCollectiveIds = remoteUser.getAdministratedCollectiveIds();
+        const include = {
+          association: 'collective',
+          required: true,
+          attributes: [],
+          where: {
+            [Op.or]: [
+              { id: adminOfCollectiveIds }, // Either `remoteUser` is an admin of the collective
+              { ParentCollectiveId: adminOfCollectiveIds }, // Or an admin of the parent collective
+              { HostCollectiveId: adminOfCollectiveIds }, // Or `remoteUser` is an admin of the collective's host
+            ],
+          },
+        };
         administratedMembers = await models.Member.findAll({
           attributes: ['MemberCollectiveId'],
           group: ['MemberCollectiveId'],
           raw: true,
           mapToModel: false,
           where: { MemberCollectiveId: otherAccountsCollectiveIds, role: { [Op.ne]: MemberRoles.FOLLOWER } },
-          include: {
-            association: 'collective',
-            required: true,
-            attributes: [],
-            where: {
-              [Op.or]: [
-                { id: adminOfCollectiveIds }, // Either `remoteUser` is an admin of the collective
-                { ParentCollectiveId: adminOfCollectiveIds }, // Or an admin of the parent collective
-                { HostCollectiveId: adminOfCollectiveIds }, // Or `remoteUser` is an admin of the collective's host
-              ],
-            },
-          },
+          include,
         });
+        const invitedMembers = await models.MemberInvitation.findAll({
+          attributes: ['MemberCollectiveId'],
+          group: ['MemberCollectiveId'],
+          raw: true,
+          mapToModel: false,
+          where: { MemberCollectiveId: otherAccountsCollectiveIds },
+          include,
+        });
+        administratedMembers = administratedMembers.concat(invitedMembers);
       }
 
       // User must be self or directly administered by remoteUser

--- a/test/server/graphql/loaders/collective.test.ts
+++ b/test/server/graphql/loaders/collective.test.ts
@@ -9,6 +9,7 @@ import {
   fakeActiveHost,
   fakeCollective,
   fakeMember,
+  fakeMemberInvitation,
   fakeTransaction,
   fakeUser,
   multiple,
@@ -22,10 +23,11 @@ describe('server/graphql/loaders/collective', () => {
 
   describe('canSeePrivateProfileInfo', () => {
     describe('User info', () => {
-      let userWithPrivateInfo, randomUser, collectiveAdmin, hostAdmin;
+      let userWithPrivateInfo, randomUser, collectiveAdmin, hostAdmin, invitedUserWithPrivateInfo;
 
       before(async () => {
         userWithPrivateInfo = await fakeUser();
+        invitedUserWithPrivateInfo = await fakeUser();
         randomUser = await fakeUser();
         collectiveAdmin = await fakeUser();
         hostAdmin = await fakeUser();
@@ -34,6 +36,11 @@ describe('server/graphql/loaders/collective', () => {
         await collective.addUserWithRole(userWithPrivateInfo, 'BACKER');
         await collective.addUserWithRole(collectiveAdmin, 'ADMIN');
         await collective.host.addUserWithRole(hostAdmin, 'ADMIN');
+        await fakeMemberInvitation({
+          CollectiveId: collective.id,
+          MemberCollectiveId: invitedUserWithPrivateInfo.CollectiveId,
+          role: MemberRoles.ADMIN,
+        });
       });
 
       it('Cannot see infos as unauthenticated', async () => {
@@ -57,6 +64,12 @@ describe('server/graphql/loaders/collective', () => {
       it('Can see infos if collective admin', async () => {
         const loader = CollectiveLoaders.canSeePrivateProfileInfo({ remoteUser: collectiveAdmin });
         const result = await loader.load(userWithPrivateInfo.CollectiveId);
+        expect(result).to.be.true;
+      });
+
+      it('Can see infos if user is invited to collective', async () => {
+        const loader = CollectiveLoaders.canSeePrivateProfileInfo({ remoteUser: collectiveAdmin });
+        const result = await loader.load(invitedUserWithPrivateInfo.CollectiveId);
         expect(result).to.be.true;
       });
 


### PR DESCRIPTION
This fixes a bug where admins would not be able to see an invited member's email.