### PR TITLE
perf: fix UploadedFiles S3 hash index operator

### DIFF
--- a/migrations/20260415105000-reindex-uploaded-files-s3-2.js
+++ b/migrations/20260415105000-reindex-uploaded-files-s3-2.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "UploadedFiles_s3_hash"`);
+    await queryInterface.sequelize.query(`
+      CREATE INDEX "UploadedFiles_s3_hash"
+      ON public."UploadedFiles" ((data #>> '{s3SHA256}'))
+      WHERE "deletedAt" IS NULL AND data #>> '{s3SHA256}' IS NOT NULL
+    `);
+  },
+
+  async down() {
+    console.log("Not bringing back the old index since it wasn't working with the new query");
+  },
+};

--- a/migrations/20260415105000-reindex-uploaded-files-s3-2.js
+++ b/migrations/20260415105000-reindex-uploaded-files-s3-2.js
@@ -5,7 +5,7 @@ module.exports = {
   async up(queryInterface) {
     await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "UploadedFiles_s3_hash"`);
     await queryInterface.sequelize.query(`
-      CREATE INDEX "UploadedFiles_s3_hash"
+      CREATE INDEX CONCURRENTLY "UploadedFiles_s3_hash"
       ON public."UploadedFiles" ((data #>> '{s3SHA256}'))
       WHERE "deletedAt" IS NULL AND data #>> '{s3SHA256}' IS NOT NULL
     `);


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/8597

I was digging into [sentry](https://open-collective.sentry.io/dashboard/183903/?globalFilter=%7B%22dataset%22%3A%22spans%22%2C%22tag%22%3A%7B%22key%22%3A%22sentry.normalized_description%22%2C%22name%22%3A%22sentry.normalized_description%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22%22%7D&globalFilter=%7B%22dataset%22%3A%22spans%22%2C%22tag%22%3A%7B%22key%22%3A%22span.group%22%2C%22name%22%3A%22span.group%22%2C%22kind%22%3A%22tag%22%7D%2C%22value%22%3A%22span.group%3A%5B812548c64f8b5059%5D%22%2C%22isTemporary%22%3Atrue%7D&project=-1&release=&statsPeriod=7d) and found a performance issue with one query related to expense security check.

It seems that the operator we used in the UploadedFiles s3SHA256 index does not match the operator that sequelize generates when querying the database.

It is important to note that for Postgres index, `data->>'field' != data#>>'{field}'` when indexing and querying, and that sequelzie always render queries using `#>>`.

