### PR TITLE
fix(expenses): reset approval when tax/currency change, serialize edits with payout

### DIFF
--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -959,6 +959,14 @@ export const canMarkAsPaid: ExpensePermissionEvaluator = async (
       throw new Forbidden('Can not pay expense in current status', EXPENSE_PERMISSION_ERROR_CODES.UNSUPPORTED_STATUS);
     }
     return false;
+  } else if (expense.onHold) {
+    if (options?.throw) {
+      throw new Forbidden(
+        'This expense is currently on hold and cannot be paid',
+        EXPENSE_PERMISSION_ERROR_CODES.UNSUPPORTED_STATUS,
+      );
+    }
+    return false;
   } else if (!canUseFeature(req.remoteUser, FEATURE.USE_EXPENSES)) {
     if (options?.throw) {
       throw new Forbidden('User cannot pay expenses', EXPENSE_PERMISSION_ERROR_CODES.UNSUPPORTED_USER_FEATURE);
@@ -1730,6 +1738,8 @@ export const scheduleExpenseForPayment = async (
 ): Promise<Expense> => {
   if (expense.status === 'SCHEDULED_FOR_PAYMENT') {
     throw new BadRequest('Expense is already scheduled for payment');
+  } else if (expense.onHold) {
+    throw new Forbidden('This expense is currently on hold and cannot be scheduled for payment');
   } else if (!(await canPayExpense(req, expense))) {
     throw new Forbidden("You're authenticated but you can't schedule this expense for payment");
   }
@@ -2616,13 +2626,14 @@ export const changesRequireStatusUpdate = (
 ): boolean => {
   const updatedValues = { ...expense.dataValues, ...newExpenseData };
   const hasAmountChanges = typeof updatedValues.amount !== 'undefined' && updatedValues.amount !== expense.amount;
+  const hasCurrencyChanges = Boolean(newExpenseData.currency && newExpenseData.currency !== expense.currency);
   const isPaidOrProcessingCharge =
     expense.type === ExpenseType.CHARGE && ['PAID', 'PROCESSING'].includes(expense.status);
 
   if (isPaidOrProcessingCharge && !hasAmountChanges) {
     return false;
   }
-  return hasItemsChanges || hasAmountChanges || hasPayoutChanges;
+  return hasItemsChanges || hasAmountChanges || hasPayoutChanges || hasCurrencyChanges;
 };
 
 /** Returns infos about the changes made to items */
@@ -3268,6 +3279,26 @@ export async function editExpense(
   let oldPayoutMethodId = null;
 
   const updatedExpense: Expense = await sequelize.transaction(async transaction => {
+    // Re-check lock and status under a row lock so a concurrent payment cannot be
+    // overwritten (or paid twice) if the expense was edited while payout was starting.
+    const lockedExpense = await models.Expense.findByPk(expense.id, { lock: true, transaction });
+    if (!lockedExpense) {
+      throw new NotFound('Expense not found');
+    } else if (lockedExpense.data?.isLocked) {
+      throw new ValidationFailed('This expense is currently being processed, please try again later');
+    }
+
+    const isPaidCreditCardChargeInTx =
+      lockedExpense.type === ExpenseType.CHARGE &&
+      ['PAID', 'PROCESSING'].includes(lockedExpense.status) &&
+      Boolean(lockedExpense.VirtualCardId);
+    if (
+      ['PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT', 'CANCELED', 'INVITE_DECLINED'].includes(lockedExpense.status) &&
+      !isPaidCreditCardChargeInTx
+    ) {
+      throw new Forbidden("You don't have permission to edit this expense");
+    }
+
     // Update payout method if we get new data from one of the param for it
     if (
       !isPaidCreditCardCharge &&
@@ -3335,7 +3366,14 @@ export async function editExpense(
     hasPayoutMethodChanges = PayoutMethodId !== expense.PayoutMethodId;
     newPayoutMethodId = PayoutMethodId;
     oldPayoutMethodId = expense.PayoutMethodId;
-    const shouldUpdateStatus = changesRequireStatusUpdate(expense, expenseData, hasItemChanges, hasPayoutMethodChanges);
+    const newAmount = models.Expense.computeTotalAmountForExpense(expense.items, taxes);
+    const expenseDataForStatusUpdate = { ...expenseData, amount: newAmount };
+    const shouldUpdateStatus = changesRequireStatusUpdate(
+      expense,
+      expenseDataForStatusUpdate,
+      hasItemChanges,
+      hasPayoutMethodChanges,
+    );
 
     const isChangingPayee =
       expenseData.fromCollective?.id && expenseData.fromCollective.id !== expense.FromCollectiveId;
@@ -3382,14 +3420,14 @@ export async function editExpense(
     let status = expense.status;
     if (status === 'INCOMPLETE') {
       // When dealing with expenses marked as INCOMPLETE, only return to PENDING if the expense change requires Collective review
-      status = changesRequireStatusUpdate(expense, expenseData, hasItemChanges) ? 'PENDING' : 'APPROVED';
+      status = changesRequireStatusUpdate(expense, expenseDataForStatusUpdate, hasItemChanges) ? 'PENDING' : 'APPROVED';
     } else if (shouldUpdateStatus) {
       status = 'PENDING';
     }
 
     const updatedExpenseProps = {
       ...cleanExpenseData,
-      amount: models.Expense.computeTotalAmountForExpense(expense.items, taxes), // We've reloaded the items above
+      amount: newAmount, // We've reloaded the items above
       lastEditedById: remoteUser.id,
       incurredAt: expenseData.incurredAt || min(expense.items.map(item => item.incurredAt)) || new Date(),
       status,
@@ -3882,6 +3920,9 @@ export async function payExpense(req: express.Request, args: PayExpenseArgs): Pr
       expense.status !== ExpenseStatus.ERROR
     ) {
       throw new Forbidden(`Expense needs to be approved. Current status of the expense: ${expense.status}.`);
+    }
+    if (expense.onHold) {
+      throw new Forbidden('This expense is currently on hold and cannot be paid');
     }
 
     const permissionFn = forceManual ? canMarkAsPaid : canPayExpense;

--- a/server/graphql/common/expenses.ts
+++ b/server/graphql/common/expenses.ts
@@ -959,14 +959,6 @@ export const canMarkAsPaid: ExpensePermissionEvaluator = async (
       throw new Forbidden('Can not pay expense in current status', EXPENSE_PERMISSION_ERROR_CODES.UNSUPPORTED_STATUS);
     }
     return false;
-  } else if (expense.onHold) {
-    if (options?.throw) {
-      throw new Forbidden(
-        'This expense is currently on hold and cannot be paid',
-        EXPENSE_PERMISSION_ERROR_CODES.UNSUPPORTED_STATUS,
-      );
-    }
-    return false;
   } else if (!canUseFeature(req.remoteUser, FEATURE.USE_EXPENSES)) {
     if (options?.throw) {
       throw new Forbidden('User cannot pay expenses', EXPENSE_PERMISSION_ERROR_CODES.UNSUPPORTED_USER_FEATURE);
@@ -1738,8 +1730,6 @@ export const scheduleExpenseForPayment = async (
 ): Promise<Expense> => {
   if (expense.status === 'SCHEDULED_FOR_PAYMENT') {
     throw new BadRequest('Expense is already scheduled for payment');
-  } else if (expense.onHold) {
-    throw new Forbidden('This expense is currently on hold and cannot be scheduled for payment');
   } else if (!(await canPayExpense(req, expense))) {
     throw new Forbidden("You're authenticated but you can't schedule this expense for payment");
   }
@@ -2630,7 +2620,8 @@ export const changesRequireStatusUpdate = (
   const isPaidOrProcessingCharge =
     expense.type === ExpenseType.CHARGE && ['PAID', 'PROCESSING'].includes(expense.status);
 
-  if (isPaidOrProcessingCharge && !hasAmountChanges) {
+  if (isPaidOrProcessingCharge) {
+    // Receipts are attached to card charges after the money moved, so those edits never need a new review
     return false;
   }
   return hasItemsChanges || hasAmountChanges || hasPayoutChanges || hasCurrencyChanges;
@@ -3279,24 +3270,14 @@ export async function editExpense(
   let oldPayoutMethodId = null;
 
   const updatedExpense: Expense = await sequelize.transaction(async transaction => {
-    // Re-check lock and status under a row lock so a concurrent payment cannot be
-    // overwritten (or paid twice) if the expense was edited while payout was starting.
+    // The lock/status checks above run before this transaction opens, so a payout that starts in
+    // between would be overwritten by this edit. Take the row lock and re-read to serialize with
+    // `lockExpense`, which holds the same lock while flagging the expense as being processed.
     const lockedExpense = await models.Expense.findByPk(expense.id, { lock: true, transaction });
     if (!lockedExpense) {
       throw new NotFound('Expense not found');
-    } else if (lockedExpense.data?.isLocked) {
+    } else if (lockedExpense.data?.isLocked || lockedExpense.status !== expense.status) {
       throw new ValidationFailed('This expense is currently being processed, please try again later');
-    }
-
-    const isPaidCreditCardChargeInTx =
-      lockedExpense.type === ExpenseType.CHARGE &&
-      ['PAID', 'PROCESSING'].includes(lockedExpense.status) &&
-      Boolean(lockedExpense.VirtualCardId);
-    if (
-      ['PAID', 'PROCESSING', 'SCHEDULED_FOR_PAYMENT', 'CANCELED', 'INVITE_DECLINED'].includes(lockedExpense.status) &&
-      !isPaidCreditCardChargeInTx
-    ) {
-      throw new Forbidden("You don't have permission to edit this expense");
     }
 
     // Update payout method if we get new data from one of the param for it
@@ -3920,9 +3901,6 @@ export async function payExpense(req: express.Request, args: PayExpenseArgs): Pr
       expense.status !== ExpenseStatus.ERROR
     ) {
       throw new Forbidden(`Expense needs to be approved. Current status of the expense: ${expense.status}.`);
-    }
-    if (expense.onHold) {
-      throw new Forbidden('This expense is currently on hold and cannot be paid');
     }
 
     const permissionFn = forceManual ? canMarkAsPaid : canPayExpense;

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -1244,20 +1244,6 @@ describe('server/graphql/common/expenses', () => {
       });
     });
 
-    it('cannot pay expenses that are on hold', async () => {
-      await runForAllContexts(async context => {
-        const { expense, req } = context;
-        await expense.update({ status: 'APPROVED', onHold: true });
-        expect(await canPayExpense(req.hostAdmin, expense)).to.be.false;
-        expect(await canMarkAsPaid(req.hostAdmin, expense)).to.be.false;
-        await expense.update({ onHold: false });
-        expect(await canPayExpense(req.hostAdmin, expense)).to.eq(context.expense.type !== 'CHARGE');
-        expect(await canMarkAsPaid(req.hostAdmin, expense)).to.eq(
-          context.expense.type !== 'CHARGE' || !!context.expense.data?.isManualVirtualCardCharge,
-        );
-      });
-    });
-
     it('only with the allowed roles', async () => {
       await runForAllContexts(async context => {
         const { expense } = context;

--- a/test/server/graphql/common/expenses.test.js
+++ b/test/server/graphql/common/expenses.test.js
@@ -1244,6 +1244,20 @@ describe('server/graphql/common/expenses', () => {
       });
     });
 
+    it('cannot pay expenses that are on hold', async () => {
+      await runForAllContexts(async context => {
+        const { expense, req } = context;
+        await expense.update({ status: 'APPROVED', onHold: true });
+        expect(await canPayExpense(req.hostAdmin, expense)).to.be.false;
+        expect(await canMarkAsPaid(req.hostAdmin, expense)).to.be.false;
+        await expense.update({ onHold: false });
+        expect(await canPayExpense(req.hostAdmin, expense)).to.eq(context.expense.type !== 'CHARGE');
+        expect(await canMarkAsPaid(req.hostAdmin, expense)).to.eq(
+          context.expense.type !== 'CHARGE' || !!context.expense.data?.isManualVirtualCardCharge,
+        );
+      });
+    });
+
     it('only with the allowed roles', async () => {
       await runForAllContexts(async context => {
         const { expense } = context;

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -1669,6 +1669,49 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         expect(result.data.editExpense.status).to.equal('APPROVED');
         expect(result.data.editExpense.amount).to.equal(expense.amount);
       });
+
+      it('Tax => should change status and amount', async () => {
+        const collective = await fakeCollective({
+          currency: 'EUR',
+          settings: { VAT: { type: 'OWN', idNumber: 'XXXXXX' } },
+        });
+        const expense = await fakeExpense({
+          type: expenseTypes.INVOICE,
+          status: 'APPROVED',
+          amount: 10000,
+          items: [],
+          CollectiveId: collective.id,
+          currency: 'EUR',
+        });
+        await fakeExpenseItem({ ExpenseId: expense.id, amount: 10000 });
+
+        const newExpenseData = {
+          id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE),
+          tax: [{ type: 'VAT', rate: 0.21 }],
+        };
+        const result = await graphqlQueryV2(editExpenseMutation, { expense: newExpenseData }, expense.User);
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        expect(result.data.editExpense.status).to.equal('PENDING');
+        expect(result.data.editExpense.amount).to.equal(12100);
+      });
+
+      it('Currency => should change status', async () => {
+        const host = await fakeActiveHost({ currency: 'USD' });
+        const collective = await fakeCollective({ HostCollectiveId: host.id, currency: 'USD' });
+        const expense = await fakeExpense({
+          status: 'APPROVED',
+          CollectiveId: collective.id,
+          currency: 'USD',
+        });
+        const newExpenseData = { id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE), currency: 'EUR' };
+        const result = await graphqlQueryV2(editExpenseMutation, { expense: newExpenseData }, expense.User);
+        result.errors && console.error(result.errors);
+        expect(result.errors).to.not.exist;
+        expect(result.data.editExpense.status).to.equal('PENDING');
+        await expense.reload();
+        expect(expense.currency).to.equal('EUR');
+      });
     });
 
     describe('clears stored Stripe paymentIntent when payment-relevant fields change', () => {
@@ -2183,6 +2226,14 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
       const result = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.eq("You don't have permission to edit this expense");
+    });
+
+    it('cannot edit an expense that is being paid', async () => {
+      const expense = await fakeExpense({ status: 'APPROVED', data: { isLocked: true } });
+      const updatedExpenseData = { id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE), description: randStr() };
+      const result = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.eq('This expense is currently being processed, please try again later');
     });
 
     it(`fails if it's not an allowed expense type`, async () => {
@@ -4732,6 +4783,22 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         }
       });
 
+      it('Fails if expense is on hold', async () => {
+        const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
+        const expense = await fakeExpense({
+          amount: 1000,
+          CollectiveId: collective.id,
+          status: 'APPROVED',
+          onHold: true,
+          PayoutMethodId: payoutMethod.id,
+        });
+        await fakeTransaction({ type: 'CREDIT', CollectiveId: collective.id, amount: expense.amount });
+        const mutationParams = { expenseId: expense.id, action: 'PAY' };
+        const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.eq('This expense is currently on hold and cannot be paid');
+      });
+
       it('Fails if balance is too low', async () => {
         const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
         const expense = await fakeExpense({
@@ -6039,6 +6106,16 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
         expect(result.errors).to.exist;
         expect(result.errors[0].message).to.eq("You're authenticated but you can't schedule this expense for payment");
+      });
+
+      it('Fails if expense is on hold', async () => {
+        const expense = await fakeExpense({ CollectiveId: collective.id, status: 'APPROVED', onHold: true });
+        const mutationParams = { expenseId: expense.id, action: 'SCHEDULE_FOR_PAYMENT' };
+        const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
+        expect(result.errors).to.exist;
+        expect(result.errors[0].message).to.eq(
+          'This expense is currently on hold and cannot be scheduled for payment',
+        );
       });
 
       it('Schedules the expense for payment', async () => {

--- a/test/server/graphql/v2/mutation/ExpenseMutations.test.js
+++ b/test/server/graphql/v2/mutation/ExpenseMutations.test.js
@@ -32,7 +32,7 @@ import {
   TwoFactorMethod,
 } from '../../../../../server/lib/two-factor-authentication/lib';
 import { sleep } from '../../../../../server/lib/utils';
-import models, { Expense, UploadedFile } from '../../../../../server/models';
+import models, { Expense, sequelize, UploadedFile } from '../../../../../server/models';
 import { LEGAL_DOCUMENT_TYPE } from '../../../../../server/models/LegalDocument';
 import { PayoutMethodTypes } from '../../../../../server/models/PayoutMethod';
 import UserTwoFactorMethod from '../../../../../server/models/UserTwoFactorMethod';
@@ -2234,6 +2234,32 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
       const result = await graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
       expect(result.errors).to.exist;
       expect(result.errors[0].message).to.eq('This expense is currently being processed, please try again later');
+    });
+
+    it('cannot edit an expense when a payout starts right after the lock check', async () => {
+      const expense = await fakeExpense({ status: 'APPROVED' });
+      const initialDescription = expense.description;
+
+      // Reproduce what `lockExpense` does when a payout starts: take the row lock and flag the
+      // expense, but only after `editExpense` has already read it and seen no lock.
+      const payoutTransaction = await sequelize.transaction();
+      await models.Expense.findByPk(expense.id, { lock: true, transaction: payoutTransaction });
+      await models.Expense.update(
+        { data: { ...expense.data, isLocked: true } },
+        { where: { id: expense.id }, transaction: payoutTransaction },
+      );
+
+      const updatedExpenseData = { id: idEncode(expense.id, IDENTIFIER_TYPES.EXPENSE), description: randStr() };
+      const resultPromise = graphqlQueryV2(editExpenseMutation, { expense: updatedExpenseData }, expense.User);
+      await sleep(2000); // Give the edit time to pass its checks and block on the row lock
+      await payoutTransaction.commit();
+
+      const result = await resultPromise;
+      expect(result.errors).to.exist;
+      expect(result.errors[0].message).to.eq('This expense is currently being processed, please try again later');
+
+      await expense.reload();
+      expect(expense.description).to.eq(initialDescription);
     });
 
     it(`fails if it's not an allowed expense type`, async () => {
@@ -4783,22 +4809,6 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         }
       });
 
-      it('Fails if expense is on hold', async () => {
-        const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
-        const expense = await fakeExpense({
-          amount: 1000,
-          CollectiveId: collective.id,
-          status: 'APPROVED',
-          onHold: true,
-          PayoutMethodId: payoutMethod.id,
-        });
-        await fakeTransaction({ type: 'CREDIT', CollectiveId: collective.id, amount: expense.amount });
-        const mutationParams = { expenseId: expense.id, action: 'PAY' };
-        const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
-        expect(result.errors).to.exist;
-        expect(result.errors[0].message).to.eq('This expense is currently on hold and cannot be paid');
-      });
-
       it('Fails if balance is too low', async () => {
         const payoutMethod = await fakePayoutMethod({ type: 'OTHER' });
         const expense = await fakeExpense({
@@ -6106,16 +6116,6 @@ describe('server/graphql/v2/mutation/ExpenseMutations', () => {
         const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
         expect(result.errors).to.exist;
         expect(result.errors[0].message).to.eq("You're authenticated but you can't schedule this expense for payment");
-      });
-
-      it('Fails if expense is on hold', async () => {
-        const expense = await fakeExpense({ CollectiveId: collective.id, status: 'APPROVED', onHold: true });
-        const mutationParams = { expenseId: expense.id, action: 'SCHEDULE_FOR_PAYMENT' };
-        const result = await graphqlQueryV2(processExpenseMutation, mutationParams, hostAdmin);
-        expect(result.errors).to.exist;
-        expect(result.errors[0].message).to.eq(
-          'This expense is currently on hold and cannot be scheduled for payment',
-        );
       });
 
       it('Schedules the expense for payment', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Security audit of the expense processing flow. Two of the three issues from the first pass survived validation; the third was retracted after checking upstream intent.

### 1. Approval is not reset when tax or currency changes (integrity, valid)

`changesRequireStatusUpdate` derives `hasAmountChanges` from `newExpenseData.amount`, but `amount` is not an editable expense field, so from `editExpense` that value is always `undefined` and the check never fires. Meanwhile `editExpense` recomputes and persists `amount` from the items *and the taxes*.

The result: a payee can add a 21% VAT to an already-APPROVED expense and the stored amount goes from 10000 to 12100 while the status stays `APPROVED`, ready for payout. The same applies to `currency`, which is in `EXPENSE_EDITABLE_FIELDS` — switching an approved USD expense to EUR changes what the host pays without a new review.

Fix: pass the recomputed amount into `changesRequireStatusUpdate` and treat a currency change as requiring re-approval, so the expense goes back to `PENDING`.

The paid/processing-charge branch is now an unconditional early return. `hasAmountChanges` was always `false` there before, so that branch always returned `false`; feeding it the real amount would have started flipping PAID card charges to PENDING when a receipt's total differed from the charge. Behavior is unchanged, the now-live condition is just removed.

### 2. `editExpense` lock check is a TOCTOU against payout (valid, narrow)

`editExpense` reads the expense and checks `data.isLocked` well before it opens its write transaction. `lockExpense` (used by `payExpense`) sets that flag in its own short transaction. A payout that starts inside that window is silently overwritten by the edit: the payment creates ledger entries for the amount it read while the row ends up with a different amount and status.

Fix: the edit transaction re-reads the expense with `lock: true`, the same row lock `lockExpense` takes, and bails out if the expense is locked or its status moved. This serializes the two paths — whichever grabs the row lock first wins, and the loser gets a retryable error.

## Test plan

Each fix has a test that fails against unpatched `server/graphql/common/expenses.ts`:

- `Tax => should change status and amount` — VAT added to an APPROVED expense; asserts `PENDING` and 12100.
- `Currency => should change status` — USD to EUR on an APPROVED expense; asserts `PENDING`.
- `cannot edit an expense when a payout starts right after the lock check` — reproduces the race deterministically by holding the row lock in an open transaction and flagging `isLocked` after `editExpense` has already read the expense; asserts the edit is rejected and the description is unchanged.

Before the fix, all three fail:

```
  1) cannot edit an expense when a payout starts right after the lock check:
     AssertionError: expected undefined to exist
  2) Tax => should change status and amount:
     AssertionError: expected 'APPROVED' to equal 'PENDING'
  3) Currency => should change status:
     AssertionError: expected 'APPROVED' to equal 'PENDING'
```

After the fix, the three expense suites are green (446 passing, 0 failing):

- `test/server/graphql/v2/mutation/ExpenseMutations.test.js`
- `test/server/graphql/v2/mutation/ExpenseMutations-legacy.test.js`
- `test/server/graphql/common/expenses.test.js`

`npx tsc --noEmit` and `npx eslint` on the changed files are clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2942b9b-cc9b-4826-a470-9c053ab5b2fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2942b9b-cc9b-4826-a470-9c053ab5b2fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

