### PR TITLE
Fix exclusion constraint error when reactivating money management the same day

### DIFF
--- a/server/models/Collective.ts
+++ b/server/models/Collective.ts
@@ -1145,7 +1145,8 @@ class Collective extends ModelWithPublicId<
       // Cancel the platform subscription if it exists
       const currentSubscription = await PlatformSubscription.getCurrentSubscription(this.id, { transaction });
       if (currentSubscription) {
-        // Inclusive: false in case they start a new subscription on the same day. This also means we won't bill for the last day.
+        // The subscription is terminated at the start of the day (we don't bill for the deactivation day),
+        // so that a new one can be created if money management is reactivated the same day.
         await currentSubscription.terminate({ inclusive: false, transaction });
       }
     };

--- a/server/models/PlatformSubscription.ts
+++ b/server/models/PlatformSubscription.ts
@@ -229,7 +229,9 @@ class PlatformSubscription extends Model<
     if (subStart.isSameOrAfter(dayStart)) {
       await this.destroy({ transaction });
     } else {
-      await this.update({ period: [this.start, { value: date, inclusive }] }, { transaction });
+      // Periods are aligned to day boundaries (see `createSubscription`): terminate at the start of
+      // the day so that a subscription created later the same day doesn't overlap this one.
+      await this.update({ period: [this.start, { value: dayStart.toDate(), inclusive }] }, { transaction });
     }
   }
 
@@ -578,7 +580,9 @@ class PlatformSubscription extends Model<
       notify?: boolean;
     },
   ): Promise<PlatformSubscription> {
-    const currentSubscription = await PlatformSubscription.getCurrentSubscription(collective.id);
+    const currentSubscription = await PlatformSubscription.getCurrentSubscription(collective.id, {
+      transaction: opts?.transaction,
+    });
     const newSubscriptionStart = moment.utc(when).startOf('day');
     const previousPlan = currentSubscription?.plan;
 

--- a/test/server/models/PlatformSubscriptions.test.ts
+++ b/test/server/models/PlatformSubscriptions.test.ts
@@ -240,6 +240,42 @@ describe('server/models/PlatformSubscriptions', () => {
       ).to.be.rejectedWith(Error);
     });
 
+    it('can create a subscription the same day the previous one was terminated', async () => {
+      const admin = await fakeUser();
+      const collective = await fakeCollective({ admin });
+      const subscription = await PlatformSubscription.createSubscription(
+        collective,
+        new Date(Date.UTC(2016, 0, 1)),
+        {
+          title: 'A plan',
+        },
+        admin,
+      );
+
+      // Terminate mid-day, like `deactivateMoneyManagement` does
+      await subscription.terminate({ date: new Date(Date.UTC(2016, 0, 5, 13, 59, 46)), inclusive: false });
+
+      // The termination is aligned to the start of the day
+      await subscription.reload();
+      expect(subscription.end.inclusive).to.be.false;
+      expect(moment.utc(subscription.end.value).toISOString()).to.equal('2016-01-05T00:00:00.000Z');
+
+      const newSubscription = await PlatformSubscription.createSubscription(
+        collective,
+        new Date(Date.UTC(2016, 0, 5, 15, 0, 0)),
+        {
+          title: 'A plan',
+        },
+        admin,
+      );
+
+      expect(newSubscription.start.inclusive).to.be.true;
+      expect(moment.utc(newSubscription.start.value).toISOString()).to.equal('2016-01-05T00:00:00.000Z');
+
+      expect(newSubscription.end.inclusive).to.be.true;
+      expect(newSubscription.end.value).to.equal(Infinity);
+    });
+
     it('emits PLATFORM_SUBSCRIPTION_UPDATED activity', async () => {
       const admin = await fakeUser();
       const collective = await fakeCollective({ admin });
@@ -348,6 +384,37 @@ describe('server/models/PlatformSubscriptions', () => {
 
       expect(newSubscription.start.inclusive).to.be.true;
       expect(moment.utc(newSubscription.start.value).toISOString()).to.equal('2016-01-02T00:00:00.000Z');
+
+      expect(newSubscription.end.inclusive).to.be.true;
+      expect(newSubscription.end.value).to.equal(Infinity);
+    });
+
+    it('can replace a subscription the same day the previous one was terminated', async () => {
+      const admin = await fakeUser();
+      const collective = await fakeCollective({ admin });
+      const subscription = await PlatformSubscription.createSubscription(
+        collective,
+        new Date(Date.UTC(2016, 0, 1)),
+        {
+          title: 'A plan',
+        },
+        admin,
+      );
+
+      // Terminate mid-day, like `deactivateMoneyManagement` does
+      await subscription.terminate({ date: new Date(Date.UTC(2016, 0, 5, 13, 59, 46)), inclusive: false });
+
+      const newSubscription = await PlatformSubscription.replaceCurrentSubscription(
+        collective,
+        new Date(Date.UTC(2016, 0, 5, 15, 0, 0)),
+        {
+          title: 'A new plan',
+        },
+        admin,
+      );
+
+      expect(newSubscription.start.inclusive).to.be.true;
+      expect(moment.utc(newSubscription.start.value).toISOString()).to.equal('2016-01-05T00:00:00.000Z');
 
       expect(newSubscription.end.inclusive).to.be.true;
       expect(newSubscription.end.value).to.equal(Infinity);

--- a/test/server/models/PlatformSubscriptions.test.ts
+++ b/test/server/models/PlatformSubscriptions.test.ts
@@ -276,6 +276,43 @@ describe('server/models/PlatformSubscriptions', () => {
       expect(newSubscription.end.value).to.equal(Infinity);
     });
 
+    it('supports repeatedly terminating and re-creating subscriptions the same day', async () => {
+      const admin = await fakeUser();
+      const collective = await fakeCollective({ admin });
+      const plan = { title: 'A plan' };
+      const firstSubscription = await PlatformSubscription.createSubscription(
+        collective,
+        new Date(Date.UTC(2016, 0, 1)),
+        plan,
+        admin,
+      );
+
+      // First deactivation: the subscription started on a previous day, its period is truncated
+      await firstSubscription.terminate({ date: new Date(Date.UTC(2016, 0, 5, 10, 0, 0)), inclusive: false });
+
+      // Second and third cycles: the subscription started the same day, it is destroyed on termination
+      for (const hour of [11, 13]) {
+        const subscription = await PlatformSubscription.createSubscription(
+          collective,
+          new Date(Date.UTC(2016, 0, 5, hour, 0, 0)),
+          plan,
+          admin,
+        );
+        await subscription.terminate({ date: new Date(Date.UTC(2016, 0, 5, hour + 1, 0, 0)), inclusive: false });
+        await subscription.reload({ paranoid: false });
+        expect(subscription.deletedAt).to.not.be.null;
+      }
+
+      const lastSubscription = await PlatformSubscription.createSubscription(
+        collective,
+        new Date(Date.UTC(2016, 0, 5, 15, 0, 0)),
+        plan,
+        admin,
+      );
+      expect(moment.utc(lastSubscription.start.value).toISOString()).to.equal('2016-01-05T00:00:00.000Z');
+      expect(lastSubscription.end.value).to.equal(Infinity);
+    });
+
     it('emits PLATFORM_SUBSCRIPTION_UPDATED activity', async () => {
       const admin = await fakeUser();
       const collective = await fakeCollective({ admin });


### PR DESCRIPTION
## Problem

When an organization deactivates money management and tries to reactivate it later the same day, the activation fails with an exclusion constraint error (`PlatformSubscriptions_unique_period_per_CollectiveId`) and the "Activate" button appears to do nothing. It starts working again the next day (UTC). Reported for industra (Aug 14), and earlier for neuromancers / mastodon-japan-net (April).

The mechanism:

1. `deactivateMoneyManagement` terminates the platform subscription at `now`, leaving a period ending mid-day, e.g. `[May 25 00:00, Aug 14 13:59:46)`.
2. `activateMoneyManagement` → `replaceCurrentSubscription` → `createSubscription` creates the new subscription starting at `startOf('day')`, e.g. `[Aug 14 00:00, infinity]`, which overlaps the just-terminated period → Postgres rejects the insert.
3. `replaceCurrentSubscription` only looks for the *current* subscription (`period @> now`), so the already-terminated row is invisible to it and nothing adjusts the new period.

The `Inclusive: false in case they start a new subscription on the same day` comment in `deactivateMoneyManagement` anticipated same-day reactivation, but the exclusive end only avoids overlap if the new subscription starts at the termination timestamp, and it actually starts at midnight.

## Fix

Keep subscription periods aligned to day boundaries, which the code already half-assumes: `createSubscription` aligns starts to `startOf('day')` and `replaceCurrentSubscription` terminates at `startOf('day')`. The one mid-day writer was `terminate()` when called with a mid-day date (from `deactivateMoneyManagement`, via the default `date = now`): it now aligns the termination to the start of the day. A subscription created later the same day then starts exactly where the previous one ended (`[.., day)` + `[day, ∞]`), so the constraint is satisfied.

This means an organization is not billed for the day it deactivates money management, which the previous code's comment already intended ("we won't bill for the last day").

Also passes the missing `transaction` to the `getCurrentSubscription` lookup in `replaceCurrentSubscription`.

## Tests

Two regression tests reproducing the deactivate → same-day reactivate flow (both fail with the exclusion constraint error without the fix). Also verified the platform billing cron tests, which terminate a subscription mid-day, still pass.