### PR TITLE
fix(graphql-v1): enforce private account visibility on Tier query

### DIFF
--- a/server/graphql/v1/queries.js
+++ b/server/graphql/v1/queries.js
@@ -58,8 +58,13 @@ const queries = {
     args: {
       id: { type: new GraphQLNonNull(GraphQLInt) },
     },
-    resolve(_, args) {
-      return models.Tier.findByPk(args.id);
+    async resolve(_, args, req) {
+      const tier = await models.Tier.findByPk(args.id);
+      if (tier) {
+        const collective = await req.loaders.Collective.byId.load(tier.CollectiveId);
+        await assertCanSeeAccount(req, collective);
+      }
+      return tier;
     },
   },
 

--- a/test/server/graphql/v1/tiers.test.js
+++ b/test/server/graphql/v1/tiers.test.js
@@ -6,7 +6,7 @@ import { createSandbox } from 'sinon';
 import { VAT_OPTIONS } from '../../../../server/constants/vat';
 import stripe from '../../../../server/lib/stripe';
 import models from '../../../../server/models';
-import { randStr } from '../../../test-helpers/fake-data';
+import { fakeCollective, fakePrivateHost, fakeTier, fakeUser, randStr } from '../../../test-helpers/fake-data';
 import * as utils from '../../../utils';
 
 describe('server/graphql/v1/tiers', () => {
@@ -134,6 +134,83 @@ describe('server/graphql/v1/tiers', () => {
     sandbox.stub(stripe.balanceTransactions, 'retrieve').callsFake(() => Promise.resolve(balanceTransaction));
 
     /* eslint-enable camelcase */
+  });
+
+  describe('fetch a tier directly by id (Tier query)', () => {
+    it('does not allow a random user to fetch a tier belonging to a private organization', async () => {
+      const privateHost = await fakePrivateHost();
+      const privateCollective = await fakeCollective({
+        HostCollectiveId: privateHost.id,
+        isPrivate: true,
+        approvedAt: new Date(),
+      });
+      const privateTier = await fakeTier({ CollectiveId: privateCollective.id });
+      const randomUser = await fakeUser();
+
+      const tierQuery = gqlV1 /* GraphQL */ `
+        query Tier($id: Int!) {
+          Tier(id: $id) {
+            id
+            name
+          }
+        }
+      `;
+
+      const res = await utils.graphqlQuery(tierQuery, { id: privateTier.id }, randomUser);
+      expect(res.errors).to.exist;
+      expect(res.data?.Tier).to.not.exist;
+    });
+
+    it('allows an admin of the private collective to fetch its tier', async () => {
+      const privateHost = await fakePrivateHost();
+      const collectiveAdminUser = await fakeUser();
+      const privateCollective = await fakeCollective({
+        HostCollectiveId: privateHost.id,
+        isPrivate: true,
+        approvedAt: new Date(),
+        admin: collectiveAdminUser.collective,
+      });
+      const privateTier = await fakeTier({ CollectiveId: privateCollective.id });
+
+      const tierQuery = gqlV1 /* GraphQL */ `
+        query Tier($id: Int!) {
+          Tier(id: $id) {
+            id
+            name
+          }
+        }
+      `;
+
+      const res = await utils.graphqlQuery(tierQuery, { id: privateTier.id }, collectiveAdminUser);
+      res.errors && console.error(res.errors[0]);
+      expect(res.errors).to.not.exist;
+      expect(res.data.Tier.id).to.equal(privateTier.id);
+    });
+
+    it('allows an admin of the private host to fetch a tier of a hosted private collective', async () => {
+      const hostAdminUser = await fakeUser();
+      const privateHost = await fakePrivateHost({ admin: hostAdminUser.collective });
+      const privateCollective = await fakeCollective({
+        HostCollectiveId: privateHost.id,
+        isPrivate: true,
+        approvedAt: new Date(),
+      });
+      const privateTier = await fakeTier({ CollectiveId: privateCollective.id });
+
+      const tierQuery = gqlV1 /* GraphQL */ `
+        query Tier($id: Int!) {
+          Tier(id: $id) {
+            id
+            name
+          }
+        }
+      `;
+
+      const res = await utils.graphqlQuery(tierQuery, { id: privateTier.id }, hostAdminUser);
+      res.errors && console.error(res.errors[0]);
+      expect(res.errors).to.not.exist;
+      expect(res.data.Tier.id).to.equal(privateTier.id);
+    });
   });
 
   describe('graphql.tiers.test', () => {


### PR DESCRIPTION
## Problem
The v1 `Tier` query (`server/graphql/v1/queries.js`) resolved tiers with a bare `findByPk` and no authorization check. Since `id` is a small sequential integer, anyone calling GraphQL v1 (including unauthenticated callers) could enumerate tier IDs and retrieve tier names, amounts, intervals, descriptions, and the parent collective linkage for tiers belonging to **private organizations**.

The v2 equivalent (`TierQuery`) already enforces this via `assertCanSeeAccount` on the tier's parent collective.

## Fix
The v1 `Tier` resolver now loads the tier's parent collective and calls `assertCanSeeAccount` before returning it, mirroring v2's behavior and the existing v1 `Collective` query pattern in the same file.

## Tests
Added a new describe block in `test/server/graphql/v1/tiers.test.js` covering:
- A random user cannot fetch a tier belonging to a private organization via `Tier(id)`
- Admins of the private collective / private host can still fetch it

All existing tests continue to pass.
