### PR TITLE
Generate Application credentials in a beforeCreate hook

### DIFF
--- a/server/models/Application.ts
+++ b/server/models/Application.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 
-import { isNil, merge } from 'lodash';
+import { isNil } from 'lodash';
 import type {
   Association,
   BelongsToGetAssociationMixin,
@@ -168,22 +168,19 @@ Application.init(
     sequelize,
     modelName: 'Application',
     paranoid: true,
+    hooks: {
+      // Credentials are always generated server-side, whatever the caller passes in
+      beforeCreate(application) {
+        if (application.type === 'apiKey') {
+          application.apiKey = randomBytes(20).toString('hex');
+        }
+        if (application.type === 'oAuth') {
+          application.clientId = randomBytes(10).toString('hex'); // Will be 20 length in ascii
+          application.clientSecret = randomBytes(20).toString('hex'); // Will be 40 length in ascii
+        }
+      },
+    },
   },
 );
-
-Application.create = (props?): Promise<ReturnType<typeof Application.create>> => {
-  if (props.type === 'apiKey') {
-    props = merge(props, {
-      apiKey: randomBytes(20).toString('hex'),
-    });
-  }
-  if (props.type === 'oAuth') {
-    props = merge(props, {
-      clientId: randomBytes(10).toString('hex'), // Will be 20 length in ascii
-      clientSecret: randomBytes(20).toString('hex'), // Will be 40 length in ascii
-    });
-  }
-  return Application.build(props).save();
-};
 
 export default Application;


### PR DESCRIPTION
Preparation for #12072 (TypeScript 7). With TS 7.0.2 the only error in this repo is:

```
server/models/Application.ts(186,10): error TS2684: The 'this' context of type 'typeof Application' is not assignable to method's 'this' of type 'ModelStatic<M>'.
```

It comes from reassigning the static `Application.create` with a narrower, self-referential signature and then calling `Application.build()` inside it. This moves the credential generation into a `beforeCreate` hook and drops the override. Behavior is unchanged: `apiKey` for `apiKey` applications and `clientId` / `clientSecret` for `oAuth` applications are still always generated server-side, whatever the caller passes (the previous `merge` also overwrote them). `Application.build().save()` was not used anywhere else, so no other path gains the hook.

Verified with TS 7.0.2 (`tsc --noEmit` clean) and TS 6 on `main`, and with the Application, scope-check and token credential test suites (90 passing).

#12072 itself stays blocked on tooling: `@typescript-eslint/parser` 8.69 declares `typescript >=4.8.4 <6.1.0` and refuses TS 7.0 (typescript-eslint/typescript-eslint#10940), and `ts-unused-exports` crashes on it.