### PR TITLE
Reject payment method changes for balance-only contributors before any write

### DIFF
--- a/server/graphql/v2/mutation/OrderMutations.ts
+++ b/server/graphql/v2/mutation/OrderMutations.ts
@@ -516,6 +516,24 @@ const orderMutations = {
         );
       }
 
+      // Hosted collectives (and their events/projects/funds) can only contribute from their own
+      // collective balance. The contribution flow enforces this at creation time; mirror it here so
+      // the payment-method update path can't be used to move such a contributor onto an external
+      // (Stripe/PayPal) payment method. The PayPal case is validated up-front, before any detail
+      // changes are written, so a rejection can't leave the order partially updated.
+      const balanceOnlyContributorTypes = [
+        CollectiveType.COLLECTIVE,
+        CollectiveType.EVENT,
+        CollectiveType.PROJECT,
+        CollectiveType.FUND,
+      ];
+      const isBalanceOnlyContributor = balanceOnlyContributorTypes.includes(order.fromCollective.type);
+      if (hasPaymentMethodChanged && isBalanceOnlyContributor && args.paypalSubscriptionId) {
+        throw new ValidationFailed(
+          'This account can only contribute from its collective balance and cannot use a PayPal subscription',
+        );
+      }
+
       let previousOrderValues, previousSubscriptionValues;
 
       // Update details (eg. amount, tier)
@@ -561,6 +579,7 @@ const orderMutations = {
 
       if (hasPaymentMethodChanged) {
         const previousOrderStatus = order.status;
+
         if (args.paypalSubscriptionId) {
           // Update from PayPal subscription ID
           try {
@@ -577,6 +596,17 @@ const orderMutations = {
         } else {
           // Update payment method
           const newPaymentMethod = await fetchPaymentMethodWithReference(args.paymentMethod);
+          if (
+            isBalanceOnlyContributor &&
+            !(
+              newPaymentMethod.service === PAYMENT_METHOD_SERVICE.OPENCOLLECTIVE &&
+              newPaymentMethod.type === PAYMENT_METHOD_TYPE.COLLECTIVE &&
+              newPaymentMethod.CollectiveId === order.FromCollectiveId
+            )
+          ) {
+            throw new ValidationFailed('This account can only contribute from its own collective balance');
+          }
+
           order = await updatePaymentMethodForSubscription(req.remoteUser, order, newPaymentMethod);
         }
 

--- a/test/server/graphql/v2/mutation/OrderMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrderMutations.test.ts
@@ -3148,6 +3148,148 @@ describe('server/graphql/v2/mutation/OrderMutations', () => {
         expect(result.errors[0].message).to.match(/This payment method is not valid for the order host/);
       });
 
+      it('cannot move a hosted collective contributor onto an external payment method', async () => {
+        const contributorAdmin = await fakeUser();
+        const contributorCollective = await fakeCollective({ HostCollectiveId: host.id, admin: contributorAdmin });
+        const hostedOrder = await fakeOrder(
+          {
+            CreatedByUserId: contributorAdmin.id,
+            FromCollectiveId: contributorCollective.id,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+          },
+          { withSubscription: true },
+        );
+        const cardPaymentMethod = await fakePaymentMethod({
+          service: PAYMENT_METHOD_SERVICE.STRIPE,
+          type: PAYMENT_METHOD_TYPE.CREDITCARD,
+          data: { expMonth: 11, expYear: 2030, stripeAccount: 'host_stripe_account' },
+          CollectiveId: contributorCollective.id,
+        });
+
+        const result = await graphqlQueryV2(
+          updateOrderMutation,
+          {
+            order: { id: idEncode(hostedOrder.id, 'order') },
+            paymentMethod: { id: idEncode(cardPaymentMethod.id, 'paymentMethod') },
+          },
+          contributorAdmin,
+        );
+
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.match(/can only contribute from its own collective balance/);
+      });
+
+      it('cannot move a hosted collective contributor onto a PayPal subscription', async () => {
+        const updateOrderWithPaypalMutation = gql`
+          mutation UpdateOrderWithPaypal($order: OrderReferenceInput!, $paypalSubscriptionId: String) {
+            updateOrder(order: $order, paypalSubscriptionId: $paypalSubscriptionId) {
+              id
+            }
+          }
+        `;
+        const contributorAdmin = await fakeUser();
+        const contributorCollective = await fakeCollective({ HostCollectiveId: host.id, admin: contributorAdmin });
+        const hostedOrder = await fakeOrder(
+          {
+            CreatedByUserId: contributorAdmin.id,
+            FromCollectiveId: contributorCollective.id,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+          },
+          { withSubscription: true },
+        );
+
+        const result = await graphqlQueryV2(
+          updateOrderWithPaypalMutation,
+          {
+            order: { id: idEncode(hostedOrder.id, 'order') },
+            paypalSubscriptionId: 'I-FAKESUBSCRIPTION',
+          },
+          contributorAdmin,
+        );
+
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.match(/can only contribute from its collective balance/);
+      });
+
+      it('cannot move a hosted collective contributor onto a different collective balance', async () => {
+        const contributorAdmin = await fakeUser();
+        const contributorCollective = await fakeCollective({ HostCollectiveId: host.id, admin: contributorAdmin });
+        const otherCollective = await fakeCollective({ HostCollectiveId: host.id, admin: contributorAdmin });
+        const hostedOrder = await fakeOrder(
+          {
+            CreatedByUserId: contributorAdmin.id,
+            FromCollectiveId: contributorCollective.id,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+          },
+          { withSubscription: true },
+        );
+        // Balance payment method belonging to another collective the same user admins
+        const otherBalancePaymentMethod = await fakePaymentMethod({
+          service: PAYMENT_METHOD_SERVICE.OPENCOLLECTIVE,
+          type: PAYMENT_METHOD_TYPE.COLLECTIVE,
+          CollectiveId: otherCollective.id,
+        });
+
+        const result = await graphqlQueryV2(
+          updateOrderMutation,
+          {
+            order: { id: idEncode(hostedOrder.id, 'order') },
+            paymentMethod: { id: idEncode(otherBalancePaymentMethod.id, 'paymentMethod') },
+          },
+          contributorAdmin,
+        );
+
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.match(/can only contribute from its own collective balance/);
+      });
+
+      it('does not apply detail changes when rejecting a balance-only contributor PayPal switch', async () => {
+        const updateOrderAmountWithPaypalMutation = gql`
+          mutation UpdateOrderAmountWithPaypal(
+            $order: OrderReferenceInput!
+            $amount: AmountInput
+            $paypalSubscriptionId: String
+          ) {
+            updateOrder(order: $order, amount: $amount, paypalSubscriptionId: $paypalSubscriptionId) {
+              id
+            }
+          }
+        `;
+        const contributorAdmin = await fakeUser();
+        const contributorCollective = await fakeCollective({ HostCollectiveId: host.id, admin: contributorAdmin });
+        const hostedOrder = await fakeOrder(
+          {
+            CreatedByUserId: contributorAdmin.id,
+            FromCollectiveId: contributorCollective.id,
+            CollectiveId: collective.id,
+            status: OrderStatuses.ACTIVE,
+            totalAmount: 5000,
+            currency: 'USD',
+          },
+          { withSubscription: true },
+        );
+
+        const result = await graphqlQueryV2(
+          updateOrderAmountWithPaypalMutation,
+          {
+            order: { id: idEncode(hostedOrder.id, 'order') },
+            amount: { value: 100, currency: 'USD' }, // $100.00, different from the original $50.00
+            paypalSubscriptionId: 'I-FAKESUBSCRIPTION',
+          },
+          contributorAdmin,
+        );
+
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.match(/can only contribute from its collective balance/);
+
+        // The amount change must not have been persisted before the validation failed
+        await hostedOrder.reload();
+        expect(hostedOrder.totalAmount).to.equal(5000);
+      });
+
       it('cannot update an order with an amount that does not match the fixed tier', async () => {
         const result = await graphqlQueryV2(
           updateOrderMutation,


### PR DESCRIPTION
Follow-up to #11874, which blocks payment method changes on recurring contributions from hosted collectives, events and projects. Two gaps remain.

## The check runs after a write

It sits inside the `hasPaymentMethodChanged` block, after `updateSubscriptionDetails`. `paypalSubscriptionId` can be sent together with `amount`/`tier`, so a balance-only contributor doing both gets the amount persisted, then a `ValidationFailed`. The check moves into the up-front validation chain, before any write. Same error message as before.

## FUND is missing

The frontend's `balanceOnlyCollectiveTypes` includes FUND; `BALANCE_ONLY_COLLECTIVE_TYPES` in the API does not. Added, which also applies to the v1 `createOrder` guard.

## Tests

One case per gap, both failing on `main`:

- `rejects a PayPal switch from a collective balance contribution before applying detail changes`
- `cannot update a fund balance recurring contribution to a credit card`