### PR TITLE
SignUp: delete user.collective after OTP fails

### DIFF
--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -484,6 +484,10 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
 
     const destroyInTransaction = async transaction => {
       await this.update({ email: newEmail }, { transaction });
+      const collective = await Collective.findByPk(this.CollectiveId, { transaction });
+      if (collective) {
+        await collective.destroy({ transaction });
+      }
       return this.destroy({ transaction });
     };
 


### PR DESCRIPTION
This was missing and triggering some DB checks.