### PR TITLE
Fiscal-host admin not subject to hosted Collective's EXPENSE_AUTHOR_CANNOT_APPROVE policy

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -1020,29 +1020,41 @@ export const canApprove: ExpensePermissionEvaluator = async (
     }
 
     const currency = expense.collective.host?.currency || expense.collective.currency;
+    const requesterIsHostAdmin = await isHostAdmin(req, expense);
     const hostPolicy = await getPolicy(expense.collective.host, POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE);
     const collectivePolicy = await getPolicy(expense.collective, POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE);
 
-    let policy = collectivePolicy;
-    if (hostPolicy.enabled && hostPolicy.appliesToHostedCollectives) {
-      policy = hostPolicy;
+    const hostPolicyApplies = hostPolicy.enabled && hostPolicy.appliesToHostedCollectives;
+    const collectivePolicyApplies =
+      collectivePolicy.enabled && (!hostPolicyApplies || hostPolicy.amountInCents >= collectivePolicy.amountInCents);
+    const expenseAuthor = req.remoteUser.id === expense.UserId;
 
-      if (!hostPolicy.appliesToSingleAdminCollectives) {
-        const collectiveAdminCount = await req.loaders.Member.countAdminMembersOfCollective.load(expense.collective.id);
-        if (collectiveAdminCount === 1) {
-          policy = collectivePolicy;
-        }
-      }
-    }
+    // Fiscal Host admins are exclusively subject to the applicable Fiscal Host policy.
+    const hostAdminCannotApprove =
+      requesterIsHostAdmin && expenseAuthor && hostPolicyApplies && expense.amount >= hostPolicy.amountInCents;
+    // Collective admins are subject to the applicable Fiscal Host and/or Collective policy.
+    // When both policies apply, the stricter policy has the lower amount threshold.
+    const collectiveAdminCannotApprove =
+      !requesterIsHostAdmin &&
+      expenseAuthor &&
+      ((collectivePolicyApplies && expense.amount >= collectivePolicy.amountInCents) ||
+        (hostPolicyApplies &&
+          (hostPolicy.appliesToSingleAdminCollectives ||
+            (await req.loaders.Member.countAdminMembersOfCollective.load(expense.collective.id)) > 1) &&
+          expense.amount >= hostPolicy.amountInCents));
+    const authorCannotApprove = hostAdminCannotApprove || collectiveAdminCannotApprove;
 
-    if (policy.enabled && expense.amount >= policy.amountInCents && req.remoteUser.id === expense.UserId) {
+    if (authorCannotApprove) {
+      const amountInCents =
+        hostAdminCannotApprove || !collectivePolicyApplies ? hostPolicy.amountInCents : collectivePolicy.amountInCents;
+
       if (options?.throw) {
         throw new Forbidden(
           'User cannot approve their own expenses',
           EXPENSE_PERMISSION_ERROR_CODES.AUTHOR_CANNOT_APPROVE,
           {
             reasonDetails: {
-              amount: policy.amountInCents / 100,
+              amount: amountInCents / 100,
               currency,
             },
           },

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -1532,6 +1532,52 @@ describe('server/graphql/common/expenses', () => {
         );
         expect(await canApprove(req.collectiveAdmin, newExpense)).to.be.false;
       });
+
+      it('by collective uses the stricter collective threshold when host policy applies', async () => {
+        const { req, collective } = contexts.normal;
+        await collective.setPolicies({
+          [POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE]: { enabled: true, amountInCents: 10e2 },
+        });
+        collective.host = await collective.host.setPolicies({
+          [POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE]: {
+            enabled: true,
+            amountInCents: 20e2,
+            appliesToHostedCollectives: true,
+            appliesToSingleAdminCollectives: true,
+          },
+        });
+        newExpense.collective = collective;
+
+        expect(await getApolloErrorCode(canApprove(req.collectiveAdmin, newExpense, { throw: true }))).to.be.equal(
+          EXPENSE_PERMISSION_ERROR_CODES.AUTHOR_CANNOT_APPROVE,
+        );
+        expect(await canApprove(req.collectiveAdmin, newExpense)).to.be.false;
+      });
+
+      it('by a host admin author uses only the applicable host policy', async () => {
+        const { req, collective } = contexts.normal;
+        await collective.setPolicies({
+          [POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE]: { enabled: true, amountInCents: 0 },
+        });
+        newExpense.collective = await collective.reload();
+        await newExpense.update({ UserId: req.hostAdmin.remoteUser.id });
+
+        expect(await canApprove(req.hostAdmin, newExpense)).to.be.true;
+
+        newExpense.collective.host = await collective.host.setPolicies({
+          [POLICIES.EXPENSE_AUTHOR_CANNOT_APPROVE]: {
+            enabled: true,
+            amountInCents: 10e2,
+            appliesToHostedCollectives: true,
+            appliesToSingleAdminCollectives: true,
+          },
+        });
+
+        expect(await getApolloErrorCode(canApprove(req.hostAdmin, newExpense, { throw: true }))).to.be.equal(
+          EXPENSE_PERMISSION_ERROR_CODES.AUTHOR_CANNOT_APPROVE,
+        );
+        expect(await canApprove(req.hostAdmin, newExpense)).to.be.false;
+      });
     });
 
     describe('manually created virtual card charges', () => {


### PR DESCRIPTION
Fixes the bug related to fiscal-host admins being blocked from approving expense submitted to their own collectives.