### PR TITLE
Optimize AdminCommunityTransactionSummary and AdminCommunityActivitySummary materialized view costs

### DIFF
--- a/migrations/20260902130000-rewrite-admin-community-transaction-summary.ts
+++ b/migrations/20260902130000-rewrite-admin-community-transaction-summary.ts
@@ -137,7 +137,7 @@ const optimizedSummaryQuery = `
         COALESCE(COUNT(t.id) FILTER (WHERE (((t.type) = 'CREDIT') AND t."isRefund")), (0)) AS "refundDebitCount"
       FROM
         "Transactions" t
-        INNER JOIN "Collectives" h ON t."HostCollectiveId" = h.id AND h."deletedAt" IS NULL AND h."hasHosting" IS TRUE
+        INNER JOIN "Collectives" h ON t."HostCollectiveId" = h.id AND h."deletedAt" IS NULL AND h."hasMoneyManagement" IS TRUE
         INNER JOIN "Collectives" c ON t."FromCollectiveId" = c.id AND c."deletedAt" IS NULL
       WHERE t."deletedAt" IS NULL
         AND t."hostCurrency" = h.currency

--- a/migrations/20260902130000-rewrite-admin-community-transaction-summary.ts
+++ b/migrations/20260902130000-rewrite-admin-community-transaction-summary.ts
@@ -1,0 +1,200 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+
+const dropViews = async (queryInterface, transaction) => {
+  await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "AdminCommunityHostTransactionSummary";`, {
+    transaction,
+  });
+  await queryInterface.sequelize.query(
+    `DROP MATERIALIZED VIEW IF EXISTS "AdminCommunityHostYearlyTransactionSummary";`,
+    { transaction },
+  );
+  await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "AdminCommunityTransactionSummary";`, {
+    transaction,
+  });
+};
+
+const createTransactionSummary = async (queryInterface, summaryQuery, transaction) => {
+  await queryInterface.sequelize.query(
+    `CREATE MATERIALIZED VIEW "AdminCommunityTransactionSummary" AS (
+    ${summaryQuery}
+  );`,
+    { transaction },
+  );
+
+  await queryInterface.sequelize.query(
+    `
+    CREATE UNIQUE INDEX "admin_community_transaction_summary__unique_index"
+      ON "AdminCommunityTransactionSummary"("HostCollectiveId", "FromCollectiveId", "CollectiveId", "year", "kind");
+    CREATE INDEX "admin_community_transaction_summary__combined_collective_ids"
+      ON "AdminCommunityTransactionSummary"("HostCollectiveId", "FromCollectiveId", "CollectiveId")
+      INCLUDE ("kind", "year", "creditTotalAcc", "debitTotalAcc");
+    CREATE INDEX "admin_community_transaction_summary__host_collective_id"
+      ON "AdminCommunityTransactionSummary" ("HostCollectiveId")
+      INCLUDE ("kind", "year", "creditTotalAcc", "debitTotalAcc");
+    CREATE INDEX "admin_community_transaction_summary__from_collective_id"
+      ON "AdminCommunityTransactionSummary" ("FromCollectiveId")
+      INCLUDE ("kind", "year", "creditTotalAcc", "debitTotalAcc");
+    CREATE INDEX "admin_community_transaction_summary__collective_id"
+      ON "AdminCommunityTransactionSummary" ("CollectiveId")
+      INCLUDE ("kind", "year", "creditTotalAcc", "debitTotalAcc");
+  `,
+    { transaction },
+  );
+};
+
+const createDependentViews = async (queryInterface, transaction) => {
+  await queryInterface.sequelize.query(
+    `
+    CREATE MATERIALIZED VIEW "AdminCommunityHostYearlyTransactionSummary"
+      ("FromCollectiveId", "HostCollectiveId", "hostCurrency", "year", "kind", "debitTotal", "debitCount", "creditTotal", "creditCount", "refundDebitTotal", "refundDebitCount") AS
+    WITH summary AS (
+      SELECT
+        "FromCollectiveId", "HostCollectiveId", "hostCurrency", "year", "kind",
+        SUM("debitTotal") AS "debitTotal", SUM("debitCount") AS "debitCount",
+        SUM("creditTotal") AS "creditTotal", SUM("creditCount") AS "creditCount",
+        SUM("refundDebitTotal") AS "refundDebitTotal", SUM("refundDebitCount") AS "refundDebitCount"
+      FROM "AdminCommunityTransactionSummary"
+      GROUP BY "FromCollectiveId", "HostCollectiveId", "hostCurrency", "year", "kind"
+    )
+    SELECT "FromCollectiveId", "HostCollectiveId", "hostCurrency", "year", "kind", "debitTotal", "debitCount", "creditTotal", "creditCount", "refundDebitTotal", "refundDebitCount"
+    FROM summary
+    UNION ALL
+    SELECT
+      "FromCollectiveId", "HostCollectiveId", "hostCurrency", "year", NULL AS "kind",
+      SUM("debitTotal"), SUM("debitCount"), SUM("creditTotal"), SUM("creditCount"),
+      SUM("refundDebitTotal"), SUM("refundDebitCount")
+    FROM summary
+    GROUP BY "FromCollectiveId", "HostCollectiveId", "hostCurrency", "year"
+    ORDER BY "FromCollectiveId", "HostCollectiveId", "year" DESC;
+
+    CREATE UNIQUE INDEX "admin_community_host_yearly_transaction_summary__unique_index"
+      ON "AdminCommunityHostYearlyTransactionSummary"("HostCollectiveId", "FromCollectiveId", "hostCurrency", "year", "kind");
+    CREATE INDEX "admin_community_host_yearly_transaction_summary__combined_collective_ids"
+      ON "AdminCommunityHostYearlyTransactionSummary"("HostCollectiveId", "FromCollectiveId")
+      INCLUDE ("kind", "year", "creditTotal", "debitTotal");
+    CREATE INDEX "admin_community_host_yearly_transaction_summary__host_collective_id"
+      ON "AdminCommunityHostYearlyTransactionSummary" ("HostCollectiveId")
+      INCLUDE ("kind", "year", "creditTotal", "debitTotal");
+    CREATE INDEX "admin_community_host_yearly_transaction_summary__from_collective_id"
+      ON "AdminCommunityHostYearlyTransactionSummary" ("FromCollectiveId")
+      INCLUDE ("kind", "year", "creditTotal", "debitTotal");
+  `,
+    { transaction },
+  );
+
+  await queryInterface.sequelize.query(
+    `
+    CREATE MATERIALIZED VIEW "AdminCommunityHostTransactionSummary"
+      ("FromCollectiveId", "HostCollectiveId", "hostCurrency", "kind", "debitTotal", "debitCount", "creditTotal", "creditCount", "refundDebitTotal", "refundDebitCount") AS
+    WITH summary AS (
+      SELECT
+        "FromCollectiveId", "HostCollectiveId", "hostCurrency", "kind",
+        SUM("debitTotal") AS "debitTotal", SUM("debitCount") AS "debitCount",
+        SUM("creditTotal") AS "creditTotal", SUM("creditCount") AS "creditCount",
+        SUM("refundDebitTotal") AS "refundDebitTotal", SUM("refundDebitCount") AS "refundDebitCount"
+      FROM "AdminCommunityTransactionSummary"
+      GROUP BY "FromCollectiveId", "HostCollectiveId", "hostCurrency", "kind"
+    )
+    SELECT "FromCollectiveId", "HostCollectiveId", "hostCurrency", "kind", "debitTotal", "debitCount", "creditTotal", "creditCount", "refundDebitTotal", "refundDebitCount"
+    FROM summary
+    UNION ALL
+    SELECT
+      "FromCollectiveId", "HostCollectiveId", "hostCurrency", NULL AS "kind",
+      SUM("debitTotal"), SUM("debitCount"), SUM("creditTotal"), SUM("creditCount"),
+      SUM("refundDebitTotal"), SUM("refundDebitCount")
+    FROM summary
+    GROUP BY "FromCollectiveId", "HostCollectiveId", "hostCurrency"
+    ORDER BY "FromCollectiveId", "HostCollectiveId";
+
+    CREATE UNIQUE INDEX "admin_community_host_transaction_summary__unique_index"
+      ON "AdminCommunityHostTransactionSummary"("HostCollectiveId", "FromCollectiveId", "hostCurrency", "kind");
+    CREATE INDEX "admin_community_host_transaction_summary__combined_collective_ids"
+      ON "AdminCommunityHostTransactionSummary"("HostCollectiveId", "FromCollectiveId")
+      INCLUDE ("kind", "creditTotal", "debitTotal");
+    CREATE INDEX "admin_community_host_transaction_summary__host_collective_id"
+      ON "AdminCommunityHostTransactionSummary" ("HostCollectiveId")
+      INCLUDE ("kind", "creditTotal", "debitTotal");
+    CREATE INDEX "admin_community_host_transaction_summary__from_collective_id"
+      ON "AdminCommunityHostTransactionSummary" ("FromCollectiveId")
+      INCLUDE ("kind", "creditTotal", "debitTotal");
+  `,
+    { transaction },
+  );
+};
+
+const optimizedSummaryQuery = `
+  WITH
+    anual AS (
+      SELECT
+        COALESCE(((c.data #> '{UserCollectiveId}')::integer), c.id) AS "FromCollectiveId", t."CollectiveId", t."HostCollectiveId", EXTRACT(YEAR FROM t."createdAt") AS year, t.kind,
+        h.currency AS "hostCurrency", COALESCE(SUM(ABS(t."amountInHostCurrency")) FILTER (WHERE ((t.type) = 'DEBIT')), (0)) AS "debitTotal",
+        COALESCE(COUNT(t.id) FILTER (WHERE ((t.type) = 'DEBIT')), (0)) AS "debitCount",
+        COALESCE(SUM(ABS(t."amountInHostCurrency")) FILTER (WHERE ((t.type) = 'CREDIT')), (0)) AS "creditTotal",
+        COALESCE(COUNT(t.id) FILTER (WHERE ((t.type) = 'CREDIT')), (0)) AS "creditCount",
+        COALESCE(SUM(ABS(t."amountInHostCurrency")) FILTER (WHERE (((t.type) = 'CREDIT') AND t."isRefund")), (0)) AS "refundDebitTotal",
+        COALESCE(COUNT(t.id) FILTER (WHERE (((t.type) = 'CREDIT') AND t."isRefund")), (0)) AS "refundDebitCount"
+      FROM
+        "Transactions" t
+        INNER JOIN "Collectives" h ON t."HostCollectiveId" = h.id AND h."deletedAt" IS NULL AND h."hasHosting" IS TRUE
+        INNER JOIN "Collectives" c ON t."FromCollectiveId" = c.id AND c."deletedAt" IS NULL
+      WHERE t."deletedAt" IS NULL
+        AND t."hostCurrency" = h.currency
+      GROUP BY COALESCE(((c.data #> '{UserCollectiveId}')::integer), c.id), t."CollectiveId", t."HostCollectiveId", (EXTRACT(YEAR FROM t."createdAt")), h.currency, t.kind
+      ORDER BY COALESCE(((c.data #> '{UserCollectiveId}')::integer), c.id), t."CollectiveId", t."HostCollectiveId", t.kind, (EXTRACT(YEAR FROM t."createdAt")) DESC
+    )
+  SELECT
+    "FromCollectiveId", "CollectiveId", "HostCollectiveId", year, kind, "hostCurrency", "debitTotal", "debitCount", "creditTotal", "creditCount", "refundDebitTotal",
+    "refundDebitCount", SUM("debitTotal") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "debitTotalAcc",
+    SUM("debitCount") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "debitCountAcc",
+    SUM("creditTotal") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "creditTotalAcc",
+    SUM("creditCount") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "creditCountAcc",
+    SUM("refundDebitTotal") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "refundDebitTotalAcc",
+    SUM("refundDebitCount") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "refundDebitCountAcc"
+  FROM anual`;
+
+const previousSummaryQuery = `
+  WITH anual AS (
+    SELECT
+      COALESCE((c.data #> '{UserCollectiveId}')::INTEGER, c.id) AS "FromCollectiveId", t."CollectiveId", t."HostCollectiveId", EXTRACT(YEAR FROM t."createdAt") AS year, t.kind, h.currency AS "hostCurrency",
+      COALESCE(SUM(ABS(t."amountInHostCurrency")) FILTER (WHERE t.type::text = 'DEBIT'::text), 0::bigint) AS "debitTotal",
+      COALESCE(COUNT(t.id) FILTER (WHERE t.type::text = 'DEBIT'::text), 0::bigint) AS "debitCount",
+      COALESCE(SUM(ABS(t."amountInHostCurrency")) FILTER (WHERE t.type::text = 'CREDIT'::text), 0::bigint) AS "creditTotal",
+      COALESCE(COUNT(t.id) FILTER (WHERE t.type::text = 'CREDIT'::text), 0::bigint) AS "creditCount",
+      COALESCE(SUM(ABS(t."amountInHostCurrency")) FILTER (WHERE t.type::text = 'CREDIT'::text AND t."isRefund"), 0::bigint) AS "refundDebitTotal",
+      COALESCE(COUNT(t.id) FILTER (WHERE t.type::text = 'CREDIT'::text AND t."isRefund"), 0::bigint) AS "refundDebitCount"
+    FROM "Transactions" t
+      JOIN "Collectives" h ON t."HostCollectiveId" = h.id
+      JOIN "Collectives" c ON t."FromCollectiveId" = c.id
+    WHERE t."deletedAt" IS NULL AND t."hostCurrency"::text = h.currency::text
+    GROUP BY COALESCE((c.data #> '{UserCollectiveId}')::INTEGER, c.id), t."CollectiveId", t."HostCollectiveId", EXTRACT(YEAR FROM t."createdAt"), h.currency, t.kind
+    ORDER BY COALESCE((c.data #> '{UserCollectiveId}')::INTEGER, c.id), t."CollectiveId", t."HostCollectiveId", t.kind, EXTRACT(YEAR FROM t."createdAt") DESC
+  )
+  SELECT
+    "FromCollectiveId", "CollectiveId", "HostCollectiveId", year, kind, "hostCurrency", "debitTotal", "debitCount", "creditTotal", "creditCount", "refundDebitTotal", "refundDebitCount",
+    SUM("debitTotal") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "debitTotalAcc",
+    SUM("debitCount") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "debitCountAcc",
+    SUM("creditTotal") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "creditTotalAcc",
+    SUM("creditCount") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "creditCountAcc",
+    SUM("refundDebitTotal") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "refundDebitTotalAcc",
+    SUM("refundDebitCount") OVER (PARTITION BY "FromCollectiveId", "HostCollectiveId", "CollectiveId", kind, "hostCurrency" ORDER BY year) AS "refundDebitCountAcc"
+  FROM anual`;
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await dropViews(queryInterface, transaction);
+      await createTransactionSummary(queryInterface, optimizedSummaryQuery, transaction);
+      await createDependentViews(queryInterface, transaction);
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await dropViews(queryInterface, transaction);
+      await createTransactionSummary(queryInterface, previousSummaryQuery, transaction);
+      await createDependentViews(queryInterface, transaction);
+    });
+  },
+};

--- a/migrations/20260903150000-rewrite-admin-community-activity-summary.ts
+++ b/migrations/20260903150000-rewrite-admin-community-activity-summary.ts
@@ -39,7 +39,7 @@ const optimizedViewQuery = `
         a."CollectiveId", a.type, e.type AS "expenseType"
       FROM
         "Activities" a
-        INNER JOIN "Collectives" h ON a."CollectiveId" = h.id
+        INNER JOIN "Collectives" h ON a."HostCollectiveId" = h.id
         LEFT JOIN "Expenses" e ON a."ExpenseId" = e.id
         LEFT JOIN "Collectives" fc ON a."FromCollectiveId" = fc.id
       WHERE h."deletedAt" IS NULL

--- a/migrations/20260903150000-rewrite-admin-community-activity-summary.ts
+++ b/migrations/20260903150000-rewrite-admin-community-activity-summary.ts
@@ -43,6 +43,7 @@ const optimizedViewQuery = `
         LEFT JOIN "Expenses" e ON a."ExpenseId" = e.id
         LEFT JOIN "Collectives" fc ON a."FromCollectiveId" = fc.id
       WHERE h."deletedAt" IS NULL
+        AND h."hasMoneyManagement"
         AND a."HostCollectiveId" IS NOT NULL
         AND a.type IN (
           'collective.expense.approved', 'collective.expense.rejected',

--- a/migrations/20260903150000-rewrite-admin-community-activity-summary.ts
+++ b/migrations/20260903150000-rewrite-admin-community-activity-summary.ts
@@ -1,0 +1,173 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+
+const dropView = async (queryInterface, transaction) => {
+  await queryInterface.sequelize.query(`DROP MATERIALIZED VIEW IF EXISTS "AdminCommunityActivitySummary";`, {
+    transaction,
+  });
+};
+
+const createIndexes = async (queryInterface, transaction) => {
+  await queryInterface.sequelize.query(
+    `
+    CREATE UNIQUE INDEX "admin_community_activity_summary__all_collective_ids"
+      ON "AdminCommunityActivitySummary" ("HostCollectiveId", "FromCollectiveId", "CollectiveId");
+    CREATE INDEX "admin_community_activity_summary__collective_id"
+      ON "AdminCommunityActivitySummary" ("CollectiveId");
+    CREATE INDEX "admin_community_activity_summary__host_collective_id"
+      ON "AdminCommunityActivitySummary" ("HostCollectiveId");
+    CREATE INDEX "admin_community_activity_summary__from_collective_id"
+      ON "AdminCommunityActivitySummary" ("FromCollectiveId");
+  `,
+    { transaction },
+  );
+};
+
+const createView = async (queryInterface, viewQuery, transaction) => {
+  await queryInterface.sequelize.query(viewQuery, { transaction });
+  await createIndexes(queryInterface, transaction);
+};
+
+const optimizedViewQuery = `
+  CREATE MATERIALIZED VIEW "AdminCommunityActivitySummary" AS
+  WITH
+    relevant_activities AS (
+      SELECT DISTINCT
+        a."HostCollectiveId", a."UserId",
+        COALESCE((fc.data -> 'UserCollectiveId')::integer, fc.id) AS "FromCollectiveId",
+        a."CollectiveId", a.type, e.type AS "expenseType"
+      FROM
+        "Activities" a
+        INNER JOIN "Collectives" h ON a."CollectiveId" = h.id
+        LEFT JOIN "Expenses" e ON a."ExpenseId" = e.id
+        LEFT JOIN "Collectives" fc ON a."FromCollectiveId" = fc.id
+      WHERE h."deletedAt" IS NULL
+        AND a."HostCollectiveId" IS NOT NULL
+        AND a.type IN (
+          'collective.expense.approved', 'collective.expense.rejected',
+          'collective.expense.paid', 'collective.expense.created'
+        )
+    ),
+    roles AS (
+      SELECT
+        a."HostCollectiveId",
+        CASE
+          WHEN a.type IN (
+            'collective.expense.approved', 'collective.expense.rejected', 'collective.expense.created'
+          ) AND a."UserId" IS NOT NULL THEN u."CollectiveId"
+          ELSE a."FromCollectiveId"
+        END AS "FromCollectiveId",
+        a."CollectiveId", a.type,
+        CASE
+          WHEN a.type IN ('collective.expense.approved', 'collective.expense.rejected') THEN 'EXPENSE_APPROVER'
+          WHEN a.type = 'collective.expense.paid' AND a."expenseType" = 'GRANT'::"enum_Expenses_type" THEN 'GRANTEE'
+          WHEN a.type = 'collective.expense.paid' THEN 'PAYEE'
+          WHEN a.type = 'collective.expense.created' THEN 'EXPENSE_SUBMITTER'
+          ELSE NULL
+        END AS relations
+      FROM
+        relevant_activities a
+        LEFT JOIN "Users" u ON u.id = a."UserId"
+      WHERE a."HostCollectiveId" IS NOT NULL
+      UNION ALL
+      SELECT
+        c."HostCollectiveId",
+        COALESCE((fc.data -> 'UserCollectiveId')::integer, fc.id) AS "FromCollectiveId",
+        c.id AS "CollectiveId", NULL::character varying AS type,
+        CASE WHEN m.role::text = 'BACKER'::text THEN 'CONTRIBUTOR'::character varying ELSE m.role END AS relations
+      FROM
+        "Members" m
+        INNER JOIN "Collectives" c ON m."CollectiveId" = c.id AND c."HostCollectiveId" IS NOT NULL
+        INNER JOIN "Collectives" fc ON m."MemberCollectiveId" = fc.id
+      WHERE m.role::text = ANY (ARRAY ['ADMIN', 'CONTRIBUTOR', 'ATTENDEE', 'BACKER'])
+        AND m."deletedAt" IS NULL
+    )
+  SELECT
+    ra."HostCollectiveId", ra."CollectiveId", ra."FromCollectiveId",
+    jsonb_agg_strict(DISTINCT ra.type) AS activities,
+    jsonb_agg_strict(DISTINCT ra.relations) AS relations
+  FROM roles ra
+  GROUP BY ra."HostCollectiveId", ra."CollectiveId", ra."FromCollectiveId";
+`;
+
+const previousViewQuery = `
+  CREATE MATERIALIZED VIEW "AdminCommunityActivitySummary" AS
+  WITH
+    relevant_activities AS (
+      (
+        SELECT
+          a."HostCollectiveId", NULL::integer AS "UserId",
+          COALESCE((fc.data -> 'UserCollectiveId')::integer, fc.id) AS "FromCollectiveId",
+          a."CollectiveId", a.type, a."createdAt",
+          CASE
+            WHEN a.type IN ('order.processed', 'ticket.confirmed') THEN 'CONTRIBUTOR'
+            WHEN a.type = 'collective.expense.paid' AND e.type = 'GRANT'::"enum_Expenses_type" THEN 'GRANTEE'
+            WHEN a.type = 'collective.expense.paid' THEN 'PAYEE'
+            WHEN a.type = 'collective.expense.created' THEN 'EXPENSE_SUBMITTER'
+            ELSE NULL
+          END AS relations
+        FROM
+          "Activities" a
+          LEFT JOIN "Expenses" e ON a.type = 'collective.expense.paid' AND e.id = a."ExpenseId"
+          LEFT JOIN "Collectives" fc ON a."FromCollectiveId" = fc.id
+        WHERE a.type IN (
+          'order.processed', 'collective.expense.approved', 'collective.expense.paid',
+          'collective.expense.created', 'ticket.confirmed'
+        )
+        UNION ALL
+        SELECT
+          a."HostCollectiveId", a."UserId", NULL::integer AS "FromCollectiveId",
+          a."CollectiveId", a.type, a."createdAt",
+          CASE
+            WHEN a.type IN ('collective.expense.approved', 'collective.expense.rejected') THEN 'EXPENSE_APPROVER'
+            ELSE NULL
+          END AS relations
+        FROM "Activities" a
+        WHERE a.type IN ('collective.expense.approved', 'collective.expense.rejected')
+      )
+      UNION
+      SELECT
+        c."HostCollectiveId", (fc.data -> 'UserId')::integer AS "UserId",
+        COALESCE((fc.data -> 'UserCollectiveId')::integer, fc.id) AS "FromCollectiveId",
+        c.id AS "CollectiveId", NULL::character varying AS type, m."createdAt",
+        CASE WHEN m.role = 'BACKER' THEN 'CONTRIBUTOR' ELSE m.role END AS relations
+      FROM
+        "Members" m
+        INNER JOIN "Collectives" c ON m."CollectiveId" = c.id
+        INNER JOIN "Collectives" fc ON m."MemberCollectiveId" = fc.id
+      WHERE m.role::text = ANY (ARRAY ['ADMIN', 'CONTRIBUTOR', 'ATTENDEE', 'BACKER'])
+        AND m."deletedAt" IS NULL
+    )
+  SELECT
+    ra."HostCollectiveId", ra."CollectiveId",
+    COALESCE(ra."FromCollectiveId", u."CollectiveId") AS "FromCollectiveId",
+    jsonb_agg_strict(DISTINCT ra.type) AS activities,
+    jsonb_agg_strict(DISTINCT ra.relations) AS relations,
+    MAX(ra."createdAt") AS "lastInteractionAt",
+    MIN(ra."createdAt") AS "firstInteractionAt"
+  FROM
+    relevant_activities ra
+    LEFT JOIN "Users" u ON u.id = ra."UserId"
+  WHERE (ra."UserId" IS NOT NULL OR ra."FromCollectiveId" IS NOT NULL)
+    AND ra."HostCollectiveId" IS NOT NULL
+    AND ra."CollectiveId" IS NOT NULL
+  GROUP BY
+    ra."HostCollectiveId", ra."CollectiveId", COALESCE(ra."FromCollectiveId", u."CollectiveId");
+`;
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await dropView(queryInterface, transaction);
+      await createView(queryInterface, optimizedViewQuery, transaction);
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await dropView(queryInterface, transaction);
+      await createView(queryInterface, previousViewQuery, transaction);
+    });
+  },
+};

--- a/server/graphql/loaders/collective.ts
+++ b/server/graphql/loaders/collective.ts
@@ -16,8 +16,6 @@ type AdminCommunityActivitySummaryRow = {
   FromCollectiveId: number;
   activities: string[];
   relations: string[];
-  lastInteractionAt: Date;
-  firstInteractionAt: Date;
 };
 
 export default {
@@ -322,7 +320,7 @@ export default {
               fc.*,
               JSONB_OBJECT_AGG(cas."CollectiveId", cas."relations") FILTER (WHERE c."type" IN ('COLLECTIVE', 'FUND', 'PROJECT', 'EVENT')) AS "associatedCollectives",
               JSONB_OBJECT_AGG(cas."CollectiveId", cas."relations") FILTER (WHERE c."type" = 'ORGANIZATION') AS "associatedOrganizations",
-              cas."HostCollectiveId" AS "contextualHostCollectiveId", MAX(cas."lastInteractionAt") as "lastInteractionAt", MIN(cas."firstInteractionAt") as "firstInteractionAt"
+              cas."HostCollectiveId" AS "contextualHostCollectiveId"
             FROM
               "AdminCommunityActivitySummary" cas
               INNER JOIN "Collectives" fc ON fc.id = cas."FromCollectiveId"

--- a/server/graphql/v2/object/CommunityStats.ts
+++ b/server/graphql/v2/object/CommunityStats.ts
@@ -1,5 +1,4 @@
 import { GraphQLEnumType, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
-import { GraphQLDateTime } from 'graphql-scalars';
 import { compact, flatten, uniq, values } from 'lodash';
 import moment from 'moment';
 import type { Sequelize } from 'sequelize';
@@ -187,18 +186,6 @@ export const GraphQLCommunityStats = new GraphQLObjectType({
             timeUnit: 'YEAR',
             nodes,
           };
-        },
-      },
-      lastInteractionAt: {
-        type: GraphQLDateTime,
-        resolve(account) {
-          return account?.dataValues?.lastInteractionAt;
-        },
-      },
-      firstInteractionAt: {
-        type: GraphQLDateTime,
-        resolve(account) {
-          return account?.dataValues?.firstInteractionAt;
         },
       },
       activities: {

--- a/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
+++ b/server/graphql/v2/query/collection/ActivitiesCollectionQuery.ts
@@ -132,7 +132,12 @@ const ActivitiesCollectionQuery = {
         throw new Error('Cannot retrieve children accounts activity for more than 100 accounts at the same time');
       }
 
-      const allowedAccounts = isRoot ? accounts : accounts.filter(a => req.remoteUser.isAdminOfCollectiveOrHost(a));
+      const allowedAccounts =
+        isRoot ||
+        // It is fine to load host/account related activities. Adding the double check to avoid accidents in the future.
+        (host && req.remoteUser.isAdminOfCollectiveOrHost(host))
+          ? accounts
+          : accounts.filter(a => req.remoteUser.isAdminOfCollectiveOrHost(a));
       for (const account of allowedAccounts) {
         // Include all activities related to the account itself
         if (!args.excludeParentAccount) {

--- a/server/types/kysely-views.ts
+++ b/server/types/kysely-views.ts
@@ -10,8 +10,6 @@ export interface AdminCommunityActivitySummaryRow {
   FromCollectiveId?: number;
   activities?: Record<string, unknown> | unknown[];
   relations?: Record<string, unknown> | unknown[];
-  lastInteractionAt?: string;
-  firstInteractionAt?: string;
 }
 
 export interface AdminCommunityHostTransactionSummaryRow {
@@ -174,7 +172,6 @@ export interface HostedCollectivesHostingPeriodsRow {
   HostCollectiveId?: number;
   ParentCollectiveId?: number;
   collectiveType?: string;
-  isArchived?: boolean;
   startDate?: string;
   endDate?: string;
 }

--- a/test/server/graphql/v2/query/CommunityQuery.test.ts
+++ b/test/server/graphql/v2/query/CommunityQuery.test.ts
@@ -607,6 +607,7 @@ describe('server/graphql/v2/query/CommunityQuery', () => {
         FromCollectiveId: contributorWithOrderAndExpense.CollectiveId,
         CollectiveId: snapshotCollective.id,
         HostCollectiveId: snapshotHost.id,
+        UserId: contributorWithOrderAndExpense.id,
       });
       await fakeActivity({
         type: 'collective.expense.paid',
@@ -673,6 +674,7 @@ describe('server/graphql/v2/query/CommunityQuery', () => {
         FromCollectiveId: hostContributorWithOrderAndExpense.CollectiveId,
         CollectiveId: snapshotHost.id,
         HostCollectiveId: snapshotHost.id,
+        UserId: hostContributorWithOrderAndExpense.id,
       });
       await fakeActivity({
         type: 'collective.expense.paid',

--- a/test/test-helpers/fake-data.ts
+++ b/test/test-helpers/fake-data.ts
@@ -255,9 +255,9 @@ export const fakeActiveHost = async (hostData: Parameters<typeof fakeCollective>
     slug: randStr('host-'),
     HostCollectiveId: null,
     hasMoneyManagement: true,
+    hasHosting: true,
     isActive: true,
     approvedAt: new Date(),
-    hasHosting: true,
     ...hostData,
   });
 


### PR DESCRIPTION
## Summary

**AdminCommunityTransactionSummary**
- Estimated planner cost: **1,968,257 -> 896,025**, down **54.5%**.
- Execution time: **225.9s -> 109.7s**, saving **116.2s / 51.5%**.

**AdminCommunityActivitySummary**
- Replaces the activity materialized view with a smaller five-column shape.
- Removes the bulk interaction timestamp aggregation from `CommunityStats`.
- Uses account-scoped activity queries for first/latest interaction data.

## Testing

- `CommunityQuery` tests: 19 passing.
- API and frontend TypeScript checks pass.
- Frontend GraphQL code generation passes.

## Related

Requires [frontend PR #12367](https://github.com/opencollective/opencollective-frontend/pull/12367)