### PR TITLE
enhancement(Expense): misc fixes on expense edit

### DIFF
--- a/server/graphql/common/activities.ts
+++ b/server/graphql/common/activities.ts
@@ -10,6 +10,8 @@ export const sanitizeActivityData = async (req: Express.Request, activity): Prom
   const toPick = [];
   if (activity.type === ActivityTypes.COLLECTIVE_EXPENSE_PAID) {
     toPick.push('isManualPayout');
+  } else if (activity.type === ActivityTypes.COLLECTIVE_EXPENSE_UPDATED) {
+    toPick.push('previousData.status', 'expense.status');
   } else if (activity.type === ActivityTypes.COLLECTIVE_EXPENSE_ERROR) {
     if (activity.CollectiveId) {
       const collective = await req.loaders.Collective.byId.load(activity.CollectiveId);

--- a/server/models/Expense.ts
+++ b/server/models/Expense.ts
@@ -256,6 +256,7 @@ class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Ex
           'notifyCollective',
           'reference',
           'estimatedDelivery',
+          'previousData',
         ]),
         host: get(host, 'minimal'),
         collective: { ...this.collective.minimal, isActive: this.collective.isActive },


### PR DESCRIPTION
See https://oficonsortium.slack.com/archives/C05KG5KB80P/p1762207618158119

- Allow owners to edit their pending expenses
- Fix various permissions issues
- Fix wrong tests setups
- Prevent editing a locked expense
- Record status changes (to be displayed in the interface)
