### PR TITLE
Users signup to record Collective

### DIFF
--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -36,6 +36,7 @@ type UserData = {
   limits?: {
     draftExpenses?: 'bypass';
   };
+  requiresVerification?: boolean;
 };
 
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {


### PR DESCRIPTION
- [x] Users will no longer be created without collective while waiting for verification.
- [x] Adding new flag to prevent OTP waiting users to sign in with same email.
- [x] Creates suspended user collectives to prevent Collective page from being rendered.