### PR TITLE
fix(fetch): abort timed-out outbound requests

### DIFF
--- a/server/lib/fetch.ts
+++ b/server/lib/fetch.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, omit } from 'lodash';
 
 import logger from './logger';
 
@@ -7,36 +7,24 @@ type FetchOptions = RequestInit & { timeoutInMs?: number };
 /**
  * Make a fetch call with a timeout. Returns a thenable Promise.
  */
-
 export const fetchWithTimeout = (url: string, fetchOptions: FetchOptions): Promise<Response> => {
   const timeoutInMs = get(fetchOptions, 'timeoutInMs', 5000);
+  const externalSignal = fetchOptions.signal;
+  const restOptions = omit(fetchOptions, 'timeoutInMs');
 
-  return new Promise((resolve, reject) => {
-    let timedOut = false;
+  const timeoutSignal = AbortSignal.timeout(timeoutInMs);
+  const signal = externalSignal ? AbortSignal.any([externalSignal, timeoutSignal]) : timeoutSignal;
 
-    const timer = setTimeout(() => {
-      timedOut = true;
-      logger.warn(`Fetch request to ${url} timed out`);
-      return reject(new Error(`Fetch request to ${url} timed out`));
-    }, timeoutInMs);
-
-    fetch(url, fetchOptions)
-      .then(
-        response => {
-          if (!timedOut) {
-            logger.info(`Fetch request to ${url} successful`);
-            return resolve(response);
-          }
-        },
-        err => {
-          if (timedOut) {
-            return;
-          }
-          return reject(new Error(`Fetch error: ${err.message}`));
-        },
-      )
-      .finally(() => {
-        clearTimeout(timer);
-      });
-  });
+  return fetch(url, { ...restOptions, signal })
+    .then(response => {
+      logger.info(`Fetch request to ${url} successful`);
+      return response;
+    })
+    .catch(err => {
+      if (err.name === 'TimeoutError' || (timeoutSignal.aborted && !externalSignal?.aborted)) {
+        logger.warn(`Fetch request to ${url} timed out`);
+        throw new Error(`Fetch request to ${url} timed out`);
+      }
+      throw new Error(`Fetch error: ${err.message}`);
+    });
 };


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/11891#discussion_r3440945127

## Summary

- Update `fetchWithTimeout` to cancel in-flight requests on timeout via `AbortSignal.timeout`, instead of only rejecting the promise with `setTimeout`
- Strip the custom `timeoutInMs` option before passing options to `fetch`, and compose with a caller-provided `signal` when present (`AbortSignal.any`)
- Preserve existing timeout and fetch error messages for callers (PDF and ML services)
