### PR TITLE
feat(search): make other searches diacritic insensitive with the `unaccent` extension

### DIFF
--- a/migrations/20260406053419-create-extension-unaccent.js
+++ b/migrations/20260406053419-create-extension-unaccent.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE EXTENSION IF NOT EXISTS unaccent;
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP EXTENSION IF EXISTS unaccent;
+    `);
+  },
+};

--- a/server/graphql/v2/interface/Account.ts
+++ b/server/graphql/v2/interface/Account.ts
@@ -627,7 +627,7 @@ const accountFieldsDefinition = () => ({
       const searchTermConditions = buildSearchConditions(searchTerm, {
         idFields: ['id'],
         slugFields: ['$fromCollective.slug$'],
-        textFields: ['$fromCollective.name$', 'title', 'html'],
+        textFields: ['$fromCollective.name$', 'Update.title', 'Update.html'],
         publicIdFields: [
           { field: 'publicId', prefix: EntityShortIdPrefix.Update },
           { field: '$fromCollective.publicId$', prefix: EntityShortIdPrefix.Collective },

--- a/server/graphql/v2/interface/IsMemberOf.js
+++ b/server/graphql/v2/interface/IsMemberOf.js
@@ -147,7 +147,7 @@ export const IsMemberOfFields = {
       const searchTermConditions = buildSearchConditions(args.searchTerm, {
         idFields: ['id', '$collective.id$'],
         slugFields: ['$collective.slug$'],
-        textFields: ['$collective.name$', '$collective.description$', 'description', 'role'],
+        textFields: ['$collective.name$', '$collective.description$', 'Member.description', 'Member.role'],
         stringArrayFields: ['$collective.tags$'],
         stringArrayTransformFn: str => str.toLowerCase(), // collective tags are stored lowercase
         castStringArraysToVarchar: true,

--- a/server/graphql/v2/object/Host.ts
+++ b/server/graphql/v2/object/Host.ts
@@ -33,6 +33,7 @@ import { getPolicy } from '../../../lib/policies';
 import SQLQueries from '../../../lib/queries';
 import sequelize from '../../../lib/sequelize';
 import { buildKyselySearchConditions, buildSearchConditions } from '../../../lib/sql-search';
+import { removeDiacritics } from '../../../lib/string-utils';
 import { getHostReportNodesFromQueryResult } from '../../../lib/transaction-reports';
 import { ifStr, parseToBoolean } from '../../../lib/utils';
 import models, { Collective, ConnectedAccount, Op, TransactionsImportRow } from '../../../models';
@@ -1005,7 +1006,10 @@ export const GraphQLHost = new GraphQLObjectType({
           const hasExpenseToDate = !isNil(args.withExpensesDateTo);
           const hasExpensePeriodFilter = hasExpenseFromDate || hasExpenseToDate;
           const hasSearchTerm = !isNil(args.searchTerm) && args.searchTerm.length !== 0;
-          const searchTerm = `%${args.searchTerm}%`;
+          const searchTerm =
+            hasSearchTerm && typeof args.searchTerm === 'string'
+              ? `%${removeDiacritics(args.searchTerm)}%`
+              : `%${args.searchTerm}%`;
 
           const baseQuery = `
             SELECT
@@ -1079,8 +1083,8 @@ export const GraphQLHost = new GraphQLObjectType({
               ${ifStr(
                 hasSearchTerm,
                 `AND (
-                vc.name ILIKE :searchTerm
-                OR vc.data#>>'{last4}' ILIKE :searchTerm
+                unaccent(vc.name) ILIKE :searchTerm
+                OR unaccent(vc.data#>>'{last4}') ILIKE :searchTerm
               )`,
               )}
           `;
@@ -2338,7 +2342,7 @@ export const GraphQLHost = new GraphQLObjectType({
           if (args.searchTerm) {
             where.push({
               [Op.or]: buildSearchConditions(args.searchTerm, {
-                textFields: ['description', 'sourceId'],
+                textFields: ['TransactionsImportRow.description', 'TransactionsImportRow.sourceId'],
                 publicIdFields: [{ field: 'publicId', prefix: EntityShortIdPrefix.TransactionsImportRow }],
               }),
             });

--- a/server/graphql/v2/query/collection/CommunityQuery.ts
+++ b/server/graphql/v2/query/collection/CommunityQuery.ts
@@ -6,6 +6,7 @@ import { isNil } from 'lodash';
 import { QueryTypes, Sequelize } from 'sequelize';
 
 import { parseSearchTerm, sanitizeSearchTermForILike } from '../../../../lib/sql-search';
+import { removeDiacritics } from '../../../../lib/string-utils';
 import { ifStr } from '../../../../lib/utils';
 import { Collective, sequelize } from '../../../../models';
 import { allowContextPermission, PERMISSION_TYPE } from '../../../common/context-permissions';
@@ -59,10 +60,10 @@ const buildSearchConditions = (
       replacements: { searchTerm: parsed.term },
     };
   } else {
-    const sanitizedTerm = sanitizeSearchTermForILike(parsed.term);
+    const sanitizedTerm = sanitizeSearchTermForILike(removeDiacritics(parsed.term));
     return {
       joinClause: `LEFT JOIN "Users" u ON u."CollectiveId" = fc.id AND u."deletedAt" IS NULL`,
-      whereClause: `AND (fc."name" ILIKE :searchTermPattern OR fc.slug ILIKE :searchTermPattern OR u."email" ILIKE :searchTermPattern)`,
+      whereClause: `AND (unaccent(fc."name") ILIKE :searchTermPattern OR unaccent(fc.slug) ILIKE :searchTermPattern OR unaccent(u."email") ILIKE :searchTermPattern)`,
       replacements: { searchTermPattern: `%${sanitizedTerm}%` },
     };
   }

--- a/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ExpensesCollectionQuery.ts
@@ -482,7 +482,7 @@ export const ExpensesCollectionQueryResolver = async (
     idFields: ['id'],
     dataFields: ['data.transactionId', 'data.transfer.id', 'data.transaction_id', 'data.batchGroup.id', 'reference'],
     slugFields: ['$fromCollective.slug$', '$collective.slug$', '$User.collective.slug$'],
-    textFields: ['$fromCollective.name$', '$collective.name$', '$User.collective.name$', 'description'],
+    textFields: ['$fromCollective.name$', '$collective.name$', '$User.collective.name$', 'Expense.description'],
     emailFields: isHostAdmin ? ['$User.email$'] : [],
     amountFields: ['amount'],
     stringArrayFields: ['tags'],

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -17,6 +17,7 @@ import { TransactionKind } from '../../../../constants/transaction-kind';
 import { DatabaseWithViews, getKysely, kyselyToSequelizeModels } from '../../../../lib/kysely';
 import { EntityShortIdPrefix, isEntityPublicId } from '../../../../lib/permalink/entity-map';
 import { buildSearchConditions } from '../../../../lib/sql-search';
+import { removeDiacritics } from '../../../../lib/string-utils';
 import models, { Collective, ManualPaymentProvider, Op, PaymentMethod, Tier, User } from '../../../../models';
 import { checkScope } from '../../../common/scope-check';
 import { Forbidden, NotFound, Unauthorized } from '../../../errors';
@@ -521,7 +522,7 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
           .select('Orders.id')
           .where('Orders.deletedAt', 'is', null)
           .$if(!!args.searchTerm, qb => {
-            return qb.where(({ or, eb }) => {
+            return qb.where(({ fn, or, eb }) => {
               if (isFinite(Number(args.searchTerm)) && isInteger(Number(args.searchTerm))) {
                 ors.push(eb('Orders.id', '=', Number(args.searchTerm)));
               }
@@ -535,9 +536,17 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
                 ors.push(eb('Orders.FromCollectiveId', '=', collectiveBySearchTerm.id));
               }
 
-              ors.push(eb('Orders.description', 'ilike', `%${args.searchTerm}%`));
+              const searchTermNoDiacrits =
+                typeof args.searchTerm === 'string' ? removeDiacritics(args.searchTerm) : args.searchTerm;
+              ors.push(eb(fn<string>('unaccent', ['Orders.description']), 'ilike', `%${searchTermNoDiacrits}%`));
               ors.push(eb(sql`"Orders".data->>'ponumber'`, 'ilike', `%${args.searchTerm}%`));
-              ors.push(eb(sql`"Orders".data#>>'{fromAccountInfo,name}'`, 'ilike', `%${args.searchTerm}%`));
+              ors.push(
+                eb(
+                  fn<string>('unaccent', [sql`"Orders".data#>>'{fromAccountInfo,name}'`]),
+                  'ilike',
+                  `%${searchTermNoDiacrits}%`,
+                ),
+              );
               ors.push(eb(sql`"Orders".data#>>'{fromAccountInfo,email}'`, 'ilike', `%${args.searchTerm}%`));
               ors.push(
                 eb('Orders.tags', '&&', sql<string[]>`ARRAY[${args.searchTerm.toLocaleLowerCase()}]::varchar[]`),
@@ -915,8 +924,8 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
       const { limit = 10, offset = 0, searchTerm } = subArgs;
 
       const searchConditions = buildSearchConditions(searchTerm, {
-        slugFields: ['slug'],
-        textFields: ['name'],
+        slugFields: ['Collective.slug'],
+        textFields: ['Collective.name'],
         publicIdFields: [{ field: 'publicId', prefix: EntityShortIdPrefix.Collective }],
       });
 

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -423,7 +423,7 @@ export const TransactionsCollectionResolver = async (
   const searchTermConditions = buildSearchConditions(args.searchTerm, {
     idFields: ['id', 'ExpenseId', 'OrderId'],
     slugFields: ['$fromCollective.slug$', '$collective.slug$'],
-    textFields: ['$fromCollective.name$', '$collective.name$', 'description'],
+    textFields: ['$fromCollective.name$', '$collective.name$', 'Transaction.description'],
     amountFields: ['amount'],
     publicIdFields: [
       { field: 'publicId', prefix: EntityShortIdPrefix.Transaction },

--- a/server/lib/sql-search.ts
+++ b/server/lib/sql-search.ts
@@ -629,9 +629,21 @@ export const buildSearchConditions = (
   }
   // Conditions for text fields
   const strTerm = parsedTerm.term.toString(); // Some terms are returned as numbers
-  const iLikeQuery = `%${sanitizeSearchTermForILike(strTerm)}%`;
+  const iLikeQuery = `%${sanitizeSearchTermForILike(removeDiacritics(strTerm))}%`;
   const allTextFields = [...(slugFields || []), ...(textFields || [])];
-  allTextFields.forEach(field => conditions.push({ [field]: { [Op.iLike]: iLikeQuery } }));
+  allTextFields.forEach(field => {
+    let fieldToQuery = field;
+    // For slug fields that may be defined for an associated table,
+    // strip the $ so that the field name can work with sequelize.col
+    if (fieldToQuery.startsWith('$') && fieldToQuery.endsWith('$')) {
+      fieldToQuery = fieldToQuery.slice(1, fieldToQuery.length - 1);
+    }
+    conditions.push(
+      sequelize.where(sequelize.fn('unaccent', sequelize.col(fieldToQuery)), {
+        [Op.iLike]: iLikeQuery,
+      }),
+    );
+  });
 
   // Conditions for string array (usually tags lists)
   if (stringArrayFields?.length) {
@@ -719,10 +731,12 @@ export const buildKyselySearchConditions =
 
     // Conditions for text fields
     const strTerm = parsedTerm.term.toString(); // Some terms are returned as numbers
-    const iLikeQuery = `%${sanitizeSearchTermForILike(strTerm)}%`;
+    const iLikeQuery = `%${sanitizeSearchTermForILike(removeDiacritics(strTerm))}%`;
     const allTextFields = [...(slugFields || []), ...(textFields || [])];
 
-    q = q.where(({ eb, or }) => or(allTextFields.map(field => eb(field, 'ilike', iLikeQuery))));
+    q = q.where(({ fn, eb, or }) =>
+      or(allTextFields.map(field => eb(fn<string>('unaccent', [field]), 'ilike', iLikeQuery))),
+    );
     return q;
   };
 

--- a/test/server/graphql/v2/collection/OrdersCollectionQuery.test.ts
+++ b/test/server/graphql/v2/collection/OrdersCollectionQuery.test.ts
@@ -937,7 +937,7 @@ describe('server/graphql/v2/collection/OrdersCollectionQuery', () => {
       collective = await fakeCollective();
 
       // Create users with specific names for search testing
-      user1 = await fakeUser(null, { name: 'Alice Anderson' });
+      user1 = await fakeUser(null, { name: 'Alicé Anderson' });
       user2 = await fakeUser(null, { name: 'Bob Builder' });
 
       // Create orders by different users
@@ -960,7 +960,7 @@ describe('server/graphql/v2/collection/OrdersCollectionQuery', () => {
       const result = await graphqlQueryV2(ordersQuery, {
         account: { legacyId: collective.id },
         filter: 'INCOMING',
-        searchTerm: 'Alice',
+        searchTerm: 'Alice', // should be diacritic insensitive
       });
 
       expect(result.errors).to.not.exist;

--- a/test/server/lib/search.test.js
+++ b/test/server/lib/search.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import config from 'config';
 import { times } from 'lodash';
+import sequelize from 'sequelize';
 
 import { CollectiveType } from '../../../server/graphql/v1/CollectiveInterface';
 import { EntityShortIdPrefix } from '../../../server/lib/permalink/entity-map';
@@ -367,7 +368,7 @@ describe('server/lib/search', () => {
     const TEST_FIELDS_CONFIGURATION = {
       slugFields: ['slug', '$fromCollective.slug$'],
       idFields: ['id', '$fromCollective.id$'],
-      textFields: ['name', '$fromCollective.name$'],
+      textFields: ['Table.name', 'fromCollective.name'],
       amountFields: ['amount', '$order.totalAmount$'],
       stringArrayFields: ['tags'],
     };
@@ -378,6 +379,12 @@ describe('server/lib/search', () => {
 
     const testBuildSearchConditions = searchTerm => {
       return testBuildSearchConditionsWithCustomConfig(searchTerm, TEST_FIELDS_CONFIGURATION);
+    };
+
+    const unAccentedColumnILike = (col, text) => {
+      return sequelize.where(sequelize.fn('unaccent', sequelize.col(col)), {
+        [Op.iLike]: text,
+      });
     };
 
     it('returns no condition for an empty search', () => {
@@ -404,26 +411,10 @@ describe('server/lib/search', () => {
       };
       expect(buildSearchConditions(publicId, base)).to.deep.eq([
         { publicId },
-        {
-          slug: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          '$fromCollective.slug$': {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          name: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          '$fromCollective.name$': {
-            [Op.iLike]: term,
-          },
-        },
+        unAccentedColumnILike('slug', term),
+        unAccentedColumnILike('fromCollective.slug', term),
+        unAccentedColumnILike('Table.name', term),
+        unAccentedColumnILike('fromCollective.name', term),
         {
           tags: {
             [Op.overlap]: [publicId],
@@ -442,26 +433,10 @@ describe('server/lib/search', () => {
       ).to.deep.eq([
         { publicId },
         { mirrorPublicId: publicId },
-        {
-          slug: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          '$fromCollective.slug$': {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          name: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          '$fromCollective.name$': {
-            [Op.iLike]: term,
-          },
-        },
+        unAccentedColumnILike('slug', term),
+        unAccentedColumnILike('fromCollective.slug', term),
+        unAccentedColumnILike('Table.name', term),
+        unAccentedColumnILike('fromCollective.name', term),
         {
           tags: {
             [Op.overlap]: [publicId],
@@ -477,26 +452,10 @@ describe('server/lib/search', () => {
       ).to.deep.eq([
         { publicId },
         { 'Collective.publicId': publicId },
-        {
-          slug: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          '$fromCollective.slug$': {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          name: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          '$fromCollective.name$': {
-            [Op.iLike]: term,
-          },
-        },
+        unAccentedColumnILike('slug', term),
+        unAccentedColumnILike('fromCollective.slug', term),
+        unAccentedColumnILike('Table.name', term),
+        unAccentedColumnILike('fromCollective.name', term),
         {
           tags: {
             [Op.overlap]: [publicId],
@@ -515,21 +474,9 @@ describe('server/lib/search', () => {
           publicIdFields: [{ field: 'publicId', prefix: EntityShortIdPrefix.Collective }],
         }),
       ).to.deep.eq([
-        {
-          slug: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          name: {
-            [Op.iLike]: term,
-          },
-        },
-        {
-          description: {
-            [Op.iLike]: term,
-          },
-        },
+        unAccentedColumnILike('slug', term),
+        unAccentedColumnILike('name', term),
+        unAccentedColumnILike('description', term),
       ]);
     });
 
@@ -537,20 +484,21 @@ describe('server/lib/search', () => {
       const publicId = 'acc_noExclusiveFields';
       const iLike = `%${sanitizeSearchTermForILike(publicId)}%`;
       expect(testBuildSearchConditions(publicId)).to.deep.eq([
-        { slug: { [Op.iLike]: iLike } },
-        { '$fromCollective.slug$': { [Op.iLike]: iLike } },
-        { name: { [Op.iLike]: iLike } },
-        { '$fromCollective.name$': { [Op.iLike]: iLike } },
+        unAccentedColumnILike('slug', iLike),
+        unAccentedColumnILike('fromCollective.slug', iLike),
+        unAccentedColumnILike('Table.name', iLike),
+        unAccentedColumnILike('fromCollective.name', iLike),
         { tags: { [Op.overlap]: [publicId] } },
       ]);
     });
 
     it('build conditions for numbers', () => {
+      let iLike = '%4242%';
       expect(testBuildSearchConditions('4242')).to.deep.eq([
-        { slug: { [Op.iLike]: '%4242%' } },
-        { '$fromCollective.slug$': { [Op.iLike]: '%4242%' } },
-        { name: { [Op.iLike]: '%4242%' } },
-        { '$fromCollective.name$': { [Op.iLike]: '%4242%' } },
+        unAccentedColumnILike('slug', iLike),
+        unAccentedColumnILike('fromCollective.slug', iLike),
+        unAccentedColumnILike('Table.name', iLike),
+        unAccentedColumnILike('fromCollective.name', iLike),
         { tags: { [Op.overlap]: ['4242'] } },
         { id: 4242 },
         { '$fromCollective.id$': 4242 },
@@ -558,11 +506,12 @@ describe('server/lib/search', () => {
         { '$order.totalAmount$': 424200 },
       ]);
 
+      iLike = '%4242.66%';
       expect(testBuildSearchConditions('4242.66')).to.deep.eq([
-        { slug: { [Op.iLike]: '%4242.66%' } },
-        { '$fromCollective.slug$': { [Op.iLike]: '%4242.66%' } },
-        { name: { [Op.iLike]: '%4242.66%' } },
-        { '$fromCollective.name$': { [Op.iLike]: '%4242.66%' } },
+        unAccentedColumnILike('slug', iLike),
+        unAccentedColumnILike('fromCollective.slug', iLike),
+        unAccentedColumnILike('Table.name', iLike),
+        unAccentedColumnILike('fromCollective.name', iLike),
         { tags: { [Op.overlap]: ['4242.66'] } },
         { amount: 424266 },
         { '$order.totalAmount$': 424266 },
@@ -570,12 +519,24 @@ describe('server/lib/search', () => {
     });
 
     it('build conditions for full text', () => {
+      const iLike = '%hello world%';
       expect(testBuildSearchConditions('   hello world   ')).to.deep.eq([
-        { slug: { [Op.iLike]: '%hello world%' } },
-        { '$fromCollective.slug$': { [Op.iLike]: '%hello world%' } },
-        { name: { [Op.iLike]: '%hello world%' } },
-        { '$fromCollective.name$': { [Op.iLike]: '%hello world%' } },
+        unAccentedColumnILike('slug', iLike),
+        unAccentedColumnILike('fromCollective.slug', iLike),
+        unAccentedColumnILike('Table.name', iLike),
+        unAccentedColumnILike('fromCollective.name', iLike),
         { tags: { [Op.overlap]: ['hello world'] } },
+      ]);
+    });
+
+    it('build conditions for text with diacritics', () => {
+      const iLike = '%creme brulee%';
+      expect(testBuildSearchConditions('crème brûlée')).to.deep.eq([
+        unAccentedColumnILike('slug', iLike),
+        unAccentedColumnILike('fromCollective.slug', iLike),
+        unAccentedColumnILike('Table.name', iLike),
+        unAccentedColumnILike('fromCollective.name', iLike),
+        { tags: { [Op.overlap]: ['crème brûlée'] } },
       ]);
     });
 


### PR DESCRIPTION
Fixes opencollective/opencollective#8582

- Adds the [`unaccent` extension](https://www.postgresql.org/docs/16/unaccent.html) in the postgres db, which includes a function that can remove diacritics from strings.
- Uses the new `unaccent` function on db fields when they are being filtered with an `ILIKE`, and prepare search terms with `removeDiacritics` accordingly
    - In `sql-search.ts`, `buildSearchConditions` and `buildKyselySearchConditions` uses `unaccent` and `removeDiacritics` for searching on text fields.
    - As a consequence of this change, for `sequelize`-based queries built on `buildSearchConditions`, `sequelize.col` complains if the column name could be ambiguous. So, I went through all the usages of `buildSearchConditions` and specified the tables for `textFields` where necessary (just whenever there was an `include` clause aka an associated table / join. I figured usages that did not have an `include` would not have this problem.)
    - There were a one-off query using sequelize and a couple of one-off queries using Kysely that used an `ILIKE` that I had to manually convert to use `unaccent`. The fact that these aren’t centralized feels a little off to me personally.

For reviewing, `sql-search.ts` has the main logic change. `CommunityQuery.ts`, `OrdersCollectionQuery.ts` and `Host.ts` also has new usages of `unaccent` since they are one-offs. The other changes are due to `sequelize.col` needing more specific column references.

I think I got all the relevant places where there is search, but given my unfamiliarity with the whole codebase, I wouldn’t be surprised if I missed some. As a caveat, I also haven’t thought about performance at all while implementing this.

<details>
<summary>Screenshots of various pages with diacritic insensitive search</summary>
<img width="1255" height="727" alt="Screenshot 2026-04-06 at 9 43 55 PM" src="https://github.com/user-attachments/assets/8289b0c9-3e6f-42c6-b7d7-91ce64144615" />
<img width="1086" height="632" alt="Screenshot 2026-04-06 at 9 43 44 PM" src="https://github.com/user-attachments/assets/a5813a52-250f-4c54-9663-55526d61d9ef" />
<img width="1171" height="634" alt="Screenshot 2026-04-06 at 9 43 34 PM" src="https://github.com/user-attachments/assets/fe0afeb8-f030-471d-b1b6-1a52d1689c70" />
<img width="1244" height="665" alt="Screenshot 2026-04-06 at 9 43 20 PM" src="https://github.com/user-attachments/assets/a3a40995-d956-4884-96c9-14938e30ef53" />
<img width="1397" height="577" alt="Screenshot 2026-04-06 at 9 40 55 PM" src="https://github.com/user-attachments/assets/4f391c6d-4f23-4104-91ed-348bf67439d2" />
<img width="1254" height="582" alt="Screenshot 2026-04-06 at 9 40 41 PM" src="https://github.com/user-attachments/assets/aee2643c-0c9c-4907-a570-a2447f4d16fd" />
</details>
