### PR TITLE
Fix PayPal refund to store both capture and refund IDs 

### DIFF
--- a/migrations/20260715120000-index-paypal-refund-id.ts
+++ b/migrations/20260715120000-index-paypal-refund-id.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import type { QueryInterface } from 'sequelize';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    // Create index
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "transactions__data_paypal_refund_id"
+      ON "Transactions"
+      USING BTREE (("data"#>>'{paypalRefundId}') ASC)
+      WHERE "data"#>>'{paypalRefundId}' IS NOT NULL
+      AND "deletedAt" IS NULL
+    `);
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "transactions__data_paypal_refund_id";
+    `);
+  },
+};

--- a/scripts/fixes/repair-paypal-refund-transaction-data.ts
+++ b/scripts/fixes/repair-paypal-refund-transaction-data.ts
@@ -1,0 +1,308 @@
+/**
+ * Backfill script for a bug where PayPal refunds overwrote `Transaction.data` on both the
+ * original (non-refund) and refund transaction rows with a flat refund payload, wiping out the
+ * original capture/sale info (`data.capture`, `data.paypalCaptureId`, ...) in the process. This
+ * broke `merchantId` resolution used to reconcile transactions against PayPal reports.
+ *
+ * Corrupted rows look like:
+ *
+ * {
+ *   "hasPlatformTip": false,
+ *   "paypalResponse": {
+ *     "id": "22572252RX9045022",
+ *     "links": [
+ *       { "rel": "self", "href": ".../v2/payments/refunds/22572252RX9045022", "method": "GET" },
+ *       { "rel": "up", "href": ".../v2/payments/captures/9GW92517ME7806848", "method": "GET" }
+ *     ],
+ *     "status": "COMPLETED"
+ *   }
+ * }
+ *
+ * This script finds transactions of kind `CONTRIBUTION` with that corrupted shape, re-fetches the
+ * original capture and the refund from the PayPal API once per `TransactionGroup` (CREDIT/DEBIT
+ * pairs share the same group and were corrupted identically), and re-persists `data` for both
+ * rows in the pair following the new decoupled schema (see `associateTransactionRefundId` in
+ * `server/lib/payments.ts`), where refund-time information is only ever recorded on the refund
+ * transaction, and the original (non-refund) transaction keeps its own capture/sale data untouched:
+ * - Non-refund rows only get `capture` / `paypalCaptureId` restored. They never get `refund` /
+ *   `paypalRefundId`, since that information now belongs exclusively to the refund transaction.
+ * - Refund rows (`isRefund: true`) get both `capture` / `paypalCaptureId` (inherited from the
+ *   original transaction, as done when creating a refund) and `refund` / `paypalRefundId`,
+ *   instead of the flattened `paypalResponse`.
+ *
+ * Usage:
+ *   Dry run:  DRY=1 npx babel-node scripts/fixes/repair-paypal-refund-transaction-data.ts
+ *   Live run: HOST_ID=123 SINCE=2023-01-01 npx babel-node scripts/fixes/repair-paypal-refund-transaction-data.ts
+ *
+ * Env vars:
+ *   DRY       If set, only logs what would change without persisting anything.
+ *   HOST_ID   Restricts the search to transactions for a single host (HostCollectiveId). This host
+ *             must be connected to PayPal. If not set, all hosts connected to PayPal are scanned.
+ *   SINCE     Restricts the search to transactions created on or after this date.
+ */
+import '../../server/env';
+
+import assert from 'assert';
+
+import { get, omit } from 'lodash';
+import { QueryTypes } from 'sequelize';
+
+import { Service } from '../../server/constants/connected-account';
+import { TransactionKind } from '../../server/constants/transaction-kind';
+import logger from '../../server/lib/logger';
+import { getHostsWithPayPalConnected } from '../../server/lib/paypal';
+import models, { sequelize } from '../../server/models';
+import Collective from '../../server/models/Collective';
+import Transaction from '../../server/models/Transaction';
+import { paypalRequestV2 } from '../../server/paymentProviders/paypal/api';
+import { PaypalCapture, PaypalRefund } from '../../server/types/paypal';
+
+const parsePositiveIntEnvVar = (name: string, value: string): number => {
+  if (!/^\d+$/.test(value.trim())) {
+    throw new Error(`Invalid ${name}: "${value}" is not a positive integer`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${name}: "${value}" is not a positive safe integer`);
+  }
+
+  return parsed;
+};
+
+const DRY = Boolean(process.env.DRY);
+const HOST_ID = process.env.HOST_ID !== undefined ? parsePositiveIntEnvVar('HOST_ID', process.env.HOST_ID) : undefined;
+const SINCE = process.env.SINCE ? new Date(process.env.SINCE) : undefined;
+const BATCH_SIZE = 100;
+
+type PaypalLink = { href: string; rel: string; method: string };
+
+/** Extracts the trailing resource id from a PayPal HATEOAS link whose href matches `/payments/{resourceType}/{id}` */
+const getPaypalIdFromLink = (links: PaypalLink[] | undefined, resourceType: 'captures' | 'refunds'): string | null => {
+  const link = links?.find(l => new RegExp(`/payments/${resourceType}/`).test(l.href));
+  if (!link) {
+    return null;
+  }
+
+  const path = link.href.replace(/^.+\/v2\//, ''); // https://api.paypal.com/v2/payments/captures/XXX -> payments/captures/XXX
+  return path.split('/').pop() || null;
+};
+
+/**
+ * Resolves the list of hosts to scan for corrupted transactions.
+ * - If `HOST_ID` is set, validates that this specific host is connected to PayPal.
+ * - Otherwise, returns all hosts connected to PayPal.
+ */
+const getHostsToScan = async (): Promise<Collective[]> => {
+  if (HOST_ID === undefined) {
+    return getHostsWithPayPalConnected();
+  }
+
+  const host = await models.Collective.findByPk(HOST_ID);
+  if (!host) {
+    throw new Error(`Host #${HOST_ID} not found`);
+  }
+
+  const paypalAccount = await host.getAccountForPaymentProvider(Service.PAYPAL);
+  if (!paypalAccount) {
+    throw new Error(`Host #${HOST_ID} (${host.slug}) is not connected to PayPal`);
+  }
+
+  return [host];
+};
+
+/**
+ * Fetches one page of corrupted transaction groups using keyset pagination on the group's minimum
+ * `id`. Since repaired transactions no longer match the WHERE clause (their `paypalResponse` key
+ * is removed), this stays correct even when running live (non-DRY) without needing to track an
+ * offset.
+ *
+ * CONTRIBUTION transactions are always created in CREDIT/DEBIT pairs sharing the same
+ * `TransactionGroup`, and the refund bug overwrote `data` identically on both, so each returned
+ * group contains all the rows that need to be repaired together.
+ */
+const findCorruptedTransactionGroups = async (
+  hostIds: number[],
+  lastId: number,
+): Promise<Array<{ transactionGroup: string; minId: number }>> => {
+  return sequelize.query(
+    `
+    SELECT t."TransactionGroup" AS "transactionGroup", MIN(t."id") AS "minId"
+    FROM "Transactions" t
+    WHERE t."kind" = 'CONTRIBUTION'
+      AND t."data" -> 'paypalResponse' ->> 'id' IS NOT NULL
+      AND jsonb_typeof(t."data" -> 'paypalResponse' -> 'links') = 'array'
+      AND t."HostCollectiveId" IN (:hostIds)
+      AND (:since::timestamp IS NULL OR t."createdAt" >= :since)
+    GROUP BY t."TransactionGroup"
+    HAVING MIN(t."id") > :lastId
+    ORDER BY MIN(t."id")
+    LIMIT :batchSize
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { lastId, hostIds, since: SINCE ?? null, batchSize: BATCH_SIZE },
+    },
+  );
+};
+
+/**
+ * Simple in-memory cache for PayPal refund/capture lookups, keyed by resource id.
+ */
+const paypalRefundCache = new Map<string, Promise<PaypalRefund>>();
+const paypalCaptureCache = new Map<string, Promise<PaypalCapture>>();
+
+const getCachedPaypalRefund = (refundId: string, host: Collective): Promise<PaypalRefund> => {
+  if (!paypalRefundCache.has(refundId)) {
+    paypalRefundCache.set(
+      refundId,
+      paypalRequestV2(`payments/refunds/${refundId}`, host, 'GET') as Promise<PaypalRefund>,
+    );
+  }
+  return paypalRefundCache.get(refundId);
+};
+
+const getCachedPaypalCapture = (captureId: string, host: Collective): Promise<PaypalCapture> => {
+  if (!paypalCaptureCache.has(captureId)) {
+    paypalCaptureCache.set(
+      captureId,
+      paypalRequestV2(`payments/captures/${captureId}`, host, 'GET') as Promise<PaypalCapture>,
+    );
+  }
+  return paypalCaptureCache.get(captureId);
+};
+
+const repairTransactionGroup = async (transactions: Transaction[], stats: Record<string, number>): Promise<void> => {
+  const transactionWithPaypalResponse = transactions.find(t => get(t.data, 'paypalResponse.id'));
+  const paypalResponse = get(transactionWithPaypalResponse?.data, 'paypalResponse') as {
+    id: string;
+    links?: PaypalLink[];
+  };
+  const refundId = paypalResponse?.id;
+  if (!refundId) {
+    stats.skipped += transactions.length;
+    return;
+  }
+
+  const captureId = getPaypalIdFromLink(paypalResponse.links, 'captures');
+  if (!captureId) {
+    logger.warn(
+      `TransactionGroup ${transactions[0]?.TransactionGroup}: could not find capture id in refund links, skipping`,
+    );
+    stats.skipped += transactions.length;
+    return;
+  }
+
+  // All rows in the group were corrupted identically by the same bug, so every transaction that
+  // still carries a `paypalResponse` payload must resolve to the same refund/capture ids.
+  const otherIds = transactions
+    .map(t => get(t.data, 'paypalResponse') as { id: string; links?: PaypalLink[] } | undefined)
+    .filter(Boolean)
+    .map(response => ({ refundId: response.id, captureId: getPaypalIdFromLink(response.links, 'captures') }));
+  assert(
+    otherIds.every(ids => ids.refundId === refundId && ids.captureId === captureId),
+    `TransactionGroup ${transactions[0]?.TransactionGroup}: mismatched refund/capture ids across grouped transactions`,
+  );
+
+  const host = await transactionWithPaypalResponse.getHostCollective();
+  if (!host) {
+    logger.warn(`TransactionGroup ${transactions[0]?.TransactionGroup}: could not find host, skipping`);
+    stats.skipped += transactions.length;
+    return;
+  }
+
+  // Re-fetch fresh, authoritative data from PayPal rather than trusting whatever is left in `data`
+  const [refundDetails, captureDetails] = await Promise.all([
+    getCachedPaypalRefund(refundId, host),
+    getCachedPaypalCapture(captureId, host),
+  ]);
+
+  for (const transaction of transactions) {
+    const baseData = omit(transaction.data, [
+      'paypalResponse',
+      'refund',
+      'paypalRefundId',
+      'capture',
+      'paypalCaptureId',
+    ]);
+    const newData = transaction.isRefund
+      ? {
+          ...baseData,
+          capture: captureDetails,
+          refund: refundDetails,
+          paypalCaptureId: captureDetails.id,
+          paypalRefundId: refundDetails.id,
+        }
+      : {
+          ...baseData,
+          capture: captureDetails,
+          paypalCaptureId: captureDetails.id,
+        };
+
+    logger.info(
+      DRY
+        ? `Would update data for Transaction #${transaction.id} (isRefund=${transaction.isRefund}) from:\n${JSON.stringify(transaction.data, null, 2)}\n to \n${JSON.stringify(newData, null, 2)}`
+        : `Updating data for Transaction #${transaction.id} (isRefund=${transaction.isRefund})`,
+    );
+
+    if (!DRY) {
+      await transaction.update({ data: newData });
+    }
+
+    stats.updated++;
+  }
+};
+
+const main = async () => {
+  const hosts = await getHostsToScan();
+  if (!hosts.length) {
+    logger.info('No hosts connected to PayPal found, nothing to do');
+    return;
+  }
+
+  const hostIds = hosts.map(host => host.id);
+  const hostSlugs = hosts.map(host => host.slug).join(', ');
+  logger.info(
+    `Scanning ${hosts.length} host(s) connected to PayPal for corrupted transactions${DRY ? ' (DRY RUN, no changes will be made)' : ''}: ${hostSlugs}`,
+  );
+
+  const stats = { updated: 0, skipped: 0, errored: 0 };
+  let lastId = 0;
+  while (true) {
+    const groups = await findCorruptedTransactionGroups(hostIds, lastId);
+    if (!groups.length) {
+      break;
+    }
+
+    for (const group of groups) {
+      const transactions = await models.Transaction.findAll({
+        where: { TransactionGroup: group.transactionGroup, kind: TransactionKind.CONTRIBUTION },
+        order: [['id', 'ASC']],
+      });
+
+      try {
+        await repairTransactionGroup(transactions, stats);
+      } catch (e) {
+        stats.errored += transactions.length;
+        logger.error(`TransactionGroup ${transactions[0]?.TransactionGroup}: failed to repair - ${e.message}`);
+      }
+    }
+
+    lastId = groups[groups.length - 1].minId;
+
+    if (groups.length < BATCH_SIZE) {
+      break;
+    }
+  }
+
+  logger.info(`Done. Updated: ${stats.updated}, Skipped: ${stats.skipped}, Errored: ${stats.errored}`);
+};
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit())
+    .catch(e => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/server/lib/payments.ts
+++ b/server/lib/payments.ts
@@ -550,7 +550,6 @@ async function refundPaymentProcessorFee(
           processorFeeTransaction,
           processorFeeRefundTransaction,
           sqlTransaction,
-          null,
           refundKind,
         );
       }
@@ -616,13 +615,7 @@ export async function refundHostFee(
       const hostFeeRefundTransaction = await Transaction.createDoubleEntry(hostFeeRefund, {
         sequelizeTransaction: sqlTransaction,
       });
-      await associateTransactionRefundId(
-        hostFeeTransaction,
-        hostFeeRefundTransaction,
-        sqlTransaction,
-        null,
-        refundKind,
-      );
+      await associateTransactionRefundId(hostFeeTransaction, hostFeeRefundTransaction, sqlTransaction, refundKind);
 
       // Refund Host Fee Share
       const hostFeeShareTransaction = await transaction.getHostFeeShareTransaction(null, { sqlTransaction });
@@ -635,7 +628,6 @@ export async function refundHostFee(
           hostFeeShareTransaction,
           hostFeeShareRefundTransaction,
           sqlTransaction,
-          null,
           refundKind,
         );
 
@@ -670,7 +662,6 @@ export async function refundHostFee(
             hostFeeShareDebtTransaction,
             hostFeeShareDebtRefundTransaction,
             sqlTransaction,
-            null,
             refundKind,
           );
           await TransactionSettlement.createForTransaction(
@@ -705,7 +696,7 @@ async function refundTax(
       const taxRefundTransaction = await Transaction.createDoubleEntry(taxRefundData, {
         sequelizeTransaction: sqlTransaction,
       });
-      await associateTransactionRefundId(taxTransaction, taxRefundTransaction, sqlTransaction, null, refundKind);
+      await associateTransactionRefundId(taxTransaction, taxRefundTransaction, sqlTransaction, refundKind);
     }
   };
 
@@ -791,7 +782,6 @@ export async function createRefundTransaction(
         platformTipTransaction,
         platformTipRefundTransaction,
         sqlTransaction,
-        data,
         refundKind,
       );
 
@@ -853,7 +843,6 @@ export async function createRefundTransaction(
           platformTipDebtTransaction,
           platformTipDebtRefundTransaction,
           sqlTransaction,
-          data,
           refundKind,
         );
         await TransactionSettlement.createForTransaction(
@@ -888,7 +877,6 @@ export async function createRefundTransaction(
         applicationFeeTransaction,
         applicationFeeRefundTransaction,
         sqlTransaction,
-        data,
         refundKind,
       );
     }
@@ -924,7 +912,7 @@ export async function createRefundTransaction(
       sequelizeTransaction: sqlTransaction,
     });
     await syncPaymentIntentFromRefund(refundTransaction, sqlTransaction);
-    return associateTransactionRefundId(transaction, refundTransaction, sqlTransaction, data, refundKind);
+    return associateTransactionRefundId(transaction, refundTransaction, sqlTransaction, refundKind);
   };
 
   return sqlTransaction ? runInTransaction(sqlTransaction) : sequelize.transaction(runInTransaction);
@@ -934,7 +922,6 @@ export async function associateTransactionRefundId(
   transaction: Transaction,
   refund: Transaction,
   sqlTransaction: SequelizeTransaction,
-  data?: TransactionData,
   refundKind?: RefundKind,
 ): Promise<Transaction> {
   const transactions = await Transaction.findAll({
@@ -952,12 +939,6 @@ export async function associateTransactionRefundId(
   const debit = transactions.find(t => !t.isRefund && t.type === DEBIT);
   const refundCredit = transactions.find(t => t.isRefund && t.type === CREDIT);
   const refundDebit = transactions.find(t => t.isRefund && t.type === DEBIT);
-
-  // After refunding a transaction, in some cases the data may be updated as well (stripe data changes after refunds)
-  if (data && Object.keys(data).length) {
-    debit.data = data;
-    credit.data = data;
-  }
 
   if (refundCredit && debit) {
     debit.RefundTransactionId = refundCredit.id;

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -3460,7 +3460,7 @@ class Collective extends ModelWithPublicId<
     });
   };
 
-  getHostStripeAccount = function () {
+  getHostStripeAccount = function (): Promise<ConnectedAccount> {
     let HostCollectiveId;
     return this.getHostCollectiveId()
       .then(id => {

--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -56,11 +56,11 @@ const { CONTRIBUTION, EXPENSE, ADDED_FUNDS } = TransactionKind;
 export const MERCHANT_ID_PATHS = {
   [CONTRIBUTION]: [
     'data.charge.id', // stripeId
-    'data.refund.id', // PayPal and Stripe refund ids
     'data.paypalRefundId', // Stores refund and reversal ids
     'data.paypalCaptureId', // Stores capture and sale ID
-    // 'data.capture.id', // onetimePaypalPaymentId
-    // 'data.paypalSale.id', // recurringPaypalPaymentId
+    'data.capture.id', // onetimePaypalPaymentId
+    'data.refund.id', // PayPal and Stripe refund ids
+    'data.paypalSale.id', // recurringPaypalPaymentId
     // 'data.paypalResponse.id', // legacy paypalRefundOrReversalId (kept for historical transactions)
   ],
   [EXPENSE]: [
@@ -2022,18 +2022,8 @@ Transaction.init(
       },
 
       merchantId() {
-        // Refund/reversal transactions should be matched against PayPal's own refund report using the
-        // refund's PayPal id (not the id of the original capture/sale), since that's what shows up
-        // as the merchant/transaction id on PayPal's side for the refund.
-        if (this.isRefund) {
-          const refundMerchantId =
-            get(this, 'data.paypalRefundId') ?? get(this, 'data.refund.id') ?? get(this, 'data.paypalResponse.id');
-          if (refundMerchantId) {
-            return refundMerchantId;
-          }
-        }
-
-        return head(compact(MERCHANT_ID_PATHS[this.kind]?.map(path => get(this, path))));
+        const ids = MERCHANT_ID_PATHS[this.kind]?.map(path => get(this, path));
+        return head(compact(ids));
       },
     },
 

--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -61,7 +61,7 @@ export const MERCHANT_ID_PATHS = {
     'data.capture.id', // onetimePaypalPaymentId
     'data.refund.id', // PayPal and Stripe refund ids
     'data.paypalSale.id', // recurringPaypalPaymentId
-    // 'data.paypalResponse.id', // legacy paypalRefundOrReversalId (kept for historical transactions)
+    'data.paypalResponse.id', // legacy paypalRefundOrReversalId (kept for historical transactions)
   ],
   [EXPENSE]: [
     'data.transfer.id', // wiseId

--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -33,7 +33,7 @@ import { reportErrorToSentry, reportMessageToSentry } from '../lib/sentry';
 import sequelize, { DataTypes, Op } from '../lib/sequelize';
 import { getOrCreateHostPlatformTipsAccount, getPaymentProcessorFeeVendor, getTaxVendor } from '../lib/transactions';
 import { exportToCSV, parseToBoolean } from '../lib/utils';
-import type { PaypalCapture, PaypalSale, PaypalTransaction } from '../types/paypal';
+import type { PaypalCapture, PaypalRefund, PaypalSale, PaypalTransaction } from '../types/paypal';
 import type { Transfer } from '../types/transferwise';
 
 import Activity from './Activity';
@@ -56,9 +56,12 @@ const { CONTRIBUTION, EXPENSE, ADDED_FUNDS } = TransactionKind;
 export const MERCHANT_ID_PATHS = {
   [CONTRIBUTION]: [
     'data.charge.id', // stripeId
-    'data.capture.id', // onetimePaypalPaymentId
-    'data.paypalSale.id', // recurringPaypalPaymentId
-    'data.paypalResponse.id', // paypalResponseId
+    'data.refund.id', // PayPal and Stripe refund ids
+    'data.paypalRefundId', // Stores refund and reversal ids
+    'data.paypalCaptureId', // Stores capture and sale ID
+    // 'data.capture.id', // onetimePaypalPaymentId
+    // 'data.paypalSale.id', // recurringPaypalPaymentId
+    // 'data.paypalResponse.id', // legacy paypalRefundOrReversalId (kept for historical transactions)
   ],
   [EXPENSE]: [
     'data.transfer.id', // wiseId
@@ -103,6 +106,7 @@ export type TransactionData = {
   oppositeTransactionHostCurrencyFxRate?: number;
   paymentProcessorFeeMigration?: string;
   paypalCaptureId?: string;
+  paypalRefundId?: string;
   paypalResponse?: Record<string, unknown>;
   paypalSale?: Partial<PaypalSale>;
   paypalTransaction?: Partial<PaypalTransaction>;
@@ -111,7 +115,8 @@ export type TransactionData = {
   platformTipInHostCurrency?: number;
   preMigrationData?: Record<string, unknown>;
   migration?: unknown;
-  refund?: Stripe.Refund;
+  /** Stripe stores its own `Stripe.Refund` object here; PayPal stores a `Partial<PaypalRefund>` object here */
+  refund?: Stripe.Refund | Partial<PaypalRefund>;
   refundedFromDoubleTransactionsScript?: boolean;
   refundReason?: string;
   refundTransactionId?: Transaction['id'];
@@ -2017,6 +2022,17 @@ Transaction.init(
       },
 
       merchantId() {
+        // Refund/reversal transactions should be matched against PayPal's own refund report using the
+        // refund's PayPal id (not the id of the original capture/sale), since that's what shows up
+        // as the merchant/transaction id on PayPal's side for the refund.
+        if (this.isRefund) {
+          const refundMerchantId =
+            get(this, 'data.paypalRefundId') ?? get(this, 'data.refund.id') ?? get(this, 'data.paypalResponse.id');
+          if (refundMerchantId) {
+            return refundMerchantId;
+          }
+        }
+
         return head(compact(MERCHANT_ID_PATHS[this.kind]?.map(path => get(this, path))));
       },
     },

--- a/server/paymentProviders/paypal/payment.ts
+++ b/server/paymentProviders/paypal/payment.ts
@@ -18,7 +18,7 @@ import models from '../../models';
 import Order from '../../models/Order';
 import Transaction from '../../models/Transaction';
 import User from '../../models/User';
-import { PaypalCapture, PaypalSale, PaypalTransaction } from '../../types/paypal';
+import { PaypalCapture, PaypalRefund, PaypalSale, PaypalTransaction } from '../../types/paypal';
 import { BasePaymentProviderService, PaymentProviderServiceWithoutRecurring } from '../types';
 
 import { paypalRequestV2 } from './api';
@@ -236,13 +236,13 @@ export const refundPaypalCapture = async (
     // eslint-disable-next-line camelcase
     const payload = { note_to_payer: truncate(reason, { length: 255 }) || undefined };
     const result = await paypalRequestV2(`payments/captures/${captureId}/refund`, host, 'POST', payload);
-    const refundDetails = await paypalRequestV2(`payments/refunds/${result.id}`, host, 'GET');
-    const rawRefundedPaypalFee = <string>get(refundDetails, 'seller_payable_breakdown.paypal_fee.value', '0.00');
+    const refund = (await paypalRequestV2(`payments/refunds/${result.id}`, host, 'GET')) as PaypalRefund;
+    const rawRefundedPaypalFee = <string>get(refund, 'seller_payable_breakdown.paypal_fee.value', '0.00');
     const refundedPaypalFee = floatAmountToCents(parseFloat(rawRefundedPaypalFee));
     return createRefundTransaction(
       transaction,
       refundedPaypalFee,
-      { refundReason: reason, paypalResponse: result },
+      { ...transaction.data, refundReason: reason, refund, paypalRefundId: refund.id as string },
       user,
       null,
       null,

--- a/server/paymentProviders/paypal/webhook.ts
+++ b/server/paymentProviders/paypal/webhook.ts
@@ -17,7 +17,7 @@ import { validateWebhookEvent, WatchedPaypalWebhookEvent } from '../../lib/paypa
 import { recordOrderProcessed } from '../../lib/recurring-contributions';
 import { reportErrorToSentry, reportMessageToSentry } from '../../lib/sentry';
 import models from '../../models';
-import { PayoutWebhookRequest, PaypalCapture } from '../../types/paypal';
+import { PayoutWebhookRequest, PaypalCapture, PaypalRefund } from '../../types/paypal';
 
 import { paypalRequestV2 } from './api';
 import { findTransactionByPaypalId, recordPaypalCapture, recordPaypalSale } from './payment';
@@ -292,7 +292,7 @@ async function handleSaleRefunded(req: Request): Promise<void> {
     await createRefundTransaction(
       transaction,
       refundedPaypalFee,
-      { paypalResponse: refund, isRefundedFromPayPal: true },
+      { ...transaction.data, refund: refund, isRefundedFromPayPal: true, paypalRefundId: refund.id },
       null,
     );
   });
@@ -334,7 +334,12 @@ async function handleSaleReversed(req: Request): Promise<void> {
       return;
     }
 
-    await createRefundTransaction(transaction, 0, { paypalResponse: sale, isRefundedFromPayPal: true }, null);
+    await createRefundTransaction(
+      transaction,
+      0,
+      { ...transaction.data, refund: sale, isRefundedFromPayPal: true, paypalRefundId: sale.id },
+      null,
+    );
   });
 }
 
@@ -350,7 +355,7 @@ async function handleCaptureRefunded(req: Request): Promise<void> {
 
   // Retrieve the data for this event
   const refund = req.body.resource;
-  const refundDetails = await paypalRequestV2(`payments/refunds/${refund.id}`, host, 'GET');
+  const refundDetails = (await paypalRequestV2(`payments/refunds/${refund.id}`, host, 'GET')) as PaypalRefund;
   const refundLinks = <Record<string, string>[]>refundDetails.links;
   const captureLink = refundLinks.find(l => l.rel === 'up' && l.method === 'GET');
   const capturePath = captureLink.href.replace(/^.+\/v2\//, ''); // https://api.sandbox.paypal.com/v2/payments/captures/... -> payments/captures/...
@@ -399,7 +404,12 @@ async function handleCaptureRefunded(req: Request): Promise<void> {
     // Record the refund transactions
     const rawRefundedPaypalFee = <string>get(refundDetails, 'seller_payable_breakdown.paypal_fee.value', '0.00');
     const refundedPaypalFee = floatAmountToCents(parseFloat(rawRefundedPaypalFee));
-    const dataPayload = { paypalResponse: refundDetails, isRefundedFromPayPal: true };
+    const dataPayload = {
+      ...transaction.data,
+      refund: refundDetails,
+      isRefundedFromPayPal: true,
+      paypalRefundId: refundDetails.id,
+    };
     await createRefundTransaction(transaction, refundedPaypalFee, dataPayload, null);
   });
 }

--- a/server/paymentProviders/stripe/common.ts
+++ b/server/paymentProviders/stripe/common.ts
@@ -1,6 +1,7 @@
 import config from 'config';
 import { get, result, toUpper } from 'lodash';
 import moment from 'moment';
+import assert from 'node:assert';
 import type { CreateOptions } from 'sequelize';
 import Stripe from 'stripe';
 
@@ -55,8 +56,19 @@ export const refundTransaction: BasePaymentProviderService['refundTransaction'] 
     { charge: chargeId, refund_application_fee: hasApplicationFees }, // eslint-disable-line camelcase
     { stripeAccount: hostStripeAccount.username },
   );
+  assert(refund, `Refund for charge ${chargeId} failed for host #${hostStripeAccount.CollectiveId}`);
+
+  // Record the refund reference on the original transaction (and its opposite ledger entry) so that
+  // a concurrent/duplicate refund request is blocked by the guard above while it's still pending on Stripe.
+  // We only add the `refund` key here, we don't touch the rest of the original transaction's data
+  // (e.g. `charge`, `balanceTransaction`), which must keep reflecting the original charge.
+  const oppositeTransaction = await transaction.getOppositeTransaction();
+  await Promise.all(
+    [transaction, oppositeTransaction].filter(Boolean).map(t => t.update({ data: { ...t.data, refund } })),
+  );
 
   const charge = await stripe.charges.retrieve(chargeId, { stripeAccount: hostStripeAccount.username });
+  assert(charge, `Charge ${chargeId} not found in Stripe for host #${hostStripeAccount.CollectiveId}`);
   const refundBalance = await stripe.balanceTransactions.retrieve(refund.balance_transaction as string, {
     stripeAccount: hostStripeAccount.username,
   });
@@ -69,7 +81,8 @@ export const refundTransaction: BasePaymentProviderService['refundTransaction'] 
     {
       ...transaction.data,
       refund,
-      balanceTransaction: refundBalance, // TODO: This is overwriting the original balanceTransaction with the refund balance transaction, which remove important info
+      // This is no longer replicated into the original set of transactions, but we keep it here for backward compatibility with existing transactions
+      balanceTransaction: refundBalance,
       charge,
       refundReason: reason,
     },

--- a/server/types/paypal.ts
+++ b/server/types/paypal.ts
@@ -263,6 +263,77 @@ export type PaypalCapture = {
   }>;
 };
 
+/**
+ * A refund, as returned by `payments/refunds/{refund_id}` or the `payments/captures/{capture_id}/refund` operation.
+ * Based on the `refund` schema from PayPal's Orders v2 OpenAPI spec.
+ * See https://raw.githubusercontent.com/paypal/paypal-js/refs/heads/main/packages/paypal-js/types/apis/openapi/checkout_orders_v2.d.ts
+ */
+export type PaypalRefund = {
+  /** The PayPal-generated ID for the refund. */
+  id?: string;
+  /** The status of the refund. */
+  status?: 'CANCELLED' | 'FAILED' | 'PENDING' | 'COMPLETED';
+  /** The details of the refund status. */
+  status_details?: {
+    /** The reason why the refund has the `PENDING` or `FAILED` status. */
+    reason?: 'ECHECK';
+  };
+  /** The amount that the payee refunded to the payer. */
+  amount?: PaypalTransactionAmount;
+  /** The API caller-provided external invoice number for this order. */
+  invoice_id?: string;
+  /** The API caller-provided external ID. Used to reconcile API caller-initiated transactions with PayPal transactions. */
+  custom_id?: string;
+  /** Reference ID issued for the card transaction. Can be used to track the transaction across processors, card brands and issuing banks. */
+  acquirer_reference_number?: string;
+  /** The reason for the refund. Appears in both the payer's transaction history and the emails that the payer receives. */
+  note_to_payer?: string;
+  /** The breakdown of the refund. */
+  seller_payable_breakdown?: {
+    /** The amount that the payee refunded to the payer. */
+    gross_amount?: PaypalTransactionAmount;
+    /** The PayPal fee that was refunded to the payer in the currency of the transaction. */
+    paypal_fee?: PaypalTransactionAmount;
+    /** The PayPal fee that was refunded to the payer in the receivable currency. */
+    paypal_fee_in_receivable_currency?: PaypalTransactionAmount;
+    /** The net amount that the payee's account is debited in the transaction currency. */
+    net_amount?: PaypalTransactionAmount;
+    /** The net amount that the payee's account is debited in the receivable currency. */
+    net_amount_in_receivable_currency?: PaypalTransactionAmount;
+    /** An array of platform or partner fees, commissions, or brokerage fees for the refund. */
+    platform_fees?: Array<{
+      amount: PaypalTransactionAmount;
+      payee?: {
+        email_address?: string;
+        merchant_id?: string;
+      };
+    }>;
+    /** Breakdown values for the net amount, returned when the refund currency differs from the currency of the PayPal account where the payee holds their funds. */
+    net_amount_breakdown?: Array<{
+      payable_amount?: PaypalTransactionAmount;
+      converted_amount?: PaypalTransactionAmount;
+      exchange_rate?: {
+        source_currency?: string;
+        target_currency?: string;
+        value?: string;
+      };
+    }>;
+    /** The total amount refunded from the original capture to date. */
+    total_refunded_amount?: PaypalTransactionAmount;
+  };
+  /** The details associated with the merchant for this transaction. */
+  payer?: {
+    email_address?: string;
+    merchant_id?: string;
+  };
+  /** An array of related HATEOAS links. */
+  links?: PayPalLink[];
+  /** The date and time when the refund occurred. */
+  create_time?: string;
+  /** The date and time when the refund was last updated. */
+  update_time?: string;
+};
+
 export type PaypalOrder = {
   id: string;
   intent: string;

--- a/test/server/graphql/v2/query/SearchQuery.test.ts
+++ b/test/server/graphql/v2/query/SearchQuery.test.ts
@@ -332,7 +332,9 @@ describe('server/graphql/v2/query/SearchQuery', () => {
         amount: 1000,
         HostCollectiveId: host.id,
         description: 'AVeryUniqueTransactionDescription',
-        data: { capture: { id: 'AVeryUniqueTransactionCaptureId' } },
+        data: {
+          paypalCaptureId: 'AVeryUniqueTransactionCaptureId',
+        },
       },
       {
         createDoubleEntry: true,

--- a/test/server/paymentProviders/paypal/payment.test.js
+++ b/test/server/paymentProviders/paypal/payment.test.js
@@ -10,7 +10,14 @@ import { stub } from 'sinon';
 import models from '../../../../server/models';
 import * as paypalPayment from '../../../../server/paymentProviders/paypal/payment';
 // import * as store from '../../../stores';
-import { fakeCollective, fakeHost, fakeOrder, fakePaymentMethod } from '../../../test-helpers/fake-data';
+import {
+  fakeCollective,
+  fakeHost,
+  fakeOrder,
+  fakePaymentMethod,
+  fakeTransaction,
+  fakeUser,
+} from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
 // const application = utils.data('application');
@@ -161,6 +168,76 @@ describe('server/paymentProviders/paypal/payment', () => {
         mockPaypalOrderDetail({ failOnOrderDetails: true });
         await expect(paypalPayment.processOrder(order)).to.be.rejectedWith('401');
         expect(authorizePaymentNock.isDone()).to.be.false; // Shouldn't call authorize
+      });
+    });
+
+    describe('#refundPaypalCapture', () => {
+      let host, collective, transaction, user;
+      const captureId = 'fake-capture-id';
+      const refundId = 'fake-refund-id';
+
+      before(async () => {
+        const secrets = { clientId: 'my-client-id', clientSecret: 'my-client-secret' };
+        const paypal = await models.ConnectedAccount.create({
+          service: 'paypal',
+          clientId: secrets.clientId,
+          token: secrets.clientSecret,
+        });
+        host = await fakeHost();
+        await host.addConnectedAccount(paypal);
+        collective = await fakeCollective({ HostCollectiveId: host.id });
+      });
+
+      beforeEach(async () => {
+        user = await fakeUser();
+        const order = await fakeOrder({ CollectiveId: collective.id });
+        transaction = await fakeTransaction(
+          {
+            CollectiveId: collective.id,
+            HostCollectiveId: host.id,
+            OrderId: order.id,
+            amount: 1000,
+            currency: 'USD',
+            data: { paypalCaptureId: captureId },
+          },
+          { createDoubleEntry: true },
+        );
+
+        nock('https://api.sandbox.paypal.com')
+          .persist()
+          .post('/v1/oauth2/token')
+          .basicAuth({ user: 'my-client-id', pass: 'my-client-secret' })
+          .reply(200, { access_token: 'dat-token' });
+
+        nock('https://api.sandbox.paypal.com')
+          .matchHeader('Authorization', 'Bearer dat-token')
+          .post(`/v2/payments/captures/${captureId}/refund`)
+          .reply(200, { id: refundId, status: 'COMPLETED' });
+
+        nock('https://api.sandbox.paypal.com')
+          .matchHeader('Authorization', 'Bearer dat-token')
+          .get(`/v2/payments/refunds/${refundId}`)
+          .reply(200, {
+            id: refundId,
+            status: 'COMPLETED',
+            seller_payable_breakdown: { paypal_fee: { value: '0.30' } },
+          });
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      it('records the refund with the new `refund`/`paypalRefundId` fields and preserves original data', async () => {
+        const refundTransaction = await paypalPayment.refundPaypalCapture(transaction, captureId, user, 'Some reason');
+
+        expect(refundTransaction).to.exist;
+        expect(refundTransaction.data.paypalRefundId).to.equal(refundId);
+        expect(refundTransaction.data.refund).to.deep.include({ id: refundId, status: 'COMPLETED' });
+        expect(refundTransaction.data.paypalResponse).to.not.exist;
+        // Original transaction data (e.g. paypalCaptureId) must be preserved on the refund transaction
+        expect(refundTransaction.data.paypalCaptureId).to.equal(captureId);
+        expect(refundTransaction.data.refundReason).to.equal('Some reason');
       });
     });
   });

--- a/test/server/paymentProviders/paypal/payment.test.js
+++ b/test/server/paymentProviders/paypal/payment.test.js
@@ -198,6 +198,7 @@ describe('server/paymentProviders/paypal/payment', () => {
             OrderId: order.id,
             amount: 1000,
             currency: 'USD',
+            kind: 'CONTRIBUTION',
             data: { paypalCaptureId: captureId },
           },
           { createDoubleEntry: true },
@@ -229,7 +230,13 @@ describe('server/paymentProviders/paypal/payment', () => {
       });
 
       it('records the refund with the new `refund`/`paypalRefundId` fields and preserves original data', async () => {
-        const refundTransaction = await paypalPayment.refundPaypalCapture(transaction, captureId, user, 'Some reason');
+        const originalTransaction = await paypalPayment.refundPaypalCapture(
+          transaction,
+          captureId,
+          user,
+          'Some reason',
+        );
+        const refundTransaction = await originalTransaction.getRefundTransaction();
 
         expect(refundTransaction).to.exist;
         expect(refundTransaction.data.paypalRefundId).to.equal(refundId);
@@ -238,6 +245,10 @@ describe('server/paymentProviders/paypal/payment', () => {
         // Original transaction data (e.g. paypalCaptureId) must be preserved on the refund transaction
         expect(refundTransaction.data.paypalCaptureId).to.equal(captureId);
         expect(refundTransaction.data.refundReason).to.equal('Some reason');
+
+        // Guarantee MerchantID is consistent between the original transaction and the refund transaction
+        expect(refundTransaction.merchantId).to.equal(refundId);
+        expect(originalTransaction.merchantId).to.equal(captureId);
       });
     });
   });

--- a/test/server/paymentProviders/paypal/webhook.test.ts
+++ b/test/server/paymentProviders/paypal/webhook.test.ts
@@ -325,9 +325,10 @@ describe('server/paymentProviders/paypal/webhook', () => {
         },
       );
 
+      const refundId = 'REFUND-002';
       sandbox.stub(PaypalLib, 'validateWebhookEvent').resolves();
       await callPaymentSaleRefunded(host.id, {
-        resource: { sale_id: saleId, transaction_fee: { value: '0.50' } },
+        resource: { id: refundId, sale_id: saleId, transaction_fee: { value: '0.50' } },
       });
 
       const refundTransaction = await models.Transaction.findOne({
@@ -335,6 +336,10 @@ describe('server/paymentProviders/paypal/webhook', () => {
       });
       expect(refundTransaction).to.exist;
       expect(refundTransaction.data.isRefundedFromPayPal).to.be.true;
+      expect(refundTransaction.data.paypalRefundId).to.equal(refundId);
+      expect(refundTransaction.data.refund).to.exist;
+      // Original transaction data (e.g. paypalCaptureId) is preserved on the refund transaction
+      expect(refundTransaction.data.paypalCaptureId).to.equal(saleId);
     });
   });
 
@@ -467,6 +472,10 @@ describe('server/paymentProviders/paypal/webhook', () => {
       });
       expect(refundTransaction).to.exist;
       expect(refundTransaction.data.isRefundedFromPayPal).to.be.true;
+      expect(refundTransaction.data.paypalRefundId).to.equal(reversalId);
+      expect(refundTransaction.data.refund).to.exist;
+      // Original transaction data (e.g. paypalCaptureId) is preserved on the refund transaction
+      expect(refundTransaction.data.paypalCaptureId).to.equal(captureId);
     });
   });
 
@@ -548,6 +557,10 @@ describe('server/paymentProviders/paypal/webhook', () => {
       });
       expect(refundTransaction).to.exist;
       expect(refundTransaction.data.isRefundedFromPayPal).to.be.true;
+      expect(refundTransaction.data.paypalRefundId).to.equal(saleId);
+      expect(refundTransaction.data.refund).to.exist;
+      // Original transaction data (e.g. paypalCaptureId) is preserved on the refund transaction
+      expect(refundTransaction.data.paypalCaptureId).to.equal(saleId);
     });
   });
 });


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/8845

- Stop propagating `refundTransaction.data` into `originalTransaction.data` by default.
  - Still storing Stripe's refund object into `originalTransaction.data` for backward compatibility.
- We still store `originalTransaction.data` in `refundTransaction.data` to keep consistency.
  - To be reevaluated later.