### PR TITLE
Force graphql-inspector onto Node 20 to unblock the deprecated action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,11 @@ jobs:
   graphql-inspector:
     name: GraphQL Inspector
     runs-on: ubuntu-latest
+    # kamilkisiela/graphql-inspector@v3.4.0 is bundled for the Node 20 action runtime, which GitHub
+    # now force-runs on Node 24 (Node 20 deprecation), crashing the action. The action is
+    # unmaintained (no Node 24 build), so opt back into Node 20 until we replace or drop this job.
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     services:
       redis:
         image: redis


### PR DESCRIPTION
The `GraphQL Inspector` CI job has been failing on every branch (including `main`) since GitHub started force-running Node 20 actions on Node 24 as part of the [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

`kamilkisiela/graphql-inspector@v3.4.0` is bundled for the Node 20 action runtime and crashes when forced onto Node 24 — it fails in ~27s and dumps its webpack bundle instead of running. It is not a schema problem (the step uses `fail-on-breaking: false`, and the separate `schema-update` job still passes).

The action is unmaintained (no Node 24 build), so this opts the job back into Node 20 via `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` to unblock CI now. This is a temporary measure: GitHub will remove Node 20 entirely later, at which point the job should be replaced with a self-hosted `@graphql-inspector/cli diff` step or dropped in favor of `schema-update`.