### PR TITLE
fix(Tiers): count recurring orders once in availableQuantity

### DIFF
--- a/server/graphql/loaders/tiers.ts
+++ b/server/graphql/loaders/tiers.ts
@@ -11,7 +11,6 @@ export const generateTierAvailableQuantityLoader = () => {
       SELECT t.id, (t."maxQuantity" - (
         SELECT COALESCE(SUM(o.quantity), 0)
         FROM "Orders" o
-        LEFT JOIN "Transactions" trx ON trx."OrderId" = o.id AND trx."kind" = 'CONTRIBUTION' AND trx."type" = 'CREDIT' AND trx."deletedAt" IS NULL
         WHERE o."TierId" = t.id
         AND o."deletedAt" IS NULL
         AND (
@@ -19,8 +18,27 @@ export const generateTierAvailableQuantityLoader = () => {
           OR (o."status" IN ('NEW', 'REQUIRE_CLIENT_CONFIRMATION', 'PROCESSING') AND o."updatedAt" > NOW() - INTERVAL '12 hour') -- Allow 12 hours to complete a payment
         )
         AND (
-          trx.id IS NULL -- No transactions yet, important to consider for payment intents that are processed asynchronously
-          OR trx."RefundTransactionId" IS NULL -- Not refunded
+          -- Occupied if there are no contribution credits yet (async payment intents)
+          -- or if at least one contribution credit is not refunded.
+          -- Count each order once so recurring charges do not consume extra quantity.
+          -- See https://github.com/opencollective/opencollective/issues/8875
+          NOT EXISTS (
+            SELECT 1
+            FROM "Transactions" trx
+            WHERE trx."OrderId" = o.id
+              AND trx."kind" = 'CONTRIBUTION'
+              AND trx."type" = 'CREDIT'
+              AND trx."deletedAt" IS NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM "Transactions" trx
+            WHERE trx."OrderId" = o.id
+              AND trx."kind" = 'CONTRIBUTION'
+              AND trx."type" = 'CREDIT'
+              AND trx."deletedAt" IS NULL
+              AND trx."RefundTransactionId" IS NULL
+          )
         )
       )) AS "availableQuantity"
       FROM "Tiers" t

--- a/test/server/graphql/loaders/tiers.test.ts
+++ b/test/server/graphql/loaders/tiers.test.ts
@@ -3,10 +3,22 @@ import moment from 'moment';
 import { QueryTypes } from 'sequelize';
 
 import OrderStatuses from '../../../../server/constants/order-status';
+import { TransactionKind } from '../../../../server/constants/transaction-kind';
 import { generateTierAvailableQuantityLoader } from '../../../../server/graphql/loaders/tiers';
 import { refundTransaction } from '../../../../server/lib/payments';
 import { sequelize } from '../../../../server/models';
-import { fakeOrder, fakeTier } from '../../../test-helpers/fake-data';
+import { fakeOrder, fakeTier, fakeTransaction } from '../../../test-helpers/fake-data';
+
+const addContributionCharge = async (order: Awaited<ReturnType<typeof fakeOrder>>) => {
+  await fakeTransaction({
+    OrderId: order.id,
+    type: 'CREDIT',
+    kind: TransactionKind.CONTRIBUTION,
+    FromCollectiveId: order.FromCollectiveId,
+    CollectiveId: order.CollectiveId,
+    amount: order.totalAmount,
+  });
+};
 
 describe('server/graphql/loaders/tiers', () => {
   describe('availableQuantity', () => {
@@ -93,6 +105,42 @@ describe('server/graphql/loaders/tiers', () => {
       const loader = generateTierAvailableQuantityLoader();
       const availableQuantity = await loader.load(tier.id);
       expect(availableQuantity).to.equal(8); // Only one "NEW" and one "PROCESSING" recent order
+    });
+
+    it('counts recurring orders once even when they have multiple contribution charges', async () => {
+      const tier = await fakeTier({ maxQuantity: 8 });
+
+      // Reproduce https://github.com/opencollective/opencollective/issues/8875:
+      // 4 active subscriptions, each charged twice, must occupy 4 slots (not 8).
+      for (let i = 0; i < 4; i++) {
+        const order = await fakeOrder(
+          { TierId: tier.id, status: OrderStatuses.ACTIVE, quantity: 1 },
+          { withSubscription: true, withTransactions: true },
+        );
+        await addContributionCharge(order);
+      }
+
+      const loader = generateTierAvailableQuantityLoader();
+      const availableQuantity = await loader.load(tier.id);
+      expect(availableQuantity).to.equal(4);
+    });
+
+    it('still occupies a slot if only some recurring charges were refunded', async () => {
+      const tier = await fakeTier({ maxQuantity: 5 });
+      const order = await fakeOrder(
+        { TierId: tier.id, status: OrderStatuses.ACTIVE, quantity: 1 },
+        { withSubscription: true, withTransactions: true },
+      );
+      await addContributionCharge(order);
+
+      const [firstCharge] = await order.getTransactions({
+        where: { kind: TransactionKind.CONTRIBUTION, type: 'CREDIT' },
+      });
+      await refundTransaction(firstCharge);
+
+      const loader = generateTierAvailableQuantityLoader();
+      const availableQuantity = await loader.load(tier.id);
+      expect(availableQuantity).to.equal(4); // Subscription still active
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes remaining ticket/slot counts for limited tiers that have recurring contributions ([opencollective/opencollective#8875](https://github.com/opencollective/opencollective/issues/8875)).

`availableQuantity` joined each order to every `CONTRIBUTION` `CREDIT` transaction. Recurring subscriptions produce one credit per billing cycle, so `SUM(orders.quantity)` grew with each charge. Example from the report: a Platinum Sponsor tier with max 8 and 4 active sponsors showed 0 remaining because 8 charges were counted instead of 4 orders.

The loader now counts each order once:
- Include the order if it has no contribution credits yet (async payment intents)
- Or if at least one contribution credit is not refunded

Refunded one-time contributions still free their quantity. A recurring order with some refunded charges still occupies a slot while the subscription is active.

Frontend `availableQuantity` already comes from this API field, so no frontend change is required.

## Test plan

- [x] Add a regression covering 4 active subscriptions × 2 charges on a max-8 tier (`availableQuantity` is 4, not 0)
- [x] Add coverage that a partial refund on a recurring order still occupies one slot
- [x] Existing refund / paused / processing-order `availableQuantity` tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e19d6458-ada8-45bc-80cb-ba8924166f49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e19d6458-ada8-45bc-80cb-ba8924166f49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

