### PR TITLE
debt(PaymentMethod): surface bitcoin type

### DIFF
--- a/server/constants/paymentMethods.ts
+++ b/server/constants/paymentMethods.ts
@@ -31,6 +31,8 @@ export enum PAYMENT_METHOD_TYPE {
   PAYOUT = 'payout',
   VIRTUAL_CARD = 'virtual_card',
   SWISH = 'swish',
+  /** @deprecated but we still have ledger entries with this value */
+  BITCOIN = 'bitcoin',
 }
 
 export const PAYMENT_METHOD_TYPES = Object.values(PAYMENT_METHOD_TYPE);

--- a/server/graphql/v2/enum/PaymentMethodType.ts
+++ b/server/graphql/v2/enum/PaymentMethodType.ts
@@ -2,6 +2,8 @@ import { GraphQLEnumType } from 'graphql';
 
 import { PAYMENT_METHOD_TYPE } from '../../../constants/paymentMethods';
 
+const deprecatedValues: readonly PAYMENT_METHOD_TYPE[] = [PAYMENT_METHOD_TYPE.BITCOIN] as const;
+
 export const GraphQLPaymentMethodType = new GraphQLEnumType({
   name: 'PaymentMethodType',
   values: {
@@ -10,7 +12,13 @@ export const GraphQLPaymentMethodType = new GraphQLEnumType({
       {},
     ),
     ...Object.keys(PAYMENT_METHOD_TYPE).reduce(
-      (values, key) => ({ ...values, [key]: { value: PAYMENT_METHOD_TYPE[key] } }),
+      (values, key: PAYMENT_METHOD_TYPE) => ({
+        ...values,
+        [key]: {
+          deprecationReason: deprecatedValues.includes(key) ? 'This value is deprecated' : undefined,
+          value: PAYMENT_METHOD_TYPE[key],
+        },
+      }),
       {},
     ),
   },


### PR DESCRIPTION
Resolve https://open-collective.sentry.io/issues/6174057898

The type is deprecated and not usable, but we have some ledger transactions associated with the legacy Stripe bitcoin implementation from 2018.