### PR TITLE
Charge crowdfunding fee for plans without platform tips

### DIFF
--- a/cron/monthly/submit-platform-subscription-bills.ts
+++ b/cron/monthly/submit-platform-subscription-bills.ts
@@ -160,6 +160,12 @@ export async function run(baseDate: Date | moment.Moment = defaultDate): Promise
           incurredAt,
           currency,
         },
+        bill.crowdfunding.fee > 0 && {
+          description: `Crowdfunding Fee: ${bill.crowdfunding.feePercent}% of $${(bill.crowdfunding.totalAmount / 100).toFixed(2)}`,
+          amount: bill.crowdfunding.fee,
+          incurredAt,
+          currency,
+        },
       ]);
 
       const payoutMethod = await PlatformSubscription.getPreferredPlatformPayout(

--- a/server/constants/plans.ts
+++ b/server/constants/plans.ts
@@ -217,6 +217,9 @@ const legacyPlans: Record<string, HostPlan> = {
   },
 } as const;
 
+/** Fee percentage applied to crowdfunding contributions when a plan has platform tips disabled */
+export const CROWDFUNDING_FEE_PERCENT = 5;
+
 export enum PlatformSubscriptionTierTypes {
   FREE = 'Discover',
   BASIC = 'Basic',
@@ -246,7 +249,7 @@ export interface PlatformSubscriptionPlan {
     /** Whether this plan has platform tips enabled */
     platformTips: boolean;
 
-    /** If tips are not enabled, the fixed platform fee percentage on contributions */
+    /** If tips are not enabled, the fixed platform fee percentage on contributions (defaults to CROWDFUNDING_FEE_PERCENT) */
     crowdfundingFeePercent?: number;
   };
   features: Partial<Record<CommercialFeaturesType, boolean>>;

--- a/server/models/PlatformSubscription.ts
+++ b/server/models/PlatformSubscription.ts
@@ -17,12 +17,18 @@ import {
 import Temporal from 'sequelize-temporal';
 
 import ActivityTypes from '../constants/activities';
+import { SupportedCurrency } from '../constants/currencies';
 import { ENGINEERING_DOMAINS } from '../constants/engineering-domains';
 import ExpenseType from '../constants/expense-type';
 import FEATURE from '../constants/feature';
-import { PlatformSubscriptionPlan, PlatformSubscriptionTiers, PlatformSubscriptionTierTypes } from '../constants/plans';
+import {
+  CROWDFUNDING_FEE_PERCENT,
+  PlatformSubscriptionPlan,
+  PlatformSubscriptionTiers,
+  PlatformSubscriptionTierTypes,
+} from '../constants/plans';
 import { sortResultsSimple } from '../graphql/loaders/helpers';
-import { roundCentsAmount } from '../lib/currency';
+import { convertToCurrency, roundCentsAmount } from '../lib/currency';
 import { chargeExpense, getPreferredPlatformPayout } from '../lib/platform-subscriptions';
 import { reportErrorToSentry } from '../lib/sentry';
 import sequelize from '../lib/sequelize';
@@ -42,6 +48,14 @@ export type Billing = {
   base: {
     subscriptions: { title: string; amount: number; startDate: Date; endDate: Date }[];
     total: number;
+  };
+  crowdfunding: {
+    /** Crowdfunding contributions subject to the fee during the period, in USD cents */
+    totalAmount: number;
+    /** The fee percentage applied, from the plan's pricing */
+    feePercent: number;
+    /** The resulting fee, in USD cents */
+    fee: number;
   };
   totalAmount: number;
   billingPeriod: BillingPeriod;
@@ -336,6 +350,7 @@ class PlatformSubscription extends Model<
           total: 0,
           amounts: Object.fromEntries(Object.entries(utilization).map(([k]) => [k, 0])) as PeriodUtilization,
         },
+        crowdfunding: { totalAmount: 0, feePercent: 0, fee: 0 },
         totalAmount: 0,
         billingPeriod,
         subscriptions,
@@ -366,6 +381,28 @@ class PlatformSubscription extends Model<
 
     const additionalTotal = Object.entries(additionalUtilizationAmounts).reduce((acc, [, amount]) => acc + amount, 0);
 
+    // Crowdfunding fee: plans with platform tips disabled charge a percentage fee on crowdfunding
+    // contributions. Only contributions that were not subject to platform tips are counted (see
+    // `sumCrowdfundingContributions`), so hybrid periods (mid-month plan switch, older recurring
+    // contributions still carrying a tip) are not double charged.
+    const crowdfunding: Billing['crowdfunding'] = { totalAmount: 0, feePercent: 0, fee: 0 };
+    const tipsOffSubscription = subscriptions.find(sub => sub.plan.pricing?.platformTips === false);
+    if (tipsOffSubscription) {
+      const feePercent = tipsOffSubscription.plan.pricing.crowdfundingFeePercent ?? CROWDFUNDING_FEE_PERCENT;
+      if (feePercent) {
+        const billingPeriodRange = PlatformSubscription.getBillingPeriodRange(billingPeriod);
+        const amount = await PlatformSubscription.sumCrowdfundingContributions(
+          collectiveId,
+          PlatformSubscription.periodStartDate(billingPeriodRange),
+          PlatformSubscription.periodEndDate(billingPeriodRange),
+        );
+        // Refunds can make the net amount negative, never credit the organization for those
+        crowdfunding.totalAmount = Math.max(0, amount);
+        crowdfunding.feePercent = feePercent;
+        crowdfunding.fee = Math.max(0, roundCentsAmount((amount * feePercent) / 100, 'USD'));
+      }
+    }
+
     // Consolidate subscriptions so that any mid-period downgrade causes the cheaper plan to
     // cover the higher-tier plan's portion too (no pro-rata charge for the higher tier).
     const effectiveBillingEntries = consolidateSubscriptionsForBillingPeriod(subscriptions, billingPeriod);
@@ -391,7 +428,7 @@ class PlatformSubscription extends Model<
     );
     const baseTotal = subscriptionValues.reduce((acc, sub) => acc + sub.amount, 0);
 
-    const totalAmount = baseTotal + additionalTotal;
+    const totalAmount = baseTotal + additionalTotal + crowdfunding.fee;
 
     return {
       collectiveId,
@@ -404,12 +441,58 @@ class PlatformSubscription extends Model<
         amounts: additionalUtilizationAmounts,
         total: additionalTotal,
       },
+      crowdfunding,
       totalAmount: totalAmount,
       billingPeriod,
       subscriptions,
       utilization,
       dueDate,
     };
+  }
+
+  /**
+   * Sums crowdfunding contributions (Stripe, PayPal and contributor-initiated bank transfers)
+   * received by the collectives hosted by `collectiveId` between `startDate` and `endDate`
+   * (inclusive), net of refunds recorded in the same window. Only contributions whose order was
+   * not subject to platform tips are counted, so host-created pending contributions (expected
+   * funds) and added funds never count while orders still carrying a tip are not double charged.
+   * Returns the total in USD cents.
+   */
+  static async sumCrowdfundingContributions(collectiveId: number, startDate: Date, endDate: Date): Promise<number> {
+    const rows: { currency: SupportedCurrency; amount: string }[] = await sequelize.query(
+      `
+      SELECT t."hostCurrency" AS "currency", SUM(t."amountInHostCurrency") AS "amount"
+      FROM "Transactions" t
+      INNER JOIN "Orders" o ON o.id = t."OrderId"
+      LEFT JOIN "PaymentMethods" pm ON pm.id = t."PaymentMethodId"
+      WHERE t."HostCollectiveId" = :HostCollectiveId
+      AND t."kind" = 'CONTRIBUTION'
+      AND ((t."type" = 'CREDIT' AND t."isRefund" IS NOT TRUE) OR (t."type" = 'DEBIT' AND t."isRefund" IS TRUE))
+      AND t."createdAt" BETWEEN :startDate AND :endDate
+      AND t."deletedAt" IS NULL
+      AND (pm."service" IN ('stripe', 'paypal') OR o."ManualPaymentProviderId" IS NOT NULL)
+      AND o."platformTipEligible" IS FALSE
+      GROUP BY t."hostCurrency"
+    `,
+      {
+        type: QueryTypes.SELECT,
+        raw: true,
+        replacements: {
+          HostCollectiveId: collectiveId,
+          startDate,
+          endDate,
+        },
+      },
+    );
+
+    const amounts = await Promise.all(
+      rows.map(row => convertToCurrency(parseInt(row.amount, 10) || 0, row.currency, 'USD')),
+    );
+
+    return roundCentsAmount(
+      amounts.reduce((acc, amount) => acc + amount, 0),
+      'USD',
+    );
   }
 
   static rangeLiteral(range: Range<Date>): string {

--- a/test/cron/monthly/submit-platform-subscription-bills.test.ts
+++ b/test/cron/monthly/submit-platform-subscription-bills.test.ts
@@ -24,7 +24,7 @@ import { resetTestDB, waitForCondition } from '../../utils';
 
 describe('submit-platform-subscription-bills', () => {
   const date = moment.utc('2023-10-09T10:00:00Z');
-  let organizations, shortTrialGraceOrg, sandbox, emailSendMessageSpy;
+  let organizations, shortTrialGraceOrg, tipsOffOrg, sandbox, emailSendMessageSpy;
 
   before(async () => {
     sandbox = sinon.createSandbox();
@@ -97,6 +97,21 @@ describe('submit-platform-subscription-bills', () => {
     );
     await shortTrialSubscription.terminate({ date: moment.utc('2023-10-05T12:00:00Z').toDate(), inclusive: true });
     calculateUtilizationStub.withArgs(shortTrialGraceOrg.id).resolves({ activeCollectives: 0, expensesPaid: 0 });
+
+    // Platform tips disabled: charged a crowdfunding fee on contributions
+    tipsOffOrg = await fakeCollective({ type: CollectiveType.ORGANIZATION, isActive: true });
+    await tipsOffOrg.addUserWithRole(orgAdmin, roles.ADMIN);
+    await PlatformSubscription.createSubscription(
+      tipsOffOrg,
+      moment(date).subtract(2, 'month').toDate(),
+      {
+        ...PlatformSubscriptionTiers[1],
+        pricing: { ...PlatformSubscriptionTiers[1].pricing, platformTips: false },
+      },
+      user,
+    );
+    calculateUtilizationStub.withArgs(tipsOffOrg.id).resolves({ activeCollectives: 0, expensesPaid: 0 });
+    sandbox.stub(PlatformSubscription, 'sumCrowdfundingContributions').resolves(100000);
   });
 
   after(() => {
@@ -129,7 +144,7 @@ describe('submit-platform-subscription-bills', () => {
       order: [['id', 'DESC']],
     });
 
-    expect(expenses).to.have.length(4);
+    expect(expenses).to.have.length(5);
     const expensesTable = expenses.map(e =>
       pick(e.toJSON(), ['id', 'type', 'CollectiveId', 'description', 'amount', 'currency']),
     );
@@ -142,6 +157,21 @@ describe('submit-platform-subscription-bills', () => {
 
     const itemsTable = items.map(i => pick(i.toJSON(), ['ExpenseId', 'description', 'amount', 'currency']));
     expect(itemsTable).to.matchTableSnapshot();
+  });
+
+  it('bills the crowdfunding fee for plans without platform tips', async () => {
+    const expense = await models.Expense.findOne({
+      where: { CollectiveId: tipsOffOrg.id, type: expenseTypes.PLATFORM_BILLING },
+    });
+
+    expect(expense).to.exist;
+    expect(expense.data.bill.crowdfunding).to.deep.equal({ totalAmount: 100000, feePercent: 5, fee: 5000 });
+
+    const items = await models.ExpenseItem.findAll({ where: { ExpenseId: expense.id } });
+    const feeItem = items.find(item => item.description.startsWith('Crowdfunding Fee'));
+    expect(feeItem).to.exist;
+    expect(feeItem.description).to.equal('Crowdfunding Fee: 5% of $1000.00');
+    expect(feeItem.amount).to.equal(5000);
   });
 
   it('should not bill organizations twice', async () => {
@@ -159,7 +189,7 @@ describe('submit-platform-subscription-bills', () => {
       where: { type: ActivityTypes.COLLECTIVE_EXPENSE_CREATED },
     });
 
-    expect(activities).to.have.length(4);
+    expect(activities).to.have.length(5);
     const org2Activity = activities.find(a => a.CollectiveId === organizations[2].id);
     expect(org2Activity.data).to.containSubset({
       expense: { type: expenseTypes.PLATFORM_BILLING, CollectiveId: organizations[2].id, amount: 8000 },

--- a/test/cron/monthly/submit-platform-subscription-bills.test.ts.snap
+++ b/test/cron/monthly/submit-platform-subscription-bills.test.ts.snap
@@ -4,6 +4,7 @@ exports[`submit-platform-subscription-bills should submit Expenses for active su
 "
 | id | type             | CollectiveId | description                                       | amount | currency |
 | -- | ---------------- | ------------ | ------------------------------------------------- | ------ | -------- |
+| 5  | PLATFORM_BILLING | 31           | Platform subscription payment for September, 2023 | 9000   | USD      |
 | 4  | PLATFORM_BILLING | 22           | Platform subscription payment for September, 2023 | 70500  | USD      |
 | 3  | PLATFORM_BILLING | 18           | Platform subscription payment for September, 2023 | 16000  | USD      |
 | 2  | PLATFORM_BILLING | 14           | Platform subscription payment for September, 2023 | 8000   | USD      |
@@ -14,6 +15,8 @@ exports[`submit-platform-subscription-bills should submit Expenses for active su
 "
 | ExpenseId | description                                                | amount | currency |
 | --------- | ---------------------------------------------------------- | ------ | -------- |
+| 5         | Crowdfunding Fee: 5% of $1000.00                           | 5000   | USD      |
+| 5         | Base subscription Discover 5 - 01-Sep-2023 to 30-Sep-2023  | 4000   | USD      |
 | 4         | Additional Paid Expenses Utilization: 180                  | 27000  | USD      |
 | 4         | Additional Active Collective Utilization: 25               | 37500  | USD      |
 | 4         | Base subscription Basic 5 - 01-Sep-2023 to 30-Sep-2023     | 6000   | USD      |

--- a/test/server/models/PlatformSubscriptions.test.ts
+++ b/test/server/models/PlatformSubscriptions.test.ts
@@ -8,7 +8,9 @@ import { Service } from '../../../server/constants/connected-account';
 import ExpenseStatuses from '../../../server/constants/expense-status';
 import ExpenseType from '../../../server/constants/expense-type';
 import FEATURE from '../../../server/constants/feature';
+import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../server/constants/paymentMethods';
 import { PlatformSubscriptionPlan, PlatformSubscriptionTiers } from '../../../server/constants/plans';
+import { TransactionKind } from '../../../server/constants/transaction-kind';
 import * as GoCardlessConnect from '../../../server/lib/gocardless/connect';
 import * as PlaidClient from '../../../server/lib/plaid/client';
 import * as SentryLib from '../../../server/lib/sentry';
@@ -26,6 +28,9 @@ import {
   fakeConnectedAccount,
   fakeEvent,
   fakeExpense,
+  fakeManualPaymentProvider,
+  fakeOrder,
+  fakePaymentMethod,
   fakeProject,
   fakeRequiredLegalDocument,
   fakeTransaction,
@@ -1309,6 +1314,165 @@ describe('server/models/PlatformSubscriptions', () => {
           subscriptions: [{ amount: 2710 }],
         },
         totalAmount: 11710,
+      });
+    });
+
+    describe('crowdfunding fee', () => {
+      const billingPeriod = {
+        year: 2016,
+        month: BillingMonth.JANUARY,
+      };
+
+      const basicPlan = PlatformSubscriptionTiers.find(plan => plan.id === 'basic-5');
+      const tipsOffPlan = {
+        ...basicPlan,
+        pricing: { ...basicPlan.pricing, platformTips: false },
+      };
+
+      async function fakeCrowdfundedHost(plan) {
+        const admin = await fakeUser();
+        const host = await fakeActiveHost({ admin });
+        await PlatformSubscription.createSubscription(host, new Date(Date.UTC(2016, 0, 1)), plan, admin);
+        const collective = await fakeCollective({ HostCollectiveId: host.id });
+        const stripePaymentMethod = await fakePaymentMethod({
+          service: PAYMENT_METHOD_SERVICE.STRIPE,
+          type: PAYMENT_METHOD_TYPE.CREDITCARD,
+        });
+        const order = await fakeOrder({ CollectiveId: collective.id, platformTipEligible: false });
+        return {
+          admin,
+          host,
+          collective,
+          contribution: {
+            kind: TransactionKind.CONTRIBUTION,
+            HostCollectiveId: host.id,
+            CollectiveId: collective.id,
+            PaymentMethodId: stripePaymentMethod.id,
+            OrderId: order.id,
+          },
+        };
+      }
+
+      it('charges the fee on crowdfunding contributions, net of refunds', async () => {
+        const { host, contribution } = await fakeCrowdfundedHost(tipsOffPlan);
+
+        // Two Stripe contributions in the period: $100 + $50
+        await fakeTransaction({ ...contribution, amount: 10000, createdAt: new Date(Date.UTC(2016, 0, 10)) });
+        await fakeTransaction({ ...contribution, amount: 5000, createdAt: new Date(Date.UTC(2016, 0, 12)) });
+        // A $20 refund in the period
+        await fakeTransaction({
+          ...contribution,
+          amount: -2000,
+          isRefund: true,
+          createdAt: new Date(Date.UTC(2016, 0, 15)),
+        });
+        // Outside the billing period: ignored
+        await fakeTransaction({ ...contribution, amount: 99900, createdAt: new Date(Date.UTC(2015, 11, 15)) });
+        // Added Funds: ignored
+        const hostPaymentMethod = await fakePaymentMethod({
+          service: PAYMENT_METHOD_SERVICE.OPENCOLLECTIVE,
+          type: PAYMENT_METHOD_TYPE.HOST,
+        });
+        await fakeTransaction({
+          ...contribution,
+          PaymentMethodId: hostPaymentMethod.id,
+          amount: 30000,
+          createdAt: new Date(Date.UTC(2016, 0, 10)),
+        });
+
+        const billing = await PlatformSubscription.calculateBilling(host.id, billingPeriod);
+        expect(billing.crowdfunding).to.deep.equal({ totalAmount: 13000, feePercent: 5, fee: 650 });
+        expect(billing.totalAmount).to.equal(billing.base.total + billing.additional.total + 650);
+      });
+
+      it('does not charge the fee when the plan has platform tips enabled', async () => {
+        const { host, contribution } = await fakeCrowdfundedHost(basicPlan);
+
+        await fakeTransaction({ ...contribution, amount: 10000, createdAt: new Date(Date.UTC(2016, 0, 10)) });
+
+        const billing = await PlatformSubscription.calculateBilling(host.id, billingPeriod);
+        expect(billing.crowdfunding).to.deep.equal({ totalAmount: 0, feePercent: 0, fee: 0 });
+        expect(billing.totalAmount).to.equal(billing.base.total + billing.additional.total);
+      });
+
+      it('only charges contributions that were not subject to platform tips', async () => {
+        const { host, collective, contribution } = await fakeCrowdfundedHost(tipsOffPlan);
+
+        // Contribution from an order still subject to platform tips (e.g. an older recurring
+        // contribution, or one made before a mid-month plan switch): ignored
+        const tipEligibleOrder = await fakeOrder({ CollectiveId: collective.id, platformTipEligible: true });
+        await fakeTransaction({
+          ...contribution,
+          OrderId: tipEligibleOrder.id,
+          amount: 10000,
+          createdAt: new Date(Date.UTC(2016, 0, 10)),
+        });
+
+        // Contribution from a legacy order where eligibility is unknown: ignored
+        const legacyOrder = await fakeOrder({ CollectiveId: collective.id, platformTipEligible: null });
+        await fakeTransaction({
+          ...contribution,
+          OrderId: legacyOrder.id,
+          amount: 10000,
+          createdAt: new Date(Date.UTC(2016, 0, 10)),
+        });
+
+        // Contribution from an order not subject to platform tips: charged
+        await fakeTransaction({ ...contribution, amount: 10000, createdAt: new Date(Date.UTC(2016, 0, 20)) });
+
+        const billing = await PlatformSubscription.calculateBilling(host.id, billingPeriod);
+        expect(billing.crowdfunding).to.deep.equal({ totalAmount: 10000, feePercent: 5, fee: 500 });
+      });
+
+      it('includes contributor bank transfers but not host-created pending contributions', async () => {
+        const { host, collective, contribution } = await fakeCrowdfundedHost(tipsOffPlan);
+
+        // Contributor-initiated bank transfer: no payment method on the transaction, but the
+        // order points to the host's manual payment provider: charged
+        const manualPaymentProvider = await fakeManualPaymentProvider({ CollectiveId: host.id });
+        const bankTransferOrder = await fakeOrder({
+          CollectiveId: collective.id,
+          platformTipEligible: false,
+          ManualPaymentProviderId: manualPaymentProvider.id,
+        });
+        await fakeTransaction({
+          ...contribution,
+          PaymentMethodId: null,
+          OrderId: bankTransferOrder.id,
+          amount: 10000,
+          createdAt: new Date(Date.UTC(2016, 0, 10)),
+        });
+
+        // Host-created pending contribution (expected funds): ignored
+        const pendingOrder = await fakeOrder({
+          CollectiveId: collective.id,
+          platformTipEligible: false,
+          data: { isPendingContribution: true },
+        });
+        await fakeTransaction({
+          ...contribution,
+          PaymentMethodId: null,
+          OrderId: pendingOrder.id,
+          amount: 20000,
+          createdAt: new Date(Date.UTC(2016, 0, 12)),
+        });
+
+        const billing = await PlatformSubscription.calculateBilling(host.id, billingPeriod);
+        expect(billing.crowdfunding).to.deep.equal({ totalAmount: 10000, feePercent: 5, fee: 500 });
+      });
+
+      it('never credits the organization when refunds exceed contributions', async () => {
+        const { host, contribution } = await fakeCrowdfundedHost(tipsOffPlan);
+
+        await fakeTransaction({
+          ...contribution,
+          amount: -10000,
+          isRefund: true,
+          createdAt: new Date(Date.UTC(2016, 0, 10)),
+        });
+
+        const billing = await PlatformSubscription.calculateBilling(host.id, billingPeriod);
+        expect(billing.crowdfunding).to.deep.equal({ totalAmount: 0, feePercent: 5, fee: 0 });
       });
     });
   });

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -1349,6 +1349,11 @@ export const fakePlatformBill = (data: Partial<Billing> = {}): Billing => {
           activeCollectives: 0,
         },
       },
+      crowdfunding: {
+        totalAmount: 0,
+        feePercent: 0,
+        fee: 0,
+      },
       baseAmount: totalAmount,
       totalAmount: totalAmount,
       utilization: {


### PR DESCRIPTION
## What

Platform subscription plans with `pricing.platformTips: false` are now charged a **5% crowdfunding fee** (`CROWDFUNDING_FEE_PERCENT`) on crowdfunding contributions, added as a new item on the monthly `PLATFORM_BILLING` expense (e.g. `Crowdfunding Fee: 5% of $1000.00`). This implements the pricing option for hosts that opt out of the platform-tip model — contributors no longer see a tip step, and the host pays a flat fee on crowdfunded volume instead.

There is no UI or API to configure this: the flag is flipped by editing the plan JSON of the host's current `PlatformSubscriptions` row. A plan can override the rate with `pricing.crowdfundingFeePercent`.

## How the fee base is computed

`PlatformSubscription.sumCrowdfundingContributions` sums `kind = CONTRIBUTION` transactions for the host, net of refunds, converted to USD, where:

- the payment method service is `stripe` or `paypal`, **or** the order is a contributor-initiated bank transfer (`Orders."ManualPaymentProviderId"` is set — these show the tip step today, and their transactions carry no `PaymentMethodId`);
- **and** the order has `platformTipEligible = false`.

The `platformTipEligible` gate ensures hybrid situations are never double charged: contributions from orders that were subject to platform tips (mid-month plan switches, older recurring contributions still carrying a tip) don't count. Host-created pending contributions (expected funds) and added funds are excluded — they never carried tips.

Refund-heavy months can't produce a negative fee (clamped to zero).

## Tests

- 5 new model tests covering fee calculation, refund netting, tips-on plans exempt, tip-eligible/legacy orders excluded, bank transfers included / expected funds excluded, and the negative clamp.
- New cron test asserting the bill item and `bill.crowdfunding` data on the generated expense.