### PR TITLE
fix(Orders): Restore text search with Kysely

### DIFF
--- a/migrations/20260603120000-replace-orders-fromaccountinfo-email-search-index.ts
+++ b/migrations/20260603120000-replace-orders-fromaccountinfo-email-search-index.ts
@@ -1,0 +1,67 @@
+'use strict';
+
+import type { QueryInterface } from 'sequelize';
+
+/**
+ * Orders search updated to use exact match on data.fromAccountInfo.email (emailFields),
+ * not ILIKE. Replace the trigram GiST index with a btree index on lower(email).
+ */
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "Orders_data_fromAccountInfo_email_search_idx";
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "Orders_data_fromAccountInfo_email_search_idx"
+      ON "Orders" (lower(("data"#>>'{fromAccountInfo,email}')))
+      INCLUDE (
+        description,
+        tags,
+        id,
+        "SubscriptionId",
+        "createdAt",
+        "CollectiveId",
+        "FromCollectiveId",
+        "CreatedByUserId",
+        "status",
+        "TierId",
+        "interval",
+        "totalAmount",
+        "currency",
+        "PaymentMethodId",
+        "deletedAt"
+      )
+      WHERE "deletedAt" IS NULL
+        AND coalesce("data"#>>'{fromAccountInfo,email}', '') <> '';
+    `);
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "Orders_data_fromAccountInfo_email_search_idx";
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "Orders_data_fromAccountInfo_email_search_idx"
+      ON "Orders" USING gist(("data"#>>'{fromAccountInfo,email}') gist_trgm_ops)
+      INCLUDE (
+        description,
+        tags,
+        id,
+        "SubscriptionId",
+        "createdAt",
+        "CollectiveId",
+        "FromCollectiveId",
+        "CreatedByUserId",
+        "status",
+        "TierId",
+        "interval",
+        "totalAmount",
+        "currency",
+        "PaymentMethodId",
+        "deletedAt"
+      );
+    `);
+  },
+};

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -5,7 +5,7 @@ import { GraphQLBoolean, GraphQLEnumType, GraphQLInt, GraphQLList, GraphQLNonNul
 import { GraphQLDateTime } from 'graphql-scalars';
 import { Expression, ExpressionBuilder, expressionBuilder, OrderByModifiers, sql, SqlBool } from 'kysely';
 import { KyselifyModel } from 'kysely-sequelize';
-import { compact, isEmpty, isInteger, isNil, uniq } from 'lodash';
+import { compact, isEmpty, isNil, uniq } from 'lodash';
 import moment from 'moment';
 import { Includeable, WhereOptions } from 'sequelize';
 
@@ -16,9 +16,9 @@ import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../../constan
 import { MemberRolesForPrivateAccounts } from '../../../../constants/roles';
 import { TransactionKind } from '../../../../constants/transaction-kind';
 import { DatabaseWithViews, getKysely, kyselyToSequelizeModels } from '../../../../lib/kysely';
-import { EntityShortIdPrefix, isEntityPublicId } from '../../../../lib/permalink/entity-map';
+import { EntityShortIdPrefix } from '../../../../lib/permalink/entity-map';
 import { assertCanSeeAllAccounts } from '../../../../lib/private-accounts';
-import { buildSearchConditions } from '../../../../lib/sql-search';
+import { buildKyselySearchConditions, buildSearchConditions, parseSearchTerm } from '../../../../lib/sql-search';
 import models, { Collective, ManualPaymentProvider, Op, PaymentMethod, Tier, User } from '../../../../models';
 import { checkScope } from '../../../common/scope-check';
 import { Forbidden, NotFound, Unauthorized, ValidationFailed } from '../../../errors';
@@ -503,18 +503,11 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
     }
   }
 
-  const isHostAdmin = account?.hasMoneyManagement && req.remoteUser?.isAdminOfCollective(account);
-  const searchTermLooksLikeAnEmail = !!args.searchTerm && args.searchTerm.includes('@');
-
-  let collectiveBySearchTerm: Collective | null = null;
-  if (isEntityPublicId(args.searchTerm, EntityShortIdPrefix.Collective)) {
-    const collective = await models.Collective.findOne({
-      where: { publicId: args.searchTerm },
-    });
-    if (collective) {
-      collectiveBySearchTerm = collective;
-    }
-  }
+  const isCollectiveAdmin = req.remoteUser?.isAdminOfCollective(account);
+  const isHostAdmin = account?.hasMoneyManagement && isCollectiveAdmin;
+  const parsedSearchTerm = parseSearchTerm(args.searchTerm);
+  const isHostAdminEmailSearch = isHostAdmin && parsedSearchTerm.type === 'email';
+  const hasSearchTerm = !!parsedSearchTerm.term;
 
   const shouldApplyPrivateRecipientVisibilityFilter = !req.remoteUser?.isRoot() && !host;
   const kysely = getKysely();
@@ -550,53 +543,56 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
     })
     .with(
       cte => cte('filterByOrderSearchTerm').materialized(),
-      db => {
-        const ors: Expression<SqlBool>[] = [];
-        return db
+      db =>
+        db
           .selectFrom('Orders')
           .select('Orders.id')
           .where('Orders.deletedAt', 'is', null)
-          .$if(!!args.searchTerm, qb => {
-            return qb.where(({ or, eb }) => {
-              if (isFinite(Number(args.searchTerm)) && isInteger(Number(args.searchTerm))) {
-                ors.push(eb('Orders.id', '=', Number(args.searchTerm)));
-              }
-
-              if (isEntityPublicId(args.searchTerm, EntityShortIdPrefix.Order)) {
-                ors.push(eb('Orders.publicId', '=', args.searchTerm));
-              }
-
-              if (collectiveBySearchTerm) {
-                ors.push(eb('Orders.CollectiveId', '=', collectiveBySearchTerm.id));
-                ors.push(eb('Orders.FromCollectiveId', '=', collectiveBySearchTerm.id));
-              }
-
-              ors.push(eb('Orders.description', 'ilike', `%${args.searchTerm}%`));
-              ors.push(eb(sql`"Orders".data->>'ponumber'`, 'ilike', `%${args.searchTerm}%`));
-              ors.push(eb(sql`"Orders".data#>>'{fromAccountInfo,name}'`, 'ilike', `%${args.searchTerm}%`));
-              ors.push(eb(sql`"Orders".data#>>'{fromAccountInfo,email}'`, 'ilike', `%${args.searchTerm}%`));
-              ors.push(
-                eb('Orders.tags', '&&', sql<string[]>`ARRAY[${args.searchTerm.toLocaleLowerCase()}]::varchar[]`),
+          .$if(hasSearchTerm, qb => {
+            const searchQuery = qb
+              .innerJoin('Collectives as collective', join =>
+                join.onRef('collective.id', '=', 'Orders.CollectiveId').on('collective.deletedAt', 'is', null),
+              )
+              .innerJoin('Collectives as fromCollective', join =>
+                join
+                  .onRef('fromCollective.id', '=', 'Orders.FromCollectiveId')
+                  .on('fromCollective.deletedAt', 'is', null),
+              )
+              .$if(isHostAdminEmailSearch, sq =>
+                sq.leftJoin('Users', join =>
+                  join.onRef('Users.id', '=', 'Orders.CreatedByUserId').on('Users.deletedAt', 'is', null),
+                ),
               );
 
-              return or(ors);
-            });
-          })
-          .$if(isHostAdmin && searchTermLooksLikeAnEmail, qb => {
-            return qb.union(
-              db
-                .selectFrom('Orders')
-                .select('Orders.id')
-                .innerJoin('Users', 'Users.id', 'Orders.CreatedByUserId')
-                .where('Orders.deletedAt', 'is', null)
-                .where('Users.email', '=', args.searchTerm)
-                .where('Users.deletedAt', 'is', null),
-            );
-          });
-      },
+            return buildKyselySearchConditions(args.searchTerm, {
+              idFields: ['Orders.id'],
+              slugFields: ['collective.slug', 'fromCollective.slug'],
+              textFields: [
+                'collective.name',
+                'fromCollective.name',
+                'Orders.description',
+                ...(isCollectiveAdmin
+                  ? [sql`"Orders".data->>'ponumber'`, sql`"Orders".data#>>'{fromAccountInfo,name}'`]
+                  : []),
+              ],
+              emailFields: [
+                ...(isCollectiveAdmin ? [sql<string>`lower("Orders".data#>>'{fromAccountInfo,email}')`] : []),
+                ...(isHostAdminEmailSearch ? ['Users.email'] : []),
+              ],
+              stringArrayFields: ['Orders.tags'],
+              stringArrayTransformFn: (str: string) => str.toLowerCase(),
+              publicIdFields: [
+                { field: 'Orders.publicId', prefix: EntityShortIdPrefix.Order },
+                {
+                  field: ['collective.publicId', 'fromCollective.publicId'],
+                  prefix: EntityShortIdPrefix.Collective,
+                },
+              ],
+            })(searchQuery) as typeof searchQuery;
+          }),
     )
     .selectFrom('Orders')
-    .$if(!!args.searchTerm, qb => {
+    .$if(hasSearchTerm, qb => {
       return qb.innerJoin('filterByOrderSearchTerm', 'filterByOrderSearchTerm.id', 'Orders.id');
     })
     .innerJoin('Collectives as collective', join =>

--- a/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/OrdersCollectionQuery.ts
@@ -576,9 +576,9 @@ export const OrdersCollectionResolver = async (args: OrdersCollectionArgsType, r
                   : []),
               ],
               emailFields: [
-                ...(isCollectiveAdmin ? [sql<string>`lower("Orders".data#>>'{fromAccountInfo,email}')`] : []),
-                ...(isHostAdminEmailSearch ? ['Users.email'] : []),
-              ],
+                isCollectiveAdmin && sql<string>`lower("Orders".data#>>'{fromAccountInfo,email}')`,
+                isHostAdminEmailSearch && 'Users.email',
+              ].filter(Boolean),
               stringArrayFields: ['Orders.tags'],
               stringArrayTransformFn: (str: string) => str.toLowerCase(),
               publicIdFields: [

--- a/server/lib/sql-search.ts
+++ b/server/lib/sql-search.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import config from 'config';
 import type { Request } from 'express';
 import express from 'express';
-import { SelectQueryBuilder } from 'kysely';
+import { Expression, RawBuilder, SelectQueryBuilder, sql } from 'kysely';
 import slugify from 'limax';
 import { get, isEmpty, isNil, isUndefined, toString, words } from 'lodash';
 import { QueryTypes } from 'sequelize';
@@ -730,6 +730,8 @@ export const buildSearchConditions = (
   return conditions;
 };
 
+type KyselySearchField = string | Expression<unknown> | RawBuilder<unknown>;
+
 export const buildKyselySearchConditions =
   <T>(
     searchTerm: string,
@@ -737,15 +739,25 @@ export const buildKyselySearchConditions =
       slugFields = [],
       idFields = [],
       textFields = [],
+      dataFields = [],
+      amountFields = [],
       emailFields = [],
+      stringArrayFields = [],
+      stringArrayTransformFn = null,
+      castStringArraysToVarchar = false,
       publicIdFields = [],
     }: {
-      slugFields?: string[];
-      idFields?: string[];
-      textFields?: string[];
-      emailFields?: string[];
+      slugFields?: KyselySearchField[];
+      idFields?: KyselySearchField[];
+      textFields?: KyselySearchField[];
+      dataFields?: KyselySearchField[];
+      amountFields?: KyselySearchField[];
+      emailFields?: KyselySearchField[];
+      stringArrayFields?: KyselySearchField[];
+      stringArrayTransformFn?: (str: string) => string;
+      castStringArraysToVarchar?: boolean;
       publicIdFields?: {
-        field: string | string[];
+        field: KyselySearchField | KyselySearchField[];
         prefix: EntityShortIdPrefix;
       }[];
     },
@@ -758,35 +770,81 @@ export const buildKyselySearchConditions =
       return q;
     }
 
-    // Exclusive conditions: if an ID or a slug is searched, on don't search other attributes
-    // We don't use ILIKE for them, they must match exactly
+    // Exclusive conditions: if an ID, slug, or email is searched, don't search other attributes.
     if (parsedTerm.type === 'slug' && slugFields?.length) {
-      return q.where(({ eb, or }) => or(slugFields.map(field => eb(field, 'ilike', parsedTerm.term))));
-    } else if (parsedTerm.type === 'id' && idFields?.length) {
+      return q.where(({ eb, or }) => or(slugFields.map(field => eb(field, '=', parsedTerm.term))));
+    }
+    if (parsedTerm.type === 'id' && idFields?.length) {
       return q.where(({ eb, or }) => or(idFields.map(field => eb(field, '=', parsedTerm.term))));
-    } else if (parsedTerm.type === 'email' && emailFields?.length) {
+    }
+    if (parsedTerm.type === 'email' && emailFields?.length) {
       return q.where(({ eb, or }) => or(emailFields.map(field => eb(field, '=', parsedTerm.term))));
-    } else if (parsedTerm.type === 'publicId' && publicIdFields?.length) {
+    }
+    if (parsedTerm.type === 'publicId' && publicIdFields?.length) {
       const fields = publicIdFields
         .filter(field => field.prefix === parsedTerm.prefix)
-        .reduce((acc, field) => {
+        .reduce<KyselySearchField[]>((acc, field) => {
           if (Array.isArray(field.field)) {
             return [...acc, ...field.field];
           }
           return [...acc, field.field];
         }, []);
-      return q.where(({ eb, or }) => or(fields.map(field => eb(field, '=', parsedTerm.term))));
+      if (fields.length) {
+        return q.where(({ eb, or }) => or(fields.map(field => eb(field, '=', parsedTerm.term))));
+      }
     }
 
-    // Inclusive conditions, search all fields except
+    // Inclusive conditions: single OR across all applicable field groups
 
-    // Conditions for text fields
-    const strTerm = parsedTerm.term.toString(); // Some terms are returned as numbers
-    const iLikeQuery = `%${sanitizeSearchTermForILike(strTerm)}%`;
-    const allTextFields = [...(slugFields || []), ...(textFields || [])];
+    return q.where(({ eb, or }) => {
+      const conditions = [];
 
-    q = q.where(({ eb, or }) => or(allTextFields.map(field => eb(field, 'ilike', iLikeQuery))));
-    return q;
+      // Conditions for text fields
+      const strTerm = parsedTerm.term.toString(); // Some terms are returned as numbers
+      const allTextFields = [...(slugFields || []), ...(textFields || [])];
+
+      // Partial match on slug + free-text columns (also used for multi-word queries).
+      allTextFields.forEach(field => conditions.push(eb(field, 'ilike', `%${sanitizeSearchTermForILike(strTerm)}%`)));
+
+      // Tag / string-array overlap
+      if (stringArrayFields?.length) {
+        const preparedTerm = stringArrayTransformFn ? stringArrayTransformFn(strTerm) : strTerm;
+        stringArrayFields.forEach(field => {
+          if (castStringArraysToVarchar) {
+            conditions.push(eb(field, '&&', sql`CAST(ARRAY[${preparedTerm}] AS varchar[])`));
+          } else {
+            conditions.push(eb(field, '&&', sql`ARRAY[${preparedTerm}]::varchar[]`));
+          }
+        });
+      }
+
+      // Exact match on structured data columns (JSON paths, references): single token only,
+      // so "foo bar" stays a text search and does not hit dataFields.
+      if (
+        dataFields?.length &&
+        ((parsedTerm.type === 'text' && parsedTerm.words === 1) ||
+          (parsedTerm.type === 'number' && !parsedTerm.isFloat))
+      ) {
+        dataFields.forEach(field => conditions.push(eb(field, '=', toString(parsedTerm.term))));
+      }
+
+      // Bare numbers (not #id): match integer id columns and/or amount columns (stored in cents).
+      if (parsedTerm.type === 'number') {
+        if (!parsedTerm.isFloat && idFields?.length) {
+          idFields.forEach(field => conditions.push(eb(field, '=', parsedTerm.term)));
+        }
+        if (amountFields?.length) {
+          amountFields.forEach(field => conditions.push(eb(field, '=', floatAmountToCents(parsedTerm.term as number))));
+        }
+      }
+
+      // Same as buildSearchConditions returning []: skip search when no field applies.
+      if (!conditions.length) {
+        return eb.val(true);
+      }
+
+      return or(conditions);
+    });
   };
 
 /**

--- a/test/server/graphql/v2/query/collection/OrdersCollectionQuery.test.ts
+++ b/test/server/graphql/v2/query/collection/OrdersCollectionQuery.test.ts
@@ -3,6 +3,7 @@ import gql from 'fake-tag';
 
 import OrderStatuses from '../../../../../../server/constants/order-status';
 import { idEncode, IDENTIFIER_TYPES } from '../../../../../../server/graphql/v2/identifiers';
+import models from '../../../../../../server/models';
 import {
   fakeAccountingCategory,
   fakeActiveHost,
@@ -12,12 +13,14 @@ import {
   fakeOrder,
   fakePrivateHost,
   fakeUser,
+  randStr,
 } from '../../../../../test-helpers/fake-data';
 import { graphqlQueryV2, resetTestDB } from '../../../../../utils';
 
 const ordersQuery = gql`
   query Orders(
     $account: AccountReferenceInput
+    $host: AccountReferenceInput
     $hostContext: HostContext
     $filter: AccountOrdersFilter
     $includeChildrenAccounts: Boolean
@@ -29,6 +32,7 @@ const ordersQuery = gql`
   ) {
     orders(
       account: $account
+      host: $host
       hostContext: $hostContext
       filter: $filter
       includeChildrenAccounts: $includeChildrenAccounts
@@ -943,14 +947,15 @@ describe('server/graphql/v2/collection/OrdersCollectionQuery', () => {
   });
 
   describe('searchTerm argument', () => {
-    let collective, user1, user2, order1, order2;
+    let collective, collectiveAdmin, user1, user2, order1, order2;
 
     before(async () => {
-      collective = await fakeCollective();
+      collectiveAdmin = await fakeUser();
+      collective = await fakeCollective({ admin: collectiveAdmin });
 
       // Create users with specific names for search testing
       user1 = await fakeUser(null, { name: 'Alice Anderson' });
-      user2 = await fakeUser(null, { name: 'Bob Builder' });
+      user2 = await fakeUser({ email: `bob${randStr()}@test.com` }, { name: 'Bob Builder' });
 
       // Create orders by different users
       order1 = await fakeOrder({
@@ -981,7 +986,24 @@ describe('server/graphql/v2/collection/OrdersCollectionQuery', () => {
       expect(orderIds).to.include(order1.id);
     });
 
-    it("should return the order when the search term matches a user's email", async () => {
+    it('returns the order when a collective admin searches by snapshot email', async () => {
+      await collectiveAdmin.populateRoles({ force: true });
+      const result = await graphqlQueryV2(
+        ordersQuery,
+        {
+          account: { legacyId: collective.id },
+          filter: 'INCOMING',
+          searchTerm: user2.email,
+        },
+        collectiveAdmin,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(1);
+      expect(result.data.orders.nodes.map(node => node.legacyId)).to.include(order2.id);
+    });
+
+    it('does not return orders when searching by snapshot email without admin access', async () => {
       const result = await graphqlQueryV2(ordersQuery, {
         account: { legacyId: collective.id },
         filter: 'INCOMING',
@@ -989,9 +1011,149 @@ describe('server/graphql/v2/collection/OrdersCollectionQuery', () => {
       });
 
       expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(0);
+    });
+  });
+
+  describe('searchTerm argument (live collective joins)', () => {
+    let collective, fromUser, order;
+
+    before(async () => {
+      collective = await fakeCollective({ name: 'Payee Collective Search', slug: 'payee-collective-search' });
+      fromUser = await fakeUser(null, { name: 'Original From Name' });
+      order = await fakeOrder({
+        CollectiveId: collective.id,
+        FromCollectiveId: fromUser.CollectiveId,
+        CreatedByUserId: fromUser.id,
+        status: OrderStatuses.PAID,
+        data: {
+          fromAccountInfo: {
+            name: 'Stale Snapshot Name Only',
+            email: fromUser.email,
+          },
+        },
+      });
+      const fromCollective = await models.Collective.findByPk(fromUser.CollectiveId);
+      await fromCollective.update({ name: 'Live From Collective Name', slug: 'live-from-collective-slug' });
+    });
+
+    it('matches fromCollective.name via live join when it differs from data.fromAccountInfo.name', async () => {
+      const result = await graphqlQueryV2(ordersQuery, {
+        account: { legacyId: collective.id },
+        filter: 'INCOMING',
+        searchTerm: 'Live From Collective',
+      });
+
+      expect(result.errors).to.not.exist;
       expect(result.data.orders.totalCount).to.eq(1);
-      const orderIds = result.data.orders.nodes.map(node => node.legacyId);
-      expect(orderIds).to.include(order2.id);
+      expect(result.data.orders.nodes[0].legacyId).to.eq(order.id);
+    });
+
+    it('matches fromCollective.slug via live join', async () => {
+      const result = await graphqlQueryV2(ordersQuery, {
+        account: { legacyId: collective.id },
+        filter: 'INCOMING',
+        searchTerm: 'live-from-collective',
+      });
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(1);
+      expect(result.data.orders.nodes[0].legacyId).to.eq(order.id);
+    });
+
+    it('matches collective.name via live join', async () => {
+      const result = await graphqlQueryV2(ordersQuery, {
+        account: { legacyId: collective.id },
+        filter: 'INCOMING',
+        searchTerm: 'Payee Collective',
+      });
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(1);
+      expect(result.data.orders.nodes[0].legacyId).to.eq(order.id);
+    });
+
+    it('matches @slug shortcut on fromCollective slug', async () => {
+      const result = await graphqlQueryV2(ordersQuery, {
+        account: { legacyId: collective.id },
+        filter: 'INCOMING',
+        searchTerm: '@live-from-collective-slug',
+      });
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(1);
+      expect(result.data.orders.nodes[0].legacyId).to.eq(order.id);
+    });
+
+    it('matches #id shortcut on order id', async () => {
+      const result = await graphqlQueryV2(ordersQuery, {
+        account: { legacyId: collective.id },
+        filter: 'INCOMING',
+        searchTerm: `#${order.id}`,
+      });
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(1);
+      expect(result.data.orders.nodes[0].legacyId).to.eq(order.id);
+    });
+
+    it('matches Users.email for host admin', async () => {
+      const hostAdmin = await fakeUser();
+      const host = await fakeActiveHost({ admin: hostAdmin });
+      const hostedCollective = await fakeCollective({
+        HostCollectiveId: host.id,
+        approvedAt: new Date(),
+        isActive: true,
+      });
+      // parseSearchTerm only treats addresses without hyphens in the local part as emails
+      const contributor = await fakeUser({ email: `contributor${randStr()}@test.com` });
+      const hostOrder = await fakeOrder({
+        CollectiveId: hostedCollective.id,
+        FromCollectiveId: contributor.CollectiveId,
+        CreatedByUserId: contributor.id,
+        status: OrderStatuses.PAID,
+      });
+
+      await hostAdmin.populateRoles({ force: true });
+      const result = await graphqlQueryV2(
+        ordersQuery,
+        {
+          account: { legacyId: host.id },
+          hostContext: 'HOSTED',
+          filter: 'INCOMING',
+          searchTerm: contributor.email,
+        },
+        hostAdmin,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(1);
+      expect(result.data.orders.nodes[0].legacyId).to.eq(hostOrder.id);
+    });
+
+    it('does not match Users.email without host admin', async () => {
+      const host = await fakeActiveHost();
+      const hostedCollective = await fakeCollective({
+        HostCollectiveId: host.id,
+        approvedAt: new Date(),
+        isActive: true,
+      });
+      const contributor = await fakeUser({ email: `contributor${randStr()}@test.com` });
+      await fakeOrder({
+        CollectiveId: hostedCollective.id,
+        FromCollectiveId: contributor.CollectiveId,
+        CreatedByUserId: contributor.id,
+        status: OrderStatuses.PAID,
+      });
+
+      const result = await graphqlQueryV2(ordersQuery, {
+        host: { legacyId: host.id },
+        filter: 'INCOMING',
+        searchTerm: contributor.email,
+      });
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.orders.totalCount).to.eq(0);
     });
   });
 

--- a/test/server/lib/search.test.ts
+++ b/test/server/lib/search.test.ts
@@ -1,10 +1,13 @@
 import { expect } from 'chai';
 import config from 'config';
+import { sql } from 'kysely';
 import { times } from 'lodash';
 
 import { CollectiveType } from '../../../server/graphql/v1/CollectiveInterface';
+import { getKysely } from '../../../server/lib/kysely';
 import { EntityShortIdPrefix } from '../../../server/lib/permalink/entity-map';
 import {
+  buildKyselySearchConditions,
   buildSearchConditions,
   parseSearchTerm,
   sanitizeSearchTermForILike,
@@ -664,6 +667,117 @@ describe('server/lib/search', () => {
           stringArrayTransformFn: value => value.toUpperCase(),
         }),
       ).to.deep.eq([{ tags: { [Op.overlap]: ['HELLO WORLD'] } }]);
+    });
+  });
+
+  describe('buildKyselySearchConditions', () => {
+    const compileWithSearch = (searchTerm: string, config: Parameters<typeof buildKyselySearchConditions>[1]) => {
+      const kysely = getKysely();
+      const query = buildKyselySearchConditions(searchTerm, config)(kysely.selectFrom('Orders').selectAll('Orders'));
+      return query.compile();
+    };
+
+    it('returns query unchanged for an empty search', () => {
+      const { sql: compiledSql, parameters } = compileWithSearch('', { textFields: ['name'] });
+      expect(compiledSql).to.not.include('ilike');
+      expect(parameters).to.be.empty;
+    });
+
+    it('applies no search filter when no fields apply to the parsed term', () => {
+      const { sql: compiledSql, parameters } = compileWithSearch('#4242', {});
+      expect(compiledSql).to.not.include('ilike');
+      expect(compiledSql).to.not.include('"Orders"."id"');
+      expect(parameters).to.not.include(4242);
+      expect(parameters).to.include(true);
+    });
+
+    it('builds exclusive id condition for #id', () => {
+      const { sql: compiledSql, parameters } = compileWithSearch('#4242', { idFields: ['Orders.id'] });
+      expect(compiledSql).to.include('"Orders"."id"');
+      expect(compiledSql).to.not.include('ilike');
+      expect(parameters).to.include(4242);
+    });
+
+    it('builds exclusive slug condition for @slug', () => {
+      const { sql: compiledSql, parameters } = compileWithSearch('@betree', { slugFields: ['slug'] });
+      expect(compiledSql).to.include('"slug"');
+      expect(compiledSql).to.not.include('ilike');
+      expect(parameters).to.include('betree');
+    });
+
+    it('builds exclusive publicId condition without inclusive ILIKE (Kysely deviation)', () => {
+      const publicId = 'acc_searchPubId';
+      const { sql: compiledSql, parameters } = compileWithSearch(publicId, {
+        slugFields: ['slug'],
+        textFields: ['name'],
+        publicIdFields: [{ field: 'publicId', prefix: EntityShortIdPrefix.Collective }],
+      });
+      expect(compiledSql).to.include('"publicId"');
+      expect(compiledSql).to.not.include('ilike');
+      expect(parameters).to.include(publicId);
+    });
+
+    it('falls through to inclusive ILIKE when publicId prefix does not match', () => {
+      const publicId = 'tx_abc123';
+      const { sql: compiledSql } = compileWithSearch(publicId, {
+        slugFields: ['slug'],
+        textFields: ['name'],
+        publicIdFields: [{ field: 'publicId', prefix: EntityShortIdPrefix.Collective }],
+      });
+      expect(compiledSql).to.include('ilike');
+    });
+
+    it('builds inclusive conditions for numbers including id and amount', () => {
+      const { sql: compiledSql, parameters } = compileWithSearch('4242', {
+        slugFields: ['slug'],
+        textFields: ['name'],
+        idFields: ['Orders.id'],
+        amountFields: ['totalAmount'],
+        stringArrayFields: ['tags'],
+      });
+      expect(compiledSql).to.include('ilike');
+      expect(compiledSql).to.include('"Orders"."id"');
+      expect(compiledSql).to.include('"totalAmount"');
+      expect(parameters).to.include(4242);
+      expect(parameters).to.include(424200);
+    });
+
+    it('includes jsonb sql expression in textFields ILIKE OR', () => {
+      const { sql: compiledSql } = compileWithSearch('PO-123', {
+        textFields: [sql`"Orders".data->>'ponumber'`],
+      });
+      expect(compiledSql).to.include(`"Orders".data->>'ponumber'`);
+      expect(compiledSql).to.include('ilike');
+    });
+
+    it('uses exact match for dataFields on single-word text', () => {
+      const { sql: compiledSql, parameters } = compileWithSearch('ref_abc', {
+        dataFields: ['data.reference'],
+      });
+      expect(compiledSql).to.include('"data"."reference"');
+      expect(compiledSql).to.not.include('ilike');
+      expect(parameters).to.include('ref_abc');
+    });
+
+    it('falls through to inclusive ILIKE when email type has empty emailFields', () => {
+      const { sql: compiledSql, parameters } = compileWithSearch('a@b.com', {
+        emailFields: [],
+        textFields: ['data.email'],
+      });
+      expect(compiledSql).to.include('ilike');
+      expect(compiledSql).to.include('"data"."email"');
+      expect(parameters).to.not.include('a@b.com');
+    });
+
+    it('builds exclusive email condition when emailFields is set', () => {
+      const email = 'contributor@example.com';
+      const { sql: compiledSql, parameters } = compileWithSearch(email, {
+        emailFields: ['Users.email'],
+        textFields: ['description'],
+      });
+      expect(compiledSql).to.include('"Users"."email"');
+      expect(compiledSql).to.not.include('ilike');
+      expect(parameters).to.include(email);
     });
   });
 });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8643

## Summary

Restores order `searchTerm` matching on live **Collective** / **FromCollective** `name` and `slug`, which was lost when `OrdersCollectionQuery` moved to Kysely. The search CTE now joins those collectives and uses an upgraded **`buildKyselySearchConditions`** helper (same curried API as before, Organization vendor search unchanged).

## Changes

- **`buildKyselySearchConditions`**: aligned with Sequelize `buildSearchConditions` (`dataFields`, amounts, tags, `#id` / `@slug` / email shortcuts, jsonb `sql` fields). `publicId` stays **exclusive** in Kysely (Sequelize ORs it with text).
- **`OrdersCollectionQuery`**: materialized search CTE uses the helper + collective joins; host-admin email via `Users` left join.
  - Tightened search permissions on `data.ponumber/fromAccountInfo` to be restricted to collective admins, aligning with read permissions for these fields.
  - Moved the `data.fromAccountInfo.email` from inclusive `textFields` search to be exclusive `emailFields` search (and updated the index from GiST/trigram to `btree` to better support the `=` condition)
- **Tests**: compile tests for the helper; integration tests for live name/slug, `@slug`, `#id`, host-admin email, soft-deleted user exclusion.

## Test plan

- [x] `test/server/lib/search.test.ts`
- [x] `test/server/graphql/v2/collection/OrdersCollectionQuery.test.ts`