### PR TITLE
Exclude platform settlements and billing from paid expenses

### DIFF
--- a/server/models/PlatformSubscription.ts
+++ b/server/models/PlatformSubscription.ts
@@ -18,6 +18,7 @@ import Temporal from 'sequelize-temporal';
 
 import ActivityTypes from '../constants/activities';
 import { ENGINEERING_DOMAINS } from '../constants/engineering-domains';
+import ExpenseType from '../constants/expense-type';
 import FEATURE from '../constants/feature';
 import { PlatformSubscriptionPlan, PlatformSubscriptionTiers, PlatformSubscriptionTierTypes } from '../constants/plans';
 import { sortResultsSimple } from '../graphql/loaders/helpers';
@@ -274,6 +275,7 @@ class PlatformSubscription extends Model<
       `
       SELECT COUNT(DISTINCT(a."ExpenseId")) "expensesPaid"
         FROM "Activities" a
+        JOIN "Expenses" e ON e.id = a."ExpenseId"
         LEFT JOIN LATERAL (
           SELECT count(1) > 0 "previouslyPaid"
           FROM "Activities" "hist"
@@ -286,6 +288,7 @@ class PlatformSubscription extends Model<
         WHERE a."HostCollectiveId" = :HostCollectiveId
         AND a."type" = 'collective.expense.paid'
         AND a."createdAt" <@ ${billingRangeArg}
+        AND e."type" NOT IN (:excludedExpenseTypes)
         AND NOT "hist"."previouslyPaid"
     `,
       {
@@ -294,6 +297,7 @@ class PlatformSubscription extends Model<
         plain: true,
         replacements: {
           HostCollectiveId: collectiveId,
+          excludedExpenseTypes: [ExpenseType.SETTLEMENT, ExpenseType.PLATFORM_BILLING],
         },
       },
     );

--- a/test/server/models/PlatformSubscriptions.test.ts
+++ b/test/server/models/PlatformSubscriptions.test.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import { activities } from '../../../server/constants';
 import { Service } from '../../../server/constants/connected-account';
 import ExpenseStatuses from '../../../server/constants/expense-status';
+import ExpenseType from '../../../server/constants/expense-type';
 import FEATURE from '../../../server/constants/feature';
 import { PlatformSubscriptionPlan, PlatformSubscriptionTiers } from '../../../server/constants/plans';
 import * as GoCardlessConnect from '../../../server/lib/gocardless/connect';
@@ -879,6 +880,28 @@ describe('server/models/PlatformSubscriptions', () => {
         CollectiveId: rePaidInThisBillingPeriod.CollectiveId,
         ExpenseId: rePaidInThisBillingPeriod.id,
         createdAt: new Date(Date.UTC(2016, 0, 30)),
+      });
+
+      await expect(PlatformSubscription.calculateUtilization(host.id, billingPeriod)).to.eventually.eql({
+        [UtilizationType.ACTIVE_COLLECTIVES]: 4,
+        [UtilizationType.EXPENSES_PAID]: 3,
+      });
+
+      // Platform settlements and platform billing expenses must not count towards billing utilization
+      await fakeExpensePaidWithActivity({
+        HostCollectiveId: host.id,
+        CollectiveId: otherCol.id,
+        createdAt: new Date(Date.UTC(2016, 0, 30)),
+        status: ExpenseStatuses.PAID,
+        type: ExpenseType.SETTLEMENT,
+      });
+
+      await fakeExpensePaidWithActivity({
+        HostCollectiveId: host.id,
+        CollectiveId: otherCol.id,
+        createdAt: new Date(Date.UTC(2016, 0, 30)),
+        status: ExpenseStatuses.PAID,
+        type: ExpenseType.PLATFORM_BILLING,
       });
 
       await expect(PlatformSubscription.calculateUtilization(host.id, billingPeriod)).to.eventually.eql({


### PR DESCRIPTION
Platform settlement and platform billing expenses are the platform's own expenses and should not count towards a host's billing utilization. Exclude SETTLEMENT and PLATFORM_BILLING expense types from the expensesPaid count.