### PR TITLE
Wise: Include date-of-birth field when creating Alipay payout methods

### DIFF
--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -46,6 +46,7 @@ import {
   QuoteV3,
   QuoteV3PaymentOption,
   RecipientAccount,
+  TransactionRequiredFieldsGroup,
   TransactionRequirementsType,
   Transfer,
   Webhook,
@@ -693,6 +694,27 @@ function validatePayoutMethod(connectedAccount: ConnectedAccount, payoutMethod: 
   }
 }
 
+function injectFieldIntoRecipientType(
+  requiredFields: Array<TransactionRequirementsType>,
+  recipientType: string,
+  field: TransactionRequiredFieldsGroup,
+): Array<TransactionRequirementsType> {
+  return requiredFields.map(type => {
+    if (type.type !== recipientType) {
+      return type;
+    }
+    // Avoid injecting the same field twice (e.g. on repeated calls)
+    const alreadyPresent = type.fields?.some(f => f.group?.some(g => g.key === field.key));
+    if (alreadyPresent) {
+      return type;
+    }
+    return {
+      ...type,
+      fields: [...(type.fields || []), { name: field.name, group: [field] }],
+    };
+  });
+}
+
 async function getRequiredBankInformation(
   host: Collective,
   currency: SupportedCurrency,
@@ -752,6 +774,22 @@ async function getRequiredBankInformation(
       });
     });
   });
+
+  // Chinese Alipay requires the recipient's date of birth for identity verification.
+  // Wise doesn't always surface this field, so we inject it proactively.
+  if (Array.isArray(requiredFields)) {
+    requiredFields = injectFieldIntoRecipientType(requiredFields, 'chinese_alipay', {
+      key: 'dateOfBirth',
+      name: 'Date of birth',
+      type: 'date',
+      required: false,
+      example: 'YYYY-MM-DD',
+      minLength: 10,
+      maxLength: 10,
+      validationRegexp: '^\\d{4}-\\d{2}-\\d{2}$',
+      refreshRequirementsOnChange: false,
+    });
+  }
 
   cache.set(cacheKey, requiredFields, 24 * 60 * 60 /* a whole day and we could probably increase */);
   return requiredFields;

--- a/server/paymentProviders/transferwise/index.ts
+++ b/server/paymentProviders/transferwise/index.ts
@@ -782,7 +782,7 @@ async function getRequiredBankInformation(
       key: 'dateOfBirth',
       name: 'Date of birth',
       type: 'date',
-      required: false,
+      required: true,
       example: 'YYYY-MM-DD',
       minLength: 10,
       maxLength: 10,

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -644,6 +644,63 @@ describe('server/paymentProviders/transferwise/index', () => {
         { details: { bankAccount: 'fake' } },
       );
     });
+
+    it('should inject the dateOfBirth field into the chinese_alipay recipient type', async () => {
+      const requiredFields = [
+        {
+          type: 'chinese_alipay',
+          title: 'Alipay',
+          fields: [{ name: 'Alipay details', group: [{ key: 'accountHolderName', name: 'Full name', type: 'text' }] }],
+        },
+        {
+          type: 'aba',
+          title: 'Local bank account',
+          fields: [{ name: 'Bank details', group: [{ key: 'accountNumber', name: 'Account number', type: 'text' }] }],
+        },
+      ];
+      getAccountRequirements.resolves(requiredFields);
+
+      const result = await transferwise.getRequiredBankInformation(host, 'GBP');
+      const alipay = result.find(r => r.type === 'chinese_alipay');
+      const dateOfBirth = alipay.fields.find(f => f.group.some(g => g.key === 'dateOfBirth'));
+
+      expect(dateOfBirth).to.exist;
+      expect(dateOfBirth.group[0]).to.deep.include({
+        key: 'dateOfBirth',
+        name: 'Date of birth',
+        type: 'date',
+        required: false,
+        example: 'YYYY-MM-DD',
+        minLength: 10,
+        maxLength: 10,
+        validationRegexp: '^\\d{4}-\\d{2}-\\d{2}$',
+        refreshRequirementsOnChange: false,
+      });
+
+      // Other recipient types should be left untouched
+      const aba = result.find(r => r.type === 'aba');
+      expect(aba.fields.some(f => f.group.some(g => g.key === 'dateOfBirth'))).to.be.false;
+    });
+
+    it('should not duplicate the dateOfBirth field on repeated calls', async () => {
+      const requiredFields = [
+        {
+          type: 'chinese_alipay',
+          title: 'Alipay',
+          fields: [{ name: 'Alipay details', group: [{ key: 'accountHolderName', name: 'Full name', type: 'text' }] }],
+        },
+      ];
+      getAccountRequirements.resolves(requiredFields);
+
+      const first = await transferwise.getRequiredBankInformation(host, 'BRL');
+      const second = await transferwise.getRequiredBankInformation(host, 'BRL');
+      const count = second
+        .find(r => r.type === 'chinese_alipay')
+        .fields.filter(f => f.group.some(g => g.key === 'dateOfBirth')).length;
+
+      expect(first.find(r => r.type === 'chinese_alipay').fields.length).to.equal(2);
+      expect(count).to.equal(1);
+    });
   });
 
   describe('getAvailableCurrencies', () => {

--- a/test/server/paymentProviders/transferwise/index.test.ts
+++ b/test/server/paymentProviders/transferwise/index.test.ts
@@ -669,7 +669,7 @@ describe('server/paymentProviders/transferwise/index', () => {
         key: 'dateOfBirth',
         name: 'Date of birth',
         type: 'date',
-        required: false,
+        required: true,
         example: 'YYYY-MM-DD',
         minLength: 10,
         maxLength: 10,


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/8905

Injects a dateOfBirth field into the chinese_alipay recipient type's required fields so the payout method creation form collects the recipient's date of birth.