### PR TITLE
Assign PlatformSubscription when converting account to organization

### DIFF
--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -1,3 +1,4 @@
+import config from 'config';
 import cryptoRandomString from 'crypto-random-string';
 import express from 'express';
 import {
@@ -14,6 +15,7 @@ import { cloneDeep, defaultsDeep, isEmpty, isEqual, isNull, keys, omitBy, pick, 
 
 import activities from '../../../constants/activities';
 import { CollectiveType } from '../../../constants/collectives';
+import { PlatformSubscriptionTiers } from '../../../constants/plans';
 import POLICIES from '../../../constants/policies';
 import { purgeCacheForCollective } from '../../../lib/cache';
 import * as collectivelib from '../../../lib/collectivelib';
@@ -25,7 +27,8 @@ import { containsProtectedBrandName } from '../../../lib/string-utils';
 import TwoFactorAuthLib, { TwoFactorMethod } from '../../../lib/two-factor-authentication';
 import * as webauthn from '../../../lib/two-factor-authentication/webauthn';
 import { validateYubikeyOTP } from '../../../lib/two-factor-authentication/yubikey-otp';
-import models, { Collective, HostApplication, sequelize } from '../../../models';
+import { parseToBoolean } from '../../../lib/utils';
+import models, { Collective, HostApplication, PlatformSubscription, sequelize } from '../../../models';
 import { HostApplicationStatus } from '../../../models/HostApplication';
 import UserTwoFactorMethod from '../../../models/UserTwoFactorMethod';
 import { PAYPAL_SUSPEND_MAX_REASON_LENGTH } from '../../../paymentProviders/paypal/subscription';
@@ -988,6 +991,16 @@ const accountMutations = {
 
       if (args.hasMoneyManagement === true) {
         await account.activateMoneyManagement(req.remoteUser, { silent: true });
+      }
+
+      if (parseToBoolean(config.features?.newPricing)) {
+        await PlatformSubscription.createSubscription(
+          account,
+          new Date(),
+          PlatformSubscriptionTiers.find(t => t.id === 'discover-1'),
+          req.remoteUser,
+          { notify: false },
+        );
       }
 
       await models.Activity.create({

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -994,13 +994,16 @@ const accountMutations = {
       }
 
       if (parseToBoolean(config.features?.newPricing)) {
-        await PlatformSubscription.createSubscription(
-          account,
-          new Date(),
-          PlatformSubscriptionTiers.find(t => t.id === 'discover-1'),
-          req.remoteUser,
-          { notify: false },
-        );
+        const existingSubscription = await PlatformSubscription.getCurrentSubscription(account.id);
+        if (!existingSubscription) {
+          await PlatformSubscription.createSubscription(
+            account,
+            new Date(),
+            PlatformSubscriptionTiers.find(t => t.id === 'discover-1'),
+            req.remoteUser,
+            { notify: false },
+          );
+        }
       }
 
       await models.Activity.create({

--- a/server/graphql/v2/mutation/OrganizationMutations.ts
+++ b/server/graphql/v2/mutation/OrganizationMutations.ts
@@ -285,6 +285,15 @@ export default {
 
       await twoFactorAuthLib.enforceForAccount(req, organization, { alwaysAskForToken: true });
 
+      if (parseToBoolean(config.features?.newPricing)) {
+        const currentSubscription = await PlatformSubscription.getCurrentSubscription(organization.id);
+        if (currentSubscription) {
+          await currentSubscription.update({
+            period: [currentSubscription.start, { value: new Date(), inclusive: false }],
+          });
+        }
+      }
+
       const collective = await organization.update({ type: COLLECTIVE });
 
       await models.Activity.create({

--- a/server/graphql/v2/mutation/OrganizationMutations.ts
+++ b/server/graphql/v2/mutation/OrganizationMutations.ts
@@ -179,7 +179,7 @@ export default {
         await PlatformSubscription.createSubscription(
           organization,
           new Date(),
-          PlatformSubscriptionTiers.find(t => (t.id = 'discover-1')),
+          PlatformSubscriptionTiers.find(t => t.id === 'discover-1'),
           user,
           { notify: false },
         );


### PR DESCRIPTION
The convertAccountToOrganization mutation was missing PlatformSubscription creation, so converted orgs would have no plan under new pricing. Also fixes a bug in createOrganization where = was used instead of === in the PlatformSubscriptionTiers.find() call.