### PR TITLE
fix(graphql-v1): enforce private account visibility on allMembers query

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -5,6 +5,7 @@ import { isEmail } from 'validator';
 import { roles } from '../../constants';
 import { CollectiveType } from '../../constants/collectives';
 import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from '../../constants/paymentMethods';
+import { MemberRolesForPrivateAccounts } from '../../constants/roles';
 import { fetchCollectiveId } from '../../lib/cache';
 import logger from '../../lib/logger';
 import { getConsolidatedInvoicesData } from '../../lib/pdf';
@@ -284,13 +285,48 @@ const queries = {
         where.HostCollectiveId = args.MemberCollectiveId;
       }
 
+      // Preload which private collectives the current user is allowed to see. This mirrors the
+      // logic used in the GraphQL V2 `HasMembers` interface: root users see everything, users
+      // with an ADMIN/ACCOUNTANT role see the related private collectives, everyone else only
+      // sees public collectives.
+      const canSeeAllPrivateCollectives = Boolean(req.remoteUser?.isRoot());
+      const privateCollectiveAccessIds =
+        req.remoteUser && !canSeeAllPrivateCollectives
+          ? Array.from(req.remoteUser.getCollectiveIdsForRoles(MemberRolesForPrivateAccounts))
+          : [];
+
+      // Builds a fresh set of Sequelize conditions restricting private collectives visibility.
+      const getPrivateCollectiveConditions = () => {
+        const conditions = { isPrivate: false };
+        if (canSeeAllPrivateCollectives) {
+          delete conditions.isPrivate;
+        } else if (privateCollectiveAccessIds.length > 0) {
+          delete conditions.isPrivate;
+          conditions[Op.or] = [
+            { isPrivate: false },
+            { id: privateCollectiveAccessIds }, // User is an admin or accountant of the collective
+            { ParentCollectiveId: privateCollectiveAccessIds }, // ...of the collective's parent (events/projects)
+            { HostCollectiveId: privateCollectiveAccessIds }, // ...of the collective's fiscal host
+          ];
+        }
+        return conditions;
+      };
+
       if (['totalDonations', 'balance'].indexOf(args.orderBy) !== -1) {
-        const queryName = args.orderBy === 'totalDonations' ? 'getMembersWithTotalDonations' : 'getMembersWithBalance';
+        // Do not break reference to query object
+        const query =
+          args.orderBy === 'totalDonations'
+            ? rawQueries.getMembersWithTotalDonations
+            : rawQueries.getMembersWithBalance;
         const tiersById = {};
 
-        const options = args.isActive ? { ...args, limit: args.limit * 2 } : args;
+        const options = {
+          ...(args.isActive ? { ...args, limit: args.limit * 2 } : args),
+          canSeeAllPrivateCollectives,
+          privateCollectiveAccessIds,
+        };
 
-        let results = await rawQueries[queryName](where, options);
+        let results = await query(where, options);
 
         if (args.isActive) {
           const TierIds = uniq(results.map(r => r.dataValues.TierId));
@@ -325,25 +361,34 @@ const queries = {
           }),
         );
       } else {
-        const query = { where, include: [] };
+        const includes = {
+          collective: {
+            model: models.Collective,
+            as: 'collective',
+            required: true,
+            where: getPrivateCollectiveConditions(),
+          },
+          memberCollective: {
+            model: models.Collective,
+            as: 'memberCollective',
+            required: true,
+            where: getPrivateCollectiveConditions(),
+          },
+        };
+        const query = { where };
         if (args.TierId) {
           query.where.TierId = args.TierId;
         }
 
         // If we request the data of the member, we do a JOIN query
         // that allows us to sort by Member.member.name
-        const memberCond = {};
+        const memberCond = getPrivateCollectiveConditions();
         if (req.body.query.match(/ member ?\{/) || args.type) {
           if (args.type) {
             const types = args.type.split(',');
             memberCond.type = { [Op.in]: types };
           }
-          query.include.push({
-            model: models.Collective,
-            as: memberTable,
-            required: true,
-            where: memberCond,
-          });
+          includes[memberTable].where = memberCond;
           query.order = [[sequelize.literal(`"${memberTable}".name`), 'ASC']];
         }
         if (args.limit) {
@@ -368,6 +413,7 @@ const queries = {
 
         query.where[attr] = { [Op.in]: collectiveIds };
         query.where.role = { [Op.ne]: 'HOST' };
+        query.include = Object.values(includes);
         const members = await models.Member.findAll(query);
 
         // also fetch the list of collectives that are members of the host
@@ -377,13 +423,10 @@ const queries = {
             role: 'HOST',
           };
           query.order = [[sequelize.literal('collective.name'), 'ASC']];
-          query.include = [
-            {
-              model: models.Collective,
-              as: 'collective',
-              required: true,
-            },
-          ];
+          // Only join the hosted `collective` here (the `memberCollective` is always the host
+          // itself). We still apply the private-collective conditions so private hosted
+          // collectives stay hidden from unauthorized users.
+          query.include = [includes.collective];
           const hostedMembers = await models.Member.findAll(query);
           await Promise.all(
             hostedMembers.map(m => {

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -518,6 +518,34 @@ const getMembersOfCollectiveWithRole = CollectiveIds => {
 };
 
 /**
+ * Builds the SQL condition used to filter out private collectives the current user
+ * cannot see. Mirrors the logic used in the GraphQL V2 `HasMembers` interface:
+ * - Root users can see everything (no condition).
+ * - Users with an ADMIN/ACCOUNTANT role on some collectives can see those private
+ *   collectives (as well as their events/projects and hosted collectives).
+ * - Everyone else can only see public collectives.
+ *
+ * Expects `options.canSeeAllPrivateCollectives` (boolean) and
+ * `options.privateCollectiveAccessIds` (array of collective ids) to be provided by
+ * the caller. The generated SQL references the `:privateCollectiveAccessIds`
+ * replacement when the user has direct access to some private collectives.
+ */
+const getPrivateCollectivesSQLCondition = (options = {}, tableAlias = 'c') => {
+  if (options.canSeeAllPrivateCollectives) {
+    return '';
+  } else if (options.privateCollectiveAccessIds?.length > 0) {
+    return `AND (
+      ${tableAlias}."isPrivate" IS FALSE
+      OR ${tableAlias}.id IN (:privateCollectiveAccessIds)
+      OR ${tableAlias}."ParentCollectiveId" IN (:privateCollectiveAccessIds)
+      OR ${tableAlias}."HostCollectiveId" IN (:privateCollectiveAccessIds)
+    )`;
+  } else {
+    return `AND ${tableAlias}."isPrivate" IS FALSE`;
+  }
+};
+
+/**
  * Returns all the members of a collective with their `totalDonations` and
  * `role` (HOST/ADMIN/BACKER)
  */
@@ -609,6 +637,7 @@ const getMembersWithTotalDonations = (where, options = {}) => {
     LEFT JOIN "Members" member ON c.id = member."${groupBy}"
     LEFT JOIN "Users" u ON c.id = u."CollectiveId"
     WHERE member."${memberCondAttribute}" IN (:collectiveids)
+      ${getPrivateCollectivesSQLCondition(options, 'c')}
     ${roleCond}
     AND member."deletedAt" IS NULL ${untilCondition('member')}
     ${filterByMemberCollectiveType}
@@ -626,6 +655,7 @@ const getMembersWithTotalDonations = (where, options = {}) => {
         offset: options.offset || 0,
         types,
         role: where.role,
+        privateCollectiveAccessIds: options.privateCollectiveAccessIds || [],
       },
       type: QueryTypes.SELECT,
       model: models.Collective,
@@ -673,6 +703,7 @@ const getMembersWithBalance = (where, options = {}) => {
       WHERE
         c.type = 'COLLECTIVE'
         AND c."isActive" IS TRUE
+        ${getPrivateCollectivesSQLCondition(options, 'c')}
         ${whereCondition}
         AND c."deletedAt" IS NULL
         GROUP BY t."CollectiveId"
@@ -700,6 +731,7 @@ const getMembersWithBalance = (where, options = {}) => {
     LEFT JOIN "Members" member ON c.id = member."${groupBy}"
     LEFT JOIN "Users" u ON c.id = u."CollectiveId"
     WHERE member."${memberCondAttribute}" IN (:collectiveids)
+      ${getPrivateCollectivesSQLCondition(options, 'c')}
     ${roleCond}
     ${whereCondition}
     AND member."deletedAt" IS NULL ${untilCondition('member')}
@@ -715,6 +747,7 @@ const getMembersWithBalance = (where, options = {}) => {
     limit: options.limit || 100000, // we should reduce this to 100 by default but right now Webpack depends on it
     offset: options.offset || 0,
     types,
+    privateCollectiveAccessIds: options.privateCollectiveAccessIds || [],
   };
 
   return sequelize.query(

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -195,46 +195,6 @@ const getTotalAnnualBudget = async () => {
     .then(res => Math.round(parseInt(res[0].yearlyIncome, 10)));
 };
 
-/**
- * Returns the top backers (Collectives) in a given time range in given tags
- * E.g. top backers in open source collectives last June
- */
-const getTopBackers = (since, until, tags, limit) => {
-  const sinceClause = since ? `AND t."createdAt" >= '${since.toISOString()}'` : '';
-  const untilClause = until ? `AND t."createdAt" < '${until.toISOString()}'` : '';
-  const tagsClause = tags ? 'AND collective.tags && $tags' : ''; // && operator means "overlaps"
-
-  return sequelize.query(
-    `
-    SELECT
-      MAX(fromCollective.id) as id,
-      MAX(fromCollective.slug) as slug,
-      MAX(fromCollective.name) as name,
-      MAX(fromCollective.website) as "website",
-      MAX(fromCollective."twitterHandle") as "twitterHandle",
-      MAX(fromCollective.image) as "image",
-      SUM("amount") as "totalDonations",
-      MAX(t.currency) as "currency"
-    FROM "Transactions" t
-    LEFT JOIN "Collectives" fromCollective ON fromCollective.id = t."FromCollectiveId"
-    LEFT JOIN "Collectives" collective ON collective.id = t."CollectiveId"
-    WHERE
-      t.type='CREDIT'
-      AND t."deletedAt" IS NULL
-      ${sinceClause}
-      ${untilClause}
-      ${tagsClause}
-    GROUP BY "FromCollectiveId"
-    ORDER BY "totalDonations" DESC
-    LIMIT ${limit}
-    `.replace(/\s\s+/g, ' '), // this is to remove the new lines and save log space.
-    {
-      bind: { tags: tags || [] },
-      model: models.Collective,
-    },
-  );
-};
-
 export const usersToNotifyForUpdateSQLQuery = `
   WITH collective AS (
     SELECT c.*
@@ -1028,7 +988,6 @@ const queries = {
   getMembersWithTotalDonations,
   getTaxFormsRequiredForAccounts,
   getTaxFormsRequiredForExpenses,
-  getTopBackers,
   getTopSponsors,
   getTotalAnnualBudget,
   getTotalAnnualBudgetForHost,

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -412,15 +412,6 @@ class Collective extends ModelWithPublicId<
     });
   };
 
-  static getTopBackers = async (since, until, tags, limit) => {
-    const backers = await queries.getTopBackers(since || 0, until || new Date(), tags, limit || 5);
-    debug(
-      'getTopBackers',
-      backers.map(b => b.dataValues),
-    );
-    return backers;
-  };
-
   static getHostCollectiveId = async CollectiveId => {
     const res = await Member.findOne({
       attributes: ['MemberCollectiveId'],
@@ -1906,70 +1897,6 @@ class Collective extends ModelWithPublicId<
     return Member.findOne({
       where: { MemberCollectiveId, CollectiveId: this.id },
     }).then(member => member.role);
-  };
-
-  /**
-   * returns the tiers with their users
-   * e.g. collective.tiers = [
-   *  { name: 'core contributor', users: [ {UserObject} ], range: [], ... },
-   *  { name: 'backer', users: [ {UserObject}, {UserObject} ], range: [], ... }
-   * ]
-   */
-  getTiersWithUsers = async function (
-    options = {
-      active: false,
-      attributes: ['id', 'username', 'image', 'firstDonation', 'lastDonation', 'totalDonations', 'website'],
-    },
-  ) {
-    const tiersById = {};
-
-    // Get the list of tiers for the collective (including deleted ones)
-    const tiers = await Tier.findAll({ where: { CollectiveId: this.id }, paranoid: false });
-    for (const tier of tiers) {
-      tiersById[tier.id] = tier;
-    }
-
-    const backerCollectives = <Array<any>>(
-      await queries.getMembersWithTotalDonations({ CollectiveId: this.id, role: 'BACKER' }, options)
-    );
-
-    // Map the users to their respective tier
-    await Promise.all(
-      backerCollectives.map(backerCollective => {
-        const include = options.active ? [{ model: Subscription, attributes: ['isActive'] }] : [];
-        return Order.findOne({
-          attributes: ['TierId'],
-          where: {
-            FromCollectiveId: backerCollective.id,
-            CollectiveId: this.id,
-            TierId: { [Op.ne]: null },
-          },
-          include,
-        }).then(order => {
-          if (!order) {
-            debug('Collective.getTiersWithUsers: no order for a tier for ', {
-              FromCollectiveId: backerCollective.id,
-              CollectiveId: this.id,
-            });
-            return null;
-          }
-          const TierId = order.TierId;
-          tiersById[TierId] = tiersById[TierId] || order.Tier;
-          if (!tiersById[TierId]) {
-            logger.error(">>> Couldn't find a tier with id", order.TierId, 'collective: ', this.slug);
-            tiersById[TierId] = { dataValues: { users: [] } };
-          }
-          tiersById[TierId].dataValues.users = tiersById[TierId].dataValues.users || [];
-          if (options.active) {
-            backerCollective.isActive = order.Subscription.isActive;
-          }
-          debug('adding to tier', TierId, 'backer: ', backerCollective.dataValues.slug);
-          tiersById[TierId].dataValues.users.push(backerCollective.dataValues);
-        });
-      }),
-    );
-
-    return Object.values(tiersById);
   };
 
   /**
@@ -3523,18 +3450,6 @@ class Collective extends ModelWithPublicId<
     }
 
     return connectedAccount;
-  };
-
-  getTopBackers = async function (since, until, limit) {
-    const backers = await queries.getMembersWithTotalDonations(
-      { CollectiveId: this.id, role: 'BACKER' },
-      { since, until, limit },
-    );
-    debug(
-      'getTopBackers',
-      backers.map(b => b.dataValues),
-    );
-    return backers;
   };
 
   getImageUrl = function (args = {}) {

--- a/test/server/graphql/v1/collective.test.js
+++ b/test/server/graphql/v1/collective.test.js
@@ -11,6 +11,7 @@ import * as currency from '../../../../server/lib/currency';
 import models from '../../../../server/models';
 import * as store from '../../../stores';
 import {
+  fakeActiveHost,
   fakeCollective,
   fakeHost,
   fakeMember,
@@ -1252,6 +1253,309 @@ describe('server/graphql/v1/Collective - private accounts', () => {
       );
       expect(result.errors).to.be.undefined;
       expect(Array.isArray(result.data.allTransactions)).to.be.true;
+    });
+  });
+});
+
+describe('server/graphql/v1/allMembers - private collectives visibility', () => {
+  const allMembersVisibilityQuery = gqlV1 /* GraphQL */ `
+    query AllMembers($collectiveSlug: String, $memberCollectiveSlug: String, $orderBy: String) {
+      allMembers(
+        collectiveSlug: $collectiveSlug
+        memberCollectiveSlug: $memberCollectiveSlug
+        orderBy: $orderBy
+        limit: 100
+        offset: 0
+      ) {
+        id
+        role
+        collective {
+          id
+          slug
+        }
+        member {
+          id
+          slug
+        }
+      }
+    }
+  `;
+
+  // Extracts the slugs of the returned members (the `member` field resolves to the member collective).
+  const getMemberSlugs = result => (result.data.allMembers || []).map(m => m.member?.slug);
+  // Extracts the slugs of the collectives the memberships belong to.
+  const getCollectiveSlugs = result => (result.data.allMembers || []).map(m => m.collective?.slug);
+
+  let rootAdmin, hostAdmin, collectiveAdmin, collectiveAccountant, otherPrivateAdmin, randomUser, publicBacker;
+  let privateOrgAdmin;
+  let privateHost, privateCollective, publicCollective, privateOrg;
+
+  before(async () => {
+    await utils.resetTestDB();
+
+    // --- Users ---
+    rootAdmin = await fakeUser({ data: { isRoot: true } });
+    hostAdmin = await fakeUser();
+    collectiveAdmin = await fakeUser();
+    collectiveAccountant = await fakeUser();
+    otherPrivateAdmin = await fakeUser();
+    randomUser = await fakeUser();
+    publicBacker = await fakeUser();
+    privateOrgAdmin = await fakeUser();
+
+    // Make the root user an admin of the platform collective so `isRoot()` resolves to true.
+    await fakeMember({
+      CollectiveId: 1,
+      MemberCollectiveId: rootAdmin.CollectiveId,
+      role: 'ADMIN',
+      CreatedByUserId: rootAdmin.id,
+    });
+
+    // --- Private host + private collective ---
+    privateHost = await fakeActiveHost({ admin: hostAdmin.collective });
+    privateCollective = await fakeCollective({
+      HostCollectiveId: privateHost.id,
+      isPrivate: true,
+      approvedAt: new Date(),
+      admin: collectiveAdmin.collective,
+    });
+    await fakeMember({
+      CollectiveId: privateCollective.id,
+      MemberCollectiveId: collectiveAccountant.CollectiveId,
+      role: 'ACCOUNTANT',
+    });
+    await fakeMember({
+      CollectiveId: privateCollective.id,
+      MemberCollectiveId: publicBacker.CollectiveId,
+      role: 'BACKER',
+    });
+
+    // A second, unrelated private collective, used to check that access does not leak across accounts.
+    await fakeCollective({ isPrivate: true, admin: otherPrivateAdmin.collective });
+
+    // --- Public collective with a private organization as a backer (exercises the raw-query flow) ---
+    publicCollective = await fakeCollective();
+    privateOrg = await fakeOrganization({ isPrivate: true, admin: privateOrgAdmin.collective });
+    await fakeMember({
+      CollectiveId: publicCollective.id,
+      MemberCollectiveId: privateOrg.id,
+      role: 'BACKER',
+    });
+    await fakeMember({
+      CollectiveId: publicCollective.id,
+      MemberCollectiveId: publicBacker.CollectiveId,
+      role: 'BACKER',
+    });
+  });
+
+  describe('loading members of a private collective (collectiveSlug)', () => {
+    it('returns no members for unauthenticated users', async () => {
+      const result = await utils.graphqlQuery(allMembersVisibilityQuery, { collectiveSlug: privateCollective.slug });
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(result.data.allMembers).to.have.length(0);
+    });
+
+    it('returns no members for unrelated authenticated users', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: privateCollective.slug },
+        randomUser,
+      );
+      expect(result.errors).to.not.exist;
+      expect(result.data.allMembers).to.have.length(0);
+    });
+
+    it('returns no members for an admin of a different private collective', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: privateCollective.slug },
+        otherPrivateAdmin,
+      );
+      expect(result.errors).to.not.exist;
+      expect(result.data.allMembers).to.have.length(0);
+    });
+
+    it('returns the members for an admin of the collective', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: privateCollective.slug },
+        collectiveAdmin,
+      );
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      const slugs = getMemberSlugs(result);
+      expect(slugs).to.have.members([
+        collectiveAdmin.collective.slug,
+        collectiveAccountant.collective.slug,
+        publicBacker.collective.slug,
+      ]);
+    });
+
+    it('returns the members for an accountant of the collective', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: privateCollective.slug },
+        collectiveAccountant,
+      );
+      expect(result.errors).to.not.exist;
+      expect(getMemberSlugs(result)).to.include(collectiveAdmin.collective.slug);
+    });
+
+    it('returns the members for an admin of the fiscal host', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: privateCollective.slug },
+        hostAdmin,
+      );
+      expect(result.errors).to.not.exist;
+      expect(getMemberSlugs(result)).to.include(collectiveAdmin.collective.slug);
+    });
+
+    it('returns the members for root users', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: privateCollective.slug },
+        rootAdmin,
+      );
+      expect(result.errors).to.not.exist;
+      expect(getMemberSlugs(result)).to.include(collectiveAdmin.collective.slug);
+    });
+  });
+
+  describe('loading members ordered by totalDonations (raw query flow)', () => {
+    it('hides private members from unauthenticated users', async () => {
+      const result = await utils.graphqlQuery(allMembersVisibilityQuery, {
+        collectiveSlug: publicCollective.slug,
+        orderBy: 'totalDonations',
+      });
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      const slugs = getMemberSlugs(result);
+      expect(slugs).to.include(publicBacker.collective.slug);
+      expect(slugs).to.not.include(privateOrg.slug);
+    });
+
+    it('shows a private member to its own admin', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: publicCollective.slug, orderBy: 'totalDonations' },
+        privateOrgAdmin,
+      );
+      expect(result.errors).to.not.exist;
+      const slugs = getMemberSlugs(result);
+      expect(slugs).to.include(publicBacker.collective.slug);
+      expect(slugs).to.include(privateOrg.slug);
+    });
+
+    it('shows all members to root users', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { collectiveSlug: publicCollective.slug, orderBy: 'totalDonations' },
+        rootAdmin,
+      );
+      expect(result.errors).to.not.exist;
+      expect(getMemberSlugs(result)).to.include(privateOrg.slug);
+    });
+  });
+
+  describe('loading memberships of a member (memberCollectiveSlug)', () => {
+    it('hides memberships in private collectives from unauthenticated users', async () => {
+      const result = await utils.graphqlQuery(allMembersVisibilityQuery, {
+        memberCollectiveSlug: collectiveAdmin.collective.slug,
+      });
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(getCollectiveSlugs(result)).to.not.include(privateCollective.slug);
+    });
+
+    it('hides memberships in private collectives from unrelated users', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { memberCollectiveSlug: collectiveAdmin.collective.slug },
+        randomUser,
+      );
+      expect(result.errors).to.not.exist;
+      expect(getCollectiveSlugs(result)).to.not.include(privateCollective.slug);
+    });
+
+    it('shows memberships in private collectives to the member itself', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { memberCollectiveSlug: collectiveAdmin.collective.slug },
+        collectiveAdmin,
+      );
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(getCollectiveSlugs(result)).to.include(privateCollective.slug);
+    });
+
+    it('shows memberships in private collectives to the fiscal host admin', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { memberCollectiveSlug: collectiveAdmin.collective.slug },
+        hostAdmin,
+      );
+      expect(result.errors).to.not.exist;
+      expect(getCollectiveSlugs(result)).to.include(privateCollective.slug);
+    });
+
+    it('shows memberships in private collectives to root users', async () => {
+      const result = await utils.graphqlQuery(
+        allMembersVisibilityQuery,
+        { memberCollectiveSlug: collectiveAdmin.collective.slug },
+        rootAdmin,
+      );
+      expect(result.errors).to.not.exist;
+      expect(getCollectiveSlugs(result)).to.include(privateCollective.slug);
+    });
+  });
+
+  describe('loading hosted collectives (includeHostedCollectives)', () => {
+    const allMembersHostedQuery = gqlV1 /* GraphQL */ `
+      query AllMembers($collectiveSlug: String, $type: String) {
+        allMembers(
+          collectiveSlug: $collectiveSlug
+          includeHostedCollectives: true
+          type: $type
+          limit: 100
+          offset: 0
+        ) {
+          id
+          role
+          member {
+            id
+            slug
+          }
+        }
+      }
+    `;
+
+    it('returns the hosted collectives to the host admin', async () => {
+      const result = await utils.graphqlQuery(allMembersHostedQuery, { collectiveSlug: privateHost.slug }, hostAdmin);
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(getMemberSlugs(result)).to.include(privateCollective.slug);
+    });
+
+    it('still returns the hosted collectives when a type filter is provided', async () => {
+      // Regression test: the `hostedMembers` sub-query must only join the `collective`
+      // association. If it also joined `memberCollective` (the host), a `type` filter would be
+      // applied to the host and wrongly drop every hosted collective.
+      const result = await utils.graphqlQuery(
+        allMembersHostedQuery,
+        { collectiveSlug: privateHost.slug, type: 'USER' },
+        hostAdmin,
+      );
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(getMemberSlugs(result)).to.include(privateCollective.slug);
+    });
+
+    it('hides private hosted collectives from unauthorized users', async () => {
+      const result = await utils.graphqlQuery(allMembersHostedQuery, { collectiveSlug: privateHost.slug }, randomUser);
+      expect(result.errors).to.not.exist;
+      expect(getMemberSlugs(result)).to.not.include(privateCollective.slug);
     });
   });
 });

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -1104,31 +1104,6 @@ describe('server/models/Collective', () => {
   });
 
   describe('backers', () => {
-    it('gets the top backers', () => {
-      return Collective.getTopBackers().then(backers => {
-        backers = backers.map(g => g.dataValues);
-        expect(backers.length).to.equal(3);
-        expect(backers[0].totalDonations).to.equal(100000);
-        expect(backers[0]).to.have.property('website');
-      });
-    });
-
-    it('gets the top backers in a given month', () => {
-      return Collective.getTopBackers(new Date('2016-06-01'), new Date('2016-07-01')).then(backers => {
-        backers = backers.map(g => g.dataValues);
-        expect(backers.length).to.equal(2);
-        expect(backers[0].totalDonations).to.equal(50000);
-      });
-    });
-
-    it('gets the top backers in open source', () => {
-      return Collective.getTopBackers(new Date('2016-06-01'), new Date('2016-07-01'), ['open source']).then(backers => {
-        backers = backers.map(g => g.dataValues);
-        expect(backers.length).to.equal(1);
-        expect(backers[0].totalDonations).to.equal(25000);
-      });
-    });
-
     it('gets the latest transactions of a user collective', () => {
       return Collective.findOne({ where: { id: user1.CollectiveId } }).then(userCollective => {
         return userCollective
@@ -1171,45 +1146,6 @@ describe('server/models/Collective', () => {
 
     it('is false for incognito profiles', async () => {
       shouldNotBeUsableAsPayout(await fakeCollective({ type: 'USER', isIncognito: true }));
-    });
-  });
-
-  describe('tiers', () => {
-    before('adding user as backer', () => collective.addUserWithRole(user2, 'BACKER'));
-    before('creating order for backer tier', () =>
-      models.Order.create({
-        CreatedByUserId: user1.id,
-        FromCollectiveId: user1.CollectiveId,
-        CollectiveId: collective.id,
-        TierId: 1,
-      }),
-    );
-
-    before('creating order for sponsor tier', () =>
-      models.Order.create({
-        CreatedByUserId: user2.id,
-        FromCollectiveId: user2.CollectiveId,
-        CollectiveId: collective.id,
-        TierId: 2,
-      }),
-    );
-
-    it('get the tiers with users', done => {
-      collective
-        .getTiersWithUsers()
-        .then(tiers => {
-          expect(tiers).to.have.length(2);
-          const users = tiers[0].getDataValue('users');
-          expect(users).to.not.be.undefined;
-          expect(users).to.have.length(1);
-          const backer = users[0];
-          expect(parseInt(backer.totalDonations, 10)).to.equal(
-            transactions[2].amountInHostCurrency + transactions[3].amountInHostCurrency,
-          );
-          expect(new Date(backer.firstDonation).getTime()).to.equal(new Date(transactions[2].createdAt).getTime());
-          expect(new Date(backer.lastDonation).getTime()).to.equal(new Date(transactions[3].createdAt).getTime());
-        })
-        .finally(done);
     });
   });
 


### PR DESCRIPTION
### Problem

The GraphQL v1 `allMembers` resolver (`server/graphql/v1/queries.js`) unconditionally filtered out any private collective by hardcoding `isPrivate: false` on its joins. This meant that even users who are legitimately allowed to see a private account (its admins, accountants, or the fiscal host's team) could not load its members or memberships. The resolver was recently annotated as *"Does not work with Private Organizations"* for this reason.

### Solution

Instead of dropping the privacy filter entirely, `allMembers` now **preloads the private collectives the requesting user is allowed to see** and applies the same visibility rules already used by the GraphQL v2 `HasMembers` interface:

- **Root users** see everything.
- **Users with an `ADMIN`/`ACCOUNTANT` role** (`MemberRolesForPrivateAccounts`) can see the private collectives they administer, plus their events/projects (`ParentCollectiveId`) and hosted collectives (`HostCollectiveId`).
- **Everyone else** only sees public collectives.

The resolver has two execution paths, and both were updated:

1. **Sequelize path** – the hardcoded `{ isPrivate: false }` conditions on the `collective` / `memberCollective` includes (and the `memberCond` used for sorting) are replaced by a freshly-built condition object mirroring `HasMembers`.
2. **Raw-query path** (`orderBy: totalDonations` / `balance`) – `getMembersWithTotalDonations` and `getMembersWithBalance` in `server/lib/queries.js` now build their privacy `WHERE` clause dynamically via a shared `getPrivateCollectivesSQLCondition` helper, driven by the preloaded access set passed through `options`.

### Cleanup

While in the area, removed dead code that is no longer used anywhere:

- `Collective.getTopBackers` and `Collective.getTiersWithUsers` (`server/models/Collective.ts`)
- The now-unused `getTopBackers` raw query (`server/lib/queries.js`)
- Their associated tests (`test/server/models/Collective.test.js`)