### PR TITLE
fix: correct copy-paste error in the Comment.getUser comment

### DIFF
--- a/server/models/Comment.ts
+++ b/server/models/Comment.ts
@@ -68,7 +68,7 @@ class Comment extends ModelWithPublicId<
   declare public conversation?: NonAttribute<Conversation>;
   declare public commentUpdate?: NonAttribute<Update>;
 
-  // Returns the User model of the User that created this Update
+  // Returns the User model of the User that created this Comment
   getUser = function () {
     return User.findByPk(this.CreatedByUserId);
   };


### PR DESCRIPTION
The comment above Comment.getUser says it returns the user that created
"this Update" - a leftover from wherever it was copied from. It returns
the author of the comment.
