### PR TITLE
fix(search): let host admins find hidden internal accounts in host-scoped searches

### DIFF
--- a/server/lib/sql-search.ts
+++ b/server/lib/sql-search.ts
@@ -538,9 +538,19 @@ export const buildSearchCollectivesQuery = async (
     ${countryCodes ? 'LEFT JOIN "Collectives" parentCollective ON c."ParentCollectiveId" = parentCollective.id' : ''}
     ${needsTransactionStatsJoin ? 'LEFT JOIN "CollectiveTransactionStats" transaction_stats ON transaction_stats."id" = c.id' : ''}`;
 
+  // `hideFromSearch` hides internal accounts (e.g. the per-host platform-tips account) from public
+  // search, but their host's admins must still find them, e.g. in the host ledger's account filter.
+  const hideFromSearchBypassHostIds = (hostCollectiveIds || []).filter(
+    id => args.isRoot || req.remoteUser?.isAdmin(id),
+  );
+  const hideFromSearchCondition =
+    hideFromSearchBypassHostIds.length > 0
+      ? `AND ((c."data" ->> 'hideFromSearch')::boolean IS NOT TRUE OR c."HostCollectiveId" IN (:hideFromSearchBypassHostIds))`
+      : `AND (c."data" ->> 'hideFromSearch')::boolean IS NOT TRUE`;
+
   const whereClause = `
     WHERE c."deletedAt" IS NULL
-    AND (c."data" ->> 'hideFromSearch')::boolean IS NOT TRUE
+    ${hideFromSearchCondition}
     AND c.name NOT IN ('incognito', 'anonymous')
     AND c."isIncognito" = FALSE ${dynamicConditions}
     ${!isEmpty(args.consolidatedBalance) ? `AND ${CONSOLIDATED_BALANCE_SUBQUERY} ${getAmountRangeQuery(args.consolidatedBalance)}` : ''}`;
@@ -557,6 +567,7 @@ export const buildSearchCollectivesQuery = async (
     offset,
     limit,
     hostCollectiveIds,
+    hideFromSearchBypassHostIds,
     parentCollectiveIds,
     isHost,
     currency: args.currency,

--- a/test/server/lib/search.test.ts
+++ b/test/server/lib/search.test.ts
@@ -14,6 +14,7 @@ import {
   searchCollectivesByEmail,
   searchCollectivesInDB,
 } from '../../../server/lib/sql-search';
+import { getOrCreateHostPlatformTipsAccount } from '../../../server/lib/transactions';
 import { Op } from '../../../server/models';
 import { newUser } from '../../stores';
 import { fakeCollective, fakeHost, fakeUser, randStr } from '../../test-helpers/fake-data';
@@ -384,6 +385,55 @@ describe('server/lib/search', () => {
         expect(collectives[2].id).to.equal(threeCollectives.id);
         expect(collectives[3].id).to.equal(oneCollective.id);
         expect(collectives[4].id).to.equal(zeroCollectives.id);
+      });
+    });
+
+    describe('Accounts hidden from search (hideFromSearch)', () => {
+      let host, hostAdmin, platformTipsAccount;
+
+      before(async () => {
+        await resetTestDB();
+        hostAdmin = await fakeUser();
+        host = await fakeHost({ admin: hostAdmin });
+        platformTipsAccount = await getOrCreateHostPlatformTipsAccount(host);
+        await hostAdmin.populateRoles();
+      });
+
+      it('does not return hidden accounts in public search', async () => {
+        const [results] = await searchCollectivesInDB(publicReq, 'Platform Tips');
+        expect(results.find(c => c.id === platformTipsAccount.id)).to.not.exist;
+      });
+
+      it('does not return hidden accounts in host-scoped search for unrelated users', async () => {
+        const [results] = await searchCollectivesInDB(makeRequest(await fakeUser()), 'Platform Tips', 0, 100, {
+          hostCollectiveIds: [host.id],
+        });
+        expect(results.find(c => c.id === platformTipsAccount.id)).to.not.exist;
+      });
+
+      it('returns hidden accounts in host-scoped search for host admins', async () => {
+        const [results] = await searchCollectivesInDB(makeRequest(hostAdmin), 'Platform Tips', 0, 100, {
+          hostCollectiveIds: [host.id],
+        });
+        expect(results.find(c => c.id === platformTipsAccount.id)).to.exist;
+      });
+
+      it('returns hidden accounts in host-scoped search for root users', async () => {
+        const [results] = await searchCollectivesInDB(publicReq, 'Platform Tips', 0, 100, {
+          hostCollectiveIds: [host.id],
+          isRoot: true,
+        });
+        expect(results.find(c => c.id === platformTipsAccount.id)).to.exist;
+      });
+
+      it('does not return hidden accounts in host-scoped search for admins of another host', async () => {
+        const otherHostAdmin = await fakeUser();
+        await fakeHost({ admin: otherHostAdmin });
+        await otherHostAdmin.populateRoles();
+        const [results] = await searchCollectivesInDB(makeRequest(otherHostAdmin), 'Platform Tips', 0, 100, {
+          hostCollectiveIds: [host.id],
+        });
+        expect(results.find(c => c.id === platformTipsAccount.id)).to.not.exist;
       });
     });
   });


### PR DESCRIPTION
## Problem

The per-host platform-tips account (#11924) is created with `data.hideFromSearch` to keep it out of public account search and autocomplete. But the flag is enforced unconditionally in `searchCollectivesInDB`, so host admins can't find their own "Platform Tips" account either, e.g. in the account filter of the host dashboard's ledger.

## Solution

Bypass `hideFromSearch` for accounts whose `HostCollectiveId` is a host the requesting user administers (or when the requester is root), and only when the search is scoped to that host.

- Public / unscoped search: unchanged, hidden accounts never appear.
- Host-scoped search by unrelated users or admins of other hosts: unchanged. This matters because public host-profile searches are also host-scoped, so the bypass can't be unconditional.
- Host-scoped search by that host's admins or root: hidden accounts (currently just the platform-tips account) now appear.

No frontend changes needed: the ledger's account filter already queries `accounts(searchTerm, host: {slug})` as the host admin.

## Tests

Added 5 tests in `test/server/lib/search.test.ts` covering public search, unrelated users, host admins, root, and admins of another host, using a real `getOrCreateHostPlatformTipsAccount` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)