### PR TITLE
fix: Exclude Vendors in collective childrenIds loader

### DIFF
--- a/server/graphql/loaders/index.ts
+++ b/server/graphql/loaders/index.ts
@@ -557,7 +557,10 @@ export const generateLoaders = req => {
         Collective.findAll({
           mapToModel: false,
           raw: true,
-          where: { ParentCollectiveId: { [Op.in]: ids } },
+          where: {
+            ParentCollectiveId: { [Op.in]: ids },
+            type: { [Op.ne]: CollectiveType.VENDOR },
+          },
           attributes: ['ParentCollectiveId', 'id'],
         }).then((results: { ParentCollectiveId: number; id: number }[]) => {
           const groupedResults = new Map<number, Set<number>>();


### PR DESCRIPTION
Fix for issue reported on [Slack](https://oficonsortium.slack.com/archives/C088UEB5LDS/p1775647594649679), where vendor expenses were included in the "Issued Payment Requests" dashboard, due to the `childrenIds` loader used in the `expenses` query when querying for `fromAccount` + `includeChildrenExpenses`