### PR TITLE
Fix Collective available balance for refunding a transaction

### DIFF
--- a/server/models/Transaction.ts
+++ b/server/models/Transaction.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import config from 'config';
 import debugLib from 'debug';
-import { compact, get, head, isNil, isNull, isUndefined, omit, pick } from 'lodash';
+import { compact, get, head, isNil, isNull, isUndefined, omit, omitBy, pick } from 'lodash';
 import moment from 'moment';
 import {
   BelongsToGetAssociationMixin,
@@ -2117,18 +2117,25 @@ Transaction.prototype.getRelatedTransaction = function (
   });
 };
 
+/**
+ * Returns all transactions belonging to the same TransactionGroup.
+ * Defaults to filtering out debt transactions.
+ */
 Transaction.prototype.getRelatedTransactions = function (
   options: Pick<Transaction, 'type' | 'kind' | 'isDebt'>,
   { sqlTransaction }: { sqlTransaction?: SequelizeTransaction } = {},
 ): Promise<Transaction[] | null> {
   return Transaction.findAll({
     transaction: sqlTransaction,
-    where: {
-      TransactionGroup: this.TransactionGroup,
-      type: options.type || this.type,
-      kind: options.kind || this.kind,
-      isDebt: options.isDebt || { [Op.not]: true },
-    },
+    where: omitBy(
+      {
+        TransactionGroup: this.TransactionGroup,
+        type: options.type,
+        kind: options.kind,
+        isDebt: options.isDebt || { [Op.not]: true },
+      },
+      isUndefined,
+    ),
   });
 };
 

--- a/test/server/graphql/v2/mutation/TransactionMutations.test.ts
+++ b/test/server/graphql/v2/mutation/TransactionMutations.test.ts
@@ -4,6 +4,7 @@ import { pick } from 'lodash';
 import nock from 'nock';
 import { createSandbox } from 'sinon';
 import Stripe from 'stripe';
+import { v4 as uuid } from 'uuid';
 
 import { activities } from '../../../../../server/constants';
 import { SupportedCurrency } from '../../../../../server/constants/currencies';
@@ -17,7 +18,14 @@ import { calcFee, executeOrder } from '../../../../../server/lib/payments';
 import stripe, { convertFromStripeAmount, convertToStripeAmount, extractFees } from '../../../../../server/lib/stripe';
 import models from '../../../../../server/models';
 import stripeMocks from '../../../../mocks/stripe';
-import { fakeCollective, fakeOrder, fakeTransaction, fakeUser, randStr } from '../../../../test-helpers/fake-data';
+import {
+  fakeActiveHost,
+  fakeCollective,
+  fakeOrder,
+  fakeTransaction,
+  fakeUser,
+  randStr,
+} from '../../../../test-helpers/fake-data';
 import * as utils from '../../../../utils';
 import { graphqlQueryV2 } from '../../../../utils';
 
@@ -52,6 +60,24 @@ const refundTransactionAsHostMutation = gql`
     }
   }
 `;
+
+const snapshotTransactionsForRefund = async transactions => {
+  const columns = [
+    'type',
+    'kind',
+    'isRefund',
+    'CollectiveId',
+    'FromCollectiveId',
+    'amount',
+    'paymentProcessorFeeInHostCurrency',
+    'platformFeeInHostCurrency',
+    'taxAmount',
+    'netAmountInCollectiveCurrency',
+  ];
+
+  await utils.preloadAssociationsForTransactions(transactions, columns);
+  utils.snapshotTransactions(transactions, { columns });
+};
 
 describe('server/graphql/v2/mutation/TransactionMutations', () => {
   let sandbox,
@@ -392,6 +418,255 @@ describe('server/graphql/v2/mutation/TransactionMutations', () => {
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.match(/messageForContributor must be at most 2000 characters/);
     });
+
+    it('regression: refunds a cross-host contribution with platform tip, platform tip debt, host fee and payment processor fee transactions', async () => {
+      const contributor = await fakeUser({ name: 'Contributor' });
+      const giverCollective = contributor.collective;
+      const ofico = await fakeActiveHost({ name: 'OFiCo', currency: 'USD' });
+      const stripeFeesCollective = await fakeCollective({ name: 'Stripe', HostCollectiveId: null });
+      const recipientHost = await fakeActiveHost({ name: 'OSE', currency: 'EUR' });
+      const recipientCollective = await fakeCollective({
+        name: 'Collective',
+        HostCollectiveId: recipientHost.id,
+        currency: 'EUR',
+      });
+
+      const recipientHostAdmin = await fakeUser();
+      await recipientHost.addUserWithRole(recipientHostAdmin, MemberRoles.ADMIN);
+      await recipientHostAdmin.populateRoles();
+
+      const order = await fakeOrder({
+        CreatedByUserId: contributor.id,
+        FromCollectiveId: giverCollective.id,
+        CollectiveId: recipientCollective.id,
+        totalAmount: 110000,
+        currency: 'EUR',
+      });
+
+      const TransactionGroup = uuid();
+      const commonData = { OrderId: order.id, TransactionGroup };
+
+      // DEBIT/CREDIT Platform Tip: giverCollective -> ocInc
+      await fakeTransaction({
+        ...commonData,
+        type: 'DEBIT',
+        kind: TransactionKind.PLATFORM_TIP,
+        description: 'Financial contribution to the Open Collective Platform',
+        amount: -10000,
+        currency: 'EUR',
+        CollectiveId: giverCollective.id,
+        CreatedByUserId: contributor.id,
+        FromCollectiveId: ofico.id,
+        HostCollectiveId: null,
+        hostCurrency: 'USD',
+        hostCurrencyFxRate: 1.141161,
+        amountInHostCurrency: -11412,
+        netAmountInCollectiveCurrency: -10000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+      await fakeTransaction({
+        ...commonData,
+        type: 'CREDIT',
+        kind: TransactionKind.PLATFORM_TIP,
+        description: 'Financial contribution to the Open Collective Platform',
+        amount: 10000,
+        currency: 'EUR',
+        CollectiveId: ofico.id,
+        CreatedByUserId: contributor.id,
+        FromCollectiveId: giverCollective.id,
+        HostCollectiveId: ofico.id,
+        hostCurrency: 'USD',
+        hostCurrencyFxRate: 1.141161,
+        amountInHostCurrency: 11412,
+        netAmountInCollectiveCurrency: 10000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+
+      // DEBIT/CREDIT Platform Tip Debt: ocInc owes platformCollective
+      await fakeTransaction({
+        ...commonData,
+        type: 'DEBIT',
+        kind: TransactionKind.PLATFORM_TIP_DEBT,
+        isDebt: true,
+        description: 'Platform Tip collected for the Open Collective platform',
+        amount: -10000,
+        currency: 'EUR',
+        CollectiveId: ofico.id,
+        CreatedByUserId: null,
+        FromCollectiveId: recipientHost.id,
+        HostCollectiveId: ofico.id,
+        hostCurrency: 'USD',
+        hostCurrencyFxRate: 1.141161,
+        amountInHostCurrency: -11412,
+        netAmountInCollectiveCurrency: -10000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+      await fakeTransaction({
+        ...commonData,
+        type: 'CREDIT',
+        kind: TransactionKind.PLATFORM_TIP_DEBT,
+        isDebt: true,
+        description: 'Platform Tip collected for the Open Collective platform',
+        amount: 10000,
+        currency: 'EUR',
+        CollectiveId: recipientHost.id,
+        CreatedByUserId: null,
+        FromCollectiveId: ofico.id,
+        HostCollectiveId: recipientHost.id,
+        hostCurrency: 'EUR',
+        hostCurrencyFxRate: 1,
+        amountInHostCurrency: 10000,
+        netAmountInCollectiveCurrency: 10000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+
+      // DEBIT/CREDIT Host Fee: recipientCollective -> recipientHost
+      await fakeTransaction({
+        ...commonData,
+        type: 'DEBIT',
+        kind: TransactionKind.HOST_FEE,
+        description: 'Host Fee',
+        amount: -8000,
+        currency: 'EUR',
+        CollectiveId: recipientCollective.id,
+        CreatedByUserId: null,
+        FromCollectiveId: recipientHost.id,
+        HostCollectiveId: recipientHost.id,
+        hostCurrency: 'EUR',
+        hostCurrencyFxRate: 1,
+        amountInHostCurrency: -8000,
+        netAmountInCollectiveCurrency: -8000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+      await fakeTransaction({
+        ...commonData,
+        type: 'CREDIT',
+        kind: TransactionKind.HOST_FEE,
+        description: 'Host Fee',
+        amount: 8000,
+        currency: 'EUR',
+        CollectiveId: recipientHost.id,
+        CreatedByUserId: null,
+        FromCollectiveId: recipientCollective.id,
+        HostCollectiveId: recipientHost.id,
+        hostCurrency: 'EUR',
+        hostCurrencyFxRate: 1,
+        amountInHostCurrency: 8000,
+        netAmountInCollectiveCurrency: 8000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+
+      // DEBIT/CREDIT Payment Processor Fee: recipientCollective -> stripeFeesCollective
+      await fakeTransaction({
+        ...commonData,
+        type: 'DEBIT',
+        kind: TransactionKind.PAYMENT_PROCESSOR_FEE,
+        description: 'Stripe payment processor fee',
+        amount: -3600,
+        currency: 'EUR',
+        CollectiveId: recipientCollective.id,
+        CreatedByUserId: null,
+        FromCollectiveId: stripeFeesCollective.id,
+        HostCollectiveId: recipientHost.id,
+        hostCurrency: 'EUR',
+        hostCurrencyFxRate: 1,
+        amountInHostCurrency: -3600,
+        netAmountInCollectiveCurrency: -3600,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+      await fakeTransaction({
+        ...commonData,
+        type: 'CREDIT',
+        kind: TransactionKind.PAYMENT_PROCESSOR_FEE,
+        description: 'Stripe payment processor fee',
+        amount: 3600,
+        currency: 'EUR',
+        CollectiveId: stripeFeesCollective.id,
+        CreatedByUserId: null,
+        FromCollectiveId: recipientCollective.id,
+        HostCollectiveId: null,
+        hostCurrency: 'EUR',
+        hostCurrencyFxRate: 1,
+        amountInHostCurrency: 3600,
+        netAmountInCollectiveCurrency: 3600,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+
+      // DEBIT/CREDIT Contribution: giverCollective -> recipientCollective
+      await fakeTransaction({
+        ...commonData,
+        type: 'DEBIT',
+        kind: TransactionKind.CONTRIBUTION,
+        description: 'Monthly financial contribution to Recipient Collective (Partner)',
+        amount: -100000,
+        currency: 'EUR',
+        CollectiveId: giverCollective.id,
+        CreatedByUserId: contributor.id,
+        FromCollectiveId: recipientCollective.id,
+        HostCollectiveId: null,
+        hostCurrency: 'EUR',
+        hostCurrencyFxRate: 1,
+        amountInHostCurrency: -100000,
+        netAmountInCollectiveCurrency: -100000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+      const contributionCredit = await fakeTransaction({
+        ...commonData,
+        type: 'CREDIT',
+        kind: TransactionKind.CONTRIBUTION,
+        description: 'Monthly financial contribution to Recipient Collective (Partner)',
+        amount: 100000,
+        currency: 'EUR',
+        CollectiveId: recipientCollective.id,
+        CreatedByUserId: contributor.id,
+        FromCollectiveId: giverCollective.id,
+        HostCollectiveId: recipientHost.id,
+        hostCurrency: 'EUR',
+        hostCurrencyFxRate: 1,
+        amountInHostCurrency: 100000,
+        netAmountInCollectiveCurrency: 100000,
+        platformFeeInHostCurrency: 0,
+        hostFeeInHostCurrency: 0,
+        paymentProcessorFeeInHostCurrency: 0,
+      });
+
+      const result = await graphqlQueryV2(
+        refundTransactionMutation,
+        { transaction: { legacyId: contributionCredit.id } },
+        recipientHostAdmin,
+      );
+
+      result.errors && console.error(result.errors);
+      expect(result.errors).to.not.exist;
+      expect(result.data.refundTransaction.id).to.exist;
+
+      const orderTransactions = await models.Transaction.findAll({
+        where: {
+          OrderId: order.id,
+        },
+        order: [['id', 'ASC']],
+      });
+
+      await snapshotTransactionsForRefund(orderTransactions);
+    });
   });
 
   describe('rejectTransaction', () => {
@@ -592,24 +867,6 @@ describe('refundTransaction legacy tests', () => {
     });
     return { user, host, collective, tier, paymentMethod, order, transaction };
   }
-
-  const snapshotTransactionsForRefund = async transactions => {
-    const columns = [
-      'type',
-      'kind',
-      'isRefund',
-      'CollectiveId',
-      'FromCollectiveId',
-      'amount',
-      'paymentProcessorFeeInHostCurrency',
-      'platformFeeInHostCurrency',
-      'taxAmount',
-      'netAmountInCollectiveCurrency',
-    ];
-
-    await utils.preloadAssociationsForTransactions(transactions, columns);
-    utils.snapshotTransactions(transactions, { columns });
-  };
 
   beforeEach(async () => {
     await utils.resetTestDB();

--- a/test/server/graphql/v2/mutation/TransactionMutations.test.ts.snap
+++ b/test/server/graphql/v2/mutation/TransactionMutations.test.ts.snap
@@ -48,18 +48,28 @@ exports[`refundTransaction legacy tests Stripe Transaction - for hosts created b
 | CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 467500  | 0          | 25000       | 7500  | 500000                        |"
 `;
 
-exports[`refundTransaction legacy tests should create negative transactions with all the fees refunded 1`] = `
+exports[`server/graphql/v2/mutation/TransactionMutations refundTransaction regression: refunds a cross-host contribution with platform tip, platform tip debt, host fee and payment processor fee transactions 1`] = `
 "
-| type   | kind                    | isRefund | To             | From           | amount  | paymentFee | platformFee | tax   | netAmountInCollectiveCurrency |
-| ------ | ----------------------- | -------- | -------------- | -------------- | ------- | ---------- | ----------- | ----- | ----------------------------- |
-| DEBIT  | HOST_FEE                | false    | Scouts d'Arlon | WWCode         | -50000  | 0          | 0           |       | -50000                        |
-| CREDIT | HOST_FEE                | false    | WWCode         | Scouts d'Arlon | 50000   | 0          | 0           |       | 50000                         |
-| DEBIT  | CONTRIBUTION            | false    | Phil Mod       | Scouts d'Arlon | -450000 | -17500     | -25000      | -7500 | -500000                       |
-| CREDIT | CONTRIBUTION            | false    | Scouts d'Arlon | Phil Mod       | 500000  | -17500     | -25000      | -7500 | 450000                        |
-| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | WWCode         | Scouts d'Arlon | -17500  | 0          | 0           |       | -17500                        |
-| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Scouts d'Arlon | WWCode         | 17500   | 0          | 0           |       | 17500                         |
-| DEBIT  | HOST_FEE                | true     | WWCode         | Scouts d'Arlon | -50000  | 0          | 0           | 0     | -50000                        |
-| CREDIT | HOST_FEE                | true     | Scouts d'Arlon | WWCode         | 50000   | 0          | 0           | 0     | 50000                         |
-| DEBIT  | CONTRIBUTION            | true     | Scouts d'Arlon | Phil Mod       | -500000 | 0          | 25000       | 7500  | -467500                       |
-| CREDIT | CONTRIBUTION            | true     | Phil Mod       | Scouts d'Arlon | 467500  | 0          | 25000       | 7500  | 500000                        |"
+| type   | kind                    | isRefund | To          | From        | amount  | paymentFee | platformFee | tax | netAmountInCollectiveCurrency |
+| ------ | ----------------------- | -------- | ----------- | ----------- | ------- | ---------- | ----------- | --- | ----------------------------- |
+| DEBIT  | PLATFORM_TIP            | false    | Contributor | OFiCo       | -10000  | 0          | 0           |     | -10000                        |
+| CREDIT | PLATFORM_TIP            | false    | OFiCo       | Contributor | 10000   | 0          | 0           |     | 10000                         |
+| DEBIT  | PLATFORM_TIP_DEBT       | false    | OFiCo       | OSE         | -10000  | 0          | 0           |     | -10000                        |
+| CREDIT | PLATFORM_TIP_DEBT       | false    | OSE         | OFiCo       | 10000   | 0          | 0           |     | 10000                         |
+| DEBIT  | HOST_FEE                | false    | Collective  | OSE         | -8000   | 0          | 0           |     | -8000                         |
+| CREDIT | HOST_FEE                | false    | OSE         | Collective  | 8000    | 0          | 0           |     | 8000                          |
+| DEBIT  | PAYMENT_PROCESSOR_FEE   | false    | Collective  | Stripe      | -3600   | 0          | 0           |     | -3600                         |
+| CREDIT | PAYMENT_PROCESSOR_FEE   | false    | Stripe      | Collective  | 3600    | 0          | 0           |     | 3600                          |
+| DEBIT  | CONTRIBUTION            | false    | Contributor | Collective  | -100000 | 0          | 0           |     | -100000                       |
+| CREDIT | CONTRIBUTION            | false    | Collective  | Contributor | 100000  | 0          | 0           |     | 100000                        |
+| DEBIT  | PLATFORM_TIP            | true     | OFiCo       | Contributor | -10000  | 0          | 0           | 0   | -10000                        |
+| CREDIT | PLATFORM_TIP            | true     | Contributor | OFiCo       | 10000   | 0          | 0           | 0   | 10000                         |
+| DEBIT  | PLATFORM_TIP_DEBT       | true     | OSE         | OFiCo       | -10000  | 0          | 0           | 0   | -10000                        |
+| CREDIT | PLATFORM_TIP_DEBT       | true     | OFiCo       | OSE         | 10000   | 0          | 0           | 0   | 10000                         |
+| DEBIT  | PAYMENT_PROCESSOR_COVER | true     | OSE         | Collective  | -3600   | 0          | 0           |     | -3600                         |
+| CREDIT | PAYMENT_PROCESSOR_COVER | true     | Collective  | OSE         | 3600    | 0          | 0           |     | 3600                          |
+| DEBIT  | HOST_FEE                | true     | OSE         | Collective  | -8000   | 0          | 0           | 0   | -8000                         |
+| CREDIT | HOST_FEE                | true     | Collective  | OSE         | 8000    | 0          | 0           | 0   | 8000                          |
+| DEBIT  | CONTRIBUTION            | true     | Collective  | Contributor | -100000 | 0          | 0           | 0   | -100000                       |
+| CREDIT | CONTRIBUTION            | true     | Contributor | Collective  | 100000  | 0          | 0           | 0   | 100000                        |"
 `;


### PR DESCRIPTION
Updates Transaction.getRelatedTransactions to ignore kind/type by default, actually returning what the name suggests without implicit filtering.