### PR TITLE
Update CommunityActivitySummary to refresh concurrently

### DIFF
--- a/cron/hourly/50-refresh-materialized-views.js
+++ b/cron/hourly/50-refresh-materialized-views.js
@@ -5,9 +5,9 @@ import { HandlerType, reportErrorToSentry } from '../../server/lib/sentry';
 import { sequelize } from '../../server/models';
 import { runCronJob } from '../utils';
 
-const VIEWS = ['CollectiveOrderStats', 'ExpenseTagStats'];
+const VIEWS = ['CollectiveOrderStats', 'ExpenseTagStats', 'CommunityActivitySummary'];
 
-const VIEWS_WITHOUT_UNIQUE_INDEX = ['HostMonthlyTransactions', 'CollectiveTagStats', 'CommunityActivitySummary'];
+const VIEWS_WITHOUT_UNIQUE_INDEX = ['HostMonthlyTransactions', 'CollectiveTagStats'];
 
 /**
  * Refresh the materialized views.


### PR DESCRIPTION
Solves the problem with unavailability due to materialized view refreshing, which takes approx. 9 minutes every hour (~15% unavailability).