### PR TITLE
Honor per-collective platform tip override

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -27976,6 +27976,11 @@ input OrderContextInput {
   Whether this order was created using the new platform tip flow
   """
   isNewPlatformTipFlow: Boolean
+
+  """
+  Whether the platform tip was offered to the user in the contribution flow. When explicitly false, the order is persisted as not eligible for platform tips (used by the OSC platform tip A/B).
+  """
+  platformTipOffered: Boolean
 }
 
 input OrderUpdateInput {

--- a/server/graphql/v1/CollectiveInterface.js
+++ b/server/graphql/v1/CollectiveInterface.js
@@ -1366,27 +1366,7 @@ const CollectiveFields = () => {
       description:
         'Returns true if a custom contribution to Open Collective can be submitted for contributions made to this account',
       async resolve(account, _, req) {
-        if (!isNil(account.data?.platformTips)) {
-          return Boolean(account.data.platformTips);
-        } else if (PlatformConstants.AllPlatformCollectiveIds.includes(account.id)) {
-          return false;
-        }
-
-        // Look at the host's plan
-        const host = await req.loaders.Collective.host.load(account);
-        if (host) {
-          // New pricing
-          const hasPlatformTips = await req.loaders.PlatformSubscription.hasPlatformTips.load(host.id);
-          if (typeof hasPlatformTips === 'boolean') {
-            return hasPlatformTips;
-          }
-
-          // hasPlatformTips undefined means we're on a legacy plan
-          const plan = host.getLegacyPlan();
-          return Boolean(plan.platformTips);
-        }
-
-        return false;
+        return account.hasPlatformTips({ loaders: req.loaders });
       },
     },
     tiers: {

--- a/server/graphql/v1/mutations/orders.js
+++ b/server/graphql/v1/mutations/orders.js
@@ -458,7 +458,11 @@ export async function createOrder(order, req) {
       orderPublicData = pick(order.data, []);
     }
 
-    const platformTipEligible = await isPlatformTipEligible({ ...order, collective });
+    // When the frontend explicitly indicates the tip was not offered (e.g. OSC platform tip A/B
+    // treatment arm), persist the order as not eligible so downstream tip logic respects it and
+    // analytics can group by this flag.
+    const platformTipEligible =
+      order.context?.platformTipOffered === false ? false : await isPlatformTipEligible({ ...order, collective });
 
     const orderData = {
       CreatedByUserId: remoteUser.id,

--- a/server/graphql/v2/input/OrderCreateInput.ts
+++ b/server/graphql/v2/input/OrderCreateInput.ts
@@ -34,6 +34,11 @@ const GraphQLOrderContextInput = new GraphQLInputObjectType({
       type: GraphQLBoolean,
       description: 'Whether this order was created using the new platform tip flow',
     },
+    platformTipOffered: {
+      type: GraphQLBoolean,
+      description:
+        'Whether the platform tip was offered to the user in the contribution flow. When explicitly false, the order is persisted as not eligible for platform tips (used by the OSC platform tip A/B).',
+    },
   }),
 });
 

--- a/server/graphql/v2/interface/AccountWithContributions.ts
+++ b/server/graphql/v2/interface/AccountWithContributions.ts
@@ -13,7 +13,6 @@ import { GraphQLDateTime } from 'graphql-scalars';
 import { isNil, omit } from 'lodash';
 import { OrderItem, QueryTypes, WhereOptions } from 'sequelize';
 
-import PlatformConstants from '../../../constants/platform';
 import { filterContributors } from '../../../lib/contributors';
 import models, { Collective, sequelize } from '../../../models';
 import Tier, { AllTierTypes, TierType } from '../../../models/Tier';
@@ -230,27 +229,7 @@ export const AccountWithContributionsFields = {
     description:
       'Returns true if a custom contribution to Open Collective can be submitted for contributions made to this account',
     async resolve(account: Collective, _, req: express.Request): Promise<boolean> {
-      if (!isNil(account.data?.platformTips)) {
-        return account.data.platformTips;
-      } else if (PlatformConstants.AllPlatformCollectiveIds.includes(account.id)) {
-        return false;
-      }
-
-      // Look at the host's plan
-      const host = await req.loaders.Collective.host.load(account);
-      if (host) {
-        // New pricing
-        const hasPlatformTips = await req.loaders.PlatformSubscription.hasPlatformTips.load(host.id);
-        if (typeof hasPlatformTips === 'boolean') {
-          return hasPlatformTips;
-        }
-
-        // hasPlatformTips undefined means we're on a legacy plan
-        const plan = host.getLegacyPlan();
-        return plan.platformTips;
-      }
-
-      return false;
+      return account.hasPlatformTips({ loaders: req.loaders });
     },
   },
   contributionPolicy: {

--- a/server/lib/payments.ts
+++ b/server/lib/payments.ts
@@ -1346,6 +1346,15 @@ export const isPlatformTipEligible = async (order: Order): Promise<boolean> => {
     return false;
   }
 
+  if (!order.collective) {
+    order.collective = await order.getCollective();
+  }
+
+  // Per-collective override (mirrors the platformContributionAvailable resolver)
+  if (!isNil(order.collective.data?.platformTips)) {
+    return order.collective.data.platformTips;
+  }
+
   const host = await order.collective.getHostCollective();
   if (host) {
     // New pricing

--- a/server/lib/payments.ts
+++ b/server/lib/payments.ts
@@ -16,7 +16,7 @@ import roles from '../constants/roles';
 import tiers from '../constants/tiers';
 import { TransactionKind } from '../constants/transaction-kind';
 import { TransactionTypes } from '../constants/transactions';
-import { ManualPaymentProvider, Op, PlatformSubscription } from '../models';
+import { ManualPaymentProvider, Op } from '../models';
 import Activity from '../models/Activity';
 import { ManualPaymentProviderTypes, sanitizeManualPaymentProviderInstructions } from '../models/ManualPaymentProvider';
 import Order from '../models/Order';
@@ -1350,26 +1350,7 @@ export const isPlatformTipEligible = async (order: Order): Promise<boolean> => {
     order.collective = await order.getCollective();
   }
 
-  // Per-collective override (mirrors the platformContributionAvailable resolver)
-  if (!isNil(order.collective.data?.platformTips)) {
-    return order.collective.data.platformTips;
-  }
-
-  const host = await order.collective.getHostCollective();
-  if (host) {
-    // New pricing
-    const subscription = await PlatformSubscription.getCurrentSubscription(host.id);
-    if (subscription) {
-      return subscription.plan.pricing.platformTips;
-    }
-
-    // Legacy plan
-    const plan = host.getLegacyPlan();
-    // At this stage, only OSC /opensourcce and Open Collective /opencollective will return false
-    return plan?.platformTips;
-  }
-
-  return false;
+  return order.collective.hasPlatformTips();
 };
 
 export const getHostFeePercent = async (

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -3653,6 +3653,45 @@ class Collective extends ModelWithPublicId<
     return plan;
   };
 
+  hasPlatformTips = async function ({ loaders = null } = {}): Promise<boolean> {
+    if (!isNil(this.data?.platformTips)) {
+      return Boolean(this.data.platformTips);
+    }
+    if (this.ParentCollectiveId) {
+      const parent = loaders
+        ? await loaders.Collective.byId.load(this.ParentCollectiveId)
+        : await this.getParentCollective();
+      if (parent && !isNil(parent.data?.platformTips)) {
+        return Boolean(parent.data.platformTips);
+      }
+    }
+    if (PlatformConstants.CurrentPlatformCollectiveIds.includes(this.id)) {
+      return false;
+    }
+
+    const host = loaders ? await loaders.Collective.host.load(this) : await this.getHostCollective();
+    if (!host) {
+      return false;
+    }
+    if (PlatformConstants.CurrentPlatformCollectiveIds.includes(host.id)) {
+      return false;
+    }
+
+    if (loaders) {
+      const hasPlatformTips = await loaders.PlatformSubscription.hasPlatformTips.load(host.id);
+      if (typeof hasPlatformTips === 'boolean') {
+        return hasPlatformTips;
+      }
+    } else {
+      const subscription = await PlatformSubscription.getCurrentSubscription(host.id);
+      if (subscription) {
+        return Boolean(subscription.plan.pricing.platformTips);
+      }
+    }
+
+    return Boolean(host.getLegacyPlan()?.platformTips);
+  };
+
   /**
    * Returns financial metrics from the Host collective.
    * @param {Date} from The start date from which the metrics should be calculated.


### PR DESCRIPTION
- Apply `Collective.data.platformTips` override at payment time (was only used by the UI resolver)
- Extract shared resolution into `Collective.hasPlatformTips`
- Events and projects inherit the `data.platformTips` override from their parent collective
- Exclude current platform collectives from accepting tips (checked on self and on host)
- New `OrderContextInput.platformTipOffered` field: when explicitly `false`, persist the order as not eligible (used by the OSC platform tip A/B)