### PR TITLE
Enforce scope in TransactionGroupQuery

### DIFF
--- a/server/graphql/v2/query/TransactionGroupQuery.ts
+++ b/server/graphql/v2/query/TransactionGroupQuery.ts
@@ -4,6 +4,7 @@ import { roundCentsAmount } from '../../../lib/currency';
 import { assertCanSeeAccount } from '../../../lib/private-accounts';
 import { getTransactionKindPriorityCase } from '../../../lib/transactions/kind-priority';
 import { sequelize, Transaction } from '../../../models';
+import { enforceScope } from '../../common/scope-check';
 import { fetchAccountWithReference, GraphQLAccountReferenceInput } from '../input/AccountReferenceInput';
 import { GraphQLTransactionGroup } from '../object/TransactionGroup';
 
@@ -22,6 +23,8 @@ const TransactionGroupQuery = {
     },
   },
   async resolve(_, args, req) {
+    enforceScope(req, 'transactions');
+
     if (!args.account) {
       throw new Error('You need to provide an account argument');
     }

--- a/test/server/graphql/v2/query/TransactionGroupQuery.test.ts
+++ b/test/server/graphql/v2/query/TransactionGroupQuery.test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import gql from 'fake-tag';
+
+import OAuthScopes from '../../../../../server/constants/oauth-scopes';
+import { fakeOrder, fakePersonalToken, fakeUser } from '../../../../test-helpers/fake-data';
+import { personalTokenGraphqlQueryV2, resetTestDB } from '../../../../utils';
+
+const transactionGroupQuery = gql`
+  query TransactionGroup($groupId: String!, $account: AccountReferenceInput!) {
+    transactionGroup(groupId: $groupId, account: $account) {
+      id
+    }
+  }
+`;
+
+describe('TransactionGroupQuery', () => {
+  before(resetTestDB);
+
+  it('rejects personal tokens without the transactions scope', async () => {
+    const user = await fakeUser();
+    const order = await fakeOrder(
+      {
+        CreatedByUserId: user.id,
+        CollectiveId: user.CollectiveId,
+      },
+      { withTransactions: true },
+    );
+    const personalToken = await fakePersonalToken({ user, scope: [OAuthScopes.account] });
+
+    const result = await personalTokenGraphqlQueryV2(
+      transactionGroupQuery,
+      {
+        groupId: order.transactions[0].TransactionGroup,
+        account: { slug: user.collective.slug },
+      },
+      personalToken,
+    );
+
+    expect(result.errors).to.exist;
+    expect(result.errors[0].message).to.equal(
+      'The Personal Token is not allowed for operations in scope "transactions".',
+    );
+  });
+});


### PR DESCRIPTION
Enforce required scopes when querying TransactionGroup using user or personal tokens.