### PR TITLE
fix(graphql-v1): enforce private account visibility on Transaction query

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -8,7 +8,7 @@ import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../constants/pay
 import { fetchCollectiveId } from '../../lib/cache';
 import logger from '../../lib/logger';
 import { getConsolidatedInvoicesData } from '../../lib/pdf';
-import { assertCanSeeAccount } from '../../lib/private-accounts';
+import { assertCanSeeAccount, assertCanSeeAllAccounts } from '../../lib/private-accounts';
 import rawQueries from '../../lib/queries';
 import { searchCollectivesByEmail, searchCollectivesInDB } from '../../lib/sql-search';
 import models, { Op, sequelize } from '../../models';
@@ -176,8 +176,18 @@ const queries = {
         type: GraphQLString,
       },
     },
-    resolve(_, args) {
-      return models.Transaction.findOne({ where: { ...args } });
+    async resolve(_, args, req) {
+      const transaction = await models.Transaction.findOne({ where: { ...args } });
+      if (!transaction) {
+        return null;
+      }
+
+      const collectiveIds = [transaction.FromCollectiveId, transaction.CollectiveId, transaction.HostCollectiveId];
+      const uniqIds = uniq(collectiveIds.filter(Boolean));
+      const collectives = await req.loaders.Collective.byId.loadMany(uniqIds);
+      await assertCanSeeAllAccounts(req, collectives.filter(Boolean));
+
+      return transaction;
     },
   },
 

--- a/test/server/graphql/v1/transaction.test.js
+++ b/test/server/graphql/v1/transaction.test.js
@@ -7,8 +7,10 @@ import { expect } from 'chai';
 import gqlV1 from 'fake-tag';
 import { describe, it } from 'mocha';
 
+import { TransactionKind } from '../../../../server/constants/transaction-kind';
 import models from '../../../../server/models';
 import * as store from '../../../stores';
+import { fakeCollective, fakePrivateHost, fakeTransaction, fakeUser } from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
 describe('server/graphql/v1/transaction', () => {
@@ -243,6 +245,92 @@ describe('server/graphql/v1/transaction', () => {
         offset,
       });
       expect(result).to.matchSnapshot();
+    });
+  });
+
+  describe('private organizations visibility', () => {
+    const transactionByIdQuery = gqlV1 /* GraphQL */ `
+      query Transaction($id: Int) {
+        Transaction(id: $id) {
+          id
+          type
+          description
+        }
+      }
+    `;
+
+    const transactionByUuidQuery = gqlV1 /* GraphQL */ `
+      query Transaction($uuid: String) {
+        Transaction(uuid: $uuid) {
+          id
+          type
+          description
+        }
+      }
+    `;
+
+    let privateHost, privateHostAdminUser, privateCollective, privateCollectiveAdminUser, randomUser, transaction;
+
+    before(async () => {
+      privateHostAdminUser = await fakeUser();
+      privateHost = await fakePrivateHost({ admin: privateHostAdminUser.collective });
+      privateCollectiveAdminUser = await fakeUser();
+      privateCollective = await fakeCollective({
+        HostCollectiveId: privateHost.id,
+        isPrivate: true,
+        approvedAt: new Date(),
+        admin: privateCollectiveAdminUser.collective,
+      });
+      randomUser = await fakeUser();
+
+      transaction = await fakeTransaction({
+        CollectiveId: privateCollective.id,
+        HostCollectiveId: privateHost.id,
+        kind: TransactionKind.CONTRIBUTION,
+        amount: 1000,
+        description: 'Transaction to private collective',
+      });
+    });
+
+    const privateTransactionForbiddenMessage =
+      'One or more of the accounts are private. You must be a member to view them.';
+
+    it('is NOT visible to an unauthenticated user (by id)', async () => {
+      const result = await utils.graphqlQuery(transactionByIdQuery, { id: transaction.id });
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(privateTransactionForbiddenMessage);
+    });
+
+    it('is NOT visible to an unauthenticated user (by uuid)', async () => {
+      const result = await utils.graphqlQuery(transactionByUuidQuery, { uuid: transaction.uuid });
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(privateTransactionForbiddenMessage);
+    });
+
+    it('is NOT visible to a random authenticated user (by id)', async () => {
+      const result = await utils.graphqlQuery(transactionByIdQuery, { id: transaction.id }, randomUser);
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(privateTransactionForbiddenMessage);
+    });
+
+    it('is NOT visible to a random authenticated user (by uuid)', async () => {
+      const result = await utils.graphqlQuery(transactionByUuidQuery, { uuid: transaction.uuid }, randomUser);
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.equal(privateTransactionForbiddenMessage);
+    });
+
+    it('IS visible to an admin of the private collective (by id)', async () => {
+      const result = await utils.graphqlQuery(transactionByIdQuery, { id: transaction.id }, privateCollectiveAdminUser);
+      expect(result.errors).to.not.exist;
+      expect(result.data.Transaction).to.exist;
+      expect(result.data.Transaction.id).to.equal(transaction.id);
+    });
+
+    it('IS visible to an admin of the private host (by uuid)', async () => {
+      const result = await utils.graphqlQuery(transactionByUuidQuery, { uuid: transaction.uuid }, privateHostAdminUser);
+      expect(result.errors).to.not.exist;
+      expect(result.data.Transaction).to.exist;
+      expect(result.data.Transaction.id).to.equal(transaction.id);
     });
   });
 });


### PR DESCRIPTION
## Problem
The v1 `Transaction` query (`server/graphql/v1/queries.js`) resolved transactions with a bare `findOne` and no authorization check. Anyone calling GraphQL v1 (including unauthenticated callers) could fetch full transaction details — amounts, descriptions, counterparty and nested collective data — for transactions involving **private organizations**, just by knowing/guessing a transaction `id` or `uuid`.

The v2 equivalent (`TransactionQuery`) already enforces this via `assertCanSeeAllAccounts`.

## Fix
The v1 `Transaction` resolver now loads the transaction's `FromCollective`, `Collective`, and `HostCollective` and calls `assertCanSeeAllAccounts` before returning it, mirroring v2's behavior. No scope/OAuth checks were added — this change is scoped strictly to the missing private-account visibility gap.

## Tests
Added a new describe block in `test/server/graphql/v1/transaction.test.js` covering:
- Unauthenticated and random authenticated users cannot see a private organization's transaction (by id or uuid)
- Admins of the private collective / private host can still see it

All existing tests continue to pass.
