### PR TITLE
enhancement(OrdersCollectionQuery): Add opposite account scope

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -728,6 +728,11 @@ interface Account {
     host: AccountReferenceInput
 
     """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
+
+    """
     Return only orders created by these users. Limited to 1000 users at a time.
     """
     createdBy: [AccountReferenceInput]
@@ -3565,6 +3570,11 @@ type Host implements Account & AccountWithContributions & AccountWithPlatformSub
     host: AccountReferenceInput
 
     """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
+
+    """
     Return only orders created by these users. Limited to 1000 users at a time.
     """
     createdBy: [AccountReferenceInput]
@@ -5657,6 +5667,21 @@ enum ExpectedFundsFilter {
 }
 
 """
+Filters orders based on whether the opposite account (the other side of the order) is internal or external. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children (events/projects).
+"""
+enum OppositeAccountScope {
+  """
+  Only orders where the opposite account is within the same scope (same fiscal host, or same account hierarchy)
+  """
+  INTERNAL
+
+  """
+  Only orders where the opposite account is outside the scope
+  """
+  EXTERNAL
+}
+
+"""
 A collection of "Expenses"
 """
 type ExpenseCollection implements Collection {
@@ -6522,6 +6547,11 @@ type PaymentMethod {
     Return orders only for this host
     """
     host: AccountReferenceInput
+
+    """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
 
     """
     Return only orders created by these users. Limited to 1000 users at a time.
@@ -10163,6 +10193,11 @@ type Bot implements Account {
     host: AccountReferenceInput
 
     """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
+
+    """
     Return only orders created by these users. Limited to 1000 users at a time.
     """
     createdBy: [AccountReferenceInput]
@@ -11211,6 +11246,11 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     Return orders only for this host
     """
     host: AccountReferenceInput
+
+    """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
 
     """
     Return only orders created by these users. Limited to 1000 users at a time.
@@ -12833,6 +12873,11 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
     host: AccountReferenceInput
 
     """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
+
+    """
     Return only orders created by these users. Limited to 1000 users at a time.
     """
     createdBy: [AccountReferenceInput]
@@ -14170,6 +14215,11 @@ type Individual implements Account {
     Return orders only for this host
     """
     host: AccountReferenceInput
+
+    """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
 
     """
     Return only orders created by these users. Limited to 1000 users at a time.
@@ -15547,6 +15597,11 @@ type Organization implements Account & AccountWithContributions & AccountWithPla
     host: AccountReferenceInput
 
     """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
+
+    """
     Return only orders created by these users. Limited to 1000 users at a time.
     """
     createdBy: [AccountReferenceInput]
@@ -16740,6 +16795,11 @@ type Vendor implements Account & AccountWithContributions {
     Return orders only for this host
     """
     host: AccountReferenceInput
+
+    """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
 
     """
     Return only orders created by these users. Limited to 1000 users at a time.
@@ -18301,6 +18361,11 @@ type Query {
     Return orders only for this host
     """
     host: AccountReferenceInput
+
+    """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
 
     """
     Return only orders created by these users. Limited to 1000 users at a time.
@@ -21010,6 +21075,11 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
     host: AccountReferenceInput
 
     """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
+
+    """
     Return only orders created by these users. Limited to 1000 users at a time.
     """
     createdBy: [AccountReferenceInput]
@@ -22205,6 +22275,11 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
     Return orders only for this host
     """
     host: AccountReferenceInput
+
+    """
+    Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.
+    """
+    oppositeAccountScope: OppositeAccountScope
 
     """
     Return only orders created by these users. Limited to 1000 users at a time.

--- a/server/graphql/v2/enum/OppositeAccountScope.ts
+++ b/server/graphql/v2/enum/OppositeAccountScope.ts
@@ -1,0 +1,18 @@
+import { GraphQLEnumType } from 'graphql';
+
+const GraphQLOppositeAccountScope = new GraphQLEnumType({
+  name: 'OppositeAccountScope',
+  description:
+    'Filters orders based on whether the opposite account (the other side of the order) is internal or external. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children (events/projects).',
+  values: {
+    INTERNAL: {
+      description:
+        'Only orders where the opposite account is within the same scope (same fiscal host, or same account hierarchy)',
+    },
+    EXTERNAL: {
+      description: 'Only orders where the opposite account is outside the scope',
+    },
+  },
+});
+
+export default GraphQLOppositeAccountScope;

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -19,11 +19,12 @@ import { EntityShortIdPrefix, isEntityPublicId } from '../../../../lib/permalink
 import { buildSearchConditions } from '../../../../lib/sql-search';
 import models, { Collective, ManualPaymentProvider, Op, PaymentMethod, Tier, User } from '../../../../models';
 import { checkScope } from '../../../common/scope-check';
-import { Forbidden, NotFound, Unauthorized } from '../../../errors';
+import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../../../errors';
 import { GraphQLOrderCollection } from '../../collection/OrderCollection';
 import { GraphQLAccountOrdersFilter } from '../../enum/AccountOrdersFilter';
 import { GraphQLContributionFrequency } from '../../enum/ContributionFrequency';
 import GraphQLHostContext from '../../enum/HostContext';
+import GraphQLOppositeAccountScope from '../../enum/OppositeAccountScope';
 import { GraphQLOrderPausedBy } from '../../enum/OrderPausedBy';
 import { GraphQLOrderStatus } from '../../enum/OrderStatus';
 import { GraphQLPaymentMethodService } from '../../enum/PaymentMethodService';
@@ -296,6 +297,11 @@ export const OrdersCollectionArgs = {
     type: GraphQLAccountReferenceInput,
     description: 'Return orders only for this host',
   },
+  oppositeAccountScope: {
+    type: GraphQLOppositeAccountScope,
+    description:
+      'Filter orders by whether the opposite account is INTERNAL or EXTERNAL. For fiscal hosts, internal means within the same host. For regular accounts, internal means within the account and its children. When combined with `filter` (INCOMING/OUTGOING), the opposite account is the other side of the order.',
+  },
   createdBy: {
     type: new GraphQLList(GraphQLAccountReferenceInput),
     description: 'Return only orders created by these users. Limited to 1000 users at a time.',
@@ -340,6 +346,7 @@ interface OrdersCollectionArgsType {
   oppositeAccount?: AccountReferenceInput;
   hostedAccounts?: AccountReferenceInput[];
   host?: AccountReferenceInput;
+  oppositeAccountScope?: 'INTERNAL' | 'EXTERNAL';
   account?: AccountReferenceInput;
   createdBy?: AccountReferenceInput[];
 }
@@ -393,6 +400,25 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
         }
       }
     });
+  }
+
+  // Resolve scope for oppositeAccountScope filtering.
+  // For fiscal host accounts: scope is all accounts under the host (HostCollectiveId check).
+  // For regular accounts: scope is the account + its children (parent/child check).
+  let oppositeAccountScopeHostId: number | null = null;
+  let oppositeAccountScopeAccountId: number | null = null;
+  if (args.oppositeAccountScope) {
+    if (host && !account) {
+      throw new ValidationFailed(
+        'oppositeAccountScope is not supported with the `host` argument. Use `account` with `hostContext` instead.',
+      );
+    } else if (account?.hasMoneyManagement) {
+      oppositeAccountScopeHostId = account.id;
+    } else if (account) {
+      oppositeAccountScopeAccountId = account.id;
+    } else {
+      throw new ValidationFailed('oppositeAccountScope requires an `account` argument to determine the scope.');
+    }
   }
 
   let incognitoProfile: Collective | null = null;
@@ -672,6 +698,49 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
         }
 
         return or(ors);
+      });
+    })
+    .$if(!!args.oppositeAccountScope, qb => {
+      const isInternalScope = args.oppositeAccountScope === 'INTERNAL';
+      return qb.where(({ eb, not, and, or }) => {
+        type JoinAlias = 'collective' | 'fromCollective';
+        const orderIdField = (join: JoinAlias) =>
+          join === 'collective' ? ('Orders.CollectiveId' as const) : ('Orders.FromCollectiveId' as const);
+
+        // Host-level scoping: "internal" means hosted by the same fiscal host.
+        // The HostCollectiveId IS NOT NULL guard ensures null-safe negation via not().
+        const isWithinHost = (join: JoinAlias) =>
+          eb(`${join}.HostCollectiveId`, 'is not', null)
+            .and(eb(`${join}.HostCollectiveId`, '=', oppositeAccountScopeHostId))
+            .and(eb(`${join}.approvedAt`, 'is not', null));
+        const isOutsideHost = (join: JoinAlias) => not(isWithinHost(join));
+
+        // Account-level scoping: "internal" means the account itself or a non-vendor child.
+        // The ParentCollectiveId IS NOT NULL guard ensures null-safe negation via not().
+        const isWithinHierarchy = (join: JoinAlias) =>
+          or([
+            eb(orderIdField(join), '=', oppositeAccountScopeAccountId),
+            eb(`${join}.ParentCollectiveId`, 'is not', null)
+              .and(eb(`${join}.ParentCollectiveId`, '=', oppositeAccountScopeAccountId))
+              .and(eb(`${join}.type`, '!=', CollectiveType.VENDOR)),
+          ]);
+        const isOutsideHierarchy = (join: JoinAlias) => not(isWithinHierarchy(join));
+
+        const isWithinScope = oppositeAccountScopeHostId ? isWithinHost : isWithinHierarchy;
+        const isOutsideScope = oppositeAccountScopeHostId ? isOutsideHost : isOutsideHierarchy;
+
+        const oppositeJoins: JoinAlias[] =
+          args.filter === 'INCOMING'
+            ? ['fromCollective']
+            : args.filter === 'OUTGOING'
+              ? ['collective']
+              : ['collective', 'fromCollective'];
+
+        if (isInternalScope) {
+          return and(oppositeJoins.map(join => isWithinScope(join)));
+        } else {
+          return or(oppositeJoins.map(join => isOutsideScope(join)));
+        }
       });
     })
     .$if(paymentMethods.length > 0, qb => qb.where('PaymentMethodId', 'in', uniq(paymentMethods.map(pm => pm.id))))

--- a/test/server/graphql/v2/collection/OrdersCollectionQuery.test.ts
+++ b/test/server/graphql/v2/collection/OrdersCollectionQuery.test.ts
@@ -1302,6 +1302,332 @@ describe('server/graphql/v2/collection/OrdersCollectionQuery', () => {
     });
   });
 
+  describe('oppositeAccountScope filter', () => {
+    const oppositeAccountScopeQuery = gql`
+      query OrdersWithOppositeAccountScope(
+        $account: AccountReferenceInput
+        $host: AccountReferenceInput
+        $hostContext: HostContext
+        $filter: AccountOrdersFilter
+        $oppositeAccountScope: OppositeAccountScope
+      ) {
+        orders(
+          account: $account
+          host: $host
+          hostContext: $hostContext
+          filter: $filter
+          oppositeAccountScope: $oppositeAccountScope
+        ) {
+          totalCount
+          nodes {
+            id
+            legacyId
+            toAccount {
+              id
+              legacyId
+              slug
+            }
+            fromAccount {
+              id
+              legacyId
+              slug
+            }
+          }
+        }
+      }
+    `;
+
+    describe('with a fiscal host as account + hostContext ALL', () => {
+      let host, hostedCollectiveA, hostedCollectiveB, externalCollective, externalUser;
+      let internalIncomingOrder, externalIncomingOrder, internalOutgoingOrder, externalOutgoingOrder;
+
+      before(async () => {
+        host = await fakeActiveHost();
+        hostedCollectiveA = await fakeCollective({ HostCollectiveId: host.id, approvedAt: new Date() });
+        hostedCollectiveB = await fakeCollective({ HostCollectiveId: host.id, approvedAt: new Date() });
+        externalCollective = await fakeCollective();
+        externalUser = await fakeUser();
+
+        // Internal incoming: from hostedCollectiveB → hostedCollectiveA (both under same host)
+        internalIncomingOrder = await fakeOrder({
+          FromCollectiveId: hostedCollectiveB.id,
+          CollectiveId: hostedCollectiveA.id,
+          status: OrderStatuses.PAID,
+        });
+
+        // External incoming: from externalUser → hostedCollectiveA
+        externalIncomingOrder = await fakeOrder({
+          FromCollectiveId: externalUser.CollectiveId,
+          CollectiveId: hostedCollectiveA.id,
+          status: OrderStatuses.PAID,
+        });
+
+        // Internal outgoing: from hostedCollectiveA → hostedCollectiveB (both under same host)
+        internalOutgoingOrder = await fakeOrder({
+          FromCollectiveId: hostedCollectiveA.id,
+          CollectiveId: hostedCollectiveB.id,
+          status: OrderStatuses.PAID,
+        });
+
+        // External outgoing: from hostedCollectiveA → externalCollective
+        externalOutgoingOrder = await fakeOrder({
+          FromCollectiveId: hostedCollectiveA.id,
+          CollectiveId: externalCollective.id,
+          status: OrderStatuses.PAID,
+        });
+      });
+
+      it('INCOMING + INTERNAL: returns only incoming orders where the sender is within the same host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          filter: 'INCOMING',
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        // Both internal orders match: B→A is incoming to A (under host) with sender B (under host),
+        // and A→B is incoming to B (under host) with sender A (under host)
+        expect(result.data.orders.totalCount).to.eq(2);
+        const orderIds = result.data.orders.nodes.map(n => n.legacyId);
+        expect(orderIds).to.include(internalIncomingOrder.id);
+        expect(orderIds).to.include(internalOutgoingOrder.id);
+      });
+
+      it('INCOMING + EXTERNAL: returns only incoming orders where the sender is outside the host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          filter: 'INCOMING',
+          oppositeAccountScope: 'EXTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(externalIncomingOrder.id);
+      });
+
+      it('OUTGOING + INTERNAL: returns only outgoing orders where the recipient is within the same host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          filter: 'OUTGOING',
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        // Both internal orders match: A→B is outgoing from A (under host) to B (under host),
+        // and B→A is outgoing from B (under host) to A (under host)
+        expect(result.data.orders.totalCount).to.eq(2);
+        const orderIds = result.data.orders.nodes.map(n => n.legacyId);
+        expect(orderIds).to.include(internalIncomingOrder.id);
+        expect(orderIds).to.include(internalOutgoingOrder.id);
+      });
+
+      it('OUTGOING + EXTERNAL: returns only outgoing orders where the recipient is outside the host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          filter: 'OUTGOING',
+          oppositeAccountScope: 'EXTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(externalOutgoingOrder.id);
+      });
+
+      it('INTERNAL without direction: returns orders where both sides are within the same host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(2);
+        const orderIds = result.data.orders.nodes.map(n => n.legacyId);
+        expect(orderIds).to.include(internalIncomingOrder.id);
+        expect(orderIds).to.include(internalOutgoingOrder.id);
+      });
+
+      it('EXTERNAL without direction: returns orders where at least one side is outside the host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          oppositeAccountScope: 'EXTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(2);
+        const orderIds = result.data.orders.nodes.map(n => n.legacyId);
+        expect(orderIds).to.include(externalIncomingOrder.id);
+        expect(orderIds).to.include(externalOutgoingOrder.id);
+      });
+    });
+
+    describe('with a fiscal host as account (hasMoneyManagement)', () => {
+      let host, hostedCollective, externalUser;
+      let internalOrder, externalOrder;
+
+      before(async () => {
+        host = await fakeActiveHost();
+        hostedCollective = await fakeCollective({ HostCollectiveId: host.id, approvedAt: new Date() });
+        externalUser = await fakeUser();
+
+        // Internal: from hostedCollective → host
+        internalOrder = await fakeOrder({
+          FromCollectiveId: hostedCollective.id,
+          CollectiveId: host.id,
+          status: OrderStatuses.PAID,
+        });
+
+        // External: from externalUser → host
+        externalOrder = await fakeOrder({
+          FromCollectiveId: externalUser.CollectiveId,
+          CollectiveId: host.id,
+          status: OrderStatuses.PAID,
+        });
+      });
+
+      it('INCOMING + INTERNAL: sender is within the same host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          filter: 'INCOMING',
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(internalOrder.id);
+      });
+
+      it('INCOMING + EXTERNAL: sender is outside the host', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: host.id },
+          hostContext: 'ALL',
+          filter: 'INCOMING',
+          oppositeAccountScope: 'EXTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(externalOrder.id);
+      });
+    });
+
+    describe('with a regular collective (account-level scoping)', () => {
+      let collective, childEvent, externalUser;
+      let internalIncomingOrder, externalIncomingOrder, internalOutgoingOrder, externalOutgoingOrder;
+
+      before(async () => {
+        collective = await fakeCollective();
+        childEvent = await fakeEvent({ ParentCollectiveId: collective.id, approvedAt: new Date() });
+        externalUser = await fakeUser();
+
+        // Internal incoming: from childEvent → collective
+        internalIncomingOrder = await fakeOrder({
+          FromCollectiveId: childEvent.id,
+          CollectiveId: collective.id,
+          status: OrderStatuses.PAID,
+        });
+
+        // External incoming: from externalUser → collective
+        externalIncomingOrder = await fakeOrder({
+          FromCollectiveId: externalUser.CollectiveId,
+          CollectiveId: collective.id,
+          status: OrderStatuses.PAID,
+        });
+
+        // Internal outgoing: from collective → childEvent
+        internalOutgoingOrder = await fakeOrder({
+          FromCollectiveId: collective.id,
+          CollectiveId: childEvent.id,
+          status: OrderStatuses.PAID,
+        });
+
+        // External outgoing: from collective → some other collective
+        const otherCollective = await fakeCollective();
+        externalOutgoingOrder = await fakeOrder({
+          FromCollectiveId: collective.id,
+          CollectiveId: otherCollective.id,
+          status: OrderStatuses.PAID,
+        });
+      });
+
+      it('INCOMING + INTERNAL: returns orders from the account hierarchy (children)', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: collective.id },
+          filter: 'INCOMING',
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(internalIncomingOrder.id);
+      });
+
+      it('INCOMING + EXTERNAL: returns orders from outside the account hierarchy', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: collective.id },
+          filter: 'INCOMING',
+          oppositeAccountScope: 'EXTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(externalIncomingOrder.id);
+      });
+
+      it('OUTGOING + INTERNAL: returns orders to children of the account', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: collective.id },
+          filter: 'OUTGOING',
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(internalOutgoingOrder.id);
+      });
+
+      it('OUTGOING + EXTERNAL: returns orders to accounts outside the hierarchy', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          account: { legacyId: collective.id },
+          filter: 'OUTGOING',
+          oppositeAccountScope: 'EXTERNAL',
+        });
+
+        expect(result.errors).to.not.exist;
+        expect(result.data.orders.totalCount).to.eq(1);
+        expect(result.data.orders.nodes[0].legacyId).to.eq(externalOutgoingOrder.id);
+      });
+    });
+
+    describe('validation', () => {
+      it('throws an error when oppositeAccountScope is set without account', async () => {
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.include('oppositeAccountScope requires');
+      });
+
+      it('throws an error when oppositeAccountScope is used with the host argument', async () => {
+        const host = await fakeActiveHost();
+        const result = await graphqlQueryV2(oppositeAccountScopeQuery, {
+          host: { legacyId: host.id },
+          oppositeAccountScope: 'INTERNAL',
+        });
+
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.include('not supported with the `host` argument');
+      });
+    });
+  });
+
   describe('manualPaymentProvider and OPENCOLLECTIVE+MANUAL filter', () => {
     let hostForMpp, collectiveForMpp, providerMpp, orderWithMpp, hostAdminUser;
 


### PR DESCRIPTION
Project: https://github.com/opencollective/opencollective/issues/8607

Add `oppositeAccountScope` to allow filtering on INTERNAL vs EXTERNAL orders