### PR TITLE
Update config to v4.4.1 and add type declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "cloudflare": "4.5.0",
         "cloudflare-ip": "0.0.7",
         "commander": "14.0.3",
-        "config": "4.3.0",
+        "config": "4.4.1",
         "connect-redis": "9.0.0",
         "cookie-parser": "1.4.7",
         "cors": "2.8.6",
@@ -15176,9 +15176,9 @@
       }
     },
     "node_modules/config": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-4.3.0.tgz",
-      "integrity": "sha512-nY/JbYPBxOCTC+Kj9dUf21t49VxwsL6GXRsAxlTY9N6MBTx/6TBQgT2t5PsAY+XUCMCNudARJPevUZeN3NhyHQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/config/-/config-4.4.1.tgz",
+      "integrity": "sha512-XfN4Q4+wBKkGtgMyQ+5ayjepdb0MrdiGKfBr0G1PTLx9rnqsX+Xiw03LEUtSALZU0UVfcFp6+xYV0NL8HLF94g==",
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.3"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cloudflare": "4.5.0",
     "cloudflare-ip": "0.0.7",
     "commander": "14.0.3",
-    "config": "4.3.0",
+    "config": "4.4.1",
     "connect-redis": "9.0.0",
     "cookie-parser": "1.4.7",
     "cors": "2.8.6",

--- a/server/types/config.d.ts
+++ b/server/types/config.d.ts
@@ -1,0 +1,10 @@
+declare module 'config' {
+  interface IConfig {
+    get<T>(property: string): T;
+    has(property: string): boolean;
+    [key: string]: any;
+  }
+
+  const config: IConfig;
+  export = config;
+}

--- a/server/types/config.d.ts
+++ b/server/types/config.d.ts
@@ -1,7 +1,18 @@
+// Override config module types to add an index signature for direct property access
+// (e.g. config.env, config.host) used throughout the codebase.
+//
+// config@4.4.1 ships types where ConfigClass has no index signature and is not exported,
+// so a proper module augmentation cannot extend it. This ambient module declaration
+// takes precedence over the package's own types during resolution.
 declare module 'config' {
   interface IConfig {
     get<T>(property: string): T;
     has(property: string): boolean;
+    util: {
+      getEnv(varName: string): string;
+      toObject(config?: object): object;
+      [key: string]: any;
+    };
     [key: string]: any;
   }
 


### PR DESCRIPTION
Update the `config` dependency from 4.3.0 to 4.4.1. The new version ships bundled TypeScript types with a strict `ConfigClass` that lacks an index signature.