### PR TITLE
Join PaymentMethod to the transaction, not the order, in the balance check

### DIFF
--- a/checks/model/transactions.ts
+++ b/checks/model/transactions.ts
@@ -104,8 +104,7 @@ async function checkPaidTransactionsWithHostCollectiveId() {
     SELECT t.id
     FROM "Transactions" t
     INNER JOIN "Collectives" c ON t."CollectiveId" = c."id"
-    INNER JOIN "Orders" o ON t."OrderId" = o."id"
-    LEFT JOIN "PaymentMethods" pm ON pm."id" = o."PaymentMethodId"
+    INNER JOIN "PaymentMethods" pm ON pm."id" = t."PaymentMethodId"
     WHERE t."kind" = 'CONTRIBUTION'
     AND t."type" = 'DEBIT'
     AND pm."service" IN ('stripe', 'paypal')


### PR DESCRIPTION
## Problem

The model check that throws `Found STRIPE/PAYPAL paid orders affecting Collective balances` (`checks/model/transactions.ts`) joined `PaymentMethods` through `Orders."PaymentMethodId"`.

`Orders."PaymentMethodId"` is **mutable** — it is overwritten when:
- a subscription's payment method changes (`server/paymentProviders/paypal/subscription.ts:297`)
- a gift card is resolved (`server/paymentProviders/opencollective/giftcard.js:129`)
- a contributor updates the payment method on a recurring contribution

So it reflects the order's *current* payment method, not the one that actually funded a given historical transaction.

## Symptom (production)

A collective-to-collective contribution funded from a **collective balance** (DEBITs against the collective, error string `Not enough funds available (...)` from `opencollective/collective.ts`) had its order's payment method later switched to a PayPal subscription. Because the check read the order's current PM, it retroactively flagged **every** past balance-funded DEBIT as an external paid order touching the balance — a false positive across a year of legitimate rows.

## Fix

Join `PaymentMethods` on `Transactions."PaymentMethodId"` instead. The transaction-level PM is a point-in-time snapshot copied onto both legs at charge time (`server/models/Transaction.ts`) and never rewritten, so it correctly classifies each transaction by what actually funded it. The `Orders` join is removed since it was only used to reach the payment method.
