### PR TITLE
Scope the settlement CSV to the platform-tips account

### DIFF
--- a/cron/monthly/host-settlement.ts
+++ b/cron/monthly/host-settlement.ts
@@ -233,6 +233,10 @@ async function emitSettlementExpense({
         ? [TransactionKind.PLATFORM_TIP, TransactionKind.APPLICATION_FEE]
         : uniq(transactions.map(t => t.kind)),
       add: ['orderLegacyId'],
+      // Balance is a running balance over the whole account, so on a report filtered to two kinds it
+      // never matches the rows above it. The host-scoped report used until now dropped the column for
+      // the same reason; the account-scoped one includes it by default.
+      ...(isPlatformTipsAccountBundle ? { remove: ['balance'] } : null),
     });
     if (csvUrl) {
       await models.ExpenseAttachedFile.create({

--- a/cron/monthly/host-settlement.ts
+++ b/cron/monthly/host-settlement.ts
@@ -135,7 +135,7 @@ function isValidHostPayoutMethodType(
 }
 
 /**
- * Create one SETTLEMENT expense from OFiTech against `billedCollectiveId`, attach its items + CSV,
+ * Create one SETTLEMENT expense from OFiTech against `billedCollective`, attach its items + CSV,
  * mark the backing transactions INVOICED, and emit the creation activity. Returns the expense (or
  * null on a dry run).
  *
@@ -146,7 +146,7 @@ function isValidHostPayoutMethodType(
  */
 async function emitSettlementExpense({
   host,
-  billedCollectiveId,
+  billedCollective,
   billedHostId,
   items,
   transactions,
@@ -156,7 +156,7 @@ async function emitSettlementExpense({
   endDate,
 }: {
   host: Collective;
-  billedCollectiveId: number;
+  billedCollective: Collective;
   billedHostId: number;
   items: Array<{ incurredAt: Date; amount: number; currency: SupportedCurrency; description: string }>;
   transactions: Transaction[];
@@ -178,7 +178,7 @@ async function emitSettlementExpense({
     },
     PayoutMethodId: payoutMethod.id,
     amount: totalAmountCharged,
-    CollectiveId: billedCollectiveId,
+    CollectiveId: billedCollective.id,
     currency: host.currency,
     description: `Platform settlement${extraDescription} for ${momentDate.utc().format('MMMM')}`,
     incurredAt: today.toDate(),
@@ -214,20 +214,21 @@ async function emitSettlementExpense({
     return createdExpense;
   });
 
-  // Attach CSV (external S3 call, kept out of the DB transaction). New-ledger PLATFORM_TIP rows live
-  // on the host's platform-tips account (a separate collective), so the host's account-scoped
-  // `transactions` report cannot return them. Use the host-scoped `hostTransactions` report whenever
-  // such rows are in the batch — legacy *_DEBT rows carry HostCollectiveId = host too, so nothing is lost.
+  // Attach CSV (external S3 call, kept out of the DB transaction), scoped to the account being
+  // billed. The host-billed bundle mixes settled rows into the host's general ledger, so it stays
+  // filtered by the kinds actually invoiced. The platform-tips bundle is billed against the host's
+  // platform-tips account, which holds nothing but tips and their offsets, so we report every
+  // transaction on it for the period instead: the host sees each PLATFORM_TIP next to the
+  // APPLICATION_FEE that already collected it via Stripe, and can check the remainder against the
+  // amount invoiced.
   if (transactions.length > 0) {
-    const reportType = transactions.some(t => t.kind === TransactionKind.PLATFORM_TIP)
-      ? 'hostTransactions'
-      : 'transactions';
-    const csvUrl = getTransactionsCsvUrl(reportType, host, {
+    const isPlatformTipsAccountBundle = billedCollective.id !== host.id;
+    const csvUrl = getTransactionsCsvUrl('transactions', billedCollective, {
       startDate: moment(min(transactions.map(t => t.createdAt)))
         .startOf('month')
         .toDate(),
       endDate,
-      kind: uniq(transactions.map(t => t.kind)),
+      ...(isPlatformTipsAccountBundle ? null : { kind: uniq(transactions.map(t => t.kind)) }),
       add: ['orderLegacyId'],
     });
     if (csvUrl) {
@@ -586,7 +587,7 @@ export async function run(baseDate: Date | moment.Moment = defaultDate): Promise
 
         const expense = await emitSettlementExpense({
           host,
-          billedCollectiveId: host.id,
+          billedCollective: host,
           billedHostId: host.id,
           items: hostItems,
           transactions,
@@ -627,7 +628,7 @@ export async function run(baseDate: Date | moment.Moment = defaultDate): Promise
       } else {
         await emitSettlementExpense({
           host,
-          billedCollectiveId: platformTipsAccount.id,
+          billedCollective: platformTipsAccount,
           billedHostId: host.id,
           items: platformTipsItems,
           transactions: newTipTransactions,

--- a/cron/monthly/host-settlement.ts
+++ b/cron/monthly/host-settlement.ts
@@ -215,11 +215,12 @@ async function emitSettlementExpense({
   });
 
   // Attach CSV (external S3 call, kept out of the DB transaction), scoped to the account being
-  // billed. The host-billed bundle mixes settled rows into the host's general ledger, so it stays
-  // filtered by the kinds actually invoiced. The platform-tips bundle is billed against the host's
-  // platform-tips account, which holds nothing but tips and their offsets, so we report every
-  // transaction on it for the period instead: the host sees each PLATFORM_TIP next to the
-  // APPLICATION_FEE that already collected it via Stripe, and can check the remainder against the
+  // billed. The host-billed bundle mixes settled rows into the host's general ledger, so it is
+  // filtered down to the kinds actually invoiced. The platform-tips bundle is billed against the
+  // host's platform-tips account, where the invoiced amount is the tips collected net of the ones
+  // Stripe already took as an application fee, so it reports both kinds: PLATFORM_TIP alone
+  // overstates the bill, and the account's other rows (the previous settlement being paid, and its
+  // processor fee) are balance movements that are not part of it. The two kinds together sum to the
   // amount invoiced.
   if (transactions.length > 0) {
     const isPlatformTipsAccountBundle = billedCollective.id !== host.id;
@@ -228,7 +229,9 @@ async function emitSettlementExpense({
         .startOf('month')
         .toDate(),
       endDate,
-      ...(isPlatformTipsAccountBundle ? null : { kind: uniq(transactions.map(t => t.kind)) }),
+      kind: isPlatformTipsAccountBundle
+        ? [TransactionKind.PLATFORM_TIP, TransactionKind.APPLICATION_FEE]
+        : uniq(transactions.map(t => t.kind)),
       add: ['orderLegacyId'],
     });
     if (csvUrl) {

--- a/test/cron/monthly/host-settlement.test.js
+++ b/test/cron/monthly/host-settlement.test.js
@@ -769,16 +769,16 @@ describe('cron/monthly/host-settlement', () => {
       expect(ts.ExpenseId).to.equal(settlementExpense.id);
     });
 
-    it('attaches a CSV scoped to the platform-tips account, unfiltered by kind', async () => {
+    it('attaches a CSV of the platform-tips account tips and their application fees', async () => {
       const [attachment] = await settlementExpense.getAttachedFiles();
       expect(attachment).to.have.property('url');
-      // The report is scoped to the account being billed rather than the host: it holds nothing but
-      // tips and their offsets, so every row on it belongs in the settlement CSV.
+      // Scoped to the account being billed rather than the host
       expect(attachment.url).to.have.string(`/${platformTipsAccount.slug}/transactions.csv`);
       const csvUrl = new URL(attachment.url);
-      // No kind filter: the host needs the APPLICATION_FEE debits next to the PLATFORM_TIP credits
-      // to see which tips Stripe already collected and check the rest against the invoiced amount.
-      expect(csvUrl.searchParams.get('kind')).to.be.null;
+      // Both kinds, and only those two: PLATFORM_TIP alone overstates the bill, while the account's
+      // other rows (a previous settlement being paid, its processor fee) are not part of it. Summing
+      // these two over the period gives the amount invoiced.
+      expect(csvUrl.searchParams.get('kind').split(',').sort()).to.deep.equal(['APPLICATION_FEE', 'PLATFORM_TIP']);
       expect(csvUrl.searchParams.get('add')).to.equal('orderLegacyId');
     });
 

--- a/test/cron/monthly/host-settlement.test.js
+++ b/test/cron/monthly/host-settlement.test.js
@@ -780,6 +780,8 @@ describe('cron/monthly/host-settlement', () => {
       // these two over the period gives the amount invoiced.
       expect(csvUrl.searchParams.get('kind').split(',').sort()).to.deep.equal(['APPLICATION_FEE', 'PLATFORM_TIP']);
       expect(csvUrl.searchParams.get('add')).to.equal('orderLegacyId');
+      // Balance is a running total over the whole account and never lines up with a two-kind report
+      expect(csvUrl.searchParams.get('remove')).to.equal('balance');
     });
 
     it('matches the new-ledger settlement ledger snapshot', async () => {

--- a/test/cron/monthly/host-settlement.test.js
+++ b/test/cron/monthly/host-settlement.test.js
@@ -467,8 +467,10 @@ describe('cron/monthly/host-settlement', () => {
     const [attachment] = await gphHostSettlementExpense.getAttachedFiles();
     expect(attachment).to.have.property('url');
     expect(attachment.url).to.have.string('.csv');
-    // Legacy hosts keep the account-scoped report (all their settled rows live on the host account)
+    // Legacy hosts are billed against the host account, whose ledger holds everything else they do,
+    // so the report stays filtered down to the kinds actually invoiced
     expect(attachment.url).to.have.string('/transactions.csv');
+    expect(new URL(attachment.url).searchParams.get('kind')).to.exist;
   });
 
   it('should include entries from previous months in the CSV url startDate', async () => {
@@ -767,14 +769,16 @@ describe('cron/monthly/host-settlement', () => {
       expect(ts.ExpenseId).to.equal(settlementExpense.id);
     });
 
-    it('attaches a host-scoped CSV so the vendor-account PLATFORM_TIP rows are included', async () => {
+    it('attaches a CSV scoped to the platform-tips account, unfiltered by kind', async () => {
       const [attachment] = await settlementExpense.getAttachedFiles();
       expect(attachment).to.have.property('url');
-      // The account-scoped `transactions` report filters CollectiveId IN [host, children] and can
-      // never return the platform-tips account rows; the host-scoped report filters HostCollectiveId.
-      expect(attachment.url).to.have.string('/hostTransactions.csv');
+      // The report is scoped to the account being billed rather than the host: it holds nothing but
+      // tips and their offsets, so every row on it belongs in the settlement CSV.
+      expect(attachment.url).to.have.string(`/${platformTipsAccount.slug}/transactions.csv`);
       const csvUrl = new URL(attachment.url);
-      expect(csvUrl.searchParams.get('kind').split(',')).to.include('PLATFORM_TIP');
+      // No kind filter: the host needs the APPLICATION_FEE debits next to the PLATFORM_TIP credits
+      // to see which tips Stripe already collected and check the rest against the invoiced amount.
+      expect(csvUrl.searchParams.get('kind')).to.be.null;
       expect(csvUrl.searchParams.get('add')).to.equal('orderLegacyId');
     });
 


### PR DESCRIPTION
A host admin pointed out that the CSV attached to the Platform Settlement expense is not much use to them: it is scoped to the host and filtered to PLATFORM_TIP, so it lists the tips gross and there is no way to check it against the amount they were invoiced.

Now that new-ledger tips settle against the host's own platform-tips account, that account is a much better thing to report on. I scope the CSV to it and report two kinds: PLATFORM_TIP and APPLICATION_FEE. The invoiced amount is the tips collected net of the ones Stripe already took as an application fee, so those two kinds summed over the period are exactly the bill. The host can now tie the CSV to the invoice line by line. I deliberately leave out the account's other rows, which are the previous settlement being paid and its processor fee: they move the balance but are not part of what is being billed.

I checked this against production. For OSC's July settlement the account holds 139.41 of tip credits, 3.00 of tip refunds, 74.56 of application fee debits and 2.25 of reversed application fees, which is 64.10, the exact amount of the invoice. June ties out the same way at 22.40. The CSV as it stands today shows 136.41 against that 64.10 invoice.

Host-billed settlements are untouched. Those are billed against the host account, whose ledger holds everything else the host does, so that report stays filtered to the kinds actually invoiced.

- `emitSettlementExpense` now takes the billed `Collective` rather than its id, and scopes the CSV to it
- platform-tips bundles report PLATFORM_TIP and APPLICATION_FEE, host bundles keep the kinds they invoiced
- dropped the `hostTransactions` report: it only existed because the report was scoped to the host, and scoping to the tips account makes the plain account report work again
- tests cover both bundles' report URLs

The two settlement expenses already issued carry the old URL, so they need a one-off update of `ExpenseAttachedFiles.url` once this ships.

This replaces the narrowing I was attempting in #11981, which went at the same problem from the other end by trying to filter the CSV down to only the billable tips.