### PR TITLE
Use correct urls to expense item notifications

### DIFF
--- a/server/models/Expense.ts
+++ b/server/models/Expense.ts
@@ -216,7 +216,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
     }
 
     const protectedUrls = {};
-    for (const item of items) {
+    for (const item of items || []) {
       if (!item.url) {
         continue;
       }


### PR DESCRIPTION
Before
<img width="810" height="115" alt="image" src="https://github.com/user-attachments/assets/65569843-e0f5-4348-8a3f-87d70421ee3f" />

After
<img width="810" height="115" alt="image" src="https://github.com/user-attachments/assets/ab71957e-3641-4106-ac4a-13273b6bf985" />
