### PR TITLE
fix(Expenses): let payee host admins submit cross-host draft expenses

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -2731,8 +2731,12 @@ export async function submitExpenseDraft(
     isNewExpenseFlow: isNewExpenseFlow === true ? true : undefined,
   };
   if (requestedPayee) {
-    if (!req.remoteUser?.isAdminOfCollective(requestedPayee)) {
-      throw new Forbidden('User needs to be the admin of the payee to submit an expense on their behalf');
+    // Also allow admins of the payee's fiscal host (e.g. a host admin completing a cross-host
+    // draft invite on behalf of one of their hosted collectives)
+    if (!req.remoteUser?.isAdminOfCollectiveOrHost(requestedPayee)) {
+      throw new Forbidden(
+        'User needs to be an admin of the payee (or its fiscal host) to submit an expense on their behalf',
+      );
     }
   } else {
     const { organization: organizationData, ...payee } = args.expense.payee;

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -2738,6 +2738,71 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         expect(result.data.editExpense.attachedFiles[0].url).to.eql(expenseAttachedFile.url);
       });
 
+      it('allows an admin of the payee host to submit a DRAFT with the draft key (cross-host)', async () => {
+        const hostAdmin = await fakeUser();
+        const payeeHost = await fakeHost({ admin: hostAdmin });
+        const payeeCollective = await fakeCollective({ HostCollectiveId: payeeHost.id });
+        const payerCollective = await fakeCollective();
+        const expense = await fakeExpense({
+          status: expenseStatus.DRAFT,
+          type: ExpenseTypes.INVOICE,
+          CollectiveId: payerCollective.id,
+          data: {
+            draftKey: 'fake-key',
+            payee: { id: payeeCollective.id, slug: payeeCollective.slug, name: payeeCollective.name },
+          },
+        });
+
+        const updatedExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          description: 'Completed by an admin of the payee host',
+          payee: { legacyId: payeeCollective.id },
+          payoutMethod: { type: 'OTHER', data: { content: 'Bank transfer to the host', currency: 'USD' } },
+        };
+
+        const result = await graphqlQueryV2(
+          editExpenseMutation,
+          { expense: updatedExpenseData, draftKey: 'fake-key' },
+          hostAdmin,
+        );
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        expect(result.data.editExpense.payee.legacyId).to.equal(payeeCollective.id);
+        expect(result.data.editExpense.description).to.equal(updatedExpenseData.description);
+        await expense.reload();
+        expect(expense.status).to.equal(expenseStatus.PENDING);
+      });
+
+      it('rejects a DRAFT submission on behalf of a payee the user does not administer, even with the draft key', async () => {
+        const randomUser = await fakeUser();
+        const payeeHost = await fakeHost();
+        const payeeCollective = await fakeCollective({ HostCollectiveId: payeeHost.id });
+        const payerCollective = await fakeCollective();
+        const expense = await fakeExpense({
+          status: expenseStatus.DRAFT,
+          type: ExpenseTypes.INVOICE,
+          CollectiveId: payerCollective.id,
+          data: {
+            draftKey: 'fake-key',
+            payee: { id: payeeCollective.id, slug: payeeCollective.slug, name: payeeCollective.name },
+          },
+        });
+
+        const updatedExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          description: 'Completed by a random user',
+          payee: { legacyId: payeeCollective.id },
+        };
+
+        const result = await graphqlQueryV2(
+          editExpenseMutation,
+          { expense: updatedExpenseData, draftKey: 'fake-key' },
+          randomUser,
+        );
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.match(/admin of the payee/);
+      });
+
       it('allows a new user/organization to submit the DRAFT if the draft key is provided', async () => {
         const submitter = await fakeUser();
         const expenseAttachedFile = await fakeUploadedFile({


### PR DESCRIPTION
Since #10768, cross-host draft expense invites whose payee is a hosted collective are emailed to the payee's **host** admins (and collective admins can no longer read their host's payout methods, a carve-out from #6986/#6991). #11795 and opencollective-frontend#12180 then let those host admins edit the draft and pick a payout method from the recipient host.

But the final submit still required being an admin of the payee itself, so the intended completer was rejected at the last step:

> User needs to be the admin of the payee to submit an expense on their behalf

## Changes

- `submitExpenseDraft`: relax the payee gate to `isAdminOfCollectiveOrHost`. It runs after the existing draft-key/author/payee check, so the submitter has already proven they hold the invite key (or authored the draft).
- Tests: a payee-host admin with the draft key can submit (expense moves to PENDING, payout method created on the host); a random user with the key is still rejected.

Real-world case: OCE Foundation cross-host grants (USD fund to a collective hosted on the EUR host), stuck three times since December.