### PR TITLE
Allow invited draft payee to add a payout method

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1844,7 +1844,13 @@ const checkExpenseType = async (
   }
 };
 
-export const getPayoutMethodFromExpenseData = async (expenseData, remoteUser, fromCollective, dbTransaction?) => {
+export const getPayoutMethodFromExpenseData = async (
+  expenseData,
+  remoteUser,
+  fromCollective,
+  toCollective,
+  dbTransaction?,
+) => {
   if (expenseData.payoutMethod) {
     if (expenseData.payoutMethod.id) {
       const pm = await models.PayoutMethod.findByPk(expenseData.payoutMethod.id);
@@ -1869,10 +1875,14 @@ export const getPayoutMethodFromExpenseData = async (expenseData, remoteUser, fr
     } else {
       // New payout method: created on the payee by default. For cross-host expenses, when the
       // submitter is an admin of the payee's host (but not of the payee itself, e.g. a host admin
-      // completing an invited draft), create the payout method on the recipient host so they can
+      // completing an invited draft), create the payout method on the payee's host so they can
       // add their own payment method.
+      const isCrossHostExpense = Boolean(
+        toCollective?.HostCollectiveId && fromCollective.HostCollectiveId !== toCollective.HostCollectiveId,
+      );
       let payoutMethodCollective = fromCollective;
       if (
+        isCrossHostExpense &&
         fromCollective.HostCollectiveId &&
         fromCollective.HostCollectiveId !== fromCollective.id &&
         !remoteUser.isAdmin(fromCollective.id) &&
@@ -2403,7 +2413,7 @@ export async function createExpense(
   const payoutMethod =
     fromCollective.type === CollectiveType.VENDOR
       ? await fromCollective.getPayoutMethods({ where: { isSaved: true } }).then(first)
-      : await getPayoutMethodFromExpenseData(expenseData, remoteUser, fromCollective, null);
+      : await getPayoutMethodFromExpenseData(expenseData, remoteUser, fromCollective, collective, null);
 
   if (
     payoutMethod?.type === PayoutMethodTypes.STRIPE &&
@@ -3163,7 +3173,7 @@ export async function editExpense(
         payoutMethod = await fromCollective.getPayoutMethods({ where: { isSaved: true } }).then(first);
         assert(payoutMethod, 'The vendor payee must have a saved payout method');
       } else {
-        payoutMethod = await getPayoutMethodFromExpenseData(expenseData, remoteUser, fromCollective, null);
+        payoutMethod = await getPayoutMethodFromExpenseData(expenseData, remoteUser, fromCollective, collective, null);
       }
 
       if (

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -745,10 +745,12 @@ export const canEditPayoutMethod: ExpensePermissionEvaluator = async (req, expen
       throw new Forbidden('User cannot use expenses', EXPENSE_PERMISSION_ERROR_CODES.UNSUPPORTED_USER_FEATURE);
     }
     return false;
+  } else if (expense.status === ExpenseStatus.DRAFT) {
+    // Mirror `canEditExpense` for drafts: the invited payee (and host admin) must be able to
+    // set the payout method when completing a "submit on behalf" invitation, not just the owner.
+    return remoteUserMeetsOneCondition(req, expense, [isOwner, isHostAdmin, isDraftPayee], options);
   } else if (
-    [ExpenseStatus.DRAFT, ExpenseStatus.PENDING, ExpenseStatus.INCOMPLETE, ExpenseStatus.APPROVED].includes(
-      expense.status as ExpenseStatus,
-    )
+    [ExpenseStatus.PENDING, ExpenseStatus.INCOMPLETE, ExpenseStatus.APPROVED].includes(expense.status as ExpenseStatus)
   ) {
     return remoteUserMeetsOneCondition(req, expense, [isOwner], options);
   }
@@ -1865,10 +1867,24 @@ export const getPayoutMethodFromExpenseData = async (expenseData, remoteUser, fr
       }
       return pm;
     } else {
+      // New payout method: created on the payee by default. For cross-host expenses, when the
+      // submitter is an admin of the payee's host (but not of the payee itself, e.g. a host admin
+      // completing an invited draft), create the payout method on the recipient host so they can
+      // add their own payment method.
+      let payoutMethodCollective = fromCollective;
+      if (
+        fromCollective.HostCollectiveId &&
+        fromCollective.HostCollectiveId !== fromCollective.id &&
+        !remoteUser.isAdmin(fromCollective.id) &&
+        remoteUser.isAdmin(fromCollective.HostCollectiveId)
+      ) {
+        payoutMethodCollective =
+          fromCollective.host || (await models.Collective.findByPk(fromCollective.HostCollectiveId));
+      }
       return models.PayoutMethod.getOrCreateFromUserData(
         expenseData.payoutMethod,
         remoteUser,
-        fromCollective,
+        payoutMethodCollective,
         dbTransaction,
       );
     }


### PR DESCRIPTION
A host admin invited to complete a cross-host draft expense could not add or edit the payout method: canEditPayoutMethod only accepted isOwner for drafts, while canEditExpense accepts [isOwner, isHostAdmin, isDraftPayee], so Expense.permissions.canEditPayoutMethod resolved to false and the editor was hidden.

- canEditPayoutMethod: mirror canEditExpense for DRAFT (non-draft statuses unchanged)
- getPayoutMethodFromExpenseData: for cross-host, create a newly-added payout method on the recipient host (instead of the payee) when the submitter administers that host. Backend counterpart to letting host admins add a payout method in the cross-host invite flow.

Frontend: https://github.com/opencollective/opencollective-frontend/pull/12180