### PR TITLE
fix(expenses): stop flaky 2FA payout tests from stale Redis cache

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1604,19 +1604,20 @@ export const markExpenseAsSpam = async (req: express.Request, expense: Expense):
 
 const ROLLING_LIMIT_CACHE_VALIDITY = 3600; // 1h in secs for cache to expire
 
-async function validateExpensePayout2FALimit(req, host, expense, expensePaidAmountKey) {
-  const hostPayoutTwoFactorAuthenticationRollingLimit = get(
-    host,
-    'settings.payoutsTwoFactorAuth.rollingLimit',
-    1000000,
+const getExpensePayout2FALimitCacheKey = (userId: number, hostId: number) => `${userId}_2fa_payment_limit_${hostId}`;
+
+async function validateExpensePayout2FALimit(req, host, expense) {
+  const expensePaidAmountKey = getExpensePayout2FALimitCacheKey(req.remoteUser.id, host.id);
+  const hostPayoutTwoFactorAuthenticationRollingLimit = Number(
+    get(host, 'settings.payoutsTwoFactorAuth.rollingLimit', 10_000_00),
   );
 
   const twoFactorSession =
     req.jwtPayload?.sessionId || (req.personalToken?.id && `personalToken_${req.personalToken.id}`);
 
   const currentPaidExpenseAmountCache = await cache.get(expensePaidAmountKey);
-  const currentPaidExpenseAmount = currentPaidExpenseAmountCache || 0;
-  const expenseAmountInHostCurrency = await convertToCurrency(expense.amount, expense.currency, host.currency);
+  const currentPaidExpenseAmount = Number(currentPaidExpenseAmountCache) || 0;
+  const expenseAmountInHostCurrency = Number(await convertToCurrency(expense.amount, expense.currency, host.currency));
 
   // requires a 2FA token to be present if there is no value in the cache (first payout by user)
   // or the this payout would put the user over the rolling limit.
@@ -1701,8 +1702,7 @@ export const scheduleExpenseForPayment = async (
     const hostHasPayoutTwoFactorAuthenticationEnabled = get(host, 'settings.payoutsTwoFactorAuth.enabled', false);
 
     if (hostHasPayoutTwoFactorAuthenticationEnabled) {
-      const expensePaidAmountKey = `${req.remoteUser.id}_2fa_payment_limit`;
-      await validateExpensePayout2FALimit(req, host, expense, expensePaidAmountKey);
+      await validateExpensePayout2FALimit(req, host, expense);
     }
   }
 
@@ -3858,12 +3858,12 @@ export async function payExpense(req: express.Request, args: PayExpenseArgs): Pr
     const use2FARollingLimit =
       isTwoFactorAuthenticationRequiredForPayoutMethod && !forceManual && hostHasPayoutTwoFactorAuthenticationEnabled;
 
-    const totalPaidExpensesAmountKey = `${req.remoteUser.id}_2fa_payment_limit`;
+    const totalPaidExpensesAmountKey = getExpensePayout2FALimitCacheKey(req.remoteUser.id, host.id);
     let totalPaidExpensesAmount;
 
     if (use2FARollingLimit) {
       totalPaidExpensesAmount = await cache.get(totalPaidExpensesAmountKey);
-      await validateExpensePayout2FALimit(req, host, expense, totalPaidExpensesAmountKey);
+      await validateExpensePayout2FALimit(req, host, expense);
     } else {
       // Not using rolling limit, but still enforcing 2FA for all admins
       await twoFactorAuthLib.enforceForAccount(req, host, { onlyAskOnLogin: true });

--- a/test/server/graphql/loaders/index.test.ts
+++ b/test/server/graphql/loaders/index.test.ts
@@ -9,7 +9,7 @@ import { makeRequest, nockFixerRates, resetCaches, resetTestDB } from '../../../
 describe('server/graphql/loaders/index', () => {
   beforeEach(async () => {
     await resetTestDB();
-    resetCaches();
+    await resetCaches();
   });
 
   describe('Transaction.totalAmountDonatedFromTo', () => {

--- a/test/server/graphql/v2/mutation/ExpenseMutations-legacy.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations-legacy.test.js
@@ -44,6 +44,7 @@ import {
   graphqlQueryV2,
   makeRequest,
   preloadAssociationsForTransactions,
+  resetCaches,
   resetTestDB,
   snapshotTransactions,
   waitForCondition,
@@ -2891,6 +2892,7 @@ describe('server/graphql/v2/mutation/ExpenseMutations-legacy', () => {
     after(() => sandbox.restore());
 
     before(async () => {
+      await resetCaches();
       hostAdmin = await fakeUser();
       user = await fakeUser();
       collectiveAdmin = await fakeUser();

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -69,6 +69,7 @@ import {
   graphqlQueryV2,
   makeRequest,
   preloadAssociationsForTransactions,
+  resetCaches,
   resetTestDB,
   seedDefaultVendors,
   snapshotTransactions,
@@ -6094,6 +6095,7 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
     after(() => sandbox.restore());
 
     before(async () => {
+      await resetCaches();
       hostAdmin = await fakeUser();
       user = await fakeUser();
       collectiveAdmin = await fakeUser();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -22,7 +22,7 @@ import PlatformConstants from '../server/constants/platform';
 import { generateLoaders, Loaders } from '../server/graphql/loaders';
 import schemaV1 from '../server/graphql/v1/schema';
 import schemaV2 from '../server/graphql/v2/schema';
-import cache from '../server/lib/cache';
+import cache, { sessionCache } from '../server/lib/cache';
 import { crypto } from '../server/lib/encryption';
 import logger from '../server/lib/logger';
 /* Server code being used */
@@ -44,7 +44,10 @@ export const data = path => {
   return isArray(get(jsonData, path)) ? values(copy) : copy;
 };
 
-export const resetCaches = () => cache.clear();
+export const resetCaches = async () => {
+  await cache.clear();
+  await sessionCache.clear();
+};
 
 export const resetTestDB = async ({ groupedTruncate = true, retries = 5 } = {}) => {
   const resetFn = async () => {


### PR DESCRIPTION
The rolling-limit cache used only the user id (`{userId}_2fa_payment_limit`) while `resetTestDB()` restarts identity between test files in the graphql CI job. Redis kept stale rolling totals and 2FA sessions, so the third expense
could wrongly require 2FA when `ExpenseMutations-legacy.test.js` ran before `ExpenseMutations.test.js`.

- Scope the cache key per host (`{userId}_2fa_payment_limit_{hostId}`)
- Coerce cached and converted amounts with `Number()` before comparing
- Clear session Redis in `resetCaches()` and await it in tests
- Call `resetCaches()` in the "with 2FA payouts" describe `before` hook