### PR TITLE
Allow creating projects under Fund parent accounts

### DIFF
--- a/server/graphql/v2/mutation/CreateProjectMutation.js
+++ b/server/graphql/v2/mutation/CreateProjectMutation.js
@@ -42,8 +42,8 @@ async function createProject(_, args, req) {
     throw new Unauthorized('You are not authorized to create a project under this parent account');
   } else if (!req.remoteUser.hasRole([roles.ADMIN, roles.MEMBER], parent.id)) {
     throw new Forbidden(`You must be logged in as a member of the ${parent.slug} collective to create a Project`);
-  } else if (!['COLLECTIVE', 'ORGANIZATION'].includes(parent.type)) {
-    throw new BadRequest('Parent account must be a collective or organization');
+  } else if (!['COLLECTIVE', 'FUND', 'ORGANIZATION'].includes(parent.type)) {
+    throw new BadRequest('Parent account must be a Collective, a Fund or an Organization');
   } else if (parent.isFrozen()) {
     throw new Forbidden('This account is frozen and cannot create new projects at this time.');
   }


### PR DESCRIPTION
## Summary
Updated the project creation validation to allow Fund accounts as valid parent accounts, in addition to the previously supported Collective and Organization account types.

## Key Changes
- Added `'FUND'` to the list of allowed parent account types for project creation
- Updated the error message to reflect that parent accounts can now be a Collective, Fund, or Organization

## Implementation Details
The change modifies the validation logic in `CreateProjectMutation.js` to expand the scope of account types that can serve as parent accounts when creating new projects. This enables users to create projects under Fund accounts, which was previously restricted.
