### PR TITLE
security(GraphQL): add ESLint rule for scope check

### DIFF
--- a/eslint-rules/graphql-mutation-scope-check.js
+++ b/eslint-rules/graphql-mutation-scope-check.js
@@ -1,0 +1,147 @@
+'use strict';
+
+/**
+ * Custom ESLint rule: graphql-mutations/require-scope-check
+ *
+ * Ensures every GraphQL mutation resolver in the v2 mutation files contains
+ * a direct call to one of the scope-check functions from
+ * server/graphql/common/scope-check.ts (e.g. enforceScope, checkRemoteUserCanUseExpenses).
+ *
+ * This guarantees that OAuth / personal token scopes are always validated
+ * before a mutation's business logic runs.
+ *
+ * Applied only to server/graphql/v2/mutation/** via eslint.config.mjs.
+ *
+ * To opt out (e.g. for public / guest mutations that genuinely need no scope),
+ * add an eslint-disable comment on the `resolve` property with an explanation:
+ *
+ *   // eslint-disable-next-line graphql-mutations/require-scope-check -- public guest mutation
+ *   resolve: async (_, args, req) => { ... }
+ */
+
+const SCOPE_CHECK_FUNCTIONS = new Set([
+  'checkRemoteUserCanUseKYC',
+  'checkRemoteUserCanUseVirtualCards',
+  'checkRemoteUserCanUseAccount',
+  'checkRemoteUserCanUseExportRequests',
+  'checkRemoteUserCanUseHost',
+  'checkRemoteUserCanUseTransactions',
+  'checkRemoteUserCanUseOrders',
+  'checkRemoteUserCanUseApplications',
+  'checkRemoteUserCanUseConversations',
+  'checkRemoteUserCanUseExpenses',
+  'checkRemoteUserCanUseUpdates',
+  'checkRemoteUserCanUseConnectedAccounts',
+  'checkRemoteUserCanUseWebhooks',
+  'checkRemoteUserCanUseComment',
+  'checkRemoteUserCanRoot',
+  'checkScope',
+  'enforceScope',
+]);
+
+/**
+ * Returns true when the node (or any of its non-function descendants) contains
+ * a direct call to a scope-check function.
+ *
+ * We deliberately do NOT descend into nested function definitions
+ * (FunctionExpression / ArrowFunctionExpression / FunctionDeclaration) so that
+ * a scope check inside a callback like `ids.map(id => enforceScope(...))` is
+ * NOT counted – the check must live in the resolver's own code path.
+ */
+function containsScopeCheck(node) {
+  if (!node || typeof node !== 'object') {
+    return false;
+  }
+
+  if (node.type === 'CallExpression') {
+    const callee = node.callee;
+    if (callee.type === 'Identifier' && SCOPE_CHECK_FUNCTIONS.has(callee.name)) {
+      return true;
+    }
+  }
+
+  for (const key of Object.keys(node)) {
+    if (key === 'parent') {
+      continue;
+    }
+    const child = node[key];
+    if (!child || typeof child !== 'object') {
+      continue;
+    }
+
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (!item || typeof item !== 'object' || !item.type) {
+          continue;
+        }
+        if (isNestedFunctionNode(item)) {
+          continue;
+        }
+        if (containsScopeCheck(item)) {
+          return true;
+        }
+      }
+    } else if (child.type) {
+      if (isNestedFunctionNode(child)) {
+        continue;
+      }
+      if (containsScopeCheck(child)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isNestedFunctionNode(node) {
+  return (
+    node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression'
+  );
+}
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ensure every GraphQL mutation resolver calls a scope-check function from graphql/common/scope-check.ts.',
+      url: 'https://github.com/opencollective/opencollective-api/blob/main/server/graphql/common/scope-check.ts',
+    },
+    schema: [],
+    messages: {
+      missingScopeCheck:
+        'Mutation resolver is missing a scope check. Call one of the scope-check functions from ' +
+        'server/graphql/common/scope-check.ts (e.g. enforceScope, checkRemoteUserCanUseExpenses, ' +
+        'checkRemoteUserCanRoot, …) at the start of the resolver. If no scope check is needed ' +
+        '(e.g. public/guest mutation), disable this rule with an explanatory comment.',
+    },
+  },
+
+  create(context) {
+    return {
+      Property(node) {
+        // Match `resolve: <function>` and `async resolve() {}` (shorthand method).
+        const key = node.key;
+        const keyName = key.type === 'Identifier' ? key.name : key.type === 'Literal' ? key.value : null;
+        if (keyName !== 'resolve') {
+          return;
+        }
+
+        const value = node.value;
+        if (value.type !== 'FunctionExpression' && value.type !== 'ArrowFunctionExpression') {
+          return;
+        }
+
+        // Walk the function body. For arrow functions with an expression body the
+        // body itself is the expression node (not a BlockStatement).
+        if (containsScopeCheck(value.body)) {
+          return;
+        }
+
+        context.report({ node, messageId: 'missingScopeCheck' });
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -258,7 +258,11 @@ export default [
   },
   // GraphQL mutation scope-check enforcement
   {
-    files: ['server/graphql/v2/mutation/**/*.+(js|ts)'],
+    files: [
+      'server/graphql/v2/mutation/**/*.+(js|ts)',
+      'server/graphql/v1/mutations.js',
+      'server/graphql/v1/mutations/**/*.+(js|ts)',
+    ],
     plugins: {
       'graphql-mutations': {
         rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import openCollectiveConfig from 'eslint-config-opencollective/eslint-node.confi
 import mocha from 'eslint-plugin-mocha';
 import globals from 'globals';
 
+import graphqlMutationScopeCheck from './eslint-rules/graphql-mutation-scope-check.js';
 import noMathRoundAmountNames from './eslint-rules/no-math-round-amount-names.js';
 import sequelizeModelRequirePublicIdPrefix from './eslint-rules/sequelize-model-public-id-prefix.js';
 import sequelizeModelRequireTableName from './eslint-rules/sequelize-model-table-name.js';
@@ -253,6 +254,20 @@ export default [
           ],
         },
       ],
+    },
+  },
+  // GraphQL mutation scope-check enforcement
+  {
+    files: ['server/graphql/v2/mutation/**/*.+(js|ts)'],
+    plugins: {
+      'graphql-mutations': {
+        rules: {
+          'require-scope-check': graphqlMutationScopeCheck,
+        },
+      },
+    },
+    rules: {
+      'graphql-mutations/require-scope-check': 'error',
     },
   },
 ];

--- a/server/graphql/v1/mutations.js
+++ b/server/graphql/v1/mutations.js
@@ -10,6 +10,12 @@ import models from '../../models';
 import { bulkCreateGiftCards, createGiftCardsForEmails } from '../../paymentProviders/opencollective/giftcard';
 import { checkCanEmitGiftCards } from '../common/features';
 import { editPublicMessage } from '../common/members';
+import {
+  checkRemoteUserCanUseAccount,
+  checkRemoteUserCanUseHost,
+  checkRemoteUserCanUseOrders,
+  checkRemoteUserCanUseWebhooks,
+} from '../common/scope-check';
 import { createUser } from '../common/user';
 import { NotFound, RateLimitExceeded, Unauthorized, ValidationFailed } from '../errors';
 
@@ -44,6 +50,9 @@ const mutations = {
       collective: { type: new GraphQLNonNull(CollectiveInputType) },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseAccount(req, {
+        signedOutMessage: 'You need to be logged in to create a collective',
+      });
       return createCollective(_, args, req);
     },
   },
@@ -53,6 +62,7 @@ const mutations = {
     args: {
       collective: { type: new GraphQLNonNull(CollectiveInputType) },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- deprecated mutation only available in test environments
     resolve(_, args, req) {
       return createCollectiveFromGithub(_, args, req);
     },
@@ -63,6 +73,9 @@ const mutations = {
       collective: { type: new GraphQLNonNull(CollectiveInputType) },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseAccount(req, {
+        signedOutMessage: 'You need to be logged in to edit a collective',
+      });
       return editCollective(_, args, req);
     },
   },
@@ -72,6 +85,7 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseAccount(req);
       return deleteCollective(_, args, req);
     },
   },
@@ -81,6 +95,7 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseAccount(req);
       return deleteCollective(_, args, req);
     },
   },
@@ -90,6 +105,9 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseAccount(req, {
+        signedOutMessage: 'You need to be logged in to archive a collective',
+      });
       return archiveCollective(_, args, req);
     },
   },
@@ -99,6 +117,7 @@ const mutations = {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseAccount(req);
       return unarchiveCollective(_, args, req);
     },
   },
@@ -144,6 +163,7 @@ const mutations = {
         description: 'Captcha verification data',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- public mutation for account creation, no token scope required
     async resolve(_, args, req) {
       const { remoteUser } = req;
       const rateLimitKey = remoteUser ? `user_create_${remoteUser.id}` : `user_create_ip_${req.ip}`;
@@ -186,6 +206,7 @@ const mutations = {
       },
     },
     resolve: async (_, { email }, req) => {
+      checkRemoteUserCanUseAccount(req);
       await twoFactorAuthLib.validateRequest(req, { alwaysAskForToken: true });
       return updateUserEmail(req.remoteUser, email);
     },
@@ -199,6 +220,7 @@ const mutations = {
       members: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(MemberInputType))) },
     },
     async resolve(_, args, req) {
+      checkRemoteUserCanUseAccount(req);
       const collective = await req.loaders.Collective.byId.load(args.collectiveId);
       if (!collective) {
         throw new NotFound();
@@ -237,6 +259,7 @@ const mutations = {
       data: { type: new GraphQLNonNull(StripeCreditCardDataInputType) },
     },
     resolve: async (_, args, req) => {
+      checkRemoteUserCanUseOrders(req);
       return paymentMethodsMutation.replaceCreditCard(args, req);
     },
   },
@@ -289,6 +312,7 @@ const mutations = {
       expiryDate: { type: GraphQLString },
     },
     resolve: async (_, { emails, numberOfGiftCards, ...args }, req) => {
+      checkRemoteUserCanUseHost(req);
       if (numberOfGiftCards && emails && numberOfGiftCards !== emails.length) {
         throw Error("numberOfGiftCards and emails counts doesn't match");
       } else if (args.limitedToOpenSourceCollectives && args.limitedToHostCollectiveIds) {
@@ -334,6 +358,7 @@ const mutations = {
       code: { type: new GraphQLNonNull(GraphQLString) },
       user: { type: UserInputType },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- public mutation for claiming gift cards, usable without authentication
     resolve: async (_, args, req) => paymentMethodsMutation.claimPaymentMethod(args, req),
   },
   editWebhooks: {
@@ -350,6 +375,7 @@ const mutations = {
       },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseWebhooks(req);
       return editWebhooks(args, req);
     },
   },
@@ -363,6 +389,7 @@ const mutations = {
       },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseHost(req);
       return activateCollectiveAsHost(_, args, req);
     },
   },
@@ -376,6 +403,7 @@ const mutations = {
       },
     },
     resolve(_, args, req) {
+      checkRemoteUserCanUseHost(req);
       return deactivateCollectiveAsHost(_, args, req);
     },
   },

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -128,6 +128,7 @@ const accountMutations = {
         description: 'The value to set for this key',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- The scope is checked inside the transaction block
     async resolve(_: void, args, req: express.Request): Promise<Collective> {
       if (!req.remoteUser) {
         throw new Unauthorized();
@@ -899,6 +900,7 @@ const accountMutations = {
       },
       subject: { type: GraphQLString },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside sendMessage (common/collective.js)
     async resolve(_, args, req) {
       const account = await fetchAccountWithReference(args.account, { throwIfMissing: true });
 

--- a/server/graphql/v2/mutation/CommentMutations.js
+++ b/server/graphql/v2/mutation/CommentMutations.js
@@ -22,6 +22,7 @@ const commentMutations = {
         type: new GraphQLNonNull(GraphQLCommentUpdateInput),
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside editComment (common/comment.ts)
     async resolve(_, { comment }, req) {
       let id;
       if (isEntityPublicId(comment.id, EntityShortIdPrefix.Comment)) {
@@ -41,6 +42,7 @@ const commentMutations = {
         type: new GraphQLNonNull(GraphQLString),
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside deleteComment (common/comment.ts)
     async resolve(_, { id }, req) {
       let decodedId;
       if (isEntityPublicId(id, EntityShortIdPrefix.Comment)) {
@@ -60,6 +62,7 @@ const commentMutations = {
         type: new GraphQLNonNull(GraphQLCommentCreateInput),
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside createComment (common/comment.ts)
     resolve: async (_, { comment }, req) => {
       mustBeLoggedInTo(req.remoteUser, 'create a comment');
 

--- a/server/graphql/v2/mutation/ConversationMutations.ts
+++ b/server/graphql/v2/mutation/ConversationMutations.ts
@@ -35,6 +35,7 @@ const conversationMutations = {
         description: 'A list of tags for this conversation',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside createConversation (common/conversations.ts)
     async resolve(_, args, req) {
       let CollectiveId;
       if (args.account) {
@@ -66,6 +67,7 @@ const conversationMutations = {
         description: 'A list of tags for this conversation',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside editConversation (common/conversations.ts)
     async resolve(_, args, req) {
       let id;
       if (isEntityPublicId(args.id, EntityShortIdPrefix.Conversation)) {

--- a/server/graphql/v2/mutation/CreateCollectiveMutation.ts
+++ b/server/graphql/v2/mutation/CreateCollectiveMutation.ts
@@ -262,6 +262,7 @@ const createCollectiveMutation = {
       defaultValue: false,
     },
   },
+  // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside createCollective
   resolve: (_, args, req) => {
     return createCollective(_, args, req);
   },

--- a/server/graphql/v2/mutation/CreateEventMutation.js
+++ b/server/graphql/v2/mutation/CreateEventMutation.js
@@ -94,6 +94,7 @@ const createEventMutation = {
       type: new GraphQLNonNull(GraphQLAccountReferenceInput),
     },
   },
+  // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside createEvent
   resolve: (_, args, req) => {
     return createEvent(_, args, req);
   },

--- a/server/graphql/v2/mutation/CreateFundMutation.js
+++ b/server/graphql/v2/mutation/CreateFundMutation.js
@@ -124,6 +124,7 @@ const createFundMutation = {
       type: GraphQLAccountReferenceInput,
     },
   },
+  // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside createFund
   resolve: (_, args, req) => {
     return createFund(_, args, req);
   },

--- a/server/graphql/v2/mutation/CreateProjectMutation.js
+++ b/server/graphql/v2/mutation/CreateProjectMutation.js
@@ -130,6 +130,7 @@ const createProjectMutation = {
       defaultValue: false,
     },
   },
+  // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside createProject
   resolve: (_, args, req) => {
     return createProject(_, args, req);
   },

--- a/server/graphql/v2/mutation/EmojiReactionMutations.ts
+++ b/server/graphql/v2/mutation/EmojiReactionMutations.ts
@@ -48,6 +48,7 @@ const emojiReactionMutations = {
         description: 'A unique identifier for the update id associated with this reaction',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside addReactionToCommentOrUpdate
     resolve: async (entity, args, req) => {
       if (!req.remoteUser) {
         throw new Unauthorized();

--- a/server/graphql/v2/mutation/GuestMutations.ts
+++ b/server/graphql/v2/mutation/GuestMutations.ts
@@ -38,6 +38,7 @@ const guestMutations = {
         description: 'The key that you want to edit in settings',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- public mutation for guest account confirmation, no token scope required
     async resolve(
       _: void,
       args: Record<string, unknown>,

--- a/server/graphql/v2/mutation/IndividualMutations.ts
+++ b/server/graphql/v2/mutation/IndividualMutations.ts
@@ -140,6 +140,7 @@ const individualMutations = {
         description: 'The token to confirm the email.',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- this mutation explicitly rejects OAuth and personal token auth; no scope check can be applied
     resolve: async (_, { token: confirmEmailToken }, req) => {
       // Forbid this route for OAuth and Personal Tokens. Remember to check the scope if you want to allow it.
       // Also make sure to prevent exchanging OAuth/Personal tokens for session tokens.

--- a/server/graphql/v2/mutation/MemberMutations.ts
+++ b/server/graphql/v2/mutation/MemberMutations.ts
@@ -152,6 +152,7 @@ const memberMutations = {
         description: 'New public message',
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside editPublicMessage (common/members.ts)
     async resolve(_, args, req) {
       let { fromAccount, toAccount } = args;
       const { message } = args;

--- a/server/graphql/v2/mutation/OrderMutations.ts
+++ b/server/graphql/v2/mutation/OrderMutations.ts
@@ -1013,6 +1013,9 @@ const orderMutations = {
       },
     },
     async resolve(_, args, req) {
+      if (!checkScope(req, 'orders')) {
+        throw new Unauthorized('The User Token is not allowed for operations in scope "orders".');
+      }
       if (req.remoteUser && !canUseFeature(req.remoteUser, FEATURE.ORDER)) {
         throw new FeatureNotAllowedForUser();
       }

--- a/server/graphql/v2/mutation/PaymentMethodMutations.ts
+++ b/server/graphql/v2/mutation/PaymentMethodMutations.ts
@@ -297,9 +297,7 @@ const paymentMethodMutations = {
       },
     },
     async resolve(_, args, req) {
-      if (!req.remoteUser) {
-        throw new Unauthorized();
-      }
+      checkRemoteUserCanUseOrders(req);
 
       const paymentMethod = await fetchPaymentMethodWithReference(args.paymentMethod);
       if (!req.remoteUser?.isAdmin(paymentMethod.CollectiveId)) {

--- a/server/graphql/v2/mutation/PayoutMethodMutations.ts
+++ b/server/graphql/v2/mutation/PayoutMethodMutations.ts
@@ -16,7 +16,7 @@ import { checkRemoteUserCanUseExpenses } from '../../common/scope-check';
 import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../../errors';
 import { fetchAccountWithReference, GraphQLAccountReferenceInput } from '../input/AccountReferenceInput';
 import { GraphQLPayoutMethodInput } from '../input/PayoutMethodInput';
-import { fetchPayoutMethodWithReference, GraphQLPayoutMethodReferenceInput } from '../input/PayoutMethodReferenceInput';
+import { fetchPayoutMethodWithReference } from '../input/PayoutMethodReferenceInput';
 import GraphQLPayoutMethod from '../object/PayoutMethod';
 
 const payoutMethodMutations = {
@@ -105,20 +105,6 @@ const payoutMethodMutations = {
 
         return payoutMethod;
       });
-    },
-  },
-  restorePayoutMethod: {
-    description: 'Restore the given payout method. Scope: "expenses".',
-    deprecationReason: '2025-02-10: Payout methods cannot be restored.',
-    type: new GraphQLNonNull(GraphQLPayoutMethod),
-    args: {
-      payoutMethod: {
-        type: new GraphQLNonNull(GraphQLPayoutMethodReferenceInput),
-        description: 'Payout Method reference',
-      },
-    },
-    async resolve() {
-      throw new Forbidden('Payout methods cannot be restored.');
     },
   },
   editPayoutMethod: {

--- a/server/graphql/v2/mutation/PlatformSubscriptionsMutations.ts
+++ b/server/graphql/v2/mutation/PlatformSubscriptionsMutations.ts
@@ -4,6 +4,7 @@ import { GraphQLNonNull, GraphQLString } from 'graphql';
 
 import { PlatformSubscriptionPlan, PlatformSubscriptionTiers } from '../../../constants/plans';
 import { Collective, PlatformSubscription } from '../../../models';
+import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
 import { fetchAccountWithReference, GraphQLAccountReferenceInput } from '../input/AccountReferenceInput';
 import { GraphQLPlatformSubscriptionInput } from '../input/PlatformSubcriptionInput';
 import { GraphQLAccount } from '../interface/Account';
@@ -25,9 +26,9 @@ const platformSubscriptionMutations = {
       },
     },
     async resolve(_, args, req: Express.Request): Promise<Collective> {
-      if (!req.remoteUser) {
-        throw new Error('You need to be logged in to update a platform subscription');
-      }
+      checkRemoteUserCanUseAccount(req, {
+        signedOutMessage: 'You need to be logged in to update a platform subscription',
+      });
       const account = await fetchAccountWithReference(args.account, { throwIfMissing: true, paranoid: false });
 
       let plan: Partial<PlatformSubscriptionPlan>;

--- a/server/graphql/v2/mutation/SendSurveyResponseMutation.ts
+++ b/server/graphql/v2/mutation/SendSurveyResponseMutation.ts
@@ -2,7 +2,8 @@ import config from 'config';
 import { GraphQLBoolean, GraphQLInt, GraphQLNonNull, GraphQLString } from 'graphql';
 
 import RateLimit, { ONE_HOUR_IN_SECONDS } from '../../../lib/rate-limit';
-import { RateLimitExceeded, Unauthorized, UnexpectedError } from '../../errors';
+import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
+import { RateLimitExceeded, UnexpectedError } from '../../errors';
 
 export const sendSurveyResponseMutation = {
   type: GraphQLBoolean,
@@ -25,9 +26,7 @@ export const sendSurveyResponseMutation = {
     },
   },
   resolve: async (_, args, req) => {
-    if (!req.remoteUser) {
-      throw new Unauthorized();
-    }
+    checkRemoteUserCanUseAccount(req);
     const CODA_TOKEN = process.env.CODA_IN_APP_SURVEY_TOKEN;
 
     if (!CODA_TOKEN) {

--- a/server/graphql/v2/mutation/UpdateMutations.js
+++ b/server/graphql/v2/mutation/UpdateMutations.js
@@ -15,6 +15,7 @@ const updateMutations = {
         type: new GraphQLNonNull(GraphQLUpdateCreateInput),
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside createUpdate (common/update.ts)
     resolve(_, args, req) {
       return createUpdate(_, args, req);
     },
@@ -27,6 +28,7 @@ const updateMutations = {
         type: new GraphQLNonNull(GraphQLUpdateUpdateInput),
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside editUpdate (common/update.ts)
     resolve(_, args, req) {
       return editUpdate(_, args, req);
     },
@@ -42,6 +44,7 @@ const updateMutations = {
         type: GraphQLUpdateAudienceType,
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside publishUpdate (common/update.ts)
     resolve(_, args, req) {
       return publishUpdate(_, args, req);
     },
@@ -54,6 +57,7 @@ const updateMutations = {
         type: new GraphQLNonNull(GraphQLString),
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside unpublishUpdate (common/update.ts)
     resolve(_, args, req) {
       return unpublishUpdate(_, args, req);
     },
@@ -66,6 +70,7 @@ const updateMutations = {
         type: new GraphQLNonNull(GraphQLString),
       },
     },
+    // eslint-disable-next-line graphql-mutations/require-scope-check -- scope check is performed inside deleteUpdate (common/update.ts)
     resolve(_, args, req) {
       return deleteUpdate(_, args, req);
     },

--- a/server/graphql/v2/mutation/VirtualCardMutations.ts
+++ b/server/graphql/v2/mutation/VirtualCardMutations.ts
@@ -451,6 +451,7 @@ const virtualCardMutations = {
       },
     },
     async resolve(_: void, args, req: express.Request): Promise<VirtualCardRequest> {
+      checkRemoteUserCanUseVirtualCards(req);
       const virtualCardRequest = await fetchVirtualCardRequestWithReference(args.virtualCardRequest, {
         include: ['host', 'collective', 'user'],
       });

--- a/test/eslint-rules/graphql-mutation-scope-check.test.js
+++ b/test/eslint-rules/graphql-mutation-scope-check.test.js
@@ -1,0 +1,378 @@
+/**
+ * Tests for the graphql-mutations/require-scope-check ESLint rule.
+ *
+ * Uses ESLint's RuleTester which integrates with Mocha's describe/it globals.
+ */
+
+import { RuleTester } from 'eslint';
+
+import rule from '../../eslint-rules/graphql-mutation-scope-check.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('graphql-mutations/require-scope-check', rule, {
+  valid: [
+    // -----------------------------------------------------------------------
+    // Direct call to enforceScope in arrow function body
+    // -----------------------------------------------------------------------
+    {
+      name: 'enforceScope call in arrow function resolver',
+      code: `
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              enforceScope(req, 'host');
+              return doSomething();
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Named scope-check helpers
+    // -----------------------------------------------------------------------
+    {
+      name: 'checkRemoteUserCanUseAccount call',
+      code: `
+        export default {
+          updateAccount: {
+            type: GraphQLAccount,
+            resolve: async (_, args, req) => {
+              checkRemoteUserCanUseAccount(req);
+              return updateAccount(args, req);
+            },
+          },
+        };
+      `,
+    },
+    {
+      name: 'checkRemoteUserCanRoot call',
+      code: `
+        export default {
+          editFlags: {
+            type: GraphQLAccount,
+            resolve: async (_, args, req) => {
+              checkRemoteUserCanRoot(req);
+              return editFlags(args, req);
+            },
+          },
+        };
+      `,
+    },
+    {
+      name: 'checkRemoteUserCanUseExpenses call',
+      code: `
+        export default {
+          createExpense: {
+            type: GraphQLExpense,
+            resolve: async (_, args, req) => {
+              checkRemoteUserCanUseExpenses(req);
+              return createExpense(args, req);
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Scope check inside a conditional branch
+    // -----------------------------------------------------------------------
+    {
+      name: 'enforceScope inside an if block',
+      code: `
+        export default {
+          updateFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              if (req.userToken) {
+                enforceScope(req, 'host');
+              }
+              return updateFoo(args);
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Shorthand method syntax
+    // -----------------------------------------------------------------------
+    {
+      name: 'shorthand async resolve method',
+      code: `
+        export default {
+          deleteFoo: {
+            type: GraphQLFoo,
+            async resolve(_, args, req) {
+              checkRemoteUserCanUseHost(req);
+              return deleteFoo(args);
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Named export (not default)
+    // -----------------------------------------------------------------------
+    {
+      name: 'named export with scope check',
+      code: `
+        export const myMutations = {
+          createBar: {
+            type: GraphQLBar,
+            resolve: async (_, args, req) => {
+              enforceScope(req, 'orders');
+              return createBar(args);
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Single mutation export (not wrapped in an outer object)
+    // -----------------------------------------------------------------------
+    {
+      name: 'single exported mutation with scope check',
+      code: `
+        export const sendSurvey = {
+          type: GraphQLBoolean,
+          resolve: async (_, args, req) => {
+            enforceScope(req, 'account');
+            return sendSurvey(args);
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Scope check in a try block
+    // -----------------------------------------------------------------------
+    {
+      name: 'scope check inside try block',
+      code: `
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              try {
+                enforceScope(req, 'host');
+                return doSomething();
+              } catch (e) {
+                throw e;
+              }
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // checkScope (boolean check) is also accepted
+    // -----------------------------------------------------------------------
+    {
+      name: 'checkScope call counts as a scope check',
+      code: `
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              if (!checkScope(req, 'orders')) {
+                throw new Forbidden();
+              }
+              return doSomething();
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Non-resolve properties with functions are not checked
+    // -----------------------------------------------------------------------
+    {
+      name: 'non-resolve property is ignored',
+      code: `
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            deprecationReason: 'Use createBar instead',
+            beforeResolve: async (_, args, req) => {
+              // no scope check needed here
+              return preprocess(args);
+            },
+            resolve: async (_, args, req) => {
+              checkRemoteUserCanUseHost(req);
+              return doSomething();
+            },
+          },
+        };
+      `,
+    },
+
+    // -----------------------------------------------------------------------
+    // Scope check in nested block (switch statement)
+    // -----------------------------------------------------------------------
+    {
+      name: 'scope check inside switch statement',
+      code: `
+        export default {
+          processFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              switch (args.action) {
+                case 'create':
+                  enforceScope(req, 'host');
+                  break;
+                default:
+                  break;
+              }
+              return process(args);
+            },
+          },
+        };
+      `,
+    },
+  ],
+
+  invalid: [
+    // -----------------------------------------------------------------------
+    // Missing scope check entirely
+    // -----------------------------------------------------------------------
+    {
+      name: 'no scope check in resolver',
+      code: `
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              if (!req.remoteUser) {
+                throw new Unauthorized();
+              }
+              return doSomething();
+            },
+          },
+        };
+      `,
+      errors: [{ messageId: 'missingScopeCheck' }],
+    },
+
+    // -----------------------------------------------------------------------
+    // Scope check only in a nested callback – does NOT count
+    // -----------------------------------------------------------------------
+    {
+      name: 'scope check inside a nested arrow function is not counted',
+      code: `
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              const results = await Promise.all(
+                ids.map(async id => {
+                  enforceScope(req, 'host'); // inside a nested function – not counted
+                  return processId(id);
+                }),
+              );
+              return results;
+            },
+          },
+        };
+      `,
+      errors: [{ messageId: 'missingScopeCheck' }],
+    },
+
+    // -----------------------------------------------------------------------
+    // Scope check only in a called helper – does NOT count
+    // -----------------------------------------------------------------------
+    {
+      name: 'scope check only in a called helper function is not counted',
+      code: `
+        async function helperWithScopeCheck(req) {
+          enforceScope(req, 'host');
+          return doWork();
+        }
+
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              return helperWithScopeCheck(req);
+            },
+          },
+        };
+      `,
+      errors: [{ messageId: 'missingScopeCheck' }],
+    },
+
+    // -----------------------------------------------------------------------
+    // Multiple mutations – only the one missing the check is reported
+    // -----------------------------------------------------------------------
+    {
+      name: 'one of two mutations is missing a scope check',
+      code: `
+        export default {
+          createFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              enforceScope(req, 'host');
+              return createFoo(args);
+            },
+          },
+          deleteFoo: {
+            type: GraphQLFoo,
+            resolve: async (_, args, req) => {
+              // forgot the scope check
+              return deleteFoo(args.id);
+            },
+          },
+        };
+      `,
+      errors: [{ messageId: 'missingScopeCheck' }],
+    },
+
+    // -----------------------------------------------------------------------
+    // Named export without scope check
+    // -----------------------------------------------------------------------
+    {
+      name: 'named export mutation missing scope check',
+      code: `
+        export const myMutation = {
+          type: GraphQLBoolean,
+          resolve: async (_, args, req) => {
+            if (!req.remoteUser) {
+              throw new Unauthorized();
+            }
+            return sendData(args);
+          },
+        };
+      `,
+      errors: [{ messageId: 'missingScopeCheck' }],
+    },
+
+    // -----------------------------------------------------------------------
+    // Empty resolver body
+    // -----------------------------------------------------------------------
+    {
+      name: 'completely empty resolver',
+      code: `
+        export default {
+          noop: {
+            type: GraphQLBoolean,
+            resolve: async () => {
+              return true;
+            },
+          },
+        };
+      `,
+      errors: [{ messageId: 'missingScopeCheck' }],
+    },
+  ],
+});


### PR DESCRIPTION
Covering GraphQL v1 because we still have some flags to explicitely allow them (`application.data.enableGraphqlV1` on the app, `data.allowGraphQLV1` on the token).