### PR TITLE
fix(types): add config module declaration for v4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "cloudflare": "4.5.0",
         "cloudflare-ip": "0.0.7",
         "commander": "14.0.3",
-        "config": "4.3.0",
+        "config": "4.4.1",
         "connect-redis": "9.0.0",
         "cookie-parser": "1.4.7",
         "cors": "2.8.6",
@@ -15784,9 +15784,9 @@
       }
     },
     "node_modules/config": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-4.3.0.tgz",
-      "integrity": "sha512-nY/JbYPBxOCTC+Kj9dUf21t49VxwsL6GXRsAxlTY9N6MBTx/6TBQgT2t5PsAY+XUCMCNudARJPevUZeN3NhyHQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/config/-/config-4.4.1.tgz",
+      "integrity": "sha512-XfN4Q4+wBKkGtgMyQ+5ayjepdb0MrdiGKfBr0G1PTLx9rnqsX+Xiw03LEUtSALZU0UVfcFp6+xYV0NL8HLF94g==",
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.3"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cloudflare": "4.5.0",
     "cloudflare-ip": "0.0.7",
     "commander": "14.0.3",
-    "config": "4.3.0",
+    "config": "4.4.1",
     "connect-redis": "9.0.0",
     "cookie-parser": "1.4.7",
     "cors": "2.8.6",

--- a/server/types/config.d.ts
+++ b/server/types/config.d.ts
@@ -1,0 +1,21 @@
+// Override config module types to add an index signature for direct property access
+// (e.g. config.env, config.host) used throughout the codebase.
+//
+// config@4.4.1 ships types where ConfigClass has no index signature and is not exported,
+// so a proper module augmentation cannot extend it. This ambient module declaration
+// takes precedence over the package's own types during resolution.
+declare module 'config' {
+  interface IConfig {
+    get<T>(property: string): T;
+    has(property: string): boolean;
+    util: {
+      getEnv(varName: string): string;
+      toObject(config?: object): object;
+      [key: string]: any;
+    };
+    [key: string]: any;
+  }
+
+  const config: IConfig;
+  export = config;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes the `config` 4.3.0 → 4.4.1 upgrade on `renovate/config-4.x`.

## Problem

`config@4.4.1` ships bundled TypeScript types where `ConfigClass` has no index signature and is not exported. That breaks the 500+ direct property accesses used throughout this codebase (e.g. `config.env`, `config.host`, `config.stripe`).

## Solution

Add `server/types/config.d.ts` with an ambient module declaration that:

- Provides `IConfig` with `[key: string]: any` for direct property access
- Types `util.getEnv` and `util.toObject` for better IDE support
- Documents why module augmentation cannot extend the package's `ConfigClass`

## Verification

- `npm run type:check` (`tsc --noEmit`) passes with no errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61743d94-a399-43b2-947c-20b5b43c2a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61743d94-a399-43b2-947c-20b5b43c2a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

