### PR TITLE
Fixes & improvements on collective delete

### DIFF
--- a/server/models/TransactionsImportRow.ts
+++ b/server/models/TransactionsImportRow.ts
@@ -9,7 +9,6 @@ import type {
 import { TransactionsImportRowStatus } from '../graphql/v2/enum/TransactionsImportRowStatus';
 import sequelize, { DataTypes, Model } from '../lib/sequelize';
 
-import Collective from './Collective';
 import Expense from './Expense';
 import Order from './Order';
 import TransactionsImport from './TransactionsImport';
@@ -19,7 +18,6 @@ class TransactionsImportRow extends Model<
   InferCreationAttributes<TransactionsImportRow>
 > {
   declare public id: CreationOptional<number>;
-  declare public CollectiveId: ForeignKey<Collective['id']>;
   declare public TransactionsImportId: ForeignKey<TransactionsImport['id']>;
   declare public ExpenseId: ForeignKey<Expense['id']>;
   declare public OrderId: ForeignKey<Order['id']>;

--- a/sql/ban-collectives.sql
+++ b/sql/ban-collectives.sql
@@ -11,7 +11,7 @@ WITH requested_collectives AS (
   FROM    "Collectives"
   WHERE   slug = ANY($collectiveSlugs)
   AND     "deletedAt" IS NULL
-), deleted_profiles AS (
+), deleted_collectives AS (
   -- Delete all requested collectives and their children
   UPDATE ONLY "Collectives" c
   SET         "deletedAt" = NOW(),
@@ -27,8 +27,8 @@ WITH requested_collectives AS (
   UPDATE ONLY "Users" u
   SET         "deletedAt" = NOW(),
               data = (COALESCE(to_jsonb(data), '{}' :: jsonb) || '{"isBanned": true}' :: jsonb)
-  FROM        deleted_profiles
-  WHERE       u."CollectiveId" = deleted_profiles.id
+  FROM        deleted_collectives
+  WHERE       u."CollectiveId" = deleted_collectives.id
   AND         u."deletedAt" IS NULL
   RETURNING   u.id
 ), deleted_two_factor_methods AS (
@@ -58,10 +58,10 @@ WITH requested_collectives AS (
 ), transactions_groups_to_delete AS (
   SELECT DISTINCT "TransactionGroup"
   FROM "Transactions" t
-  INNER JOIN deleted_profiles
-    ON deleted_profiles.id = t."CollectiveId"
-    OR deleted_profiles.id = t."FromCollectiveId"
-    OR deleted_profiles.id = t."HostCollectiveId"
+  INNER JOIN deleted_collectives
+    ON deleted_collectives.id = t."CollectiveId"
+    OR deleted_collectives.id = t."FromCollectiveId"
+    OR deleted_collectives.id = t."HostCollectiveId"
   WHERE t."TransactionGroup" IS NOT NULL
   AND t."deletedAt" IS NULL
 ), deleted_transactions AS (
@@ -84,87 +84,87 @@ WITH requested_collectives AS (
 ), deleted_tiers AS (
   -- Delete tiers
   UPDATE ONLY "Tiers" t SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       t."CollectiveId" = deleted_profiles.id
+  FROM        deleted_collectives
+  WHERE       t."CollectiveId" = deleted_collectives.id
   AND         t."deletedAt" IS NULL
   RETURNING   t.id
 ), deleted_members AS (
   -- Delete members and memberships
   UPDATE ONLY "Members" m SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       (m."MemberCollectiveId" = deleted_profiles.id OR m."CollectiveId" = deleted_profiles.id)
+  FROM        deleted_collectives
+  WHERE       (m."MemberCollectiveId" = deleted_collectives.id OR m."CollectiveId" = deleted_collectives.id)
   AND         m."deletedAt" IS NULL
   RETURNING   m.id
 ), deleted_member_invitations AS (
   -- Delete member invitations
   UPDATE ONLY "MemberInvitations" mi SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       (mi."MemberCollectiveId" = deleted_profiles.id OR mi."CollectiveId" = deleted_profiles.id)
+  FROM        deleted_collectives
+  WHERE       (mi."MemberCollectiveId" = deleted_collectives.id OR mi."CollectiveId" = deleted_collectives.id)
   AND         mi."deletedAt" IS NULL
   RETURNING   mi.id
 ), deleted_updates AS (
   -- Delete updates
   UPDATE ONLY "Updates" u SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       (u."CollectiveId" = deleted_profiles.id OR u."FromCollectiveId" = deleted_profiles.id)
+  FROM        deleted_collectives
+  WHERE       (u."CollectiveId" = deleted_collectives.id OR u."FromCollectiveId" = deleted_collectives.id)
   AND         u."deletedAt" IS NULL
   RETURNING   u.id
 ), deleted_legal_documents AS (
   -- Delete legal documents
   UPDATE ONLY "LegalDocuments" ld SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       ld."CollectiveId" = deleted_profiles.id 
+  FROM        deleted_collectives
+  WHERE       ld."CollectiveId" = deleted_collectives.id 
   AND         ld."deletedAt" IS NULL
   RETURNING   ld.id
 ), deleted_agreements AS (
   -- Delete Agreements
   UPDATE ONLY "Agreements" a SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       (a."CollectiveId" = deleted_profiles.id OR a."HostCollectiveId" = deleted_profiles.id)
+  FROM        deleted_collectives
+  WHERE       (a."CollectiveId" = deleted_collectives.id OR a."HostCollectiveId" = deleted_collectives.id)
   AND         a."deletedAt" IS NULL
   RETURNING   a.id
 ), deleted_locations AS (
   -- Delete locations
   UPDATE ONLY "Locations" l SET "deletedAt" = NOW()
-  FROM        deleted_profiles 
-  WHERE       l."CollectiveId" = deleted_profiles.id
+  FROM        deleted_collectives 
+  WHERE       l."CollectiveId" = deleted_collectives.id
   AND         l."deletedAt" IS NULL
   RETURNING   l.id
 ), deleted_payment_methods AS (
   -- Delete payment methods
   UPDATE ONLY "PaymentMethods" pm SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       pm."CollectiveId" = deleted_profiles.id 
+  FROM        deleted_collectives
+  WHERE       pm."CollectiveId" = deleted_collectives.id 
   AND         pm."deletedAt" IS NULL
   RETURNING   pm.id
 ), deleted_connected_accounts AS (
   -- Delete connected accounts
   UPDATE ONLY "ConnectedAccounts" ca SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       ca."CollectiveId" = deleted_profiles.id
+  FROM        deleted_collectives
+  WHERE       ca."CollectiveId" = deleted_collectives.id
   AND         ca."deletedAt" IS NULL
   RETURNING   ca.id
 ), deleted_conversations AS (
   -- Delete conversations
   UPDATE ONLY "Conversations" conv SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       (conv."FromCollectiveId" = deleted_profiles.id OR conv."CollectiveId" = deleted_profiles.id)
+  FROM        deleted_collectives
+  WHERE       (conv."FromCollectiveId" = deleted_collectives.id OR conv."CollectiveId" = deleted_collectives.id)
   AND         conv."deletedAt" IS NULL
   RETURNING   conv.id
 ), deleted_conversation_followers AS (
   -- Delete conversations followers
   DELETE FROM "ConversationFollowers" f
-  USING       deleted_users, deleted_conversations
-  WHERE       f."UserId" = deleted_users.id
-  OR          f."ConversationId" = deleted_conversations.id
+  WHERE
+    EXISTS (SELECT 1 FROM deleted_users WHERE deleted_users.id = f."UserId")
+    OR EXISTS (SELECT 1 FROM deleted_conversations WHERE deleted_conversations.id = f."ConversationId")
   RETURNING   f.id
 ), deleted_expenses AS (
   -- Delete expenses
   UPDATE ONLY "Expenses" e SET "deletedAt" = NOW()
   WHERE       e."deletedAt" IS NULL
   AND         id IN (
-    SELECT id FROM "Expenses" e WHERE "CollectiveId" IN (SELECT id FROM deleted_profiles)
-    UNION DISTINCT SELECT id FROM "Expenses" e WHERE "FromCollectiveId" IN (SELECT id FROM deleted_profiles)
+    SELECT id FROM "Expenses" e WHERE "CollectiveId" IN (SELECT id FROM deleted_collectives)
+    UNION DISTINCT SELECT id FROM "Expenses" e WHERE "FromCollectiveId" IN (SELECT id FROM deleted_collectives)
     UNION DISTINCT SELECT id FROM "Expenses" e WHERE "UserId" IN (SELECT id FROM deleted_users)
   )
   RETURNING   e.id
@@ -180,8 +180,8 @@ WITH requested_collectives AS (
   UPDATE ONLY "Comments" com SET "deletedAt" = NOW()
   WHERE "deletedAt" IS NULL
   AND id IN (
-    SELECT id FROM "Comments" WHERE "CollectiveId" IN (SELECT id FROM deleted_profiles)
-    UNION DISTINCT SELECT id FROM "Comments" WHERE "FromCollectiveId" IN (SELECT id FROM deleted_profiles)
+    SELECT id FROM "Comments" WHERE "CollectiveId" IN (SELECT id FROM deleted_collectives)
+    UNION DISTINCT SELECT id FROM "Comments" WHERE "FromCollectiveId" IN (SELECT id FROM deleted_collectives)
     UNION DISTINCT SELECT id FROM "Comments" WHERE "ConversationId" IN (SELECT id FROM deleted_conversations)
     UNION DISTINCT SELECT id FROM "Comments" WHERE "ExpenseId" IN (SELECT id FROM deleted_expenses)
     UNION DISTINCT SELECT id FROM "Comments" WHERE "UpdateId" IN (SELECT id FROM deleted_updates)
@@ -192,15 +192,15 @@ WITH requested_collectives AS (
   UPDATE ONLY "Applications" app SET "deletedAt" = NOW()
   WHERE       app."deletedAt" IS NULL
   AND         id IN (
-    SELECT id FROM "Applications" WHERE "CollectiveId" IN (SELECT id FROM deleted_profiles)
+    SELECT id FROM "Applications" WHERE "CollectiveId" IN (SELECT id FROM deleted_collectives)
     UNION DISTINCT SELECT id FROM "Applications" WHERE "CreatedByUserId" IN (SELECT id FROM deleted_users)
   )
   RETURNING   app.id
 ), deleted_orders AS (
   -- Delete orders
   UPDATE ONLY "Orders" o SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       (o."FromCollectiveId" = deleted_profiles.id OR o."CollectiveId" = deleted_profiles.id)
+  FROM        deleted_collectives
+  WHERE       (o."FromCollectiveId" = deleted_collectives.id OR o."CollectiveId" = deleted_collectives.id)
   AND         o."deletedAt" IS NULL
   RETURNING   o.id
 ), deleted_notifications AS (
@@ -212,19 +212,77 @@ WITH requested_collectives AS (
 ), deleted_recurring_expenses AS (
   -- Delete Recurring Expenses 
   UPDATE ONLY "RecurringExpenses" re SET "deletedAt" = NOW()
-  FROM        deleted_profiles
-  WHERE       (re."FromCollectiveId" = deleted_profiles.id OR re."CollectiveId" = deleted_profiles.id)
+  FROM        deleted_collectives
+  WHERE       (re."FromCollectiveId" = deleted_collectives.id OR re."CollectiveId" = deleted_collectives.id)
   AND         re."deletedAt" IS NULL
   RETURNING   re.id
 ), deleted_transactions_imports AS (
   -- Delete transactions imports
   UPDATE ONLY "TransactionsImports" ti SET "deletedAt" = NOW()
-  FROM       deleted_profiles
-  WHERE       ti."CollectiveId" = deleted_profiles.id
+  FROM       deleted_collectives
+  WHERE       ti."CollectiveId" = deleted_collectives.id
   AND         ti."deletedAt" IS NULL
   RETURNING   ti.id
+), deleted_transactions_import_rows AS (
+  -- Delete transactions import rows
+  UPDATE ONLY "TransactionsImportsRows" tir SET "deletedAt" = NOW()
+  FROM        deleted_transactions_imports
+  WHERE       tir."TransactionsImportId" = deleted_transactions_imports.id
+  AND         tir."deletedAt" IS NULL
+  RETURNING   tir.id
+), deleted_host_applications AS (
+  -- Delete host applications
+  UPDATE ONLY "HostApplications" ha SET "deletedAt" = NOW()
+  FROM        deleted_collectives
+  WHERE       (ha."CollectiveId" = deleted_collectives.id OR ha."HostCollectiveId" = deleted_collectives.id)
+  AND         ha."deletedAt" IS NULL
+  RETURNING   ha.id
+), deleted_payout_methods AS (
+  -- Delete payout methods
+  UPDATE ONLY "PayoutMethods" pm SET "deletedAt" = NOW()
+  FROM        deleted_collectives
+  WHERE       pm."CollectiveId" = deleted_collectives.id
+  AND         pm."deletedAt" IS NULL
+  RETURNING   pm.id
+), deleted_virtual_cards AS (
+  -- Delete virtual cards
+  UPDATE ONLY "VirtualCards" vc SET "deletedAt" = NOW()
+  FROM        deleted_collectives
+  WHERE       (vc."CollectiveId" = deleted_collectives.id OR vc."HostCollectiveId" = deleted_collectives.id)
+  AND         vc."deletedAt" IS NULL
+  RETURNING   vc.id
+), deleted_virtual_card_requests AS (
+  -- Delete virtual card requests
+  UPDATE ONLY "VirtualCardRequests" vcr SET "deletedAt" = NOW()
+  FROM        deleted_collectives
+  WHERE       (vcr."CollectiveId" = deleted_collectives.id OR vcr."HostCollectiveId" = deleted_collectives.id)
+  AND         vcr."deletedAt" IS NULL
+  RETURNING   vcr.id
+), deleted_platform_subscriptions AS (
+  -- Delete platform subscriptions
+  UPDATE ONLY "PlatformSubscriptions" ps SET "deletedAt" = NOW()
+  FROM        deleted_collectives
+  WHERE       ps."CollectiveId" = deleted_collectives.id
+  AND         ps."deletedAt" IS NULL
+  RETURNING   ps.id
+), deleted_personal_tokens AS (
+  -- Delete personal tokens
+  UPDATE ONLY "PersonalTokens" pt SET "deletedAt" = NOW()
+  WHERE       pt."deletedAt" IS NULL
+  AND         (
+    EXISTS (SELECT 1 FROM deleted_collectives WHERE deleted_collectives.id = pt."CollectiveId")
+    OR EXISTS (SELECT 1 FROM deleted_users WHERE deleted_users.id = pt."UserId")
+  )
+  RETURNING   pt.id
+), deleted_required_legal_documents AS (
+  -- Delete required legal documents
+  UPDATE ONLY "RequiredLegalDocuments" rld SET "deletedAt" = NOW()
+  FROM        deleted_collectives
+  WHERE       rld."HostCollectiveId" = deleted_collectives.id
+  AND         rld."deletedAt" IS NULL
+  RETURNING   rld.id
 ) SELECT 
-  (SELECT COUNT(*) FROM deleted_profiles) AS nb_deleted_profiles,
+  (SELECT COUNT(*) FROM deleted_collectives) AS nb_deleted_collectives,
   (SELECT COUNT(*) FROM deleted_users) AS deleted_users,
   (SELECT COUNT(*) FROM deleted_oauth_authorization_codes) AS nb_deleted_oauth_authorization_codes,
   (SELECT COUNT(*) FROM deleted_user_tokens) AS nb_deleted_user_tokens,
@@ -245,12 +303,20 @@ WITH requested_collectives AS (
   (SELECT COUNT(*) FROM deleted_users) AS nb_deleted_users,
   (SELECT COUNT(*) FROM deleted_recurring_expenses) AS nb_deleted_recurring_expenses,
   (SELECT COUNT(*) FROM deleted_transactions_imports) AS nb_deleted_transactions_imports,
+  (SELECT COUNT(*) FROM deleted_transactions_import_rows) AS nb_deleted_transactions_import_rows,
+  (SELECT COUNT(*) FROM deleted_host_applications) AS nb_deleted_host_applications,
+  (SELECT COUNT(*) FROM deleted_payout_methods) AS nb_deleted_payout_methods,
+  (SELECT COUNT(*) FROM deleted_virtual_cards) AS nb_deleted_virtual_cards,
+  (SELECT COUNT(*) FROM deleted_virtual_card_requests) AS nb_deleted_virtual_card_requests,
+  (SELECT COUNT(*) FROM deleted_platform_subscriptions) AS nb_deleted_platform_subscriptions,
+  (SELECT COUNT(*) FROM deleted_personal_tokens) AS nb_deleted_personal_tokens,
+  (SELECT COUNT(*) FROM deleted_required_legal_documents) AS nb_deleted_required_legal_documents,
   (SELECT COUNT(*) FROM deleted_legal_documents) AS nb_deleted_legal_documents,
   (SELECT COUNT(*) FROM deleted_agreements) AS nb_deleted_agreements,
   (SELECT COUNT(*) FROM deleted_locations) AS nb_deleted_locations,
   (SELECT COUNT(*) FROM deleted_member_invitations) AS nb_deleted_member_invitations,
   (SELECT COUNT(*) FROM deleted_expense_items) AS nb_deleted_expense_items,
-  (SELECT ARRAY_AGG(deleted_profiles.id) FROM deleted_profiles) AS deleted_profiles_ids
+  (SELECT ARRAY_AGG(deleted_collectives.id) FROM deleted_collectives) AS deleted_collectives_ids
   
 -- TODO:
 -- Delete associated incognito profiles

--- a/test/server/lib/collectivelib.test.ts
+++ b/test/server/lib/collectivelib.test.ts
@@ -1,16 +1,47 @@
 import { expect } from 'chai';
 import config from 'config';
+import { assert } from 'sinon';
 
+import ActivityTypes from '../../../server/constants/activities';
+import ExpenseStatuses from '../../../server/constants/expense-status';
 import OrderStatuses from '../../../server/constants/order-status';
-import { isCollectiveDeletable, parseImageServiceUrl } from '../../../server/lib/collectivelib';
+import { deleteCollective, isCollectiveDeletable, parseImageServiceUrl } from '../../../server/lib/collectivelib';
+import models from '../../../server/models';
 import {
+  fakeActiveHost,
+  fakeActivity,
+  fakeAgreement,
+  fakeApplication,
   fakeCollective,
+  fakeComment,
+  fakeConnectedAccount,
+  fakeConversation,
   fakeEvent,
   fakeExpense,
+  fakeExpenseItem,
   fakeHost,
+  fakeHostApplication,
+  fakeLegalDocument,
+  fakeLocation,
+  fakeMember,
+  fakeMemberInvitation,
   fakeOrder,
+  fakePaymentMethod,
+  fakePayoutMethod,
+  fakePersonalToken,
+  fakePlatformSubscription,
+  fakeProject,
+  fakeRecurringExpense,
+  fakeRequiredLegalDocument,
+  fakeTier,
   fakeTransaction,
+  fakeTransactionsImport,
+  fakeTransactionsImportRow,
+  fakeUpdate,
   fakeUser,
+  fakeVendor,
+  fakeVirtualCard,
+  fakeVirtualCardRequest,
 } from '../../test-helpers/fake-data';
 
 describe('server/lib/collectivelib', () => {
@@ -80,6 +111,320 @@ describe('server/lib/collectivelib', () => {
       const parent = await fakeCollective();
       await fakeEvent({ ParentCollectiveId: parent.id });
       expect(await isCollectiveDeletable(parent)).to.be.false;
+    });
+  });
+
+  describe('deleteCollective', () => {
+    it('should delete a collective and all related models', async () => {
+      // Data that should NOT be deleted
+      const dataToNotDelete = await Promise.all([
+        fakeActivity(),
+        fakeUser(),
+        fakeActiveHost(),
+        fakeVendor(),
+        fakeEvent(),
+        fakeProject(),
+        fakeUpdate(),
+        fakeComment(),
+        fakeConversation(),
+        fakeApplication(),
+        fakeOrder(),
+        fakeExpense(),
+        fakeExpenseItem(),
+        fakeRecurringExpense(),
+        fakeTransactionsImport(),
+        fakeTransactionsImportRow(),
+        fakeHostApplication(),
+        fakeTier(),
+        fakePaymentMethod(),
+        fakePayoutMethod(),
+        fakeConnectedAccount(),
+        fakeVirtualCard(),
+        fakeVirtualCardRequest(),
+        fakePlatformSubscription(),
+        fakePersonalToken(),
+        fakeRequiredLegalDocument(),
+      ]);
+
+      // Accounts
+      const remoteUser = await fakeUser();
+      const collective = await fakeActiveHost({ admin: remoteUser });
+
+      // Create related models
+      const member = await fakeMember({ CollectiveId: collective.id });
+      const memberInvitation = await fakeMemberInvitation({ CollectiveId: collective.id });
+      const update = await fakeUpdate({ CollectiveId: collective.id });
+      const legalDocument = await fakeLegalDocument({ CollectiveId: collective.id });
+      const agreement = await fakeAgreement({ CollectiveId: collective.id });
+      const location = await fakeLocation({ CollectiveId: collective.id });
+      const conversation = await fakeConversation({ CollectiveId: collective.id });
+      const comment = await fakeComment({ CollectiveId: collective.id });
+      const application = await fakeApplication({ CollectiveId: collective.id });
+      const order = await fakeOrder({ CollectiveId: collective.id, status: OrderStatuses.PENDING });
+      const expense = await fakeExpense({ CollectiveId: collective.id, status: ExpenseStatuses.DRAFT });
+      const expenseItem = await fakeExpenseItem({ ExpenseId: expense.id });
+      const recurringExpense = await fakeRecurringExpense({ CollectiveId: collective.id });
+      const transactionsImport = await fakeTransactionsImport({ CollectiveId: collective.id });
+      const transactionsImportRow = await fakeTransactionsImportRow({ TransactionsImportId: transactionsImport.id });
+      const hostApplication = await fakeHostApplication({ CollectiveId: collective.id });
+      const tier = await fakeTier({ CollectiveId: collective.id });
+      const paymentMethod = await fakePaymentMethod({ CollectiveId: collective.id });
+      const payoutMethod = await fakePayoutMethod({ CollectiveId: collective.id });
+      const connectedAccount = await fakeConnectedAccount({ CollectiveId: collective.id });
+      const virtualCard = await fakeVirtualCard({ CollectiveId: collective.id, HostCollectiveId: collective.id });
+      const virtualCardRequest = await fakeVirtualCardRequest({ CollectiveId: collective.id });
+      const platformSubscription = await fakePlatformSubscription({ CollectiveId: collective.id });
+      const personalToken = await fakePersonalToken({ CollectiveId: collective.id });
+      const requiredLegalDocument = await fakeRequiredLegalDocument({ HostCollectiveId: collective.id });
+
+      // Delete the collective
+      await deleteCollective(collective, remoteUser);
+
+      // Verify all related models are deleted
+      expect(await models.Member.findByPk(member.id)).to.be.null;
+      expect(await models.MemberInvitation.findByPk(memberInvitation.id)).to.be.null;
+      expect(await models.Update.findByPk(update.id)).to.be.null;
+      expect(await models.LegalDocument.findByPk(legalDocument.id)).to.be.null;
+      expect(await models.Agreement.findByPk(agreement.id)).to.be.null;
+      expect(await models.Location.findByPk(location.id)).to.be.null;
+      expect(await models.Conversation.findByPk(conversation.id)).to.be.null;
+      expect(await models.Comment.findByPk(comment.id)).to.be.null;
+      expect(await models.Application.findByPk(application.id)).to.be.null;
+      expect(await models.Order.findByPk(order.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense.id)).to.be.null;
+      expect(await models.ExpenseItem.findByPk(expenseItem.id)).to.be.null;
+      expect(await models.RecurringExpense.findByPk(recurringExpense.id)).to.be.null;
+      expect(await models.TransactionsImport.findByPk(transactionsImport.id)).to.be.null;
+      expect(await models.TransactionsImportRow.findByPk(transactionsImportRow.id)).to.be.null;
+      expect(await models.HostApplication.findByPk(hostApplication.id)).to.be.null;
+      expect(await models.Tier.findByPk(tier.id)).to.be.null;
+      expect(await models.PaymentMethod.findByPk(paymentMethod.id)).to.be.null;
+      expect(await models.PayoutMethod.findByPk(payoutMethod.id)).to.be.null;
+      expect(await models.ConnectedAccount.findByPk(connectedAccount.id)).to.be.null;
+      expect(await models.VirtualCard.findByPk(virtualCard.id)).to.be.null;
+      expect(await models.VirtualCardRequest.findByPk(virtualCardRequest.id)).to.be.null;
+      expect(await models.PlatformSubscription.findByPk(platformSubscription.id)).to.be.null;
+      expect(await models.PersonalToken.findByPk(personalToken.id)).to.be.null;
+      expect(await models.RequiredLegalDocument.findByPk(requiredLegalDocument.id)).to.be.null;
+      expect(await models.Collective.findByPk(collective.id)).to.be.null;
+
+      // Verify data that should NOT be deleted still exists
+      for (const data of dataToNotDelete) {
+        try {
+          await data.reload();
+        } catch (error) {
+          assert.fail(`Data should not have been deleted: ${data.constructor.name}. Received: ${error.message}`);
+        }
+      }
+    });
+
+    it('should delete member invitations by both CollectiveId and MemberCollectiveId', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+
+      const memberInvitation1 = await fakeMemberInvitation({ CollectiveId: collective.id });
+      const memberInvitation2 = await fakeMemberInvitation({ MemberCollectiveId: collective.id });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect(await models.MemberInvitation.findByPk(memberInvitation1.id)).to.be.null;
+      expect(await models.MemberInvitation.findByPk(memberInvitation2.id)).to.be.null;
+    });
+
+    it('should delete agreements by both CollectiveId and HostCollectiveId', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const agreement1 = await fakeAgreement({ CollectiveId: collective.id });
+      const agreement2 = await fakeAgreement({ HostCollectiveId: collective.id });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect(await models.Agreement.findByPk(agreement1.id)).to.be.null;
+      expect(await models.Agreement.findByPk(agreement2.id)).to.be.null;
+    });
+
+    it('should delete expenses by CollectiveId, FromCollectiveId, and UserId (for user collectives)', async () => {
+      const user = await fakeUser();
+      const expense1 = await fakeExpense({ CollectiveId: user.collective.id, status: 'DRAFT' });
+      const expense2 = await fakeExpense({ FromCollectiveId: user.collective.id, status: 'DRAFT' });
+      const expense3 = await fakeExpense({ UserId: user.id, status: 'DRAFT' });
+
+      await deleteCollective(user.collective, user);
+
+      expect(await models.Expense.findByPk(expense1.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense2.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense3.id)).to.be.null;
+    });
+
+    it('should delete expense items when expenses are deleted', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const expense = await fakeExpense({ CollectiveId: collective.id, status: 'DRAFT' });
+      const expenseItem = await fakeExpenseItem({ ExpenseId: expense.id });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect((await expense.reload({ paranoid: false })).deletedAt).to.not.be.null;
+      expect((await expenseItem.reload({ paranoid: false })).deletedAt).to.not.be.null;
+    });
+
+    it('should delete applications by CollectiveId and CreatedByUserId (for user collectives)', async () => {
+      const user = await fakeUser();
+      const application1 = await fakeApplication({ CollectiveId: user.collective.id });
+      const application2 = await fakeApplication({ CreatedByUserId: user.id });
+
+      await deleteCollective(user.collective, user);
+
+      expect(await models.Application.findByPk(application1.id)).to.be.null;
+      expect(await models.Application.findByPk(application2.id)).to.be.null;
+    });
+
+    it('should delete orders by FromCollectiveId and CollectiveId (only non-final statuses)', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const order1 = await fakeOrder({ CollectiveId: collective.id, status: OrderStatuses.PENDING });
+      const order2 = await fakeOrder({ FromCollectiveId: collective.id, status: OrderStatuses.ERROR });
+      const order3 = await fakeOrder({ CollectiveId: collective.id, status: OrderStatuses.PAID });
+      const order4 = await fakeOrder({ CollectiveId: collective.id, status: OrderStatuses.ACTIVE });
+      const order5 = await fakeOrder({ CollectiveId: collective.id, status: OrderStatuses.CANCELLED });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect(await models.Order.findByPk(order1.id)).to.be.null;
+      expect(await models.Order.findByPk(order2.id)).to.be.null;
+      expect(await models.Order.findByPk(order3.id)).to.exist; // Should not be deleted
+      expect(await models.Order.findByPk(order4.id)).to.exist; // Should not be deleted
+      expect(await models.Order.findByPk(order5.id)).to.exist; // Should not be deleted
+    });
+
+    it('should delete expenses only with non-final statuses', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const expense1 = await fakeExpense({ CollectiveId: collective.id, status: 'DRAFT' });
+      const expense2 = await fakeExpense({ CollectiveId: collective.id, status: 'APPROVED' });
+      const expense3 = await fakeExpense({ CollectiveId: collective.id, status: 'PAID' });
+      const expense4 = await fakeExpense({ CollectiveId: collective.id, status: 'PROCESSING' });
+      const expense5 = await fakeExpense({ CollectiveId: collective.id, status: 'SCHEDULED_FOR_PAYMENT' });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect(await models.Expense.findByPk(expense1.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense2.id)).to.be.null;
+      expect(await models.Expense.findByPk(expense3.id)).to.exist; // Should not be deleted
+      expect(await models.Expense.findByPk(expense4.id)).to.exist; // Should not be deleted
+      expect(await models.Expense.findByPk(expense5.id)).to.exist; // Should not be deleted
+    });
+
+    it('should delete host applications by CollectiveId and HostCollectiveId', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const hostApplication1 = await fakeHostApplication({ CollectiveId: collective.id });
+      const hostApplication2 = await fakeHostApplication({ HostCollectiveId: collective.id });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect(await models.HostApplication.findByPk(hostApplication1.id)).to.be.null;
+      expect(await models.HostApplication.findByPk(hostApplication2.id)).to.be.null;
+    });
+
+    it('should delete virtual cards by CollectiveId and HostCollectiveId', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const virtualCard1 = await fakeVirtualCard({ CollectiveId: collective.id });
+      const virtualCard2 = await fakeVirtualCard({ HostCollectiveId: collective.id });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect(await models.VirtualCard.findByPk(virtualCard1.id)).to.be.null;
+      expect(await models.VirtualCard.findByPk(virtualCard2.id)).to.be.null;
+    });
+
+    it('should delete virtual card requests by CollectiveId and HostCollectiveId', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const virtualCardRequest1 = await fakeVirtualCardRequest({ CollectiveId: collective.id });
+      const virtualCardRequest2 = await fakeVirtualCardRequest({ HostCollectiveId: collective.id });
+
+      await deleteCollective(collective, remoteUser);
+
+      expect(await models.VirtualCardRequest.findByPk(virtualCardRequest1.id)).to.be.null;
+      expect(await models.VirtualCardRequest.findByPk(virtualCardRequest2.id)).to.be.null;
+    });
+
+    describe('Users', () => {
+      it('should delete personal tokens by CollectiveId and UserId', async () => {
+        const user = await fakeUser();
+        const personalToken1 = await fakePersonalToken({ CollectiveId: user.collective.id });
+        const personalToken2 = await fakePersonalToken({ UserId: user.id });
+
+        await deleteCollective(user.collective, user);
+
+        expect(await models.PersonalToken.findByPk(personalToken1.id)).to.be.null;
+        expect(await models.PersonalToken.findByPk(personalToken2.id)).to.be.null;
+      });
+
+      it('should delete the user when deleting a user collective', async () => {
+        const user = await fakeUser();
+        await deleteCollective(user.collective, user);
+        expect(await models.User.findByPk(user.id)).to.be.null;
+      });
+
+      it('should not delete the user when deleting a non-user collective', async () => {
+        const remoteUser = await fakeUser();
+        const collective = await fakeCollective({ admin: remoteUser });
+        const otherUser = await fakeUser();
+        await deleteCollective(collective, remoteUser);
+
+        expect(await models.User.findByPk(otherUser.id)).to.exist;
+      });
+    });
+
+    it('should NOT delete the admin profiles when deleting a collective', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      await deleteCollective(collective, remoteUser);
+
+      expect((await remoteUser.collective.reload({ paranoid: false })).deletedAt).to.be.null;
+    });
+
+    it('should create a COLLECTIVE_DELETED activity after deletion', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      await deleteCollective(collective, remoteUser);
+
+      const activity = await models.Activity.findOne({
+        where: {
+          type: ActivityTypes.COLLECTIVE_DELETED,
+          CollectiveId: collective.id,
+          UserId: remoteUser.id,
+        },
+      });
+
+      expect(activity).to.exist;
+      expect(activity.FromCollectiveId).to.equal(collective.id);
+    });
+
+    it('should handle deletion in a transaction (rollback on error)', async () => {
+      const remoteUser = await fakeUser();
+      const collective = await fakeCollective({ admin: remoteUser });
+      const member = await fakeMember({ CollectiveId: collective.id });
+
+      // Mock an error during deletion
+      const originalDestroy = models.Member.destroy;
+      models.Member.destroy = async function () {
+        throw new Error('Simulated error');
+      };
+
+      try {
+        await deleteCollective(collective, remoteUser);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error.message).to.equal('Simulated error');
+        // Verify transaction was rolled back - member should still exist
+        expect(await models.Member.findByPk(member.id)).to.exist;
+      } finally {
+        models.Member.destroy = originalDestroy;
+      }
     });
   });
 

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -24,6 +24,7 @@ import { PAYMENT_METHOD_SERVICES, PAYMENT_METHOD_TYPES } from '../../server/cons
 import { REACTION_EMOJI } from '../../server/constants/reaction-emoji';
 import MemberRoles from '../../server/constants/roles';
 import { TransactionKind } from '../../server/constants/transaction-kind';
+import { VirtualCardLimitIntervals } from '../../server/constants/virtual-cards';
 import { crypto } from '../../server/lib/encryption';
 import { createTransactionsForManuallyPaidExpense } from '../../server/lib/transactions';
 import { TwoFactorMethod } from '../../server/lib/two-factor-authentication';
@@ -48,6 +49,7 @@ import models, {
   Update,
   UploadedFile,
   VirtualCard,
+  VirtualCardRequest,
 } from '../../server/models';
 import AccountingCategory from '../../server/models/AccountingCategory';
 import Application, { ApplicationType } from '../../server/models/Application';
@@ -70,6 +72,7 @@ import User from '../../server/models/User';
 import UserToken, { TokenType } from '../../server/models/UserToken';
 import UserTwoFactorMethod from '../../server/models/UserTwoFactorMethod';
 import { VirtualCardStatus } from '../../server/models/VirtualCard';
+import { VirtualCardRequestStatus } from '../../server/models/VirtualCardRequest';
 import { randEmail, randUrl } from '../stores';
 
 export { randEmail, sequelize };
@@ -1104,6 +1107,26 @@ export const fakeVirtualCard = async (virtualCardData: Partial<InferCreationAttr
     },
     CollectiveId,
     HostCollectiveId,
+  });
+};
+
+export const fakeVirtualCardRequest = async (
+  virtualCardRequestData: Partial<InferCreationAttributes<VirtualCardRequest>> = {},
+) => {
+  const CollectiveId = virtualCardRequestData.CollectiveId || (await fakeCollective()).id;
+  const HostCollectiveId =
+    virtualCardRequestData.HostCollectiveId || (await models.Collective.getHostCollectiveId(CollectiveId));
+  return models.VirtualCardRequest.create({
+    purpose: randStr('purpose'),
+    notes: randStr('notes'),
+    status: VirtualCardRequestStatus.PENDING,
+    currency: 'USD',
+    spendingLimitAmount: randAmount(),
+    spendingLimitInterval: VirtualCardLimitIntervals.ALL_TIME,
+    ...virtualCardRequestData,
+    CollectiveId,
+    HostCollectiveId,
+    UserId: virtualCardRequestData.UserId || (await fakeUser()).id,
   });
 };
 


### PR DESCRIPTION
Some parts of the code are crashing because data associated with deleted collective is not deleted. We just had a case with Host applications being returned with a null account, which is not permitted by the GraphQL API.

This PR does mainly two things:
1. Add support for mode models in `ban-collectives` and `deleteCollective`
2.  Wrap `deleteCollective` in a SQL transaction to prevent deleting only part of the data