### PR TITLE
fix(transactions): require currency when filtering by amount

### DIFF
--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -21,7 +21,7 @@ import { AccountingCategory, Collective, Expense, PaymentMethod, sequelize } fro
 import Order from '../../../../models/Order';
 import Transaction, { MERCHANT_ID_PATHS } from '../../../../models/Transaction';
 import { checkScope, enforceScope } from '../../../common/scope-check';
-import { Forbidden, NotFound } from '../../../errors';
+import { BadRequest, Forbidden, NotFound } from '../../../errors';
 import {
   GraphQLTransactionCollection,
   GraphQLTransactionsCollectionReturnType,
@@ -538,6 +538,9 @@ export const TransactionsCollectionResolver = async (
       assert(args.amount.gte.currency === args.amount.lte.currency, 'Amount range must have the same currency');
     }
     const currency = args.amount.gte?.currency || args.amount.lte?.currency;
+    if (!currency) {
+      throw new BadRequest('A currency must be provided when filtering transactions by amount');
+    }
     const gte = args.amount.gte && getValueInCentsFromAmountInput(args.amount.gte);
     const lte = args.amount.lte && getValueInCentsFromAmountInput(args.amount.lte);
     const operator =


### PR DESCRIPTION
Fixes https://open-collective.sentry.io/issues/7331215499/?environment=production&project=5199682&query=is%3Aunresolved&referrer=issue-stream

Return BadRequest instead of crashing when amount filters omit currency.