### PR TITLE
fix(Webhooks): deliver host application activities to the host, with a real payload

### DIFF
--- a/server/constants/activities.ts
+++ b/server/constants/activities.ts
@@ -209,6 +209,13 @@ enum ActivityTypes {
   KYC_VERIFIED = 'kyc.verified',
 }
 
+/** Activities recorded on the applicant collective that the host must also be notified about. */
+export const HostApplicationActivities = [
+  ActivityTypes.COLLECTIVE_APPLY,
+  ActivityTypes.COLLECTIVE_APPROVED,
+  ActivityTypes.COLLECTIVE_REJECTED,
+];
+
 /** This array defines the type of activities that are transactional and can not be unsubscribed by the user. */
 export const TransactionalActivities = [
   ActivityTypes.USER_NEW_TOKEN,

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import config from 'config';
 
 import { channels } from '../../constants';
-import ActivityTypes from '../../constants/activities';
+import ActivityTypes, { HostApplicationActivities } from '../../constants/activities';
 import { Activity, Notification } from '../../models';
 import logger from '../logger';
 import { reportErrorToSentry, reportMessageToSentry } from '../sentry';
@@ -16,12 +16,6 @@ import {
 } from '../webhooks';
 
 import { notifyByEmail } from './email';
-
-const HOST_APPLICATION_ACTIVITIES = [
-  ActivityTypes.COLLECTIVE_APPLY,
-  ActivityTypes.COLLECTIVE_APPROVED,
-  ActivityTypes.COLLECTIVE_REJECTED,
-];
 
 const shouldSkipActivity = (activity: Activity) => {
   if (activity.type === ActivityTypes.COLLECTIVE_TRANSACTION_CREATED) {
@@ -93,7 +87,7 @@ const dispatch = async (
     // Some activities involve multiple collectives (eg. collective applying to a host). Host application
     // activities are all recorded on the applicant, so the host has to be notified explicitly.
     const collectiveIdsToNotify = [activity.CollectiveId];
-    if (HOST_APPLICATION_ACTIVITIES.includes(activity.type) && activity.data?.host?.id) {
+    if (HostApplicationActivities.includes(activity.type) && activity.data?.host?.id) {
       collectiveIdsToNotify.push(activity.data.host.id);
     }
 

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import config from 'config';
 
-import { activities, channels } from '../../constants';
+import { channels } from '../../constants';
 import ActivityTypes from '../../constants/activities';
 import { Activity, Notification } from '../../models';
 import logger from '../logger';
@@ -16,6 +16,12 @@ import {
 } from '../webhooks';
 
 import { notifyByEmail } from './email';
+
+const HOST_APPLICATION_ACTIVITIES = [
+  ActivityTypes.COLLECTIVE_APPLY,
+  ActivityTypes.COLLECTIVE_APPROVED,
+  ActivityTypes.COLLECTIVE_REJECTED,
+];
 
 const shouldSkipActivity = (activity: Activity) => {
   if (activity.type === ActivityTypes.COLLECTIVE_TRANSACTION_CREATED) {
@@ -84,9 +90,10 @@ const dispatch = async (
       return;
     }
 
-    // Some activities involve multiple collectives (eg. collective applying to a host)
+    // Some activities involve multiple collectives (eg. collective applying to a host). Host application
+    // activities are all recorded on the applicant, so the host has to be notified explicitly.
     const collectiveIdsToNotify = [activity.CollectiveId];
-    if (activity.type === activities.COLLECTIVE_APPLY) {
+    if (HOST_APPLICATION_ACTIVITIES.includes(activity.type) && activity.data?.host?.id) {
       collectiveIdsToNotify.push(activity.data.host.id);
     }
 

--- a/server/lib/webhooks.ts
+++ b/server/lib/webhooks.ts
@@ -308,6 +308,12 @@ const getUpdateInfo = update => {
   }
 };
 
+const hostApplicationActivities = [
+  activities.COLLECTIVE_APPLY,
+  activities.COLLECTIVE_APPROVED,
+  activities.COLLECTIVE_REJECTED,
+];
+
 const expenseActivities = [
   activities.COLLECTIVE_EXPENSE_CREATED,
   activities.COLLECTIVE_EXPENSE_DELETED,
@@ -372,6 +378,15 @@ export const sanitizeActivityForWebhookPayload = (activity: Activity) => {
     cleanActivity.data.fromCollective = getCollectiveInfo(activity.data.fromCollective);
     if (activity.data.order?.TierId) {
       cleanActivity.data.tier = getTierInfo({ id: activity.data.order.TierId });
+    }
+  } else if (hostApplicationActivities.includes(type)) {
+    // Never expose `data.user`: it holds the email of the admin who applied/reviewed
+    cleanActivity.data = {
+      collective: getCollectiveInfo(activity.data.collective),
+      host: getCollectiveInfo(activity.data.host),
+    };
+    if (type === activities.COLLECTIVE_REJECTED) {
+      cleanActivity.data.rejectionReason = activity.data.rejectionReason ?? null;
     }
   } else if (
     [activities.SUBSCRIPTION_CANCELED, activities.SUBSCRIPTION_PAUSED, activities.SUBSCRIPTION_RESUMED].includes(type)

--- a/server/lib/webhooks.ts
+++ b/server/lib/webhooks.ts
@@ -7,7 +7,7 @@ import ipaddr from 'ipaddr.js';
 import { pick } from 'lodash';
 import isIP from 'validator/lib/isIP';
 
-import { activities } from '../constants';
+import activities, { HostApplicationActivities } from '../constants/activities';
 import { RateLimitExceeded } from '../graphql/errors';
 import { idEncode, IDENTIFIER_TYPES } from '../graphql/v2/identifiers';
 import { Activity } from '../models';
@@ -308,12 +308,6 @@ const getUpdateInfo = update => {
   }
 };
 
-const hostApplicationActivities = [
-  activities.COLLECTIVE_APPLY,
-  activities.COLLECTIVE_APPROVED,
-  activities.COLLECTIVE_REJECTED,
-];
-
 const expenseActivities = [
   activities.COLLECTIVE_EXPENSE_CREATED,
   activities.COLLECTIVE_EXPENSE_DELETED,
@@ -379,7 +373,7 @@ export const sanitizeActivityForWebhookPayload = (activity: Activity) => {
     if (activity.data.order?.TierId) {
       cleanActivity.data.tier = getTierInfo({ id: activity.data.order.TierId });
     }
-  } else if (hostApplicationActivities.includes(type)) {
+  } else if (HostApplicationActivities.includes(type)) {
     // Never expose `data.user`: it holds the email of the admin who applied/reviewed
     cleanActivity.data = {
       collective: getCollectiveInfo(activity.data.collective),

--- a/test/server/lib/webhooks.test.js
+++ b/test/server/lib/webhooks.test.js
@@ -235,6 +235,41 @@ describe('server/lib/webhooks', () => {
       expect(sanitized.data.collective).to.not.exist;
     });
 
+    it('Sanitizes COLLECTIVE_REJECTED, without leaking the reviewer email', () => {
+      const sanitized = sanitizeActivityForWebhookPayload({
+        type: activities.COLLECTIVE_REJECTED,
+        data: {
+          collective: { id: 42, slug: 'babel' },
+          host: { id: 43, slug: 'europe' },
+          rejectionReason: 'Out of scope',
+          user: { email: 'admin@opencollective.com' },
+        },
+      });
+
+      expect(sanitized.data.collective.id).to.eq(42);
+      expect(sanitized.data.host.id).to.eq(43);
+      expect(sanitized.data.rejectionReason).to.eq('Out of scope');
+      expect(sanitized.data.user).to.not.exist;
+    });
+
+    it('Sanitizes COLLECTIVE_APPLY, without leaking the applicant email', () => {
+      const sanitized = sanitizeActivityForWebhookPayload({
+        type: activities.COLLECTIVE_APPLY,
+        data: {
+          collective: { id: 42, slug: 'babel' },
+          host: { id: 43, slug: 'europe' },
+          user: { email: 'applicant@opencollective.com' },
+          application: { message: 'Please host us' },
+        },
+      });
+
+      expect(sanitized.data.collective.slug).to.eq('babel');
+      expect(sanitized.data.host.slug).to.eq('europe');
+      expect(sanitized.data.user).to.not.exist;
+      expect(sanitized.data.application).to.not.exist;
+      expect(sanitized.data.rejectionReason).to.not.exist;
+    });
+
     it('Sanitizes COLLECTIVE_EXPENSE_CREATED', () => {
       const sanitized = sanitizeActivityForWebhookPayload({
         type: activities.COLLECTIVE_EXPENSE_CREATED,


### PR DESCRIPTION
We got feedback from a fiscal host admin asking why the UI only offers a limited set of webhook activities while the API accepts many more. They had worked around it by creating a `collective.rejected` webhook through the API. It turns out the webhook they created would never have fired, and neither would the `collective.approved` one they had set up through the UI.

`collective.apply`, `collective.approved` and `collective.rejected` all record their Activity on the applicant collective, with the host only in `data.host` and `HostCollectiveId`. But the dispatch logic only matched notifications on `activity.CollectiveId`, with a single special case pushing the host for `collective.apply`. So a webhook registered on a host account never matched for approved or rejected.

On top of that, none of the three had a branch in `sanitizeActivityForWebhookPayload`, so they fell through to the default and were delivered with an empty `data` object. Even when `collective.apply` did fire, the host received an event with no indication of which collective had applied.

Worth a second opinion on the fan-out change: hosts subscribed to the `all` activity type will now start receiving approved and rejected events for their hosted collectives. That is consistent with them already receiving `collective.apply` the same way, but it is a change in volume for existing subscribers rather than a pure addition.

Here is what the PR does:

- extend the host fan-out in `dispatch` to cover all three host application activities instead of just `collective.apply`
- add a sanitize branch for the three, exposing `collective`, `host`, and `rejectionReason` on rejection
- deliberately leave out `data.user`, which holds the email of the admin who applied or reviewed, and the applicant-entered `application.message` and `customData`
- move the shared list of the three activity types into `server/constants/activities.ts`, next to `TransactionalActivities`
- cover the new branch with two tests asserting the email never reaches the payload

The frontend side, adding `collective.rejected` to the webhook picker, comes in a separate PR.

The wider gap between the picker, the sanitizer and the API enum is documented in opencollective/opencollective#8908.