### PR TITLE
Enforce 2FA for platform subscription changes

### DIFF
--- a/server/graphql/v2/mutation/PlatformSubscriptionsMutations.ts
+++ b/server/graphql/v2/mutation/PlatformSubscriptionsMutations.ts
@@ -1,9 +1,11 @@
 import assert from 'assert';
 
+import express from 'express';
 import { GraphQLNonNull, GraphQLString } from 'graphql';
 
 import { PlatformSubscriptionPlan, PlatformSubscriptionTiers } from '../../../constants/plans';
-import { Collective, PlatformSubscription } from '../../../models';
+import twoFactorAuthLib from '../../../lib/two-factor-authentication';
+import { Collective, PlatformSubscription, sequelize } from '../../../models';
 import { checkRemoteUserCanUseAccount } from '../../common/scope-check';
 import { fetchAccountWithReference, GraphQLAccountReferenceInput } from '../input/AccountReferenceInput';
 import { GraphQLPlatformSubscriptionInput } from '../input/PlatformSubcriptionInput';
@@ -25,7 +27,7 @@ const platformSubscriptionMutations = {
         description: 'The new platform subscription tier to apply to the account',
       },
     },
-    async resolve(_, args, req: Express.Request): Promise<Collective> {
+    async resolve(_, args, req: express.Request): Promise<Collective> {
       checkRemoteUserCanUseAccount(req, {
         signedOutMessage: 'You need to be logged in to update a platform subscription',
       });
@@ -75,11 +77,16 @@ const platformSubscriptionMutations = {
         };
       }
 
-      await PlatformSubscription.replaceCurrentSubscription(account, new Date(), plan, req.remoteUser, {
-        UserTokenId: req.userToken?.id,
-      });
+      await twoFactorAuthLib.enforceForAccount(req, account, { alwaysAskForToken: true });
 
-      return account.update({ plan: null });
+      return sequelize.transaction(async transaction => {
+        await PlatformSubscription.replaceCurrentSubscription(account, new Date(), plan, req.remoteUser, {
+          UserTokenId: req.userToken?.id,
+          transaction,
+        });
+
+        return account.update({ plan: null }, { transaction });
+      });
     },
   },
 };

--- a/test/server/graphql/v2/mutation/PlatformSubscriptionsMutations.test.ts
+++ b/test/server/graphql/v2/mutation/PlatformSubscriptionsMutations.test.ts
@@ -134,6 +134,26 @@ describe('server/graphql/v2/mutation/PlatformSubscriptionsMutations', () => {
       expect(res.errors[0].message).to.eql('User cannot update subscription');
     });
 
+    it('requires 2FA when an admin with 2FA configured changes the plan', async () => {
+      const adminUser = await fakeUser({}, {}, { enable2FA: true });
+      const col = await fakeCollective({
+        admin: adminUser,
+        data: { policies: { REQUIRE_2FA_FOR_ADMINS: true } },
+      });
+
+      const res = await graphqlQueryV2(
+        updateAccountPlatformSubscriptionMutation,
+        {
+          account: { slug: col.slug },
+          planId: 'basic-5',
+        },
+        adminUser,
+      );
+
+      expect(res.errors).to.not.be.empty;
+      expect(res.errors[0].message).to.eql('Two-factor authentication required');
+    });
+
     it('must be valid plan id', async () => {
       const colUser = await fakeUser();
       const col = await fakeCollective({


### PR DESCRIPTION
Require account-scoped 2FA when updating platform subscriptions, perform the subscription replacement and account update transactionally, and add regression coverage for administrators with 2FA enabled.

Alternatively, if we think this is bad for subscriber UX, we could only enforce this for root users.