### PR TITLE
Pre-check access to incognito profile private information

### DIFF
--- a/server/graphql/v2/interface/Account.ts
+++ b/server/graphql/v2/interface/Account.ts
@@ -237,13 +237,9 @@ const accountFieldsDefinition = () => ({
       }
 
       const mainProfile = isIncognito && (await req.loaders.Collective.mainProfileFromIncognito.load(account.id));
-      const hasPermissionForMainProfile =
-        mainProfile && getContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_PRIVATE_PROFILE_INFO, mainProfile.id);
-
       if (
         canSeeIncognitoProfile(req, account) ||
-        getContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_PRIVATE_PROFILE_INFO, account.id) ||
-        hasPermissionForMainProfile
+        getContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_PRIVATE_PROFILE_INFO, account.id)
       ) {
         return mainProfile;
       }

--- a/server/graphql/v2/query/AccountQuery.ts
+++ b/server/graphql/v2/query/AccountQuery.ts
@@ -72,11 +72,30 @@ export const buildAccountQuery = ({ objectType }) => ({
     // Block access to private accounts for unauthorized viewers
     await assertCanSeeAccount(req, collective);
 
-    if (await req.loaders.Collective.canSeePrivateLocation.load(collective.id)) {
+    const [canSeePrivateLocation, canSeePrivateProfileInfo, incognitoProfile] = await Promise.all([
+      req.loaders.Collective.canSeePrivateLocation.load(collective.id),
+      req.loaders.Collective.canSeePrivateProfileInfo.load(collective.id),
+      collective.getIncognitoProfile(),
+    ]);
+    if (canSeePrivateLocation) {
       allowContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_PRIVATE_LOCATION, collective.id);
     }
-    if (await req.loaders.Collective.canSeePrivateProfileInfo.load(collective.id)) {
+    if (canSeePrivateProfileInfo) {
       allowContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_PRIVATE_PROFILE_INFO, collective.id);
+    }
+
+    // If the account has an incognito profile, check if the viewer has access to it and grant permissions accordingly
+    if (incognitoProfile) {
+      const [canSeePrivateLocationIncognito, canSeePrivateProfileInfoIncognito] = await Promise.all([
+        req.loaders.Collective.canSeePrivateLocation.load(incognitoProfile.id),
+        req.loaders.Collective.canSeePrivateProfileInfo.load(incognitoProfile.id),
+      ]);
+      if (canSeePrivateLocationIncognito) {
+        allowContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_PRIVATE_LOCATION, incognitoProfile.id);
+      }
+      if (canSeePrivateProfileInfoIncognito) {
+        allowContextPermission(req, PERMISSION_TYPE.SEE_ACCOUNT_PRIVATE_PROFILE_INFO, incognitoProfile.id);
+      }
     }
 
     return collective;

--- a/test/server/graphql/v2/interface/Account.test.ts
+++ b/test/server/graphql/v2/interface/Account.test.ts
@@ -234,39 +234,6 @@ describe('server/graphql/v2/interface/Account', () => {
       expect(result.data.account.mainProfile.slug).to.equal(user.collective.slug);
     });
 
-    it('returns the main profile when SEE_ACCOUNT_PRIVATE_PROFILE_INFO is granted for the main profile via a sibling account query', async () => {
-      const user = await fakeUser();
-      const incognito = await fakeIncognitoProfile(user);
-      const hostAdmin = await fakeUser();
-      const host = await fakeActiveHost({ admin: hostAdmin });
-      // The host admin can see the main profile's private info (e.g. the user contributed directly to the host)
-      await fakeMember({ CollectiveId: host.id, MemberCollectiveId: user.collective.id, role: MemberRoles.BACKER });
-      // Query both accounts in the same request: querying the main profile sets SEE_ACCOUNT_PRIVATE_PROFILE_INFO
-      // for main profile's id, which should then allow resolving incognito.mainProfile
-      const aliasQuery = gql`
-        query MainProfileSiblingTest($mainSlug: String!, $incognitoSlug: String!) {
-          mainAccount: account(slug: $mainSlug) {
-            slug
-          }
-          incognitoAccount: account(slug: $incognitoSlug) {
-            isIncognito
-            mainProfile {
-              slug
-            }
-          }
-        }
-      `;
-      const result = await graphqlQueryV2(
-        aliasQuery,
-        { mainSlug: user.collective.slug, incognitoSlug: incognito.slug },
-        hostAdmin,
-      );
-      expect(result.errors).to.not.exist;
-      expect(result.data.incognitoAccount.isIncognito).to.be.true;
-      expect(result.data.incognitoAccount.mainProfile).to.exist;
-      expect(result.data.incognitoAccount.mainProfile.slug).to.equal(user.collective.slug);
-    });
-
     it('returns the main profile for an admin of a fiscal host the user contributed to', async () => {
       const user = await fakeUser();
       const incognito = await fakeIncognitoProfile(user);


### PR DESCRIPTION
This fixes the incorrect assumption that a user who contributes to a host is also giving permission to the host admin to associate their incognito profile with their user.