### PR TITLE
debt: Script to remove legacy stripe payment intent keys

### DIFF
--- a/scripts/payment-intents/remove-legacy-json-keys.ts
+++ b/scripts/payment-intents/remove-legacy-json-keys.ts
@@ -1,0 +1,306 @@
+/**
+ * Remove legacy paymentIntent / previousPaymentIntents JSON keys from Orders and Expenses.
+ *
+ * Usage:
+ *   # Dry run (default)
+ *   npm run script scripts/payment-intents/remove-legacy-json-keys.ts
+ *
+ *   # Apply all phases
+ *   DRY_RUN=false npm run script scripts/payment-intents/remove-legacy-json-keys.ts
+ *
+ *   # Resume / partial
+ *   DRY_RUN=false npm run script scripts/payment-intents/remove-legacy-json-keys.ts -- --phase remove-legacy-orders --after-id 500000 --limit 10000
+ */
+
+import '../../server/env';
+
+import { Command } from 'commander';
+import type { Sequelize } from 'sequelize';
+
+import logger from '../../server/lib/logger';
+import { sequelize } from '../../server/models';
+
+type RemoveLegacyJsonKeysPhase =
+  | 'backfill-orders'
+  | 'backfill-expenses'
+  | 'remove-legacy-orders'
+  | 'remove-legacy-expenses'
+  | 'drop-indexes'
+  | 'all';
+
+type TableName = 'Orders' | 'Expenses';
+
+type RemoveLegacyJsonKeysOptions = {
+  dryRun?: boolean;
+  batchSize?: number;
+  limit?: number;
+  afterId?: number;
+};
+
+type PhaseStats = {
+  processed: number;
+  lastId: number;
+  complete: boolean;
+};
+
+const PHASES: RemoveLegacyJsonKeysPhase[] = [
+  'backfill-orders',
+  'backfill-expenses',
+  'remove-legacy-orders',
+  'remove-legacy-expenses',
+  'drop-indexes',
+];
+
+const LEGACY_KEYS_WHERE = `(data ? 'paymentIntent' OR data ? 'previousPaymentIntents')`;
+
+const getBackfillDataSQL = (table: TableName) => `
+  UPDATE "${table}"
+  SET data = data
+    || CASE
+      WHEN data ? 'paymentIntent' AND NOT data ? 'stripePaymentIntent'
+      THEN jsonb_build_object('stripePaymentIntent', data->'paymentIntent')
+      ELSE '{}'::jsonb
+    END
+    || CASE
+      WHEN data ? 'previousPaymentIntents' AND NOT data ? 'previousStripePaymentIntents'
+      THEN jsonb_build_object('previousStripePaymentIntents', data->'previousPaymentIntents')
+      ELSE '{}'::jsonb
+    END
+  WHERE id IN (
+    SELECT id
+    FROM "${table}"
+    WHERE "deletedAt" IS NULL
+      AND ${LEGACY_KEYS_WHERE}
+      AND id > :afterId
+    ORDER BY id ASC
+    LIMIT :batchSize
+  )
+  RETURNING id;
+`;
+
+const getRemoveLegacyKeysSQL = (table: TableName) => `
+  UPDATE "${table}"
+  SET data = data - 'paymentIntent' - 'previousPaymentIntents'
+  WHERE id IN (
+    SELECT id
+    FROM "${table}"
+    WHERE "deletedAt" IS NULL
+      AND ${LEGACY_KEYS_WHERE}
+      AND id > :afterId
+    ORDER BY id ASC
+    LIMIT :batchSize
+  )
+  RETURNING id;
+`;
+
+const countRemaining = async (db: Sequelize, table: TableName, afterId = 0): Promise<number> => {
+  const [rows] = (await db.query(
+    `
+      SELECT COUNT(*)::int AS count
+      FROM "${table}"
+      WHERE "deletedAt" IS NULL
+        AND ${LEGACY_KEYS_WHERE}
+        AND id > :afterId;
+    `,
+    { replacements: { afterId } },
+  )) as [{ count: number }[], unknown];
+
+  return rows[0]?.count ?? 0;
+};
+
+const runPaginatedTableUpdate = async ({
+  db,
+  table,
+  mode,
+  options = {},
+}: {
+  db: Sequelize;
+  table: TableName;
+  mode: 'backfill' | 'remove';
+  options?: RemoveLegacyJsonKeysOptions;
+}): Promise<PhaseStats> => {
+  const batchSize = options.batchSize ?? 1000;
+  const limit = options.limit ?? Infinity;
+  const dryRun = options.dryRun ?? false;
+  let afterId = options.afterId ?? 0;
+  let processed = 0;
+  let complete = false;
+  const updateSql = mode === 'backfill' ? getBackfillDataSQL(table) : getRemoveLegacyKeysSQL(table);
+
+  while (processed < limit) {
+    const pageSize = Math.min(batchSize, limit - processed);
+
+    if (dryRun) {
+      const [rows] = (await db.query(
+        `
+          SELECT id
+          FROM "${table}"
+          WHERE "deletedAt" IS NULL
+            AND ${LEGACY_KEYS_WHERE}
+            AND id > :afterId
+          ORDER BY id ASC
+          LIMIT :batchSize
+        `,
+        { replacements: { afterId, batchSize: pageSize } },
+      )) as [{ id: number }[], unknown];
+
+      if (!rows.length) {
+        complete = true;
+        break;
+      }
+
+      processed += rows.length;
+      afterId = rows[rows.length - 1].id;
+
+      if (rows.length < pageSize) {
+        complete = true;
+        break;
+      }
+
+      continue;
+    }
+
+    const [rows] = (await db.query(updateSql, {
+      replacements: { afterId, batchSize: pageSize },
+    })) as [{ id: number }[], unknown];
+
+    if (!rows.length) {
+      complete = true;
+      break;
+    }
+
+    processed += rows.length;
+    afterId = Math.max(...rows.map(({ id }) => id));
+
+    if (rows.length < pageSize) {
+      complete = true;
+      break;
+    }
+  }
+
+  return { processed, lastId: afterId, complete };
+};
+
+const logPhaseSummary = (phaseName: string, stats: PhaseStats, dryRun: boolean): void => {
+  logger.info(
+    `Phase ${phaseName} ${dryRun ? 'would process' : 'processed'} ${stats.processed} rows, lastId=${stats.lastId}, complete=${stats.complete}`,
+  );
+};
+
+export const runRemoveLegacyJsonKeys = async (
+  db: Sequelize,
+  phase: RemoveLegacyJsonKeysPhase,
+  options: RemoveLegacyJsonKeysOptions = {},
+): Promise<Record<string, PhaseStats>> => {
+  const dryRun = options.dryRun ?? false;
+  const results: Record<string, PhaseStats> = {};
+  const phasesToRun = phase === 'all' ? PHASES : [phase];
+
+  for (const currentPhase of phasesToRun) {
+    const phaseOptions = phase === 'all' ? { ...options, afterId: 0, limit: undefined } : options;
+
+    if (currentPhase === 'backfill-orders') {
+      const remaining = await countRemaining(db, 'Orders', phaseOptions.afterId ?? 0);
+      logger.info(`Starting backfill-orders (${remaining} rows remaining)...`);
+      results['backfill-orders'] = await runPaginatedTableUpdate({
+        db,
+        table: 'Orders',
+        mode: 'backfill',
+        options: phaseOptions,
+      });
+      logPhaseSummary('backfill-orders', results['backfill-orders'], dryRun);
+      continue;
+    }
+
+    if (currentPhase === 'backfill-expenses') {
+      const remaining = await countRemaining(db, 'Expenses', phaseOptions.afterId ?? 0);
+      logger.info(`Starting backfill-expenses (${remaining} rows remaining)...`);
+      results['backfill-expenses'] = await runPaginatedTableUpdate({
+        db,
+        table: 'Expenses',
+        mode: 'backfill',
+        options: phaseOptions,
+      });
+      logPhaseSummary('backfill-expenses', results['backfill-expenses'], dryRun);
+      continue;
+    }
+
+    if (currentPhase === 'remove-legacy-orders') {
+      const remaining = await countRemaining(db, 'Orders', phaseOptions.afterId ?? 0);
+      logger.info(`Starting remove-legacy-orders (${remaining} rows remaining)...`);
+      results['remove-legacy-orders'] = await runPaginatedTableUpdate({
+        db,
+        table: 'Orders',
+        mode: 'remove',
+        options: phaseOptions,
+      });
+      logPhaseSummary('remove-legacy-orders', results['remove-legacy-orders'], dryRun);
+      continue;
+    }
+
+    if (currentPhase === 'remove-legacy-expenses') {
+      const remaining = await countRemaining(db, 'Expenses', phaseOptions.afterId ?? 0);
+      logger.info(`Starting remove-legacy-expenses (${remaining} rows remaining)...`);
+      results['remove-legacy-expenses'] = await runPaginatedTableUpdate({
+        db,
+        table: 'Expenses',
+        mode: 'remove',
+        options: phaseOptions,
+      });
+      logPhaseSummary('remove-legacy-expenses', results['remove-legacy-expenses'], dryRun);
+      continue;
+    }
+
+    if (currentPhase === 'drop-indexes') {
+      logger.info('Starting drop-indexes...');
+      if (!dryRun) {
+        await db.query(`DROP INDEX CONCURRENTLY IF EXISTS "orders__data__payment_intent_id"`);
+        await db.query(`DROP INDEX CONCURRENTLY IF EXISTS "expenses__data__payment_intent_id"`);
+      }
+      results['drop-indexes'] = { processed: 0, lastId: 0, complete: true };
+      logPhaseSummary('drop-indexes', results['drop-indexes'], dryRun);
+    }
+  }
+
+  return results;
+};
+
+const main = async (): Promise<void> => {
+  const program = new Command();
+  program
+    .option('--phase <name>', 'Phase to run', 'all')
+    .option('--batch-size <n>', 'Rows per batch', parseInt)
+    .option('--limit <n>', 'Max rows to process in this run', parseInt)
+    .option('--after-id <n>', 'Resume cursor (id > after-id)', parseInt)
+    .parse();
+
+  const options = program.opts();
+  const dryRun = process.env.DRY_RUN !== 'false';
+  const phase = options.phase as RemoveLegacyJsonKeysPhase;
+  const validPhases: RemoveLegacyJsonKeysPhase[] = [...PHASES, 'all'];
+
+  if (!validPhases.includes(phase)) {
+    logger.error(`Invalid phase: ${phase}. Expected one of: ${validPhases.join(', ')}`);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    logger.info('Running in DRY RUN mode');
+  }
+
+  await runRemoveLegacyJsonKeys(sequelize, phase, {
+    dryRun,
+    batchSize: options.batchSize,
+    limit: options.limit,
+    afterId: options.afterId,
+  });
+};
+
+if (!module.parent) {
+  main()
+    .then(() => process.exit())
+    .catch(error => {
+      logger.error(error);
+      process.exit(1);
+    });
+}

--- a/test/scripts/payment-intents/remove-legacy-json-keys.test.ts
+++ b/test/scripts/payment-intents/remove-legacy-json-keys.test.ts
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+
+import { runRemoveLegacyJsonKeys } from '../../../scripts/payment-intents/remove-legacy-json-keys';
+import { sequelize } from '../../../server/models';
+import { fakeCollective, fakeExpense, fakeOrder, fakeUser, randStr } from '../../test-helpers/fake-data';
+import { resetTestDB } from '../../utils';
+
+const paymentIntent = {
+  id: randStr('pi_test'),
+  paymentIntentClientSecret: randStr('pi_test_secret'),
+  stripeAccount: randStr('acct_test'),
+  stripeAccountPublishableSecret: randStr('pk_test'),
+};
+
+const previousPaymentIntents = [{ id: randStr('pi_prev_1') }, { id: randStr('pi_prev_2') }];
+
+describe('scripts/payment-intents/remove-legacy-json-keys', () => {
+  beforeEach(async () => {
+    await resetTestDB();
+  });
+
+  it('removes legacy paymentIntent key while keeping stripePaymentIntent on Orders', async () => {
+    const user = await fakeUser();
+    const collective = await fakeCollective();
+    const order = await fakeOrder({
+      FromCollectiveId: user.CollectiveId,
+      CollectiveId: collective.id,
+      // @ts-expect-error - paymentIntent is not a valid key on Order.data anymore
+      data: { paymentIntent, stripePaymentIntent: paymentIntent },
+    });
+
+    await runRemoveLegacyJsonKeys(sequelize, 'all');
+    await order.reload();
+
+    expect(order.data.stripePaymentIntent).to.deep.equal(paymentIntent);
+    // @ts-expect-error - paymentIntent is not a valid key on Order.data anymore
+    expect(order.data.paymentIntent).to.be.undefined;
+  });
+
+  it('removes legacy previousPaymentIntents key while keeping previousStripePaymentIntents on Orders', async () => {
+    const user = await fakeUser();
+    const collective = await fakeCollective();
+    const order = await fakeOrder({
+      FromCollectiveId: user.CollectiveId,
+      CollectiveId: collective.id,
+      // @ts-expect-error - previousPaymentIntents is not a valid key on Order.data anymore
+      data: { previousPaymentIntents, previousStripePaymentIntents: previousPaymentIntents },
+    });
+
+    await runRemoveLegacyJsonKeys(sequelize, 'all');
+    await order.reload();
+
+    expect(order.data.previousStripePaymentIntents).to.deep.equal(previousPaymentIntents);
+    // @ts-expect-error - previousPaymentIntents is not a valid key on Order.data anymore
+    expect(order.data.previousPaymentIntents).to.be.undefined;
+  });
+
+  it('backfills stripePaymentIntent from paymentIntent before removing legacy keys', async () => {
+    const user = await fakeUser();
+    const collective = await fakeCollective();
+    const order = await fakeOrder({
+      FromCollectiveId: user.CollectiveId,
+      CollectiveId: collective.id,
+      // @ts-expect-error - paymentIntent is not a valid key on Order.data anymore
+      data: { paymentIntent },
+    });
+
+    await runRemoveLegacyJsonKeys(sequelize, 'all');
+    await order.reload();
+
+    expect(order.data.stripePaymentIntent).to.deep.equal(paymentIntent);
+    // @ts-expect-error - paymentIntent is not a valid key on Order.data anymore
+    expect(order.data.paymentIntent).to.be.undefined;
+  });
+
+  it('removes legacy keys on Expenses', async () => {
+    const expense = await fakeExpense({
+      data: {
+        paymentIntent,
+        previousPaymentIntents,
+        stripePaymentIntent: paymentIntent,
+        previousStripePaymentIntents: previousPaymentIntents,
+      },
+    });
+
+    await runRemoveLegacyJsonKeys(sequelize, 'all');
+    await expense.reload();
+
+    expect(expense.data.stripePaymentIntent).to.deep.equal(paymentIntent);
+    expect(expense.data.previousStripePaymentIntents).to.deep.equal(previousPaymentIntents);
+    expect(expense.data.paymentIntent).to.be.undefined;
+    expect(expense.data.previousPaymentIntents).to.be.undefined;
+  });
+
+  it('does not update soft-deleted Orders', async () => {
+    const user = await fakeUser();
+    const collective = await fakeCollective();
+    const order = await fakeOrder({
+      FromCollectiveId: user.CollectiveId,
+      CollectiveId: collective.id,
+      // @ts-expect-error - paymentIntent is not a valid key on Order.data anymore
+      data: { paymentIntent },
+    });
+    await order.destroy();
+
+    await runRemoveLegacyJsonKeys(sequelize, 'all');
+    await order.reload({ paranoid: false });
+
+    // @ts-expect-error - paymentIntent is not a valid key on Order.data anymore
+    expect(order.data.paymentIntent).to.deep.equal(paymentIntent);
+    expect(order.data.stripePaymentIntent).to.be.undefined;
+  });
+
+  it('drops legacy payment intent indexes', async () => {
+    await sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "orders__data__payment_intent_id"
+      ON "Orders" USING HASH ((data#>>'{paymentIntent,id}'))
+      WHERE data#>>'{paymentIntent,id}' IS NOT NULL and "deletedAt" IS NULL;
+    `);
+    await sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "expenses__data__payment_intent_id"
+      ON "Expenses" USING HASH ((data#>>'{paymentIntent,id}'))
+      WHERE data#>>'{paymentIntent,id}' IS NOT NULL and "deletedAt" IS NULL;
+    `);
+
+    await runRemoveLegacyJsonKeys(sequelize, 'all');
+
+    const [indexes] = (await sequelize.query(`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE tablename IN ('Orders', 'Expenses')
+        AND indexname IN (
+          'orders__data__payment_intent_id',
+          'expenses__data__payment_intent_id'
+        )
+    `)) as [{ indexname: string }[], unknown];
+
+    expect(indexes).to.be.empty;
+  });
+});


### PR DESCRIPTION
An alternative take on https://github.com/opencollective/opencollective-api/pull/11947 that ended up being stuck in production.