### PR TITLE
Clear accounting category when moving to different host

### DIFF
--- a/test/server/graphql/v2/mutation/AccountingCategoriesMutations.test.ts
+++ b/test/server/graphql/v2/mutation/AccountingCategoriesMutations.test.ts
@@ -253,12 +253,12 @@ describe('server/graphql/v2/mutation/AccountingCategoriesMutations', () => {
       expect(getNodesFromResult(result3)).to.have.length(0);
 
       // Check activities
+      await sleep(100); // For the async activity creation
       const activities = await models.Activity.findAll({
         where: { CollectiveId: host.id, type: ActivityTypes.ACCOUNTING_CATEGORIES_EDITED },
         order: [['createdAt', 'ASC']],
       });
 
-      await sleep(100); // For the async activity creation
       expect(activities).to.have.length(3);
       activities.forEach(activity => {
         expect(activity.HostCollectiveId).to.equal(host.id);


### PR DESCRIPTION
When expenses are moved to an account under a different host, the AccountingCategoryId is now cleared since accounting categories belong to specific hosts and would be invalid after the move.

The migration log now also captures the previous AccountingCategoryId for audit purposes.