### PR TITLE
Only include debt-generating platform tips in the settlement CSV

### DIFF
--- a/cron/monthly/host-settlement.ts
+++ b/cron/monthly/host-settlement.ts
@@ -219,9 +219,8 @@ async function emitSettlementExpense({
   // `transactions` report cannot return them. Use the host-scoped `hostTransactions` report whenever
   // such rows are in the batch — legacy *_DEBT rows carry HostCollectiveId = host too, so nothing is lost.
   if (transactions.length > 0) {
-    const reportType = transactions.some(t => t.kind === TransactionKind.PLATFORM_TIP)
-      ? 'hostTransactions'
-      : 'transactions';
+    const hasNewLedgerTips = transactions.some(t => t.kind === TransactionKind.PLATFORM_TIP);
+    const reportType = hasNewLedgerTips ? 'hostTransactions' : 'transactions';
     const csvUrl = getTransactionsCsvUrl(reportType, host, {
       startDate: moment(min(transactions.map(t => t.createdAt)))
         .startOf('month')
@@ -229,6 +228,10 @@ async function emitSettlementExpense({
       endDate,
       kind: uniq(transactions.map(t => t.kind)),
       add: ['orderLegacyId'],
+      // The kind filter alone would also match Stripe direct-collected tips (offset by an
+      // APPLICATION_FEE, never billed). hasDebt narrows the report to debt-generating tips — the
+      // ones carrying a TransactionSettlement row. Legacy *_DEBT kinds are debts by definition.
+      ...(hasNewLedgerTips ? { hasDebt: true } : null),
     });
     if (csvUrl) {
       await models.ExpenseAttachedFile.create({

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -727,14 +727,28 @@ export const TransactionsCollectionResolver = async (
       AND ("DebtTransaction".kind)::text = CONCAT(("Transaction"."kind")::text, '_DEBT')
       AND "DebtTransaction"."type" != "Transaction"."type"
       AND "DebtTransaction"."deletedAt" IS NULL`;
+    // New-platform-tips-ledger tips have no *_DEBT companion transaction: the obligation is a
+    // TransactionSettlement row keyed directly on the PLATFORM_TIP itself.
+    const hasSettlementSubquery = `SELECT 1 FROM "TransactionSettlements" as "Settlement"
+      WHERE "Settlement"."TransactionGroup" = "Transaction"."TransactionGroup"
+      AND "Settlement".kind = "Transaction".kind
+      AND "Settlement"."deletedAt" IS NULL`;
     if (args.hasDebt === true) {
       where.push({ kind: [PLATFORM_TIP, HOST_FEE_SHARE] }); // Need to be this kind to have debt
-      where.push(sequelize.literal(`EXISTS (${hasDebtSubquery})`));
+      where.push(
+        sequelize.or(
+          sequelize.literal(`EXISTS (${hasDebtSubquery})`),
+          sequelize.literal(`EXISTS (${hasSettlementSubquery})`),
+        ),
+      );
     } else if (args.hasDebt === false) {
       where.push(
         sequelize.or(
           { kind: { [Op.not]: [PLATFORM_TIP, HOST_FEE_SHARE] } }, // No Debt if not this kind
-          sequelize.literal(`NOT EXISTS (${hasDebtSubquery})`),
+          sequelize.and(
+            sequelize.literal(`NOT EXISTS (${hasDebtSubquery})`),
+            sequelize.literal(`NOT EXISTS (${hasSettlementSubquery})`),
+          ),
         ),
       );
     }

--- a/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/TransactionsCollectionQuery.ts
@@ -728,11 +728,17 @@ export const TransactionsCollectionResolver = async (
       AND "DebtTransaction"."type" != "Transaction"."type"
       AND "DebtTransaction"."deletedAt" IS NULL`;
     // New-platform-tips-ledger tips have no *_DEBT companion transaction: the obligation is a
-    // TransactionSettlement row keyed directly on the PLATFORM_TIP itself.
+    // TransactionSettlement row keyed directly on the PLATFORM_TIP itself. Settlements closed
+    // without ever being invoiced (SETTLED with no ExpenseId: tips refunded before invoicing,
+    // self-cancelling rows zeroed out by the settlement cron) don't count — they never generated
+    // a bill, and matching them would let a lone refund DEBIT into a settlement CSV whose original
+    // credit falls outside the report's date range. SETTLED rows WITH an ExpenseId are past
+    // invoices and must keep matching so historical settlement CSVs stay accurate after payment.
     const hasSettlementSubquery = `SELECT 1 FROM "TransactionSettlements" as "Settlement"
       WHERE "Settlement"."TransactionGroup" = "Transaction"."TransactionGroup"
       AND "Settlement".kind = "Transaction".kind
-      AND "Settlement"."deletedAt" IS NULL`;
+      AND "Settlement"."deletedAt" IS NULL
+      AND NOT ("Settlement".status = 'SETTLED' AND "Settlement"."ExpenseId" IS NULL)`;
     if (args.hasDebt === true) {
       where.push({ kind: [PLATFORM_TIP, HOST_FEE_SHARE] }); // Need to be this kind to have debt
       where.push(

--- a/server/lib/csv.js
+++ b/server/lib/csv.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 export const getTransactionsCsvUrl = (type, collective, options = {}) => {
   const url = new URL(`${config.host.rest}/v2/${collective.slug}/${type}.csv`);
 
-  const { startDate, endDate, kind, add, remove, fields } = options;
+  const { startDate, endDate, kind, add, remove, fields, hasDebt } = options;
 
   if (startDate) {
     url.searchParams.set('dateFrom', moment.utc(startDate).toISOString());
@@ -23,6 +23,9 @@ export const getTransactionsCsvUrl = (type, collective, options = {}) => {
   }
   if (fields) {
     url.searchParams.set('fields', fields.join(','));
+  }
+  if (hasDebt !== undefined) {
+    url.searchParams.set('hasDebt', hasDebt ? '1' : '0');
   }
 
   url.searchParams.set('fetchAll', '1');

--- a/server/lib/payments.ts
+++ b/server/lib/payments.ts
@@ -811,6 +811,15 @@ export async function createRefundTransaction(
           { status: TransactionSettlementStatus.SETTLED },
           { transaction: sqlTransaction },
         );
+        // Mirror the legacy debt flow: the refund pair also gets a SETTLED settlement, so anything
+        // that identifies debt-generating tips by their settlement row (e.g. the settlement expense
+        // CSV via the `hasDebt` filter) sees the refund DEBIT next to the original credit and nets
+        // to zero, instead of overstating by the refunded amount.
+        await TransactionSettlement.createForTransaction(
+          platformTipRefundTransaction,
+          TransactionSettlementStatus.SETTLED,
+          sqlTransaction,
+        );
       } else if (newLedgerTipSettlement) {
         // INVOICED/SETTLED: the host was already (or is being) billed for this tip. Mirror the
         // legacy debt flow below: carry an OWED settlement on the refund pair so the settlement

--- a/test/cron/monthly/host-settlement.test.js
+++ b/test/cron/monthly/host-settlement.test.js
@@ -469,6 +469,9 @@ describe('cron/monthly/host-settlement', () => {
     expect(attachment.url).to.have.string('.csv');
     // Legacy hosts keep the account-scoped report (all their settled rows live on the host account)
     expect(attachment.url).to.have.string('/transactions.csv');
+    // hasDebt is only meaningful for new-ledger PLATFORM_TIP rows; legacy *_DEBT kinds are debts by
+    // definition and would return nothing with hasDebt=true
+    expect(new URL(attachment.url).searchParams.get('hasDebt')).to.be.null;
   });
 
   it('should include entries from previous months in the CSV url startDate', async () => {
@@ -776,6 +779,9 @@ describe('cron/monthly/host-settlement', () => {
       const csvUrl = new URL(attachment.url);
       expect(csvUrl.searchParams.get('kind').split(',')).to.include('PLATFORM_TIP');
       expect(csvUrl.searchParams.get('add')).to.equal('orderLegacyId');
+      // Without it, the kind filter alone would also pull in Stripe direct-collected tips,
+      // which are offset by an APPLICATION_FEE and never billed
+      expect(csvUrl.searchParams.get('hasDebt')).to.equal('1');
     });
 
     it('matches the new-ledger settlement ledger snapshot', async () => {

--- a/test/server/graphql/v2/query/collection/TransactionsCollectionQuery.test.ts
+++ b/test/server/graphql/v2/query/collection/TransactionsCollectionQuery.test.ts
@@ -6,6 +6,7 @@ import { roles } from '../../../../../../server/constants';
 import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../../../../../server/constants/paymentMethods';
 import { TransactionKind } from '../../../../../../server/constants/transaction-kind';
 import { idEncode, IDENTIFIER_TYPES } from '../../../../../../server/graphql/v2/identifiers';
+import models from '../../../../../../server/models';
 import {
   fakeAccountingCategory,
   fakeActiveHost,
@@ -1242,7 +1243,8 @@ describe('TransactionsCollectionQuery - hasDebt filter', () => {
     }
   `;
 
-  let account, legacyTipCredit, newLedgerTipCredit, directCollectedTipCredit;
+  let account, legacyTipCredit, newLedgerTipCredit, directCollectedTipCredit, paidTipCredit, neverInvoicedTipCredit;
+  let contributionCredit;
 
   before(async () => {
     await resetTestDB();
@@ -1269,30 +1271,52 @@ describe('TransactionsCollectionQuery - hasDebt filter', () => {
     // Stripe direct-collected tip: no debt at all
     directCollectedTipCredit = await fakeTransaction({ ...base, kind: TransactionKind.PLATFORM_TIP, amount: 3000 });
 
+    // New-ledger tip invoiced then paid: settlement is SETTLED but carries the ExpenseId of its
+    // invoice — it generated a bill and must keep matching hasDebt=true (historical CSVs)
+    paidTipCredit = await fakeTransaction(
+      { ...base, kind: TransactionKind.PLATFORM_TIP, amount: 4000, isDebt: false },
+      { settlementStatus: 'SETTLED' },
+    );
+    const settlementExpense = await fakePaidExpense();
+    await models.TransactionSettlement.update(
+      { ExpenseId: settlementExpense.id },
+      { where: { TransactionGroup: paidTipCredit.TransactionGroup } },
+    );
+
+    // New-ledger tip whose settlement was closed without ever being invoiced (e.g. refunded
+    // pre-invoice): SETTLED with no ExpenseId, never generated a bill
+    neverInvoicedTipCredit = await fakeTransaction(
+      { ...base, kind: TransactionKind.PLATFORM_TIP, amount: 6000, isDebt: false },
+      { settlementStatus: 'SETTLED' },
+    );
+
     // Unrelated kind, never a debt
-    await fakeTransaction({ ...base, kind: TransactionKind.CONTRIBUTION, amount: 5000 });
+    contributionCredit = await fakeTransaction({ ...base, kind: TransactionKind.CONTRIBUTION, amount: 5000 });
   });
 
-  it('hasDebt=true returns both legacy (companion *_DEBT) and new-ledger (settlement row) tips', async () => {
+  it('hasDebt=true returns legacy (companion *_DEBT) and new-ledger (settlement row) tips, including paid ones', async () => {
     const result = await graphqlQueryV2(hasDebtQuery, { slug: account.slug, hasDebt: true });
     expect(result.errors).to.not.exist;
     expect(result.data.transactions.nodes.map(n => n.legacyId)).to.eqInAnyOrder([
       legacyTipCredit.id,
       newLedgerTipCredit.id,
+      paidTipCredit.id,
     ]);
   });
 
-  it('hasDebt=false returns direct-collected tips and other kinds', async () => {
+  it('hasDebt=false returns direct-collected and never-invoiced tips and other kinds', async () => {
     const result = await graphqlQueryV2(hasDebtQuery, { slug: account.slug, hasDebt: false });
     expect(result.errors).to.not.exist;
-    const kinds = result.data.transactions.nodes.map(n => n.kind);
-    expect(kinds).to.eqInAnyOrder([TransactionKind.PLATFORM_TIP, TransactionKind.CONTRIBUTION]);
-    expect(result.data.transactions.nodes.map(n => n.legacyId)).to.include(directCollectedTipCredit.id);
+    expect(result.data.transactions.nodes.map(n => n.legacyId)).to.eqInAnyOrder([
+      directCollectedTipCredit.id,
+      neverInvoicedTipCredit.id,
+      contributionCredit.id,
+    ]);
   });
 
   it('no hasDebt filter returns everything', async () => {
     const result = await graphqlQueryV2(hasDebtQuery, { slug: account.slug });
     expect(result.errors).to.not.exist;
-    expect(result.data.transactions.totalCount).to.eq(4);
+    expect(result.data.transactions.totalCount).to.eq(6);
   });
 });

--- a/test/server/graphql/v2/query/collection/TransactionsCollectionQuery.test.ts
+++ b/test/server/graphql/v2/query/collection/TransactionsCollectionQuery.test.ts
@@ -1228,3 +1228,71 @@ describe('Transaction collection visibility for private organizations', () => {
     });
   });
 });
+
+describe('TransactionsCollectionQuery - hasDebt filter', () => {
+  const hasDebtQuery = gql`
+    query TransactionsHasDebt($slug: String!, $hasDebt: Boolean) {
+      transactions(account: { slug: $slug }, hasDebt: $hasDebt) {
+        totalCount
+        nodes {
+          legacyId
+          kind
+        }
+      }
+    }
+  `;
+
+  let account, legacyTipCredit, newLedgerTipCredit, directCollectedTipCredit;
+
+  before(async () => {
+    await resetTestDB();
+    account = await fakeCollective();
+    const base = { CollectiveId: account.id };
+
+    // Legacy tip: the debt is a companion PLATFORM_TIP_DEBT transaction in the same group
+    legacyTipCredit = await fakeTransaction({ ...base, kind: TransactionKind.PLATFORM_TIP, amount: 1000 });
+    await fakeTransaction({
+      ...base,
+      kind: TransactionKind.PLATFORM_TIP_DEBT,
+      amount: -1000,
+      isDebt: true,
+      TransactionGroup: legacyTipCredit.TransactionGroup,
+    });
+
+    // New-platform-tips-ledger tip: no *_DEBT companion, the obligation is a TransactionSettlement
+    // row keyed directly on the PLATFORM_TIP
+    newLedgerTipCredit = await fakeTransaction(
+      { ...base, kind: TransactionKind.PLATFORM_TIP, amount: 2000, isDebt: false },
+      { settlementStatus: 'OWED' },
+    );
+
+    // Stripe direct-collected tip: no debt at all
+    directCollectedTipCredit = await fakeTransaction({ ...base, kind: TransactionKind.PLATFORM_TIP, amount: 3000 });
+
+    // Unrelated kind, never a debt
+    await fakeTransaction({ ...base, kind: TransactionKind.CONTRIBUTION, amount: 5000 });
+  });
+
+  it('hasDebt=true returns both legacy (companion *_DEBT) and new-ledger (settlement row) tips', async () => {
+    const result = await graphqlQueryV2(hasDebtQuery, { slug: account.slug, hasDebt: true });
+    expect(result.errors).to.not.exist;
+    expect(result.data.transactions.nodes.map(n => n.legacyId)).to.eqInAnyOrder([
+      legacyTipCredit.id,
+      newLedgerTipCredit.id,
+    ]);
+  });
+
+  it('hasDebt=false returns direct-collected tips and other kinds', async () => {
+    const result = await graphqlQueryV2(hasDebtQuery, { slug: account.slug, hasDebt: false });
+    expect(result.errors).to.not.exist;
+    const kinds = result.data.transactions.nodes.map(n => n.kind);
+    expect(kinds).to.eqInAnyOrder([TransactionKind.PLATFORM_TIP, TransactionKind.CONTRIBUTION]);
+    expect(result.data.transactions.nodes.map(n => n.legacyId)).to.include(directCollectedTipCredit.id);
+  });
+
+  it('no hasDebt filter returns everything', async () => {
+    const result = await graphqlQueryV2(hasDebtQuery, { slug: account.slug });
+    expect(result.errors).to.not.exist;
+    expect(result.data.transactions.totalCount).to.eq(4);
+  });
+});

--- a/test/server/lib/payments.test.js
+++ b/test/server/lib/payments.test.js
@@ -674,6 +674,16 @@ describe('server/lib/payments', () => {
       // Settlement must be SETTLED so the settlement cron never invoices the host for the refunded tip
       await tipSettlement.reload();
       expect(tipSettlement.status).to.eq('SETTLED');
+
+      // Mirroring the legacy debt flow, the refund pair carries its own SETTLED settlement so
+      // settlement-row-based reports (e.g. the settlement CSV `hasDebt` filter) see the refund
+      // DEBIT next to the original credit and net to zero
+      const refundTipTransactions = refundedTransactions.filter(t => t.kind === TransactionKind.PLATFORM_TIP);
+      const refundSettlement = await models.TransactionSettlement.findOne({
+        where: { TransactionGroup: refundTipTransactions[0].TransactionGroup, kind: TransactionKind.PLATFORM_TIP },
+      });
+      expect(refundSettlement).to.exist;
+      expect(refundSettlement.status).to.eq('SETTLED');
     });
 
     it('carries an OWED settlement on the refund pair when an already-invoiced tip is refunded under the new platform-tips ledger', async () => {


### PR DESCRIPTION
Under the new platform-tips ledger, all tips carry `kind=PLATFORM_TIP` on the host's ledger, so the settlement expense CSV (filtered by kind + date range only) also listed Stripe direct-collected tips — the ones offset by an `APPLICATION_FEE` and never billed. What distinguishes billable tips is their `TransactionSettlements` row.

## Changes

- **`hasDebt` filter extended** (`TransactionsCollectionQuery`): besides the legacy companion `*_DEBT` transaction check, a transaction now also has debt when a `TransactionSettlements` row exists keyed on its own `(TransactionGroup, kind)` — the new-ledger shape. Settlements closed without ever being invoiced (`SETTLED` with no `ExpenseId`: tips refunded pre-invoice, self-cancelling rows zeroed out by the cron) don't count — they never generated a bill, and matching them could pull a lone refund DEBIT into a CSV whose original credit falls outside the report's date range. `SETTLED` rows *with* an `ExpenseId` are past invoices and keep matching, so historical CSVs stay accurate after the expense is paid. This also fixes the dashboard "Has debt" filter, which returned nothing for new-ledger tips.
- **Settlement cron**: the new-ledger bundle's CSV URL now includes `hasDebt=1`. Legacy bundles are untouched (`*_DEBT` kinds are debts by definition). No opencollective-rest change needed: the host-scoped report already forwards `hasDebt` to GraphQL.
- **Refunds**: a tip refunded before invoicing now records a SETTLED settlement on the refund pair, mirroring the legacy debt flow (`payments.ts`), keeping settlement rows symmetric between the two ledger generations.

## Tests

- `hasDebt` filter suite covering legacy tip (companion `*_DEBT`), new-ledger tip (OWED settlement row), direct-collected tip, invoiced-then-paid tip (SETTLED with ExpenseId, still matches), never-invoiced closure (SETTLED without ExpenseId, excluded), and unrelated kinds.
- Pre-invoice refund test asserts the SETTLED settlement on the refund pair.
- Settlement cron tests assert `hasDebt=1` on the new-ledger CSV URL and its absence on legacy CSVs.

Known residual imprecision, inherited from the legacy CSV design: the report is date-range based, so tips invoiced by an off-cycle run within the same period would still appear. Making the CSV exactly match the batch would need a settlement-`ExpenseId` filter through api+rest, which can come later if finance ever hits it.