### PR TITLE
Handle Express 5 typed route params as string or string[]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8039,9 +8039,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
-      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
   },
   "overrides": {
     "url-regex-safe": "4.0.0",
-    "@types/express-serve-static-core": "5.0.7"
+    "@types/express-serve-static-core": "5.1.3"
   },
   "nyc": {
     "reporter": [

--- a/server/controllers/files.ts
+++ b/server/controllers/files.ts
@@ -5,6 +5,7 @@ import { hasUploadedFilePermission } from '../graphql/common/uploaded-file';
 import { idDecode, IDENTIFIER_TYPES } from '../graphql/v2/identifiers';
 import { getSignedGetURL, parseS3Url } from '../lib/awsS3';
 import { EntityShortIdPrefix, isEntityPublicId } from '../lib/permalink/entity-map';
+import { getRouteParam } from '../lib/request-utils';
 import { Expense, UploadedFile } from '../models';
 
 /**
@@ -22,7 +23,7 @@ export async function getFile(req: Request, res: Response) {
   const isThumbnail = req.query.thumbnail !== undefined;
   const isDownload = req.query.download !== undefined;
 
-  const { uploadedFileId } = req.params;
+  const uploadedFileId = getRouteParam(req, 'uploadedFileId');
   const { expenseId, draftKey } = req.query;
 
   let resolvedExpenseId: number | null = null;

--- a/server/controllers/legal-documents.ts
+++ b/server/controllers/legal-documents.ts
@@ -7,6 +7,7 @@ import { getFileFromS3 } from '../lib/awsS3';
 import { EntityShortIdPrefix, isEntityPublicId } from '../lib/permalink/entity-map';
 import SQLQueries from '../lib/queries';
 import RateLimit from '../lib/rate-limit';
+import { getRouteParam } from '../lib/request-utils';
 import { reportErrorToSentry } from '../lib/sentry';
 import twoFactorAuthLib from '../lib/two-factor-authentication';
 import { LegalDocument, RequiredLegalDocument, User } from '../models';
@@ -61,7 +62,7 @@ export default {
     }
 
     // Parse ID
-    const { id } = req.params;
+    const id = getRouteParam(req, 'id');
 
     let decodedId;
     if (isEntityPublicId(id, EntityShortIdPrefix.LegalDocument)) {

--- a/server/lib/permalink/handler.ts
+++ b/server/lib/permalink/handler.ts
@@ -1,5 +1,7 @@
 import express from 'express';
 
+import { getRouteParam } from '../request-utils';
+
 import { handleNotFound } from './entity-handlers/common';
 import {
   handleAccountingCategory,
@@ -86,7 +88,7 @@ const handlerMap: Record<EntityShortIdPrefix, Handler> = {
 };
 
 export async function handlePermalink(req: express.Request, res: express.Response) {
-  const prefix = getEntityShortIdPrefix(req.params.id);
+  const prefix = getEntityShortIdPrefix(getRouteParam(req, 'id'));
   if (!prefix) {
     return handleNotFound(req, res);
   }

--- a/server/lib/request-utils.ts
+++ b/server/lib/request-utils.ts
@@ -14,3 +14,15 @@ export const getStringIdentifiersFromRequest = (req: Express.Request) => {
 
   return pickBy({ user, userToken, personalToken, apiKey, ip, graphql }, Boolean);
 };
+
+/**
+ * Returns a route param as a string.
+ *
+ * Express 5 types `req.params` values as `string | string[]` because wildcard params (e.g.
+ * `/files/*path`) capture a list of path segments. All our routes use named params, which are
+ * always plain strings, but array values are joined back into a path just in case.
+ */
+export const getRouteParam = (req: Express.Request, name: string): string => {
+  const value = req.params?.[name];
+  return Array.isArray(value) ? value.join('/') : value;
+};

--- a/server/middleware/authentication.ts
+++ b/server/middleware/authentication.ts
@@ -17,6 +17,7 @@ import errors from '../lib/errors';
 import logger from '../lib/logger';
 import RateLimit from '../lib/rate-limit';
 import { clearRedirectCookie, setRedirectCookie } from '../lib/redirect-cookie';
+import { getRouteParam } from '../lib/request-utils';
 import { dbUserToSentryUser, reportMessageToSentry } from '../lib/sentry';
 import { getBearerTokenFromCookie, getBearerTokenFromRequestHeaders, parseToBoolean } from '../lib/utils';
 import models from '../models';
@@ -285,7 +286,7 @@ export const authenticateService = async (req: Request, res: Response, next: Nex
     return next(new errors.RateLimitExceeded());
   }
 
-  const { service } = req.params;
+  const service = getRouteParam(req, 'service');
   const { context, CollectiveId } = req.query || {};
 
   if (service === 'github') {
@@ -352,7 +353,7 @@ export const authenticateServiceCallback = async (req: Request, res: Response, n
     return next(new errors.RateLimitExceeded());
   }
 
-  const { service } = req.params;
+  const service = getRouteParam(req, 'service');
   if (get(paymentProviders, `${service}.oauth.callback`)) {
     return paymentProviders[service].oauth.callback(req, res, next);
   }
@@ -405,7 +406,7 @@ export const authenticateServiceCallback = async (req: Request, res: Response, n
 };
 
 function getOAuthCallbackUrl(req: Request) {
-  const { service } = req.params;
+  const service = getRouteParam(req, 'service');
   const params = new URLSearchParams(omitBy(pick(req.query, ['context', 'CollectiveId']), isNil));
 
   if (params.toString().length > 0) {

--- a/server/paymentProviders/paypal/webhook.ts
+++ b/server/paymentProviders/paypal/webhook.ts
@@ -15,6 +15,7 @@ import logger from '../../lib/logger';
 import { createRefundTransaction, pauseOrderInDb } from '../../lib/payments';
 import { validateWebhookEvent, WatchedPaypalWebhookEvent } from '../../lib/paypal';
 import { recordOrderProcessed } from '../../lib/recurring-contributions';
+import { getRouteParam } from '../../lib/request-utils';
 import { reportErrorToSentry, reportMessageToSentry } from '../../lib/sentry';
 import models from '../../models';
 import { PayoutWebhookRequest, PaypalCapture, PaypalRefund } from '../../types/paypal';
@@ -70,7 +71,7 @@ const loadSubscriptionForWebhookEvent = async (
   subscriptionId: string,
   { throwIfMissing = true } = {},
 ) => {
-  const hostId = parseInt(req.params.hostId);
+  const hostId = parseInt(getRouteParam(req, 'hostId'));
   const order = await models.Order.findOne({
     include: [
       { association: 'fromCollective', required: false },
@@ -158,7 +159,7 @@ async function handleSaleCompleted(req: Request): Promise<void> {
 }
 
 async function handleCaptureCompleted(req: Request): Promise<void> {
-  const hostId = parseInt(req.params.hostId);
+  const hostId = parseInt(getRouteParam(req, 'hostId'));
 
   // Retrieve the order for this event
   const capture = req.body.resource;
@@ -345,9 +346,10 @@ async function handleSaleReversed(req: Request): Promise<void> {
 
 async function handleCaptureRefunded(req: Request): Promise<void> {
   // Validate webhook event
-  const host = await models.Collective.findByPk(req.params.hostId);
+  const hostId = getRouteParam(req, 'hostId');
+  const host = await models.Collective.findByPk(hostId);
   if (!host) {
-    throw new Error(`No host found for ID ${req.params.hostId}`);
+    throw new Error(`No host found for ID ${hostId}`);
   }
 
   const paypalAccount = await getPaypalAccount(host);

--- a/server/types/express.d.ts
+++ b/server/types/express.d.ts
@@ -35,7 +35,7 @@ declare global {
       personalToken?: PersonalToken;
       loaders: Loaders;
       rawBody?: string;
-      params: Record<string, string>;
+      params: Record<string, string | string[]>;
       method: string;
       baseUrl: string;
       ip: string;


### PR DESCRIPTION
## Summary
This PR addresses compatibility with Express 5's updated type definitions for route parameters. Express 5 types `req.params` values as `string | string[]` to account for wildcard route parameters that can capture multiple path segments. Since our codebase uses only named parameters (which are always strings), this change introduces a utility function to safely extract and normalize route parameters.

## Key Changes
- **Added `getRouteParam()` utility function** in `server/lib/request-utils.ts` that safely extracts route parameters and handles the `string | string[]` union type by joining array values back into a path string
- **Updated Express type definition** in `server/types/express.d.ts` to reflect Express 5's `params: Record<string, string | string[]>` typing
- **Replaced direct `req.params` access** with `getRouteParam()` calls across multiple files:
  - `server/paymentProviders/paypal/webhook.ts` (3 occurrences)
  - `server/middleware/authentication.ts` (3 occurrences)
  - `server/lib/permalink/handler.ts` (1 occurrence)
  - `server/controllers/files.ts` (1 occurrence)
  - `server/controllers/legal-documents.ts` (1 occurrence)

## Implementation Details
The `getRouteParam()` function provides a centralized, type-safe way to access route parameters that works with both Express 4 and Express 5. It checks if the parameter value is an array and joins it with `/` to reconstruct the original path, otherwise returns the string value as-is. This ensures all route parameter access is consistent and handles the type union properly throughout the codebase.

https://claude.ai/code/session_01B5F9TzYZn4kkvZpPgiQtWG