### PR TITLE
Support platformTipAmount in updateOrder

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -25701,9 +25701,14 @@ type Mutation {
     tier: TierReferenceInput
 
     """
-    An Amount to update the order to
+    New amount to charge the contributor, excluding the platform tip. Includes taxes if any.
     """
     amount: AmountInput
+
+    """
+    Platform tip for this order. Omit or pass null to keep the current tip; provide a value (including zero) to update it.
+    """
+    platformTipAmount: AmountInput
   ): Order
 
   """

--- a/server/graphql/v2/mutation/OrderMutations.ts
+++ b/server/graphql/v2/mutation/OrderMutations.ts
@@ -453,7 +453,12 @@ const orderMutations = {
       },
       amount: {
         type: GraphQLAmountInput,
-        description: 'An Amount to update the order to',
+        description: 'New amount to charge the contributor, excluding the platform tip. Includes taxes if any.',
+      },
+      platformTipAmount: {
+        type: GraphQLAmountInput,
+        description:
+          'Platform tip for this order. Omit or pass null to keep the current tip; provide a value (including zero) to update it.',
       },
     },
     async resolve(_, args, req) {
@@ -462,7 +467,7 @@ const orderMutations = {
       const decodedId = isEntityPublicId(args.order.id, EntityShortIdPrefix.Order)
         ? await req.loaders.Order.idByPublicId.load(args.order.id)
         : idDecode(args.order.id, IDENTIFIER_TYPES.ORDER);
-      const haveDetailsChanged = !isUndefined(args.amount) || !isUndefined(args.tier);
+      const haveDetailsChanged = !isUndefined(args.amount) || !isUndefined(args.tier) || !isNil(args.platformTipAmount);
       const hasPaymentMethodChanged = !isUndefined(args.paymentMethod) || Boolean(args.paypalSubscriptionId);
 
       let order = await models.Order.findOne({
@@ -529,17 +534,28 @@ const orderMutations = {
             where: { MemberCollectiveId: order.FromCollectiveId, CollectiveId: order.CollectiveId, role: 'BACKER' },
           }));
         const expectedCurrency = order.currency;
-        let newTotalAmount = getValueInCentsFromAmountInput(args.amount, { expectedCurrency });
-        // We add the current Platform Tip to the totalAmount
-        if (order.platformTipAmount) {
-          newTotalAmount = newTotalAmount + order.platformTipAmount;
+        if (!isUndefined(args.amount)) {
+          assertAmountInputCurrency(args.amount, expectedCurrency, { name: 'amount' });
         }
-        // interval, amount, tierId, paymentMethodId
+        if (!isNil(args.platformTipAmount)) {
+          assertAmountInputCurrency(args.platformTipAmount, expectedCurrency, { name: 'platformTipAmount' });
+        }
+
+        // `args.amount` (when provided) is the post-tax total excluding the platform tip — i.e. it matches `Order.amount`.
+        // When not provided, fall back to the order's existing amount under the same convention.
+        const amountWithoutTip = !isUndefined(args.amount)
+          ? getValueInCentsFromAmountInput(args.amount, { expectedCurrency })
+          : order.totalAmount - order.platformTipAmount;
+        const platformTipAmount = isNil(args.platformTipAmount)
+          ? order.platformTipAmount
+          : getValueInCentsFromAmountInput(args.platformTipAmount, { expectedCurrency });
+        const newTotalAmount = amountWithoutTip + platformTipAmount;
         ({ previousOrderValues, previousSubscriptionValues } = await updateSubscriptionDetails(
           order,
           tier,
           membership,
           newTotalAmount,
+          platformTipAmount,
         ));
       }
 

--- a/server/lib/subscriptions.ts
+++ b/server/lib/subscriptions.ts
@@ -215,9 +215,13 @@ export const updateSubscriptionDetails = async (
   tier: Tier,
   member: Member,
   amountInCents: number,
+  platformTipAmount: number = order.platformTipAmount,
 ): Promise<OrderSubscriptionUpdate> => {
-  // Make sure the new details are ok values, that match tier's minimum amount if there's one
-  checkSubscriptionDetails(order, tier, amountInCents);
+  // Make sure the new details are ok values, that match tier's minimum amount if there's one.
+  // Validate against the contribution amount excluding the platform tip, since the tip goes to
+  // the platform rather than the tier/collective.
+  const netContribution = Math.max(0, amountInCents - (platformTipAmount || 0));
+  checkSubscriptionDetails(order, tier, netContribution);
 
   const newOrderData = {};
   const newSubscriptionData = {};
@@ -227,13 +231,20 @@ export const updateSubscriptionDetails = async (
   if (amountInCents !== order.totalAmount) {
     newOrderData['totalAmount'] = amountInCents;
     newSubscriptionData['amount'] = amountInCents;
-    // If the order has taxes, we need to update the taxAmount
-    if (order.data?.tax?.percentage) {
-      const taxRate = order.data.tax.percentage / 100;
-      const amountWithoutTip = amountInCents - order.platformTipAmount;
-      const grossAmount = amountWithoutTip / (1 + taxRate);
-      newOrderData['taxAmount'] = roundCentsAmount(amountWithoutTip - grossAmount, order.currency);
-    }
+  }
+
+  if (platformTipAmount !== order.platformTipAmount) {
+    newOrderData['platformTipAmount'] = platformTipAmount;
+  }
+
+  // Recompute the back-derived tax whenever the post-tax amount (total minus tip) changes.
+  const previousAmountWithoutTip = order.totalAmount - order.platformTipAmount;
+  const nextAmountWithoutTip = amountInCents - platformTipAmount;
+  const grossChanged = nextAmountWithoutTip !== previousAmountWithoutTip;
+  if (order.data?.tax?.percentage && grossChanged) {
+    const taxRate = order.data.tax.percentage / 100;
+    const grossAmount = nextAmountWithoutTip / (1 + taxRate);
+    newOrderData['taxAmount'] = roundCentsAmount(nextAmountWithoutTip - grossAmount, order.currency);
   }
 
   // Update interval

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -193,14 +193,25 @@ const updateOrderMutation = gql`
   mutation UpdateOrder(
     $order: OrderReferenceInput!
     $amount: AmountInput
+    $platformTipAmount: AmountInput
     $tier: TierReferenceInput
     $paymentMethod: PaymentMethodReferenceInput
   ) {
-    updateOrder(order: $order, amount: $amount, tier: $tier, paymentMethod: $paymentMethod) {
+    updateOrder(
+      order: $order
+      amount: $amount
+      platformTipAmount: $platformTipAmount
+      tier: $tier
+      paymentMethod: $paymentMethod
+    ) {
       id
       status
       amount {
         value
+        currency
+      }
+      platformTipAmount {
+        valueInCents
         currency
       }
       tier {
@@ -3257,6 +3268,162 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
         expect(orderWithTaxes.platformTipAmount).to.eq(100);
         expect(orderWithTaxes.taxAmount).to.eq(333); // 20% VAT on $2000 (tip is not included in the tax calculation)
         expect(orderWithTaxes.totalAmount - orderWithTaxes.taxAmount - orderWithTaxes.platformTipAmount).to.eq(1667); // Gross amount
+      });
+
+      it('updates the platform tip amount without changing the contribution amount', async () => {
+        const orderWithPlatformTip = await fakeOrder(
+          {
+            CreatedByUserId: user.id,
+            FromCollectiveId: user.CollectiveId,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+            totalAmount: 1100,
+            platformTipAmount: 100,
+            currency: 'USD',
+            subscription: {
+              amount: 1100,
+            },
+          },
+          {
+            withSubscription: true,
+          },
+        );
+
+        const result = await graphqlQueryV2(
+          updateOrderMutation,
+          {
+            order: { id: idEncode(orderWithPlatformTip.id, 'order') },
+            platformTipAmount: { valueInCents: 250, currency: 'USD' },
+          },
+          user,
+        );
+
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        expect(result.data.updateOrder.amount.value).to.eq(10);
+        expect(result.data.updateOrder.platformTipAmount.valueInCents).to.eq(250);
+
+        await orderWithPlatformTip.reload({ include: [{ association: 'Subscription' }] });
+        expect(orderWithPlatformTip.totalAmount).to.eq(1250);
+        expect(orderWithPlatformTip.platformTipAmount).to.eq(250);
+        expect(orderWithPlatformTip.Subscription.amount).to.eq(1250);
+      });
+
+      it('preserves tax calculation when updating the platform tip amount', async () => {
+        const orderWithTaxes = await fakeOrder(
+          {
+            CreatedByUserId: user.id,
+            FromCollectiveId: user.CollectiveId,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+            totalAmount: 1300,
+            taxAmount: 200,
+            platformTipAmount: 100,
+            currency: 'USD',
+            data: { tax: { id: 'VAT', percentage: 20 } },
+            subscription: {
+              amount: 1300,
+            },
+          },
+          {
+            withSubscription: true,
+          },
+        );
+
+        const result = await graphqlQueryV2(
+          updateOrderMutation,
+          {
+            order: { id: idEncode(orderWithTaxes.id, 'order') },
+            platformTipAmount: { valueInCents: 300, currency: 'USD' },
+          },
+          user,
+        );
+
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        await orderWithTaxes.reload({ include: [{ association: 'Subscription' }] });
+        expect(orderWithTaxes.totalAmount).to.eq(1500);
+        expect(orderWithTaxes.platformTipAmount).to.eq(300);
+        expect(orderWithTaxes.taxAmount).to.eq(200);
+        expect(orderWithTaxes.Subscription.amount).to.eq(1500);
+      });
+
+      it('recomputes tax when changing the amount and platform tip together', async () => {
+        const orderWithTaxes = await fakeOrder(
+          {
+            CreatedByUserId: user.id,
+            FromCollectiveId: user.CollectiveId,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+            totalAmount: 1300,
+            taxAmount: 200,
+            platformTipAmount: 100,
+            currency: 'USD',
+            data: { tax: { id: 'VAT', percentage: 20 } },
+            subscription: {
+              amount: 1300,
+            },
+          },
+          {
+            withSubscription: true,
+          },
+        );
+
+        const result = await graphqlQueryV2(
+          updateOrderMutation,
+          {
+            order: { id: idEncode(orderWithTaxes.id, 'order') },
+            amount: { valueInCents: 900, currency: 'USD' },
+            platformTipAmount: { valueInCents: 400, currency: 'USD' },
+          },
+          user,
+        );
+
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        await orderWithTaxes.reload({ include: [{ association: 'Subscription' }] });
+        expect(orderWithTaxes.totalAmount).to.eq(1300);
+        expect(orderWithTaxes.platformTipAmount).to.eq(400);
+        expect(orderWithTaxes.taxAmount).to.eq(150); // 20% VAT back-derived from $9.00 charge (gross $7.50)
+      });
+
+      it('clears the platform tip amount when set to zero', async () => {
+        const orderWithTaxes = await fakeOrder(
+          {
+            CreatedByUserId: user.id,
+            FromCollectiveId: user.CollectiveId,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+            totalAmount: 1500,
+            taxAmount: 200,
+            platformTipAmount: 300,
+            currency: 'USD',
+            data: { tax: { id: 'VAT', percentage: 20 } },
+            subscription: {
+              amount: 1500,
+            },
+          },
+          {
+            withSubscription: true,
+          },
+        );
+
+        const result = await graphqlQueryV2(
+          updateOrderMutation,
+          {
+            order: { id: idEncode(orderWithTaxes.id, 'order') },
+            platformTipAmount: { valueInCents: 0, currency: 'USD' },
+          },
+          user,
+        );
+
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        await orderWithTaxes.reload({ include: [{ association: 'Subscription' }] });
+        expect(orderWithTaxes.totalAmount).to.eq(1200);
+        expect(orderWithTaxes.platformTipAmount).to.eq(0);
+        expect(orderWithTaxes.taxAmount).to.eq(200);
+        expect(orderWithTaxes.Subscription.amount).to.eq(1200);
       });
 
       it('rejects amount/tier change for PayPal-managed subscription without paypalSubscriptionId', async () => {


### PR DESCRIPTION
Adds a `platformTipAmount` argument to the `updateOrder` mutation so contributors can adjust the platform tip on a recurring contribution order. Two-state semantics: undefined and null keeps the current tip, a value - including zero - sets it.

Tax is correctly recomputed when only the tip changes (previously gated solely on totalAmount changing). The `amount` argument keeps its existing meaning (post-tax total excluding the tip).