### PR TITLE
fix(security): ignore isNewUser on established member invitees

### DIFF
--- a/server/graphql/schemaV2.graphql
+++ b/server/graphql/schemaV2.graphql
@@ -27172,9 +27172,12 @@ type Mutation {
     privateNote: String
 
     """
-    When true, the invited user account was just created from the invite form. The invitee will be required to complete their profile before accepting the invitation.
+    When true, the invited user account was just created from the invite form. Ignored if the invitee has already signed in. The invitee will be required to complete their profile before accepting the invitation.
     """
     isNewUser: Boolean = false
+      @deprecated(
+        reason: "2026-09-09: Untrusted client input. The server only flags accounts that have never signed in (or already require profile completion)."
+      )
   ): MemberInvitation!
 
   """

--- a/server/graphql/v2/mutation/AccountMutations.ts
+++ b/server/graphql/v2/mutation/AccountMutations.ts
@@ -742,10 +742,14 @@ const accountMutations = {
 
       if (account.data?.requiresProfileCompletion === true) {
         updateParams.data = Object.assign({}, account.data, updateParams.data, { requiresProfileCompletion: false });
-        // Update slug if either the name is updated or if this is a previous guest account that already had a name
+        // Only auto-rewrite placeholder slugs (guest-* / user-*). `!updateParams.slug` used to
+        // match every established profile, and generateSlug() then treated the current slug as
+        // taken and assigned a random suffix — a public URL takeover if an invitation had
+        // incorrectly set requiresProfileCompletion on an existing user.
         if (
           (updateParams.name || ![DEFAULT_GUEST_NAME, 'Incognito'].includes(account.name)) &&
-          (!updateParams.slug || account.slug.startsWith('guest-') || account.slug.startsWith('user-'))
+          !updateParams.slug &&
+          (account.slug.startsWith('guest-') || account.slug.startsWith('user-'))
         ) {
           updateParams.slug = await Collective.generateSlug((updateParams.name as string) || account.name);
           previousData.slug = account.slug;

--- a/server/graphql/v2/mutation/MemberInvitationMutations.ts
+++ b/server/graphql/v2/mutation/MemberInvitationMutations.ts
@@ -81,7 +81,9 @@ const memberInvitationMutations = {
       isNewUser: {
         type: GraphQLBoolean,
         description:
-          'When true, the invited user account was just created from the invite form. The invitee will be required to complete their profile before accepting the invitation.',
+          'When true, the invited user account was just created from the invite form. Ignored if the invitee has already signed in. The invitee will be required to complete their profile before accepting the invitation.',
+        deprecationReason:
+          '2026-09-09: Untrusted client input. The server only flags accounts that have never signed in (or already require profile completion).',
         defaultValue: false,
       },
     },

--- a/server/models/MemberInvitation.ts
+++ b/server/models/MemberInvitation.ts
@@ -170,17 +170,31 @@ class MemberInvitation extends ModelWithPublicId<
       ...sequelizeParams,
     });
 
-    // If this is a freshly-created user account, flag their collective so they're prompted
-    // to complete their profile before they can accept the invitation. Mirrors the signup flow.
+    // `isNewUser` is supplied by callers (including a client-controlled GraphQL argument).
+    // Only flag accounts that have never signed in, or that already require profile completion.
+    // Otherwise an admin of any collective could invite an established user with isNewUser=true
+    // and force requiresProfileCompletion — which used to rewrite their public slug on the next
+    // profile edit (generateSlug treats the current slug as taken and appends a random suffix).
+    let treatAsNewUser = false;
     if (isNewUser) {
+      const inviteeUser = await User.findOne({
+        where: { CollectiveId: memberParams.MemberCollectiveId },
+        ...sequelizeParams,
+      });
       const inviteeCollective = await Collective.findByPk(memberParams.MemberCollectiveId, sequelizeParams);
-      if (inviteeCollective) {
+      const alreadyRequiresCompletion = Boolean(inviteeCollective?.data?.requiresProfileCompletion);
+      const hasLoggedIn = Boolean(inviteeUser?.lastLoginAt);
+      treatAsNewUser = alreadyRequiresCompletion || !hasLoggedIn;
+
+      if (treatAsNewUser && inviteeCollective && !alreadyRequiresCompletion) {
         const newData = { ...inviteeCollective.data, requiresProfileCompletion: true };
         await inviteeCollective.update({ data: newData }, sequelizeParams);
       }
     }
 
-    await invitation.sendEmail(createdByUser, skipDefaultAdmin, sequelizeParams, privateNote, { isNewUser });
+    await invitation.sendEmail(createdByUser, skipDefaultAdmin, sequelizeParams, privateNote, {
+      isNewUser: treatAsNewUser,
+    });
     return invitation;
   }
 }

--- a/server/models/MemberInvitation.ts
+++ b/server/models/MemberInvitation.ts
@@ -183,8 +183,8 @@ class MemberInvitation extends ModelWithPublicId<
       });
       const inviteeCollective = await Collective.findByPk(memberParams.MemberCollectiveId, sequelizeParams);
       const alreadyRequiresCompletion = Boolean(inviteeCollective?.data?.requiresProfileCompletion);
-      const hasLoggedIn = Boolean(inviteeUser?.lastLoginAt);
-      treatAsNewUser = alreadyRequiresCompletion || !hasLoggedIn;
+      const hasNeverSignedIn = Boolean(inviteeUser) && !inviteeUser.lastLoginAt;
+      treatAsNewUser = alreadyRequiresCompletion || hasNeverSignedIn;
 
       if (treatAsNewUser && inviteeCollective && !alreadyRequiresCompletion) {
         const newData = { ...inviteeCollective.data, requiresProfileCompletion: true };

--- a/test/server/graphql/v2/mutation/AccountMutations.test.ts
+++ b/test/server/graphql/v2/mutation/AccountMutations.test.ts
@@ -12,7 +12,7 @@ import OrderStatuses from '../../../../../server/constants/order-status';
 import { PlatformSubscriptionTiers } from '../../../../../server/constants/plans';
 import POLICIES from '../../../../../server/constants/policies';
 import MemberRoles from '../../../../../server/constants/roles';
-import { idEncode } from '../../../../../server/graphql/v2/identifiers';
+import { idEncode, IDENTIFIER_TYPES } from '../../../../../server/graphql/v2/identifiers';
 import emailLib from '../../../../../server/lib/email';
 import { TwoFactorAuthenticationHeader } from '../../../../../server/lib/two-factor-authentication/lib';
 import * as yubikeyOtp from '../../../../../server/lib/two-factor-authentication/yubikey-otp';
@@ -41,6 +41,16 @@ const editSettingsMutation = gql`
     editAccountSetting(account: $account, key: $key, value: $value) {
       id
       settings
+    }
+  }
+`;
+
+const editAccountMutation = gql`
+  mutation EditAccount($account: AccountUpdateInput!) {
+    editAccount(account: $account) {
+      id
+      slug
+      description
     }
   }
 `;
@@ -386,6 +396,57 @@ describe('server/graphql/v2/mutation/AccountMutations', () => {
       expect(result.errors[0].message).to.match(
         /Enter a valid URL. The URL should have the format https:\/\/example.com\/…/,
       );
+    });
+  });
+
+  describe('editAccount', () => {
+    it('does not rewrite an established public slug when requiresProfileCompletion is set', async () => {
+      const user = await fakeUser(null, { slug: randStr('ada-lovelace-'), data: { requiresProfileCompletion: true } });
+
+      const result = await graphqlQueryV2(
+        editAccountMutation,
+        {
+          account: {
+            id: idEncode(user.collective.id, IDENTIFIER_TYPES.ACCOUNT),
+            description: 'Completing my profile',
+          },
+        },
+        user,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.editAccount.slug).to.equal(user.collective.slug);
+      expect(result.data.editAccount.description).to.equal('Completing my profile');
+
+      await user.collective.reload();
+      expect(user.collective.data?.requiresProfileCompletion).to.not.equal(true);
+    });
+
+    it('still rewrites placeholder guest-/user- slugs when completing a profile', async () => {
+      const user = await fakeUser(null, {
+        name: 'Brand New Person',
+        slug: `guest-${randStr('slug')}`,
+        data: { requiresProfileCompletion: true },
+      });
+      const previousSlug = user.collective.slug;
+
+      const result = await graphqlQueryV2(
+        editAccountMutation,
+        {
+          account: {
+            id: idEncode(user.collective.id, IDENTIFIER_TYPES.ACCOUNT),
+            description: 'Hello world',
+          },
+        },
+        user,
+      );
+
+      expect(result.errors).to.not.exist;
+      expect(result.data.editAccount.slug).to.not.equal(previousSlug);
+      expect(result.data.editAccount.slug).to.match(/^brand-new-person/);
+
+      await user.collective.reload();
+      expect(user.collective.data?.requiresProfileCompletion).to.not.equal(true);
     });
   });
 

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -44,6 +44,7 @@ describe('MemberInvitationMutations', () => {
       $description: String
       $since: DateTime
       $privateNote: String
+      $isNewUser: Boolean
     ) {
       inviteMember(
         memberAccount: $memberAccount
@@ -52,6 +53,7 @@ describe('MemberInvitationMutations', () => {
         description: $description
         since: $since
         privateNote: $privateNote
+        isNewUser: $isNewUser
       ) {
         id
         role
@@ -243,6 +245,71 @@ describe('MemberInvitationMutations', () => {
         expect(result.errors).to.have.length(1);
         expect(result.errors[0].message).to.equal('You can only invite accountants, admins, or members.');
       }
+    });
+
+    it('does not let isNewUser flag an established (already signed-in) user for profile completion', async () => {
+      const establishedUser = await fakeUser({ lastLoginAt: new Date() });
+      const originalSlug = establishedUser.collective.slug;
+
+      const result = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(establishedUser.collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          role: roles.MEMBER,
+          isNewUser: true,
+        },
+        collectiveAdminUser,
+      );
+
+      expect(result.errors).to.not.exist;
+
+      await establishedUser.collective.reload();
+      expect(establishedUser.collective.data?.requiresProfileCompletion).to.not.equal(true);
+      expect(establishedUser.collective.slug).to.equal(originalSlug);
+
+      const emailActivity = await models.Activity.findOne({
+        where: {
+          type: ActivityTypes.COLLECTIVE_MEMBER_INVITED,
+          CollectiveId: collective.id,
+          FromCollectiveId: establishedUser.collective.id,
+        },
+        order: [['id', 'DESC']],
+      });
+      expect(emailActivity).to.exist;
+      expect(emailActivity.data.isNewUser).to.equal(false);
+    });
+
+    it('still flags a never-signed-in invitee when isNewUser is true (invite-form flow)', async () => {
+      const newInvitee = await fakeUser(); // lastLoginAt is unset
+      expect(newInvitee.lastLoginAt).to.not.exist;
+
+      const result = await utils.graphqlQueryV2(
+        inviteMemberMutation,
+        {
+          memberAccount: { id: idEncode(newInvitee.collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          account: { id: idEncode(collective.id, IDENTIFIER_TYPES.ACCOUNT) },
+          role: roles.MEMBER,
+          isNewUser: true,
+        },
+        collectiveAdminUser,
+      );
+
+      expect(result.errors).to.not.exist;
+
+      await newInvitee.collective.reload();
+      expect(newInvitee.collective.data?.requiresProfileCompletion).to.equal(true);
+
+      const emailActivity = await models.Activity.findOne({
+        where: {
+          type: ActivityTypes.COLLECTIVE_MEMBER_INVITED,
+          CollectiveId: collective.id,
+          FromCollectiveId: newInvitee.collective.id,
+        },
+        order: [['id', 'DESC']],
+      });
+      expect(emailActivity).to.exist;
+      expect(emailActivity.data.isNewUser).to.equal(true);
     });
 
     it('can only add with a user account', async () => {

--- a/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
+++ b/test/server/graphql/v2/mutation/MemberInvitationMutations.test.ts
@@ -264,6 +264,7 @@ describe('MemberInvitationMutations', () => {
 
       expect(result.errors).to.not.exist;
 
+      await utils.waitForCondition(() => sendEmailSpy.callCount);
       await establishedUser.collective.reload();
       expect(establishedUser.collective.data?.requiresProfileCompletion).to.not.equal(true);
       expect(establishedUser.collective.slug).to.equal(originalSlug);
@@ -297,6 +298,7 @@ describe('MemberInvitationMutations', () => {
 
       expect(result.errors).to.not.exist;
 
+      await utils.waitForCondition(() => sendEmailSpy.callCount);
       await newInvitee.collective.reload();
       expect(newInvitee.collective.data?.requiresProfileCompletion).to.equal(true);
 

--- a/test/server/models/Order.test.js
+++ b/test/server/models/Order.test.js
@@ -74,9 +74,12 @@ describe('server/models/Order', () => {
       const lockSpy = sandbox.spy(order, 'lock');
 
       let firstCallResult, secondCallResult;
+      let onFirstCallLocked;
+      const firstCallLocked = new Promise(resolve => (onFirstCallLocked = resolve));
       const firstCall = order.lock(
         () =>
           new Promise(resolve => {
+            onFirstCallLocked();
             setTimeout(() => {
               resolve();
               firstCallResult = 1;
@@ -84,6 +87,11 @@ describe('server/models/Order', () => {
           }),
       );
       expect(firstCallResult).to.be.undefined;
+
+      // Both calls compete for the same lock, and only the second one is allowed to retry. Wait
+      // for the first one to hold the lock, otherwise the second can win the race and the first
+      // fails outright.
+      await firstCallLocked;
 
       const secondCall = order.lock(
         () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -50,9 +50,11 @@ export const resetCaches = async () => {
 };
 
 export const resetTestDB = async ({ groupedTruncate = true, retries = 5 } = {}) => {
-  // Truncating with RESTART IDENTITY makes ids start over, so entries keyed by id (2FA sessions,
-  // collective caches...) would otherwise be applied to unrelated records created by the next file.
-  await resetCaches();
+  // Truncating with RESTART IDENTITY makes ids start over, so a 2FA session stored as
+  // `2fa:${userId}:${sessionId}` would otherwise satisfy the 2FA check for whichever unrelated
+  // user reuses that id next. Only the session cache is cleared: the default one holds things
+  // like FX rates that tests deliberately share.
+  await sessionCache.clear();
 
   const resetFn = async () => {
     // Using a manual query rather than `await sequelize.truncate({ cascade: true,  restartIdentity: true });`

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -50,6 +50,10 @@ export const resetCaches = async () => {
 };
 
 export const resetTestDB = async ({ groupedTruncate = true, retries = 5 } = {}) => {
+  // Truncating with RESTART IDENTITY makes ids start over, so entries keyed by id (2FA sessions,
+  // collective caches...) would otherwise be applied to unrelated records created by the next file.
+  await resetCaches();
+
   const resetFn = async () => {
     // Using a manual query rather than `await sequelize.truncate({ cascade: true,  restartIdentity: true });`
     // for performance reasons: https://github.com/sequelize/sequelize/issues/15865

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -52,9 +52,13 @@ export const resetCaches = async () => {
 export const resetTestDB = async ({ groupedTruncate = true, retries = 5 } = {}) => {
   // Truncating with RESTART IDENTITY makes ids start over, so a 2FA session stored as
   // `2fa:${userId}:${sessionId}` would otherwise satisfy the 2FA check for whichever unrelated
-  // user reuses that id next. Only the session cache is cleared: the default one holds things
-  // like FX rates that tests deliberately share.
-  await sessionCache.clear();
+  // user reuses that id next. Only those keys are dropped rather than clearing the cache: CI
+  // leaves `redis.serverUrlSession` unset, so sessionCache falls back to the default Redis
+  // instance and a flush would also drop entries tests share on purpose, such as FX rates.
+  const twoFactorSessionKeys = await sessionCache.keys('2fa:*');
+  if (twoFactorSessionKeys?.length) {
+    await sessionCache.delete(twoFactorSessionKeys);
+  }
 
   const resetFn = async () => {
     // Using a manual query rather than `await sequelize.truncate({ cascade: true,  restartIdentity: true });`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Security audit of the members invitation process found a **high-severity** issue:

`inviteMember` accepted a client-controlled `isNewUser` flag and wrote `requiresProfileCompletion` onto the **invitee's** account. Any collective admin could invite an established user with `isNewUser: true`. On that user's next `editAccount` call, slug regeneration treated a missing `slug` input as a placeholder and called `generateSlug()`, which sees the current slug as taken and assigns a random suffix — rewriting their public URL.

The bulk `inviteMembers` path was never exposed: `processInviteMembersInput` derives `isNewUser` server-side, setting it only when it just created the user. Only the single `inviteMember` mutation passed the raw GraphQL argument through.

### Reproduction

Against the code on `main`, a user who is admin only of a collective they created themselves can rewrite an unrelated user's public URL:

```
[repro] victim requiresProfileCompletion after attacker invite = true
[repro] victim slug before = ada-lovelace | after = ada-lovelace-4b59857b
```

The victim never requested a slug change; they only edited their profile description. With this branch applied, the same script leaves the flag unset and the slug intact.

### Fixes

1. **`MemberInvitation.invite`**: only set `requiresProfileCompletion` (and the new-user email CTA) when the invitee is an existing `User` row that has never signed in, or that already requires profile completion. A client-supplied `isNewUser` cannot flag an account that has `lastLoginAt`.
2. **`editAccount`**: only auto-rewrite `guest-*` / `user-*` placeholder slugs during profile completion. Established public slugs are left unchanged.
3. Deprecated the untrusted GraphQL `isNewUser` argument.

The legitimate invite-form flow (create a never-signed-in user, then invite with `isNewUser: true`) is unchanged.

## Two test-harness bugs surfaced along the way

Neither affects production; both are included because they made CI red.

**1. 2FA sessions bled between test files.** `resetTestDB()` truncates with `RESTART IDENTITY`, so user ids restart at 1 in every test file, while `sessionCache` lives for the whole mocha run. 2FA sessions are keyed `2fa:${userId}:${sessionId}` with `sessionId` undefined under test, so an entry written by one file satisfied the 2FA check for whichever unrelated user reused that id later. Simply adding users to `AccountMutations.test.ts` shifted the ids and broke `ApplicationMutations`' 2FA tests.

`resetTestDB()` now deletes the `2fa:*` keys. It deliberately does **not** clear the cache: `config/ci.json` sets `redis.serverUrl` but not `serverUrlSession`, so `createRedisClient(SESSION)` falls back to the default instance and in CI both caches are the same Redis database. A flush also dropped the cached FX rates, which moved the converted `PAYMENT_PROCESSOR_COVER` amount in the `createRefundTransaction` multi-currency snapshot from 64 to 68.

**2. `Order` 'retries the lock if it fails' was racy.** It launched both `lock()` calls without awaiting and assumed the `retries: 0` call would always win. When the `retries: 1000` call commits first, the `retries: 0` call rejects with `This order is already been processed, please try again later` at `await firstCall`. `Order.prototype.lock` is pure Postgres and never touches the cache, so this is pre-existing; the test now waits for the first call to hold the lock before launching the retrying one.

## Test plan

- [x] `inviteMember` with `isNewUser: true` on a user who has `lastLoginAt` does **not** set `requiresProfileCompletion` and does not send the new-user email CTA
- [x] `inviteMember` with `isNewUser: true` on a never-signed-in user still flags them (invite-form flow)
- [x] `editAccount` does not rewrite an established slug when `requiresProfileCompletion` is set
- [x] `editAccount` still rewrites `guest-*` placeholder slugs on profile completion
- [x] End-to-end attacker script reproduces the takeover on `main` and is blocked on this branch
- [x] CI's exact `test` command run locally against a Redis matching `config/ci.json`: 2576 passing, multi-currency snapshot green, only minio/network failures left
- [x] `Order.test.js` green over 5 consecutive runs; the losing interleaving reproduced separately to confirm the old race

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a94b3978-4ccf-4edd-9506-2eb87bce8265?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a94b3978-4ccf-4edd-9506-2eb87bce8265&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

