### PR TITLE
fix: don't set approvedAt on archived children when approving their parent

### DIFF
--- a/checks/model/collectives.ts
+++ b/checks/model/collectives.ts
@@ -31,6 +31,28 @@ async function checkActiveApprovedAtInconsistency() {
   }
 }
 
+async function checkArchivedActiveChildren() {
+  const message = 'archived (deactivatedAt) children must not be isActive or approved (no auto fix)';
+
+  const [results] = await sequelize.query<{ active: number; approved: number }>(
+    `
+    SELECT
+      COUNT(*) FILTER (WHERE "isActive" IS TRUE) as "active",
+      COUNT(*) FILTER (WHERE "approvedAt" IS NOT NULL) as "approved"
+    FROM "Collectives"
+    WHERE "deletedAt" IS NULL
+    AND "deactivatedAt" IS NOT NULL
+    AND "ParentCollectiveId" IS NOT NULL
+    AND "type" != 'VENDOR'
+    AND ("isActive" IS TRUE OR "approvedAt" IS NOT NULL)`,
+    { type: QueryTypes.SELECT, raw: true },
+  );
+
+  if (results.active > 0 || results.approved > 0) {
+    throw new Error(`${message} (${results.active} active, ${results.approved} approved)`);
+  }
+}
+
 async function checkNonActiveHostOrganizations({ fix = false } = {}) {
   const results = await sequelize.query<{ count: number }>(
     `
@@ -61,7 +83,11 @@ async function checkNonActiveHostOrganizations({ fix = false } = {}) {
   }
 }
 
-export const checks = [checkActiveApprovedAtInconsistency, checkNonActiveHostOrganizations];
+export const checks = [
+  checkActiveApprovedAtInconsistency,
+  checkArchivedActiveChildren,
+  checkNonActiveHostOrganizations,
+];
 
 if (!module.parent) {
   runAllChecksThenExit(checks);

--- a/migrations/20260810120000-fix-archived-children-approved-at.ts
+++ b/migrations/20260810120000-fix-archived-children-approved-at.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+import type { QueryInterface } from 'sequelize';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    // Archived (deactivated) children got `approvedAt` stamped when their parent was approved by a host
+    // (see https://github.com/opencollective/opencollective-api/pull/11787), which breaks the
+    // `approvedAt`/`isActive` consistency enforced by `checks/model/collectives.ts`.
+    await queryInterface.sequelize.query(`
+      UPDATE "Collectives"
+      SET "approvedAt" = NULL
+      WHERE "deletedAt" IS NULL
+      AND "deactivatedAt" IS NOT NULL
+      AND "ParentCollectiveId" IS NOT NULL
+      AND "isActive" IS NOT TRUE
+      AND "approvedAt" IS NOT NULL
+    `);
+  },
+
+  async down() {
+    // Data fix, nothing to revert
+  },
+};

--- a/migrations/20260810130000-fix-archived-but-active-children.ts
+++ b/migrations/20260810130000-fix-archived-but-active-children.ts
@@ -1,0 +1,63 @@
+'use strict';
+
+import type { QueryInterface } from 'sequelize';
+import { QueryTypes } from 'sequelize';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    // Archived children (deactivatedAt set) left with isActive=true and approvedAt set, from two historical bugs:
+    // - approving/re-hosting a parent used to re-activate its archived children (fixed by
+    //   https://github.com/opencollective/opencollective-api/pull/11787)
+    // - `archiveCollective` marks children as deactivated before `changeHost(null)` runs, so a failure
+    //   in between leaves them flagged archived but still active and hosted
+
+    // Children that kept transacting after their archive date are archived in name only: un-archive them
+    // to match reality instead of cutting off an account that is actively used.
+    const unarchived = await queryInterface.sequelize.query<{ id: number; slug: string }>(
+      `
+      UPDATE "Collectives" c
+      SET "deactivatedAt" = NULL,
+          "data" = COALESCE(c."data", '{}') - 'archivedFromParent'
+      WHERE c."deletedAt" IS NULL
+      AND c."deactivatedAt" IS NOT NULL
+      AND c."ParentCollectiveId" IS NOT NULL
+      AND c."isActive" IS TRUE
+      AND c."approvedAt" IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM "Transactions" t
+        WHERE t."CollectiveId" = c.id
+        AND t."deletedAt" IS NULL
+        AND t."createdAt" > c."deactivatedAt"
+        AND t."createdAt" > NOW() - INTERVAL '12 months'
+      )
+      RETURNING c.id, c.slug
+      `,
+      { type: QueryTypes.SELECT },
+    );
+
+    // The rest are dormant: complete the archive by aligning them with the regular archived-children
+    // state (inactive and unapproved, host link preserved).
+    const archived = await queryInterface.sequelize.query<{ id: number }>(
+      `
+      UPDATE "Collectives"
+      SET "isActive" = FALSE, "approvedAt" = NULL
+      WHERE "deletedAt" IS NULL
+      AND "deactivatedAt" IS NOT NULL
+      AND "ParentCollectiveId" IS NOT NULL
+      AND "isActive" IS TRUE
+      AND "approvedAt" IS NOT NULL
+      RETURNING id
+      `,
+      { type: QueryTypes.SELECT },
+    );
+
+    console.log(
+      `Un-archived ${unarchived.length} children still in use (${unarchived.map(c => c.slug).join(', ')}), completed the archive of ${archived.length}`,
+    );
+  },
+
+  async down() {
+    // Data fix, nothing to revert
+  },
+};

--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -2,7 +2,6 @@ import config from 'config';
 import express from 'express';
 import { GraphQLBoolean, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
 import { GraphQLJSON } from 'graphql-scalars';
-import { omit } from 'lodash';
 
 import { activities } from '../../../constants';
 import { CollectiveType } from '../../../constants/collectives';
@@ -368,12 +367,15 @@ const approveApplication = async (host: Collective, collective: Collective, req:
       hooks: false,
       transaction,
     });
-    // Archived children keep their host link but must stay archived and unapproved (see `checkActiveApprovedAtInconsistency`)
-    await models.Collective.update(omit(newAccountData, ['isActive', 'approvedAt']), {
-      where: { ParentCollectiveId: collective.id, deactivatedAt: { [Op.not]: null } },
-      hooks: false,
-      transaction,
-    });
+    // Archived children keep their host link but must stay archived and unapproved (see `checkArchivedActiveChildren`)
+    await models.Collective.update(
+      { ...newAccountData, isActive: false, approvedAt: null },
+      {
+        where: { ParentCollectiveId: collective.id, deactivatedAt: { [Op.not]: null } },
+        hooks: false,
+        transaction,
+      },
+    );
 
     // Convert all active tiers to host currency
     const children = await collective.getChildren({ attributes: ['id'], transaction });

--- a/server/graphql/v2/mutation/HostApplicationMutations.ts
+++ b/server/graphql/v2/mutation/HostApplicationMutations.ts
@@ -368,7 +368,8 @@ const approveApplication = async (host: Collective, collective: Collective, req:
       hooks: false,
       transaction,
     });
-    await models.Collective.update(omit(newAccountData, ['isActive']), {
+    // Archived children keep their host link but must stay archived and unapproved (see `checkActiveApprovedAtInconsistency`)
+    await models.Collective.update(omit(newAccountData, ['isActive', 'approvedAt']), {
       where: { ParentCollectiveId: collective.id, deactivatedAt: { [Op.not]: null } },
       hooks: false,
       transaction,

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -2487,12 +2487,13 @@ class Collective extends ModelWithPublicId<
       platformFeePercent: hostCollective.platformFeePercent,
       currency: undefined,
       isPrivate: this.isPrivate,
-      ...(shouldAutomaticallyApprove ? { isActive: true, approvedAt: new Date() } : null),
+      ...(shouldAutomaticallyApprove ? { isActive: true, approvedAt: new Date() as Date | null } : null),
     };
 
+    // Archived children must stay inactive and unapproved (see `checkArchivedActiveChildren`)
     if (this.ParentCollectiveId && !isNull(this.deactivatedAt)) {
       updatedValues.isActive = false;
-      delete updatedValues.approvedAt;
+      updatedValues.approvedAt = null;
     }
 
     // events should take the currency of their parent collective, not necessarily the one from their host.

--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -2492,6 +2492,7 @@ class Collective extends ModelWithPublicId<
 
     if (this.ParentCollectiveId && !isNull(this.deactivatedAt)) {
       updatedValues.isActive = false;
+      delete updatedValues.approvedAt;
     }
 
     // events should take the currency of their parent collective, not necessarily the one from their host.

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -426,12 +426,14 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
           ParentCollectiveId: collective.id,
           HostCollectiveId: host.id,
           isActive: false,
+          approvedAt: null,
           deactivatedAt: new Date(),
         });
         const archivedEvent = await fakeEvent({
           ParentCollectiveId: collective.id,
           HostCollectiveId: host.id,
           isActive: false,
+          approvedAt: null,
           deactivatedAt: new Date(),
         });
         const activeProject = await fakeProject({
@@ -468,14 +470,16 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
         expect(activeProject.approvedAt).to.not.be.null;
         expect(activeProject.deactivatedAt).to.be.null;
 
-        // The archived children should have their host preserved but remain archived
+        // The archived children should have their host preserved but remain archived and unapproved
         expect(archivedProject.HostCollectiveId).to.equal(host.id);
         expect(archivedProject.isActive).to.be.false;
+        expect(archivedProject.approvedAt).to.be.null;
         expect(archivedProject.deactivatedAt).to.not.be.null;
         expect(Boolean(archivedProject.deactivatedAt && !archivedProject.isActive)).to.be.true;
 
         expect(archivedEvent.HostCollectiveId).to.equal(host.id);
         expect(archivedEvent.isActive).to.be.false;
+        expect(archivedEvent.approvedAt).to.be.null;
         expect(archivedEvent.deactivatedAt).to.not.be.null;
         expect(Boolean(archivedEvent.deactivatedAt && !archivedEvent.isActive)).to.be.true;
 

--- a/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/HostApplicationMutations.test.ts
@@ -422,11 +422,12 @@ describe('server/graphql/v2/mutation/HostApplicationMutations', () => {
         });
 
         // Create an archived project, an archived event, and a non-archived project as children
+        // A stale approvedAt (left over from previous bugs) must be cleared by the approval
         const archivedProject = await fakeProject({
           ParentCollectiveId: collective.id,
           HostCollectiveId: host.id,
           isActive: false,
-          approvedAt: null,
+          approvedAt: new Date(),
           deactivatedAt: new Date(),
         });
         const archivedEvent = await fakeEvent({

--- a/test/server/models/Collective.test.js
+++ b/test/server/models/Collective.test.js
@@ -864,18 +864,18 @@ describe('server/models/Collective', () => {
       expect(activeProject.approvedAt).to.not.be.null;
       expect(activeProject.deactivatedAt).to.be.null;
 
-      // The archived children should have their host updated but remain archived: deactivatedAt preserved and isActive still false
+      // The archived children should have their host updated but remain archived and unapproved: deactivatedAt preserved, isActive still false and approvedAt still null
       expect(archivedProject.HostCollectiveId).to.equal(host.id);
       expect(archivedProject.deactivatedAt).to.not.be.null;
       expect(archivedProject.isActive).to.be.false;
+      expect(archivedProject.approvedAt).to.be.null;
       expect(Boolean(archivedProject.deactivatedAt && !archivedProject.isActive)).to.be.true;
-      expect(activeProject.approvedAt).to.not.be.null;
 
       expect(archivedEvent.HostCollectiveId).to.equal(host.id);
       expect(archivedEvent.deactivatedAt).to.not.be.null;
       expect(archivedEvent.isActive).to.be.false;
+      expect(archivedEvent.approvedAt).to.be.null;
       expect(Boolean(archivedEvent.deactivatedAt && !archivedEvent.isActive)).to.be.true;
-      expect(activeProject.approvedAt).to.not.be.null;
     });
 
     it('updates hostFeePercent for collective and events when adding or changing host', async () => {


### PR DESCRIPTION
Archived children (`deactivatedAt` set) can end up looking approved or active, which makes them match every host-scoped query that filters on `approvedAt` (fee propagation, host dashboards, permission scoping) and trips the daily `approvedAt`/`isActive` consistency check. Two sources:

- **Parent approval.** Since #11787 we no longer re-activate archived children when their parent is approved, but `approveApplication` and `addHost` still copy `approvedAt` to them. Archived children normally have `approvedAt = NULL`, and nothing reads it on them (`unarchiveCollective` re-derives everything from the parent).
- **`archiveCollective` failing midway**, between marking children as deactivated and unhosting them, leaving them `isActive = true` with `approvedAt` set. Fixed on the archive side by #12025.

This PR:

- `approveApplication` and `addHost` explicitly set `isActive = false` and `approvedAt = NULL` on archived children instead of stamping approval on them. This also self-heals stale rows the next time a parent is approved.
- New model check: archived children must be inactive and unapproved, so both kinds of drift get caught nightly. Vendors are excluded (they use `deactivatedAt` for their own archiving).
- A migration to complete the archive of children left `isActive = true` by the second source (host link preserved). Children that kept transacting after their archive date in the last 12 months are un-archived instead, since they are archived in name only.
- Strengthened the #11787 tests to assert `approvedAt` stays `NULL` on archived children.

Follow-up for later: the top-level accounts in the same state (28 are host organizations that `checkNonActiveHostOrganizations` deliberately keeps active, so they need their own discussion).