### PR TITLE
Fix PayPal connection token limit error

### DIFF
--- a/migrations/20260821000000-connected-accounts-token-and-refresh-token-to-text.ts
+++ b/migrations/20260821000000-connected-accounts-token-and-refresh-token-to-text.ts
@@ -1,0 +1,22 @@
+'use strict';
+
+import type { QueryInterface } from 'sequelize';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface: QueryInterface, Sequelize) {
+    await queryInterface.changeColumn('ConnectedAccounts', 'token', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+
+    await queryInterface.changeColumn('ConnectedAccounts', 'refreshToken', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+  },
+
+  async down() {
+    // Cannot be reverted because changing the column type back to STRING may cause data loss if the existing data exceeds the maximum length of STRING.
+  },
+};

--- a/server/models/ConnectedAccount.ts
+++ b/server/models/ConnectedAccount.ts
@@ -94,7 +94,7 @@ ConnectedAccount.init(
     clientId: DataTypes.STRING, // paypal app id
     // either paypal secret OR an accessToken to do requests to the provider on behalf of the user
     token: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       get() {
         const encrypted = this.getDataValue('token');
         return isNil(encrypted) ? null : crypto.decrypt(encrypted);
@@ -104,7 +104,7 @@ ConnectedAccount.init(
       },
     },
     refreshToken: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       get() {
         const encrypted = this.getDataValue('refreshToken');
         return isNil(encrypted) ? null : crypto.decrypt(encrypted);

--- a/test/server/models/ConnectedAccount.test.js
+++ b/test/server/models/ConnectedAccount.test.js
@@ -13,5 +13,17 @@ describe('server/models/ConnectedAccount', () => {
       expect(ca.getDataValue('token')).to.not.equals(params.token);
       expect(ca.getDataValue('refreshToken')).to.not.equals(params.refreshToken);
     });
+
+    it('should support long tokens and refresh tokens exceeding 255 characters', async () => {
+      const longToken = 'a'.repeat(500);
+      const longRefreshToken = 'b'.repeat(500);
+      const params = { token: longToken, refreshToken: longRefreshToken };
+      const ca = await fakeConnectedAccount(params);
+
+      expect(ca.token).to.equals(longToken);
+      expect(ca.refreshToken).to.equals(longRefreshToken);
+      expect(ca.getDataValue('token')).to.not.equals(longToken);
+      expect(ca.getDataValue('refreshToken')).to.not.equals(longRefreshToken);
+    });
   });
 });


### PR DESCRIPTION
PayPal OAuth access and refresh tokens (plus their encrypted ciphertexts) exceed 255 characters, causing database insertion errors when stored in `VARCHAR(255)` columns.

Per PayPal documentation, token lengths can vary and should not assume fixed-length limits, so this updates `ConnectedAccounts` token columns to `TEXT`.

Fixes https://open-collective.sentry.io/issues/7379196298/