### PR TITLE
Handle accounts without structured manual bank account instructions

### DIFF
--- a/server/graphql/v2/object/Host.ts
+++ b/server/graphql/v2/object/Host.ts
@@ -627,12 +627,17 @@ export const GraphQLHost = new GraphQLObjectType({
 
           // bank transfer = manual in host settings
           if (get(collective, 'settings.paymentMethods.manual', null)) {
-            const payoutMethods = await req.loaders.PayoutMethod.byCollectiveId.load(collective.id);
-            const hasManualBankTransferMethod = payoutMethods.some(
-              c => c.type === 'BANK_ACCOUNT' && c.data?.isManualBankTransfer,
-            );
-            if (hasManualBankTransferMethod) {
+            // these accounts do not have a structured bank detail in the payment instructions
+            if (get(collective, 'settings.paymentMethods.manual.legacy', false)) {
               supportedPaymentMethods.push('BANK_TRANSFER');
+            } else {
+              const payoutMethods = await req.loaders.PayoutMethod.byCollectiveId.load(collective.id);
+              const hasManualBankTransferMethod = payoutMethods.some(
+                c => c.type === 'BANK_ACCOUNT' && c.data?.isManualBankTransfer,
+              );
+              if (hasManualBankTransferMethod) {
+                supportedPaymentMethods.push('BANK_TRANSFER');
+              }
             }
           }
 


### PR DESCRIPTION
Resolve side-effect of https://github.com/opencollective/opencollective-api/pull/11186

```sql
update "Collectives" set settings = jsonb_set(settings, '{paymentMethods,manual,legacy}', 'true', TRUE)
    where id in (
        SELECT c.id
    FROM "Collectives" c
    LEFT JOIN "PayoutMethods" pm
      ON pm."CollectiveId" = c.id
      AND (pm.data -> 'isManualBankTransfer')::boolean = true
    WHERE c.settings -> 'paymentMethods' -> 'manual' IS NOT NULL
    AND c."isHostAccount" IS TRUE AND c."deletedAt" IS NULL
    AND pm.id IS NULL
)
```