### PR TITLE
Fix bug causing findUnusedVirtualCards to keep deactivating inactive cards

### DIFF
--- a/cron/daily/52-pause-virtual-cards-after-period-of-inactivity.ts
+++ b/cron/daily/52-pause-virtual-cards-after-period-of-inactivity.ts
@@ -56,9 +56,9 @@ async function findUnusedVirtualCards() {
         `),
         // the card was not resumed in the period
         sequelize.literal(`
-          "VirtualCard"."resumedAt" IS NULL OR 
-          "VirtualCard"."resumedAt" <= now() - make_interval(
-            days => cast("host".settings#>'{virtualcards,autopauseUnusedCards,period}' as integer)
+          (
+            "VirtualCard"."resumedAt" IS NULL OR 
+            "VirtualCard"."resumedAt" <= now() - make_interval(days => cast("host".settings#>'{virtualcards,autopauseUnusedCards,period}' as integer))
           )
         `),
       ],


### PR DESCRIPTION
This literal was breaking the expected AND behavior of this array.

Effectively, it was enough to have this evaluating to true and we would consider the virtual card unused.
```sql
"VirtualCard"."resumedAt" <= now() - make_interval(days => cast("host".settings#>'{virtualcards,autopauseUnusedCards,period}' as integer))
``` 