### PR TITLE
fix(notifications): defer activity dispatch until transaction commits

### DIFF
--- a/server/models/Activity.ts
+++ b/server/models/Activity.ts
@@ -1,4 +1,11 @@
-import { CreationOptional, ForeignKey, InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
+import {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+  Transaction,
+} from 'sequelize';
 
 import ActivityTypes from '../constants/activities';
 import dispatch from '../lib/notifications';
@@ -31,6 +38,21 @@ class Activity extends ModelWithPublicId<
   declare public OrderId: CreationOptional<number>;
   declare public createdAt: CreationOptional<Date>;
 }
+
+const scheduleActivityDispatch = (
+  activity: Activity,
+  { transaction, onlyAwaitEmails = true }: { transaction?: Transaction; onlyAwaitEmails?: boolean } = {},
+) => {
+  const runDispatch = () => dispatch(activity, { onlyAwaitEmails });
+
+  if (transaction) {
+    transaction.afterCommit(() => {
+      runDispatch();
+    });
+  } else {
+    return runDispatch();
+  }
+};
 
 Activity.init(
   {
@@ -120,11 +142,16 @@ Activity.init(
     sequelize,
     updatedAt: false,
     hooks: {
-      async afterCreate(activity) {
+      async afterCreate(activity, options) {
         if (activity.data?.notify !== false) {
-          const dispatchPromise = dispatch(activity, { onlyAwaitEmails: true }); // intentionally no return statement, needs to be async by default
-          if (activity.data?.awaitForDispatch) {
-            await dispatchPromise;
+          if (options?.transaction) {
+            // Defer until commit so related records (e.g. newly created collectives) are visible to notification handlers
+            scheduleActivityDispatch(activity, { transaction: options.transaction });
+          } else {
+            const dispatchPromise = scheduleActivityDispatch(activity); // intentionally no return statement, needs to be async by default
+            if (activity.data?.awaitForDispatch) {
+              await dispatchPromise;
+            }
           }
         }
       },

--- a/test/server/graphql/v2/mutation/OrganizationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/OrganizationMutations.test.ts
@@ -11,6 +11,7 @@ import MemberRoles from '../../../../../server/constants/roles';
 import { TransactionKind } from '../../../../../server/constants/transaction-kind';
 import emailLib from '../../../../../server/lib/email';
 import { crypto } from '../../../../../server/lib/encryption';
+import { notify } from '../../../../../server/lib/notifications/email';
 import { TwoFactorAuthenticationHeader } from '../../../../../server/lib/two-factor-authentication/lib';
 import models, { PlatformSubscription } from '../../../../../server/models';
 import { randEmail } from '../../../../stores';
@@ -24,6 +25,8 @@ const createOrgMutation = gql`
     $inviteMembers: [InviteMemberInput]
     $captcha: CaptchaInputType
     $roleDescription: String
+    $hasMoneyManagement: Boolean
+    $hasHosting: Boolean
   ) {
     createOrganization(
       individual: $individual
@@ -31,6 +34,8 @@ const createOrgMutation = gql`
       inviteMembers: $inviteMembers
       captcha: $captcha
       roleDescription: $roleDescription
+      hasMoneyManagement: $hasMoneyManagement
+      hasHosting: $hasHosting
     ) {
       id
       name
@@ -174,6 +179,67 @@ describe('server/graphql/v2/mutation/OrganizationMutations', () => {
       expect(secondCall.args[2].loginLink).to.include(`next=/dashboard/${createdOrg.slug}`);
 
       sendEmailspy.restore();
+    });
+
+    describe('with money management at creation', () => {
+      const defaultNewPricing = config.features.newPricing;
+      let notifyCollectiveSpy;
+
+      before(() => {
+        config.features.newPricing = true;
+      });
+
+      after(() => {
+        config.features.newPricing = defaultNewPricing;
+      });
+
+      beforeEach(() => {
+        notifyCollectiveSpy = sinon.spy(notify, 'collective');
+      });
+
+      afterEach(() => {
+        notifyCollectiveSpy.restore();
+      });
+
+      it('dispatches money management notifications after the transaction commits', async () => {
+        const user = await fakeUser();
+        const variables = {
+          organization: {
+            name: 'Money Management Org',
+            slug: randStr('mm-org-'),
+            description: 'Organization with money management',
+            website: 'https://mm.org',
+            countryISO: 'US',
+            legalName: 'Money Management Org Legal',
+            currency: 'USD',
+          },
+          roleDescription: 'President',
+          hasMoneyManagement: true,
+        };
+
+        const result = await utils.graphqlQueryV2(createOrgMutation, variables, user);
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        expect(result.data.createOrganization).to.exist;
+
+        const createdOrg = await models.Collective.findByPk(result.data.createOrganization.legacyId);
+        expect(createdOrg.hasMoneyManagement).to.be.true;
+
+        const activatedMoneyManagementCalls = notifyCollectiveSpy
+          .getCalls()
+          .filter(call => call.args[0].type === 'activated.moneyManagement');
+        expect(activatedMoneyManagementCalls).to.have.lengthOf(1);
+        expect(activatedMoneyManagementCalls[0].args[1]).to.deep.include({
+          collectiveId: createdOrg.id,
+          template: 'activated.moneyManagement',
+        });
+
+        const platformSubscriptionCalls = notifyCollectiveSpy
+          .getCalls()
+          .filter(call => call.args[0].type === 'platform.subscription.updated');
+        expect(platformSubscriptionCalls).to.have.lengthOf(1);
+        expect(platformSubscriptionCalls[0].args[0].CollectiveId).to.equal(createdOrg.id);
+      });
     });
   });
 

--- a/test/server/models/Activity.test.ts
+++ b/test/server/models/Activity.test.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import activities from '../../../server/constants/activities';
+import { CollectiveType } from '../../../server/constants/collectives';
+import { notify } from '../../../server/lib/notifications/email';
+import models, { Activity, sequelize } from '../../../server/models';
+import { randStr } from '../../test-helpers/fake-data';
+import { resetTestDB } from '../../utils';
+
+describe('server/models/Activity', () => {
+  const sandbox = createSandbox();
+
+  before(async () => {
+    await resetTestDB();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('afterCreate hook', () => {
+    it('defers notification dispatch until the transaction commits', async () => {
+      const notifyCollectiveStub = sandbox.stub(notify, 'collective').resolves([]);
+
+      await sequelize.transaction(async transaction => {
+        const collective = models.Collective.build({
+          type: CollectiveType.ORGANIZATION,
+          name: randStr('Deferred Activity Org '),
+          slug: randStr('deferred-activity-org-'),
+          isActive: false,
+        });
+        await collective.save({ transaction });
+
+        await Activity.create(
+          {
+            type: activities.ACTIVATED_MONEY_MANAGEMENT,
+            CollectiveId: collective.id,
+            FromCollectiveId: collective.id,
+            data: { collective: collective.info },
+          },
+          { transaction },
+        );
+
+        expect(notifyCollectiveStub).to.not.have.been.called;
+      });
+
+      expect(notifyCollectiveStub).to.have.been.calledOnce;
+    });
+
+    it('does not dispatch notifications when the transaction rolls back', async () => {
+      const notifyCollectiveStub = sandbox.stub(notify, 'collective').resolves([]);
+
+      await expect(
+        sequelize.transaction(async transaction => {
+          const collective = models.Collective.build({
+            type: CollectiveType.ORGANIZATION,
+            name: randStr('Rolled Back Activity Org '),
+            slug: randStr('rolled-back-activity-org-'),
+            isActive: false,
+          });
+          await collective.save({ transaction });
+
+          await Activity.create(
+            {
+              type: activities.ACTIVATED_MONEY_MANAGEMENT,
+              CollectiveId: collective.id,
+              FromCollectiveId: collective.id,
+              data: { collective: collective.info },
+            },
+            { transaction },
+          );
+
+          throw new Error('rollback');
+        }),
+      ).to.be.rejected;
+
+      expect(notifyCollectiveStub).to.not.have.been.called;
+    });
+
+    it('dispatches notifications immediately when not created in a transaction', async () => {
+      const notifyCollectiveStub = sandbox.stub(notify, 'collective').resolves([]);
+
+      const collective = models.Collective.build({
+        type: CollectiveType.ORGANIZATION,
+        name: randStr('Immediate Activity Org '),
+        slug: randStr('immediate-activity-org-'),
+        isActive: false,
+      });
+      await collective.save();
+
+      await Activity.create({
+        type: activities.ACTIVATED_MONEY_MANAGEMENT,
+        CollectiveId: collective.id,
+        FromCollectiveId: collective.id,
+        data: { collective: collective.info },
+      });
+
+      expect(notifyCollectiveStub).to.have.been.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Defer activity notification dispatch to `transaction.afterCommit()` when activities are created inside a DB transaction
- Fixes production errors during organization signup with money management, where `notify.collective` could not find the newly created collective before commit
- Adds regression tests for deferred dispatch and `createOrganization` with `hasMoneyManagement`

Fixes OC-API-74K
Fixes OC-API-744